### PR TITLE
[Doc] Fix document building for multiple tensor backends

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -55,7 +55,7 @@ def pytorch_tutorials() {
 }
 
 def mxnet_tutorials() {
-  withEnv(["DGL_LIBRARY_PATH=${env.WORKSPACE}/build", "PYTHONPATH=${env.WORKSPACE}/python"]) {
+  withEnv(["DGL_LIBRARY_PATH=${env.WORKSPACE}/build", "PYTHONPATH=${env.WORKSPACE}/python", "DGLBACKEND=mxnet"]) {
     dir("tests/scripts") {
       sh "bash task_mxnet_tutorial_test.sh"
     }

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -20,7 +20,7 @@ mxnet:
 	@echo "#                                                                #"
 	@echo "##################################################################"
 	@DGLBACKEND=mxnet $(SPHINXBUILD) -M html "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O) \
-						 -D sphinx_gallery_conf.ignore_pattern="/*(?<!mx)\.py"
+						 -D sphinx_gallery_conf.filename_pattern="/*(?<=mx)\.py"
 
 pytorch:
 	@echo "##################################################################"
@@ -29,7 +29,7 @@ pytorch:
 	@echo "#                                                                #"
 	@echo "##################################################################"
 	@DGLBACKEND=pytorch $(SPHINXBUILD) -M html "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O) \
-						 -D sphinx_gallery_conf.ignore_pattern="/*(?<=mx)\.py"
+						 -D sphinx_gallery_conf.filename_pattern="/*(?<!mx)\.py"
 
 html-noexec:
 	@echo "##################################################################"

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -13,18 +13,33 @@ help:
 
 .PHONY: help Makefile
 
+mxnet:
+	@echo "##################################################################"
+	@echo "#                                                                #"
+	@echo "#                Step 1: Building MXNet tutorials                #"
+	@echo "#                                                                #"
+	@echo "##################################################################"
+	@DGLBACKEND=mxnet $(SPHINXBUILD) -M html "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O) \
+						 -D sphinx_gallery_conf.ignore_pattern="/*(?<!mx)\.py"
+
+pytorch:
+	@echo "##################################################################"
+	@echo "#                                                                #"
+	@echo "#                Step 2: Building PyTorch tutorials              #"
+	@echo "#                                                                #"
+	@echo "##################################################################"
+	@DGLBACKEND=pytorch $(SPHINXBUILD) -M html "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O) \
+						 -D sphinx_gallery_conf.ignore_pattern="/*(?<=mx)\.py"
+
 html-noexec:
+	@echo "##################################################################"
+	@echo "#                                                                #"
+	@echo "#                Step 3: Building documents                      #"
+	@echo "#                                                                #"
+	@echo "##################################################################"
 	$(SPHINXBUILD) -D plot_gallery=0 -b html "$(SOURCEDIR)" "$(BUILDDIR)/html" 
 	@echo
 	@echo "Build finished. The HTML pages are in $(BUILDDIR)/html."
-
-pytorch: Makefile
-	@DGLBACKEND=pytorch $(SPHINXBUILD) "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O) \
-						 -D sphinx_gallery_conf.ignore_pattern="/*(?<=mx)\.py"
-
-mxnet: Makefile
-	@DGLBACKEND=mxnet $(SPHINXBUILD) "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O) \
-						 -D sphinx_gallery_conf.ignore_pattern="/*(?<!mx)\.py"
 
 html: Makefile mxnet pytorch html-noexec
 

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -32,16 +32,11 @@ pytorch:
 						 -D sphinx_gallery_conf.filename_pattern="/*(?<!mx)\.py"
 
 html-noexec:
-	@echo "##################################################################"
-	@echo "#                                                                #"
-	@echo "#                Step 3: Building documents                      #"
-	@echo "#                                                                #"
-	@echo "##################################################################"
 	$(SPHINXBUILD) -D plot_gallery=0 -b html "$(SOURCEDIR)" "$(BUILDDIR)/html" 
 	@echo
 	@echo "Build finished. The HTML pages are in $(BUILDDIR)/html."
 
-html: Makefile mxnet pytorch html-noexec
+html: Makefile mxnet pytorch
 
 # Catch-all target: route all unknown targets to Sphinx using the new
 # "make mode" option.  $(O) is meant as a shortcut for $(SPHINXOPTS).

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -18,10 +18,17 @@ html-noexec:
 	@echo
 	@echo "Build finished. The HTML pages are in $(BUILDDIR)/html."
 
+pytorch: Makefile
+	@DGLBACKEND=pytorch $(SPHINXBUILD) "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O) \
+						 -D sphinx_gallery_conf.ignore_pattern="/*(?<=mx)\.py"
+
+mxnet: Makefile
+	@DGLBACKEND=mxnet $(SPHINXBUILD) "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O) \
+						 -D sphinx_gallery_conf.ignore_pattern="/*(?<!mx)\.py"
+
+html: Makefile mxnet pytorch html-noexec
+
 # Catch-all target: route all unknown targets to Sphinx using the new
 # "make mode" option.  $(O) is meant as a shortcut for $(SPHINXOPTS).
 %: Makefile
-	@DGLBACKEND=pytorch $(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O) \
-						 -D sphinx_gallery_conf.ignore_pattern="/*(?<=mx)\.py"
-	@DGLBACKEND=mxnet $(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O) \
-						 -D sphinx_gallery_conf.ignore_pattern="/*(?<!mx)\.py"
+	@$(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O) 

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -21,4 +21,7 @@ html-noexec:
 # Catch-all target: route all unknown targets to Sphinx using the new
 # "make mode" option.  $(O) is meant as a shortcut for $(SPHINXOPTS).
 %: Makefile
-	@$(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
+	@DGLBACKEND=pytorch $(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O) \
+						 -D sphinx_gallery_conf.ignore_pattern="/*(?<=mx)\.py"
+	@DGLBACKEND=mxnet $(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O) \
+						 -D sphinx_gallery_conf.ignore_pattern="/*(?<!mx)\.py"

--- a/docs/README.md
+++ b/docs/README.md
@@ -13,13 +13,9 @@ Then build:
 make html
 ```
 
-Note: due to the backend loading issue, it actually takes 3 rounds to build:
+Note: due to the backend loading issue, it actually takes 2 rounds to build:
 1. build tutorials that uses MXNet as backend
 2. build tutorials that uses PyTorch as backend
-3. build all documents without running code
-
-Step 1 and 2 will generate warnings which can be safely ignored. Warnings
-generated in Step 3 should be fixed.
 
 Render locally
 --------------

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,9 +1,29 @@
 DGL document and tutorial folder
 ================================
 
-To build,
+Build documents
+---------------
+First, clean up existing files:
+```
+./clean.sh
+```
+
+Then build:
 ```
 make html
 ```
 
-and then render the page `build/html/index.html`.
+Note: due to the backend loading issue, it actually takes 3 rounds to build:
+1. build tutorials that uses MXNet as backend
+2. build tutorials that uses PyTorch as backend
+3. build all documents without running code
+
+Step 1 and 2 will generate warnings which can be safely ignored. Warnings
+generated in Step 3 should be fixed.
+
+Render locally
+--------------
+```
+cd build/html
+python3 -m http.server 8000
+```

--- a/python/dgl/contrib/sampling/sampler.py
+++ b/python/dgl/contrib/sampling/sampler.py
@@ -99,8 +99,10 @@ def NeighborSampler(g, batch_size, expand_factor, num_hops=1,
 
     The subgraph loader returns a list of subgraphs and a dictionary of additional
     information about the subgraphs. The size of the subgraph list is the number of workers.
+
     The dictionary contains:
-        'seeds': a list of 1D tensors of seed Ids, if return_seed_id is True.
+
+    - seeds: a list of 1D tensors of seed Ids, if return_seed_id is True.
 
     Parameters
     ----------

--- a/tutorials/models/1_gnn/8_sse_mx.py
+++ b/tutorials/models/1_gnn/8_sse_mx.py
@@ -92,9 +92,6 @@ Stochastic Steady-state Embedding (SSE)
 import mxnet as mx
 import os
 import dgl
-# DGL backend defaults to PyTorch, so we need to switch backend.
-# One can also set the environment variable outside Python.
-dgl.load_backend('mxnet')
 
 def T(g):
     def message_func(edges):

--- a/tutorials/models/4_old_wines/7_transformer.py
+++ b/tutorials/models/4_old_wines/7_transformer.py
@@ -219,12 +219,12 @@ Transformer Tutorial
 # function, including:
 #
 # - ``fn.src_mul_egdes(src_field, edges_field, out_field)`` multiplies
-# source’s attribute and edges attribute, and send the result to the
-# destination node’s mailbox keyed by ``out_field``.
+#   source’s attribute and edges attribute, and send the result to the
+#   destination node’s mailbox keyed by ``out_field``.
 # - ``fn.copy_edge(edges_field, out_field)`` copies edge’s attribute to
-# destination node’s mailbox.
+#   destination node’s mailbox.
 # - ``fn.sum(edges_field, out_field)`` sums up
-# edge’s attribute and sends aggregation to destination node’s mailbox.
+#   edge’s attribute and sends aggregation to destination node’s mailbox.
 #
 # Here we assemble those built-in function into ``propagate_attention``,
 # which is also the main graph operation function in our final
@@ -540,6 +540,7 @@ Transformer Tutorial
 #        print(graph.tgt[0]) # Output word index list
 #        print(graph.tgt[1]) # Ouptut positions
 #        break
+#
 # Output:
 #
 # .. code::


### PR DESCRIPTION
## Description
Current document build fails and has to be fixed manually because different tutorials use different tensor backend (pytorch, mxnet) but sphinx builds using only one process and loads DGL only once.

Instead of tweaking tutorial code to dynamically switch backend, this PR builds documents in two rounds to bypass the issue:
- First round builds all documents which uses MXNet
- Second round builds all documents which uses PyTorch

Step 1 and 2 build documents twice, so there are redundant work. But I am not sure how to minimize each step.

## Checklist
- [x] The PR title starts with [$CATEGORY] (such as [Model], [Doc], [Feature]])
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage
- [x] Code is well-documented
- [x] To the my best knowledge, examples are either not affected by this change,
      or have been fixed to be compatible with this change

## Changes
- [x] Build doc in two rounds
- [x] Remove backend loading in model code
- [x] Fix some warnings in tutorial docstring

