### PR TITLE
[Bugfix] Fix multiple send recv

### DIFF
--- a/python/dgl/backend/backend.py
+++ b/python/dgl/backend/backend.py
@@ -618,7 +618,7 @@ def unique(input):
     """
     pass
 
-def full_1d(length, fill_value):
+def full_1d(length, fill_value, dtype, ctx):
     """Create a 1D tensor full of the fill_value.
 
     Parameters
@@ -627,6 +627,10 @@ def full_1d(length, fill_value):
         The length of the vector.
     fill_value : int
         The filled value.
+    dtype : data type
+        It should be one of the values in the data type dict.
+    ctx : context
+        The device of the result tensor.
 
     Returns
     -------

--- a/python/dgl/backend/mxnet/tensor.py
+++ b/python/dgl/backend/mxnet/tensor.py
@@ -171,8 +171,8 @@ def unique(input):
     tmp = np.unique(tmp)
     return nd.array(tmp, ctx=input.context, dtype=input.dtype)
 
-def full_1d(length, fill_value):
-    return nd.full((length,), fill_value)
+def full_1d(length, fill_value, dtype, ctx):
+    return nd.full((length,), fill_value, dtype=dtype, ctx=ctx)
 
 def nonzero_1d(input):
     # TODO: fallback to numpy is unfortunate

--- a/python/dgl/backend/pytorch/tensor.py
+++ b/python/dgl/backend/pytorch/tensor.py
@@ -140,8 +140,8 @@ def unsorted_1d_segment_mean(input, seg_id, n_segs, dim):
 def unique(input):
     return th.unique(input)
 
-def full_1d(length, fill_value):
-    return th.full((length,), fill_value)
+def full_1d(length, fill_value, dtype, ctx):
+    return th.full((length,), fill_value, dtype=dtype, device=ctx)
 
 def nonzero_1d(input):
     return th.nonzero(input).squeeze()

--- a/python/dgl/frame.py
+++ b/python/dgl/frame.py
@@ -366,6 +366,20 @@ class Frame(MutableMapping):
             # directly updating columns.
             self._columns = {key: Column.create(data) for key, data in other.items()}
         else:
+            # pad columns that no new were provided
+            for key, col in self.items():
+                if key not in other:
+                    scheme = col.scheme
+                    ctx = F.context(col.data)
+                    if self.get_initializer(key) is None:
+                        self._warn_and_set_initializer()
+                    new_data = self.get_initializer(key)(
+                            (other.num_rows,) + scheme.shape, scheme.dtype,
+                            ctx, slice(self._num_rows,
+                                       self._num_rows + other.num_rows)
+                    )
+                    other[key] = new_data
+            # append other to self
             for key, col in other.items():
                 if key not in self._columns:
                     # the column does not exist; init a new column

--- a/python/dgl/frame.py
+++ b/python/dgl/frame.py
@@ -366,7 +366,7 @@ class Frame(MutableMapping):
             # directly updating columns.
             self._columns = {key: Column.create(data) for key, data in other.items()}
         else:
-            # pad columns that no new were provided
+            # pad columns that are not provided in the other frame with initial values
             for key, col in self.items():
                 if key not in other:
                     scheme = col.scheme

--- a/python/dgl/graph.py
+++ b/python/dgl/graph.py
@@ -1951,6 +1951,10 @@ class DGLGraph(object):
             eid = utils.toindex(edges)
             u, v, _ = self._graph.find_edges(eid)
 
+        if len(eid) == 0:
+            # no edge to be triggered
+            return
+
         with ir.prog() as prog:
             scheduler.schedule_send(graph=self, u=u, v=v, eid=eid,
                                     message_func=message_func)

--- a/python/dgl/graph.py
+++ b/python/dgl/graph.py
@@ -179,7 +179,9 @@ class DGLGraph(object):
         # graph
         self._readonly=readonly
         self._graph = create_graph_index(graph_data, multigraph, readonly)
-        # frame
+        # msg frame
+        self._msg_frame = FrameRef()
+        # node and edge frame
         if node_frame is None:
             self._node_frame = FrameRef(Frame(num_rows=self.number_of_nodes()))
         else:
@@ -188,8 +190,7 @@ class DGLGraph(object):
             self._edge_frame = FrameRef(Frame(num_rows=self.number_of_edges()))
         else:
             self._edge_frame = edge_frame
-        # msg frame
-        self._msg_frame = FrameRef()
+            self._msg_frame.add_rows(edge_frame.num_rows)
         # set initializer for message frame
         # all fields including message indicator should use zero_initializer
         self._msg_frame.set_initializer(dgl.init.zero_initializer)

