### PR TITLE
[GraphIndex] Create graph index directly from scipy matrix.

### DIFF
--- a/python/dgl/data/citation_graph.py
+++ b/python/dgl/data/citation_graph.py
@@ -206,7 +206,8 @@ def get_gnp_generator(args):
         return nx.fast_gnp_random_graph(n, p, seed, True)
     return _gen
 
-class ScipyGraph:
+class ScipyGraph(object):
+    """A simple graph object that uses scipy matrix."""
     def __init__(self, mat):
         self._mat = mat
 


### PR DESCRIPTION
it's very slow to create synthetic data with NetworkX. It's faster to create synthetic data with scipy and way faster to load scipy data to GraphIndex.

A little benchmark (create and load a graph with 100,000 vertices and 2,303,327 edges):

x | NetworkX | SciPy
------------ | ------------- | -------------
load data | 7.25s | 3.55s
create index | 16.74s | 0.84s
