### PR TITLE
[Hotfix] Forgot to remove conda branch meta

### DIFF
--- a/conda/dgl/meta.yaml
+++ b/conda/dgl/meta.yaml
@@ -3,7 +3,6 @@ package:
   version: "0.0.1"
 
 source:
-  git_rev: conda
   git_url: https://github.com/jermainewang/dgl.git
 
 requirements:


### PR DESCRIPTION
See #187 .  Forgot to do that...