### PR TITLE
Use edge update to impl sendto

### DIFF
--- a/examples/pagerank.py
+++ b/examples/pagerank.py
@@ -10,8 +10,8 @@ K = 10
 def message_func(src, dst, edge):
     return src['pv'] / src['deg']
 
-def update_func(node, msgs):
-    pv = (1 - DAMP) / N + DAMP * sum(msgs)
+def update_func(node, accum):
+    pv = (1 - DAMP) / N + DAMP * accum
     return {'pv' : pv}
 
 def compute_pagerank(g):
@@ -19,6 +19,7 @@ def compute_pagerank(g):
     print(g.number_of_edges(), g.number_of_nodes())
     g.register_message_func(message_func)
     g.register_update_func(update_func)
+    g.register_reduce_func('sum')
     # init pv value
     for n in g.nodes():
         g.node[n]['pv'] = 1 / N

--- a/tests/test_basics.py
+++ b/tests/test_basics.py
@@ -3,9 +3,8 @@ from dgl.graph import DGLGraph
 def message_func(src, dst, edge):
     return src['h']
 
-def update_func(node, msgs):
-    m = sum(msgs)
-    return {'h' : node['h'] + m}
+def update_func(node, accum):
+    return {'h' : node['h'] + accum}
 
 def generate_graph():
     g = DGLGraph()
@@ -29,6 +28,7 @@ def test_sendrecv():
     check(g, [1, 2, 3, 4, 5, 6, 7, 8, 9, 10])
     g.register_message_func(message_func)
     g.register_update_func(update_func)
+    g.register_reduce_func('sum')
     g.sendto(0, 1)
     g.recvfrom(1, [0])
     check(g, [1, 3, 3, 4, 5, 6, 7, 8, 9, 10])
@@ -42,6 +42,7 @@ def test_multi_sendrecv():
     check(g, [1, 2, 3, 4, 5, 6, 7, 8, 9, 10])
     g.register_message_func(message_func)
     g.register_update_func(update_func)
+    g.register_reduce_func('sum')
     # one-many
     g.sendto(0, [1, 2, 3])
     g.recvfrom([1, 2, 3], [[0], [0], [0]])
@@ -60,6 +61,7 @@ def test_update_routines():
     check(g, [1, 2, 3, 4, 5, 6, 7, 8, 9, 10])
     g.register_message_func(message_func)
     g.register_update_func(update_func)
+    g.register_reduce_func('sum')
     g.update_by_edge(0, 1)
     check(g, [1, 3, 3, 4, 5, 6, 7, 8, 9, 10])
     g.update_to(9)


### PR DESCRIPTION
This PR implements `sendto` using the `edge_update` function. As a result, the system side still only needs to care about two types of computation: on node and on edge. One minor change in the API. All `register` and `sendto/recvfrom/edge_update` now has an extra `name` argument to tell which registered function should be used. The default behavior is the same as our old APIs so no code change is required.

Also fixed examples and tests with missing reduce func.

For @GaiYu0 , you may want to have a look and try to incorporate this PR in your batching PR.