### PR TITLE
[BUG] potential context mismatch in send-and-recv executor

### DIFF
--- a/python/dgl/scheduler.py
+++ b/python/dgl/scheduler.py
@@ -348,8 +348,9 @@ class SendRecvExecutor(BasicExecutor):
                 dat = F.squeeze(dat, dim=1)
         else:
             dat = F.ones((len(self.u), ), dtype=F.float32, ctx=ctx)
-        adjmat = F.sparse_matrix(dat, ('coo', self.graph_idx), self.graph_shape)
-        return F.copy_to(adjmat, ctx)
+        adjmat = F.sparse_matrix(
+                dat, ('coo', F.copy_to(self.graph_idx, ctx)), self.graph_shape)
+        return adjmat
 
 
 class BundledExecutor(BasicExecutor):


### PR DESCRIPTION
When using `send_and_recv` with e.g. `copy_src`, adjacency matrix index is always constructed on CPU, so adj matrix may fail to construct if the source context is on GPU.