--- a/python/dgl/graph.py
+++ b/python/dgl/graph.py
@@ -179,8 +179,6 @@ class DGLGraph(object):
         # graph
         self._readonly=readonly
         self._graph = create_graph_index(graph_data, multigraph, readonly)
-        # msg frame
-        self._msg_frame = FrameRef()
         # node and edge frame
         if node_frame is None:
             self._node_frame = FrameRef(Frame(num_rows=self.number_of_nodes()))
@@ -188,6 +186,7 @@ class DGLGraph(object):
             self._node_frame = node_frame
         if edge_frame is None:
             self._edge_frame = FrameRef(Frame(num_rows=self.number_of_edges()))
+            self._msg_frame = FrameRef(Frame(num_rows=self.number_of_edges()))
         else:
             self._edge_frame = edge_frame
             self._msg_frame.add_rows(edge_frame.num_rows)
@@ -1166,6 +1165,7 @@ class DGLGraph(object):
         self._graph.from_networkx(nx_graph)
         self._node_frame.add_rows(self.number_of_nodes())
         self._edge_frame.add_rows(self.number_of_edges())
+        self._msg_frame.add_rows(self.number_of_edges())
 
         # copy attributes
         def _batcher(lst):
@@ -1223,6 +1223,7 @@ class DGLGraph(object):
         self._graph.from_scipy_sparse_matrix(a)
         self._node_frame.add_rows(self.number_of_nodes())
         self._edge_frame.add_rows(self.number_of_edges())
+        self._msg_frame.add_rows(self.number_of_edges())
 
     def node_attr_schemes(self):
         """Return the node feature schemes.

--- a/python/dgl/graph.py
+++ b/python/dgl/graph.py
@@ -194,7 +194,6 @@ class DGLGraph(object):
         # message frame
         self._msg_frame = FrameRef(Frame(num_rows=self.number_of_edges()))
         # set initializer for message frame
-        # all fields including message indicator should use zero_initializer
         self._msg_frame.set_initializer(dgl.init.zero_initializer)
         # registered functions
         self._message_func = None
@@ -359,14 +358,14 @@ class DGLGraph(object):
         u = utils.toindex(u)
         v = utils.toindex(v)
         self._graph.add_edges(u, v)
+        num = max(len(u), len(v))
         if data is None:
             # Initialize feature placeholders if there are features existing
             # NOTE: use max due to edge broadcasting syntax
-            self._edge_frame.add_rows(max(len(u), len(v)))
+            self._edge_frame.add_rows(num)
         else:
             self._edge_frame.append(data)
         # initialize feature placeholder for messages
-        num = max(len(u), len(v))
         self._msg_index = self._msg_index.add_elements(num)
         self._msg_frame.add_rows(num)
 

--- a/python/dgl/graph.py
+++ b/python/dgl/graph.py
@@ -188,6 +188,8 @@ class DGLGraph(object):
             self._edge_frame = FrameRef(Frame(num_rows=self.number_of_edges()))
         else:
             self._edge_frame = edge_frame
+        # message indicator:
+        # if self._msg_index[eid] == 1, then edge eid has message
         self._msg_index = utils.zero_index(size=self.number_of_edges())
         # message frame
         self._msg_frame = FrameRef(Frame(num_rows=self.number_of_edges()))

--- a/python/dgl/graph.py
+++ b/python/dgl/graph.py
@@ -186,10 +186,10 @@ class DGLGraph(object):
             self._node_frame = node_frame
         if edge_frame is None:
             self._edge_frame = FrameRef(Frame(num_rows=self.number_of_edges()))
-            self._msg_frame = FrameRef(Frame(num_rows=self.number_of_edges()))
         else:
             self._edge_frame = edge_frame
-            self._msg_frame.add_rows(edge_frame.num_rows)
+        # message frame
+        self._msg_frame = FrameRef(Frame(num_rows=self.number_of_edges()))
         # set initializer for message frame
         # all fields including message indicator should use zero_initializer
         self._msg_frame.set_initializer(dgl.init.zero_initializer)

--- a/python/dgl/graph.py
+++ b/python/dgl/graph.py
@@ -306,7 +306,7 @@ class DGLGraph(object):
         else:
             self._edge_frame.append(data)
         # resize msg_index and msg_frame
-        self._msg_index = self._msg_index.add_elements(1)
+        self._msg_index = self._msg_index.append_zeros(1)
         self._msg_frame.add_rows(1)
 
     def add_edges(self, u, v, data=None):
@@ -366,7 +366,7 @@ class DGLGraph(object):
         else:
             self._edge_frame.append(data)
         # initialize feature placeholder for messages
-        self._msg_index = self._msg_index.add_elements(num)
+        self._msg_index = self._msg_index.append_zeros(num)
         self._msg_frame.add_rows(num)
 
     def clear(self):

--- a/python/dgl/runtime/ir/executor.py
+++ b/python/dgl/runtime/ir/executor.py
@@ -34,6 +34,7 @@ class OpCode(object):
     WRITE_DICT_ = 24
     APPEND_ROW_ = 25
     WRITE_ROW_INPLACE_ = 26
+    CLEAR_FRAME_ = 27
 
 class Executor(object):
     @abstractmethod
@@ -645,3 +646,32 @@ IR_REGISTRY[OpCode.APPEND_ROW_] = {
 def APPEND_ROW_(fd1, fd2):
     reg = IR_REGISTRY[OpCode.APPEND_ROW_]
     get_current_prog().issue(reg['executor_cls'](fd1, fd2))
+
+class ClearFrame_Executor(Executor):
+    def __init__(self, fd):
+        self.fd = fd
+
+    def opcode(self):
+        return OpCode.CLEAR_FRAME_
+
+    def arg_vars(self):
+        return []
+
+    def ret_var(self):
+        return None
+
+    def run(self):
+        frame = self.fd.data
+        num_rows = frame.num_rows
+        frame.clear()
+        frame.add_rows(num_rows)
+
+IR_REGISTRY[OpCode.CLEAR_FRAME_] = {
+    'name': 'CLEAR_FRAME_',
+    'args_type': [],
+    'ret_type': None,
+    'executor_cls': ClearFrame_Executor,
+}
+def CLEAR_FRAME_(fd):
+    reg = IR_REGISTRY[OpCode.CLEAR_FRAME_]
+    get_current_prog().issue(reg['executor_cls'](fd))

--- a/python/dgl/runtime/ir/executor.py
+++ b/python/dgl/runtime/ir/executor.py
@@ -655,7 +655,7 @@ class ClearFrame_Executor(Executor):
         return OpCode.CLEAR_FRAME_
 
     def arg_vars(self):
-        return []
+        return [self.fd]
 
     def ret_var(self):
         return None
@@ -668,7 +668,7 @@ class ClearFrame_Executor(Executor):
 
 IR_REGISTRY[OpCode.CLEAR_FRAME_] = {
     'name': 'CLEAR_FRAME_',
-    'args_type': [],
+    'args_type': [VarType.FEAT_DICT],
     'ret_type': None,
     'executor_cls': ClearFrame_Executor,
 }

--- a/python/dgl/runtime/scheduler.py
+++ b/python/dgl/runtime/scheduler.py
@@ -75,10 +75,12 @@ def schedule_recv(graph,
     inplace: bool
         If True, the update will be done in place
     """
