### PR TITLE
[DOC] Fix repo link 

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -41,7 +41,7 @@ Free software
 -------------
 DGL is free software; you can redistribute it and/or modify it under the terms
 of the Apache License 2.0. We welcome contributions.
-Join us on `GitHub <https://github.com/jermainewang/dgl>`_.
+Join us on `GitHub <https://github.com/dmlc/dgl>`_ and checkout our `contribution guidelines <https://github.com/dmlc/dgl/blob/master/CONTRIBUTING.md>`_.
 
 History
 -------

--- a/docs/source/install/index.rst
+++ b/docs/source/install/index.rst
@@ -74,7 +74,7 @@ First, download the source files from GitHub:
 
 .. code:: bash
 
-   git clone --recursive https://github.com/jermainewang/dgl.git
+   git clone --recursive https://github.com/dmlc/dgl.git
 
 One can also clone the repository first and run the following:
 


### PR DESCRIPTION
## Description
Fixed the link to the repo after migrating to dmlc. 

## Checklist
Please feel free to remove inapplicable items for your PR.
- [x] The PR title starts with [$CATEGORY] (such as [Model], [Doc], [Feature]])
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] To the my best knowledge, examples are either not affected by this change,
      or have been fixed to be compatible with this change

