### PR TITLE
[Dataset] update s3 links to dgl.ai bucket under team account

### DIFF
--- a/python/dgl/data/citation_graph.py
+++ b/python/dgl/data/citation_graph.py
@@ -15,9 +15,9 @@ import os, sys
 from .utils import download, extract_archive, get_download_dir
 
 _urls = {
-    'cora' : 'https://s3.amazonaws.com/dgl-data/dataset/cora.zip',
-    'citeseer' : 'https://s3.amazonaws.com/dgl-data/dataset/citeseer.zip',
-    'pubmed' : 'https://s3.amazonaws.com/dgl-data/dataset/pubmed.zip',
+    'cora' : 'https://s3.us-east-2.amazonaws.com/dgl.ai/dataset/cora.zip',
+    'citeseer' : 'https://s3.us-east-2.amazonaws.com/dgl.ai/dataset/citeseer.zip',
+    'pubmed' : 'https://s3.us-east-2.amazonaws.com/dgl.ai/dataset/pubmed.zip',
 }
 
 class CitationGraphDataset(object):

--- a/python/dgl/data/tree.py
+++ b/python/dgl/data/tree.py
@@ -17,7 +17,7 @@ import dgl.backend as F
 from dgl.data.utils import download, extract_archive, get_download_dir
 
 _urls = {
-    'sst' : 'https://s3.amazonaws.com/dgl-data/dataset/sst.zip',
+    'sst' : 'https://s3.us-east-2.amazonaws.com/dgl.ai/dataset/sst.zip',
 }
 
 SSTBatch = namedtuple('SSTBatch', ['graph', 'mask', 'wordid', 'label'])

--- a/tutorials/models/5_dgmg.py
+++ b/tutorials/models/5_dgmg.py
@@ -713,7 +713,7 @@ class DGMG(DGMGSkeleton):
 import torch.utils.model_zoo as model_zoo
 
 # Download a pre-trained model state dict for generating cycles with 10-20 nodes.
-state_dict = model_zoo.load_url('https://s3.amazonaws.com/dgl-data/model/dgmg_cycles-5a0c40be.pth')
+state_dict = model_zoo.load_url('https://s3.us-east-2.amazonaws.com/dgl.ai/model/dgmg_cycles-5a0c40be.pth')
 model = DGMG(v_max=20, node_hidden_size=16, num_prop_rounds=2)
 model.load_state_dict(state_dict)
 model.eval()


### PR DESCRIPTION
The datasets have now been migrated to the `dgl.ai` bucket. 

cc @yzh119 