-    _, _, eid = graph._graph.in_edges(recv_nodes)
+    src, dst, eid = graph._graph.in_edges(recv_nodes)
     if len(eid) > 0:
         nonzero_idx = graph._msg_index.get_items(eid).nonzero()
         eid = eid.get_items(nonzero_idx)
+        src = src.get_items(nonzero_idx)
+        dst = dst.get_items(nonzero_idx)
     if len(eid) == 0:
         # Downgrade to apply nodes if
         #   1) all recv nodes are 0-degree nodes
@@ -86,7 +88,6 @@ def schedule_recv(graph,
         if apply_func is not None:
             schedule_apply_nodes(graph, recv_nodes, apply_func, inplace)
     else:
-        src, dst, _ = graph._graph.find_edges(eid)
         var_nf = var.FEAT_DICT(graph._node_frame, name='nf')
         # sort and unique the argument
         recv_nodes, _ = F.sort_1d(F.unique(recv_nodes.tousertensor()))

--- a/python/dgl/runtime/scheduler.py
+++ b/python/dgl/runtime/scheduler.py
@@ -77,8 +77,8 @@ def schedule_recv(graph,
     """
     _, _, eid = graph._graph.in_edges(recv_nodes)
     if len(eid) > 0:
-        e_mask = graph._msg_index.get_items(eid).nonzero()
-        eid = eid.get_items(e_mask)
+        nonzero_idx = graph._msg_index.get_items(eid).nonzero()
+        eid = eid.get_items(nonzero_idx)
     if len(eid) == 0:
         # Downgrade to apply nodes if
         #   1) all recv nodes are 0-degree nodes

--- a/python/dgl/utils.py
+++ b/python/dgl/utils.py
@@ -143,10 +143,15 @@ class Index(object):
         return Index(tensor)
 
     def add_elements(self, num):
-        tensor = self.tousertensor()
+        if num == 0:
+            return self
         new_items = F.zeros((num,), dtype=F.int64, ctx=F.cpu())
-        tensor = F.cat((tensor, new_items), dim=0)
-        return Index(tensor)
+        if len(self) == 0:
+            return Index(new_items)
+        else:
+            tensor = self.tousertensor()
+            tensor = F.cat((tensor, new_items), dim=0)
+            return Index(tensor)
 
     def nonzero(self):
         tensor = self.tousertensor()

--- a/python/dgl/utils.py
+++ b/python/dgl/utils.py
@@ -130,13 +130,27 @@ class Index(object):
     def get_items(self, index):
         tensor = self.tousertensor()
         if isinstance(index, Index):
-            index = index.tousertensor()
+            if isinstance(index._pydata, slice):
+                # XXX: assuming tensor supports index using slices
+                #      cannot call tousertensor because for slice type it would
+                #      further call tonumpy, which overwrites _pydata and causes
+                #      future bugs...
+                index = index._pydata
+            else:
+                index = index.tousertensor()
         return Index(tensor[index])
 
     def set_items(self, index, value):
         tensor = self.tousertensor()
         if isinstance(index, Index):
-            index = index.tousertensor()
+            if isinstance(index._pydata, slice):
+                # XXX: assuming tensor supports index using slices
+                #      cannot call tousertensor because for slice type it would
+                #      further call tonumpy, which overwrites _pydata and causes
+                #      future bugs...
+                index = index._pydata
+            else:
+                index = index.tousertensor()
         if isinstance(value, Index):
             value = value.tousertensor()
         tensor[index] = value

--- a/python/dgl/utils.py
+++ b/python/dgl/utils.py
@@ -15,9 +15,10 @@ class Index(object):
         self._initialize_data(data)
 
     def _initialize_data(self, data):
-        self._pydata = None   # a numpy type data or a slice
+        self._pydata = None   # a numpy type data
         self._user_tensor_data = dict()  # dictionary of user tensors
         self._dgl_tensor_data = None  # a dgl ndarray
+        self._slice_data = None # a slice type data
         self._dispatch(data)
 
     def __iter__(self):
@@ -25,12 +26,9 @@ class Index(object):
             yield int(i)
 
     def __len__(self):
-        if self._pydata is not None and isinstance(self._pydata, slice):
-            slc = self._pydata
-            if slc.step is None:
-                return slc.stop - slc.start
-            else:
-                return (slc.stop - slc.start) // slc.step
+        if self._slice_data is not None:
+            slc = self._slice_data
+            return slc.stop - slc.start
         elif self._pydata is not None:
             return len(self._pydata)
         elif len(self._user_tensor_data) > 0:
@@ -60,7 +58,9 @@ class Index(object):
             self._dgl_tensor_data = data
         elif isinstance(data, slice):
             # save it in the _pydata temporarily; materialize it if `tonumpy` is called
-            self._pydata = data
+            assert data.step == 1 or data.step is None, \
+                "step for slice type must be 1"
+            self._slice_data = slice(data.start, data.stop)
         else:
             try:
                 self._pydata = np.array([int(data)]).astype(np.int64)
@@ -79,15 +79,14 @@ class Index(object):
     def tonumpy(self):
         """Convert to a numpy ndarray."""
         if self._pydata is None:
-            if self._dgl_tensor_data is not None:
+            if self._slice_data is not None:
+                slc = self._slice_data
+                self._pydata = np.arange(slc.start, slc.stop).astype(np.int64)
+            elif self._dgl_tensor_data is not None:
                 self._pydata = self._dgl_tensor_data.asnumpy()
             else:
                 data = self.tousertensor()
                 self._pydata = F.zerocopy_to_numpy(data)
-        elif isinstance(self._pydata, slice):
-            # convert it to numpy array
-            slc = self._pydata
-            self._pydata = np.arange(slc.start, slc.stop, slc.step).astype(np.int64)
         return self._pydata
 
     def tousertensor(self, ctx=None):
@@ -117,9 +116,9 @@ class Index(object):
             self._dgl_tensor_data = nd.from_dlpack(dl)
         return self._dgl_tensor_data
 
-    def is_slice(self, start, stop, step=None):
-        return (isinstance(self._pydata, slice)
-                and self._pydata == slice(start, stop, step))
+    def is_slice(self, start, stop):
+        """Check if Index wraps a slice data with given start and stop"""
+        return self._slice_data == slice(start, stop)
 
     def __getstate__(self):
         return self.tousertensor()
@@ -128,35 +127,60 @@ class Index(object):
         self._initialize_data(state)
 
     def get_items(self, index):
-        tensor = self.tousertensor()
-        if isinstance(index, Index):
-            if isinstance(index._pydata, slice):
-                # XXX: assuming tensor supports index using slices
-                #      cannot call tousertensor because for slice type it would
-                #      further call tonumpy, which overwrites _pydata and causes
-                #      future bugs...
-                index = index._pydata
+        """Return values at given positions of an Index
+
+        Parameters
+        ----------
+        index: utils.Index
+
+        Returns
+        -------
+        utils.Index
+
+        """
+        if index._slice_data is None:
+            tensor = self.tousertensor()
+            index = index.tousertensor()
+            return Index(F.gather_row(tensor, index))
+        else:
+            if self._slice_data is None:
+                tensor = self.tousertensor()
+                index = index._slice_data
+                return Index(F.narrow_row(tensor, index.start, index.stop))
             else:
-                index = index.tousertensor()
-        return Index(tensor[index])
+                # both self and index wrap a slice object, then return another
+                # Index wrapping a slice
+                start = self._slicedata.start
+                index = index._slice_data
+                return Index(slice(start + index.start, start + index.stop))
 
     def set_items(self, index, value):
-        tensor = self.tousertensor()
-        if isinstance(index, Index):
-            if isinstance(index._pydata, slice):
-                # XXX: assuming tensor supports index using slices
-                #      cannot call tousertensor because for slice type it would
-                #      further call tonumpy, which overwrites _pydata and causes
-                #      future bugs...
-                index = index._pydata
-            else:
-                index = index.tousertensor()
-        if isinstance(value, Index):
-            value = value.tousertensor()
-        tensor[index] = value
-        return Index(tensor)
+        """Set values at given positions of an Index. Set is not done in place,
+        instead, a new Index object will be returned.
 
-    def add_elements(self, num):
+        Parameters
+        ----------
+        index: utils.Index
+            Positions to set values
+        value: int or utils.Index
+            Values to set. If value is an integer, then all positions are set
+            to the same value
+
+        Returns
+        -------
+        utils.Index
+
+        """
+        tensor = self.tousertensor()
+        index = index.tousertensor()
+        if isinstance(value, int):
+            value = F.full_1d(len(index), value, dtype=F.int64, ctx=F.cpu())
+        else:
+            value = value.tousertensor()
+        return Index(F.scatter_row(tensor, index, value))
+
+    def append_zeros(self, num):
+        """Append zeros to an Index """
         if num == 0:
             return self
         new_items = F.zeros((num,), dtype=F.int64, ctx=F.cpu())
@@ -168,11 +192,13 @@ class Index(object):
             return Index(tensor)
 
     def nonzero(self):
+        """Return the nonzero positions"""
         tensor = self.tousertensor()
         mask = F.nonzero_1d(tensor != 0)
         return Index(mask)
 
     def has_nonzero(self):
+        """Check if there is any nonzero value in this Index"""
         tensor = self.tousertensor()
         return F.sum(tensor, 0) > 0
 

--- a/python/dgl/utils.py
+++ b/python/dgl/utils.py
@@ -142,17 +142,16 @@ class Index(object):
             tensor = self.tousertensor()
             index = index.tousertensor()
             return Index(F.gather_row(tensor, index))
+        elif self._slice_data is None:
+            tensor = self.tousertensor()
+            index = index._slice_data
+            return Index(F.narrow_row(tensor, index.start, index.stop))
         else:
-            if self._slice_data is None:
-                tensor = self.tousertensor()
-                index = index._slice_data
-                return Index(F.narrow_row(tensor, index.start, index.stop))
-            else:
-                # both self and index wrap a slice object, then return another
-                # Index wrapping a slice
-                start = self._slicedata.start
-                index = index._slice_data
-                return Index(slice(start + index.start, start + index.stop))
+            # both self and index wrap a slice object, then return another
+            # Index wrapping a slice
+            start = self._slicedata.start
+            index = index._slice_data
+            return Index(slice(start + index.start, start + index.stop))
 
     def set_items(self, index, value):
         """Set values at given positions of an Index. Set is not done in place,

--- a/python/dgl/utils.py
+++ b/python/dgl/utils.py
@@ -180,7 +180,13 @@ class Index(object):
         return Index(F.scatter_row(tensor, index, value))
 
     def append_zeros(self, num):
-        """Append zeros to an Index """
+        """Append zeros to an Index
+
+        Parameters
+        ----------
+        num: int
+            number of zeros to append
+        """
         if num == 0:
             return self
         new_items = F.zeros((num,), dtype=F.int64, ctx=F.cpu())
@@ -206,6 +212,12 @@ def toindex(x):
     return x if isinstance(x, Index) else Index(x)
 
 def zero_index(size):
+    """Create a index with provided size initialized to zero
+
+    Parameters
+    ----------
+    size: int
+    """
     return Index(F.zeros((size,), dtype=F.int64, ctx=F.cpu()))
 
 class LazyDict(Mapping):

--- a/tests/pytorch/test_basics.py
+++ b/tests/pytorch/test_basics.py
@@ -614,6 +614,10 @@ def test_dynamic_addition():
     g.edges[4].data['h1'] = th.randn(1, D)
     assert g.edata['h1'].shape[0] == g.edata['h2'].shape[0] == 5
 
+    # test add edge with part of the features
+    g.add_edge(2, 1, {'h1': th.randn(1, D)})
+    assert len(g.edata['h1']) == len(g.edata['h2'])
+
 
 def test_repr():
     G = dgl.DGLGraph()

--- a/tests/pytorch/test_basics.py
+++ b/tests/pytorch/test_basics.py
@@ -490,34 +490,6 @@ def test_pull_0deg():
     # non-0deg check: not touched
     assert U.allclose(new[1], old[1])
 
-def _disabled_test_send_twice():
-    # TODO(minjie): please re-enable this unittest after the send code problem is fixed.
-    g = DGLGraph()
-    g.add_nodes(3)
-    g.add_edge(0, 1)
-    g.add_edge(2, 1)
-    def _message_a(edges):
-        return {'a': edges.src['a']}
-    def _message_b(edges):
-        return {'a': edges.src['a'] * 3}
-    def _reduce(nodes):
-        return {'a': nodes.mailbox['a'].max(1)[0]}
-
-    old_repr = th.randn(3, 5)
-    g.ndata['a'] = old_repr
-    g.send((0, 1), _message_a)
-    g.send((0, 1), _message_b)
-    g.recv(1, _reduce)
-    new_repr = g.ndata['a']
-    assert U.allclose(new_repr[1], old_repr[0] * 3)
-
-    g.ndata['a'] = old_repr
-    g.send((0, 1), _message_a)
-    g.send((2, 1), _message_b)
-    g.recv(1, _reduce)
-    new_repr = g.ndata['a']
-    assert U.allclose(new_repr[1], th.stack([old_repr[0], old_repr[2] * 3], 0).max(0)[0])
-
 def test_send_multigraph():
     g = DGLGraph(multigraph=True)
     g.add_nodes(3)

--- a/tests/pytorch/test_multi_send_recv.py
+++ b/tests/pytorch/test_multi_send_recv.py
@@ -1,0 +1,255 @@
+import torch as th
+from torch.autograd import Variable
+import numpy as np
+import dgl
+from dgl.graph import DGLGraph
+import utils as U
+from collections import defaultdict as ddict
+
+D = 5
+HAS_MSG = "__has_msg__"
+
+def message_func(edges):
+    assert len(edges.src['h'].shape) == 2
+    assert edges.src['h'].shape[1] == D
+    return {'m' : edges.src['h']}
+
+def reduce_func(nodes):
+    msgs = nodes.mailbox['m']
+    assert len(msgs.shape) == 3
+    assert msgs.shape[2] == D
+    return {'accum' : th.sum(msgs, 1)}
+
+def apply_node_func(nodes):
+    return {'h' : nodes.data['h'] + nodes.data['accum']}
+
+def generate_graph(grad=False):
+    g = DGLGraph()
+    g.add_nodes(10) # 10 nodes.
+    # create a graph where 0 is the source and 9 is the sink
+    # 16 edges
+    for i in range(1, 9):
+        g.add_edge(0, i)
+        g.add_edge(i, 9)
+    # add a back flow from 9 to 0
+    ncol = Variable(th.randn(10, D), requires_grad=grad)
+    ecol = Variable(th.randn(16, D), requires_grad=grad)
+    g.set_n_initializer(dgl.init.zero_initializer)
+    g.set_e_initializer(dgl.init.zero_initializer)
+    g.ndata['h'] = ncol
+    g.edata['w'] = ecol
+    return g
+
+def test_multi_send():
+    g = generate_graph()
+    def _fmsg(edges):
+        assert edges.src['h'].shape == (5, D)
+        return {'m' : edges.src['h']}
+    g.register_message_func(_fmsg)
+    # many-many send
+    u = th.tensor([0, 0, 0, 0, 0])
+    v = th.tensor([1, 2, 3, 4, 5])
+    g.send((u, v))
+    # duplicate send
+    u = th.tensor([0])
+    v = th.tensor([1, 2, 3, 4, 5])
+    g.send((u, v))
+    # send more
+    u = th.tensor([1, 2, 3, 4, 5])
+    v = th.tensor([9])
+    g.send((u, v))
+
+    # check if message indicator is as expected
+    expected = th.zeros((g.number_of_edges(),), dtype=th.int8)
+    eid = g.edge_ids([0, 0, 0, 0, 0, 1, 2, 3, 4, 5],
+                     [1, 2, 3, 4, 5, 9, 9, 9, 9, 9])
+    expected[eid] = 1
+    assert th.equal(g._msg_frame[HAS_MSG], expected)
+
+def test_multi_recv():
+    # basic recv test
+    g = generate_graph()
+    h = g.ndata['h']
+    g.register_message_func(message_func)
+    g.register_reduce_func(reduce_func)
+    g.register_apply_node_func(apply_node_func)
+    expected = th.zeros((g.number_of_edges(),), dtype=th.int8)
+    # two separate round of send and recv
+    u = [4, 5, 6]
+    v = [9]
+    g.send((u, v))
+    eid = g.edge_ids(u, v)
+    expected[eid] = 1
+    assert th.equal(g._msg_frame[HAS_MSG], expected)
+    g.recv(v)
+    expected[eid] = 0
+    assert th.equal(g._msg_frame[HAS_MSG], expected)
+
+    u = [0]
+    v = [1, 2, 3]
+    g.send((u, v))
+    eid = g.edge_ids(u, v)
+    expected[eid] = 1
+    assert th.equal(g._msg_frame[HAS_MSG], expected)
+    g.recv(v)
+    expected[eid] = 0
+    assert th.equal(g._msg_frame[HAS_MSG], expected)
+
+    h1 = g.ndata['h']
+
+    # one send, two recv
+    g.ndata['h'] = h
+    u = th.tensor([0, 0, 0, 4, 5, 6])
+    v = th.tensor([1, 2, 3, 9, 9, 9])
+    g.send((u, v))
+    eid = g.edge_ids(u, v)
+    expected[eid] = 1
+    assert th.equal(g._msg_frame[HAS_MSG], expected)
+    u = [4, 5, 6]
+    v = [9]
+    g.recv(v)
+    eid = g.edge_ids(u, v)
+    expected[eid] = 0
+    assert th.equal(g._msg_frame[HAS_MSG], expected)
+    u = [0]
+    v = [1, 2, 3]
+    g.recv(v)
+    eid = g.edge_ids(u, v)
+    expected[eid] = 0
+    assert th.equal(g._msg_frame[HAS_MSG], expected)
+
+    h2 = g.ndata['h']
+    assert U.allclose(h1, h2)
+
+def test_multi_recv_0deg():
+    # test recv with 0deg nodes;
+    g = DGLGraph()
+    def _message(edges):
+        return {'m' : edges.src['h']}
+    def _reduce(nodes):
+        return {'h' : nodes.data['h'] + nodes.mailbox['m'].sum(1)}
+    def _apply(nodes):
+        return {'h' : nodes.data['h'] * 2}
+    def _init2(shape, dtype, ctx, ids):
+        return 2 + th.zeros(shape, dtype=dtype, device=ctx)
+    g.register_message_func(_message)
+    g.register_reduce_func(_reduce)
+    g.register_apply_node_func(_apply)
+    g.set_n_initializer(_init2)
+    g.add_nodes(2)
+    g.add_edge(0, 1)
+    # recv both 0deg and non-0deg nodes
+    old = th.randn((2, 5))
+    g.ndata['h'] = old
+    g.send((0, 1))
+    g.recv([0, 1])
+    new = g.ndata['h']
+    # 0deg check: initialized with the func and got applied
+    assert U.allclose(new[0], th.full((5,), 4))
+    # non-0deg check
+    assert U.allclose(new[1], th.sum(old, 0) * 2)
+
+    # recv again on zero degree node
+    g.recv([0])
+    assert U.allclose(g.nodes[0].data['h'], th.full((5,), 8))
+
+    # recv again on node with no incoming message
+    g.recv([1])
+    assert U.allclose(g.nodes[1].data['h'], th.sum(old, 0) * 4)
+
+def test_send_twice_different_msg():
+    g = DGLGraph()
+    g.set_n_initializer(dgl.init.zero_initializer)
+    g.add_nodes(3)
+    g.add_edge(0, 1)
+    g.add_edge(2, 1)
+    def _message_a(edges):
+        return {'a': edges.src['a']}
+    def _message_b(edges):
+        return {'a': edges.src['a'] * 3}
+    def _reduce(nodes):
+        return {'a': nodes.mailbox['a'].max(1)[0]}
+
+    old_repr = th.randn(3, 5)
+    g.ndata['a'] = old_repr
+    g.send((0, 1), _message_a)
+    g.send((0, 1), _message_b)
+    g.recv(1, _reduce)
+    new_repr = g.ndata['a']
+    assert U.allclose(new_repr[1], old_repr[0] * 3)
+
+    g.ndata['a'] = old_repr
+    g.send((0, 1), _message_a)
+    g.send((2, 1), _message_b)
+    g.recv(1, _reduce)
+    new_repr = g.ndata['a']
+    assert U.allclose(new_repr[1], th.stack([old_repr[0], old_repr[2] * 3], 0).max(0)[0])
+
+def test_dynamic_addition():
+    N = 3
+    D = 1
+
+    g = DGLGraph()
+    def _init(shape, dtype, ctx, ids):
+        return th.randn(shape, dtype=dtype, device=ctx)
+    g.set_n_initializer(_init)
+    g.set_e_initializer(_init)
+
+    def _message(edges):
+        return {'m' : edges.src['h1'] + edges.dst['h2'] + edges.data['h1'] +
+                edges.data['h2']}
+    def _reduce(nodes):
+        return {'h' : nodes.mailbox['m'].sum(1)}
+    def _apply(nodes):
+        return {'h' : nodes.data['h']}
+
+    g.register_message_func(_message)
+    g.register_reduce_func(_reduce)
+    g.register_apply_node_func(_apply)
+    g.set_n_initializer(dgl.init.zero_initializer)
+    g.set_e_initializer(dgl.init.zero_initializer)
+
+    # add nodes and edges
+    g.add_nodes(N)
+    g.ndata.update({'h1': th.randn(N, D),
+                    'h2': th.randn(N, D)})
+    g.add_nodes(3)
+    g.add_edge(0, 1)
+    g.add_edge(1, 0)
+    g.edata.update({'h1': th.randn(2, D),
+                    'h2': th.randn(2, D)})
+    g.send()
+    expected = th.ones((g.number_of_edges(),), dtype=th.int8)
+    assert th.equal(g._msg_frame[HAS_MSG], expected)
+
+    # add more edges
+    g.add_edges([0, 2], [2, 0], {'h1': th.randn(2, D)})
+    g.send(([0, 2], [2, 0]))
+    g.recv(0)
+
+    g.add_edge(1, 2)
+    g.edges[4].data['h1'] = th.randn(1, D)
+    g.send((1, 2))
+    g.recv([1, 2])
+
+    h = g.ndata.pop('h')
+
+    # a complete round of send and recv
+    g.send()
+    g.recv()
+    assert U.allclose(h, g.ndata['h'])
+
+def test_recv_no_send():
+    g = generate_graph()
+    g.recv(1, reduce_func)
+    # test recv after clear
+    g.clear()
+    g.recv(1, reduce_func)
+
+if __name__ == '__main__':
+    test_multi_send()
+    test_multi_recv()
+    test_multi_recv_0deg()
+    test_dynamic_addition()
+    test_send_twice_different_msg()
+    test_recv_no_send()


### PR DESCRIPTION
## Description
This PR fixes #75 and other small bugs (see below) and supports multiple recv after send.

Previously, each recv call clears message graph so following recv won't see any message. This PR fix the bug by removing message graph and put message in edge space (but still in a separate message frame). Now message frame has the same size as edge frame and whether there is a message on an edge is indicated by a special "boolean" index in DGLGraph (graph._msg_index).

Now users can:
- call multiple send (on the edges or not), each using a different message function (with different message fields)
- call multiple recv

## Checklist
- [x] The PR title starts with [$CATEGORY] (such as [Model], [Doc], [Feature]])
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage
- [x] Code is well-documented
- [x] To the my best knowledge, examples are either not affected by this change,
      or have been fixed to be compatible with this change
- [x] Related issue is referred in this PR

## Changes
- [x] fix multiple send (using different fields)
- [x] fix multiple recv and remove message graph
- [x] fix frame append bug when some feature is not in the new frame
- [x] fix bug in send when edges is ALL
