### PR TITLE
[Docs] [0.1.x] Move file_pattern option from Makefile to conf.py

### DIFF
--- a/docs/Makefile
+++ b/docs/Makefile
@@ -13,12 +13,30 @@ help:
 
 .PHONY: help Makefile
 
+mxnet:
+	@echo "##################################################################"
+	@echo "#                                                                #"
+	@echo "#                Step 1: Building MXNet tutorials                #"
+	@echo "#                                                                #"
+	@echo "##################################################################"
+	@DGLBACKEND=mxnet $(SPHINXBUILD) -M html "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
+
+pytorch:
+	@echo "##################################################################"
+	@echo "#                                                                #"
+	@echo "#                Step 2: Building PyTorch tutorials              #"
+	@echo "#                                                                #"
+	@echo "##################################################################"
+	@DGLBACKEND=pytorch $(SPHINXBUILD) -M html "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O) 
+
 html-noexec:
 	$(SPHINXBUILD) -D plot_gallery=0 -b html "$(SOURCEDIR)" "$(BUILDDIR)/html" 
 	@echo
 	@echo "Build finished. The HTML pages are in $(BUILDDIR)/html."
 
+html: Makefile mxnet pytorch
+
 # Catch-all target: route all unknown targets to Sphinx using the new
 # "make mode" option.  $(O) is meant as a shortcut for $(SPHINXOPTS).
 %: Makefile
-	@$(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
+	@$(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O) 

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -214,7 +214,7 @@ sphinx_gallery_conf = {
     'download_all_examples' : False,
 }
 
-import os
+# Compatibility for different backend when builds tutorials
 if os.environ['DGLBACKEND'] == 'mxnet':
     sphinx_gallery_conf['filename_pattern'] = "/*(?<=mx)\.py"
 if os.environ['DGLBACKEND'] == 'pytorch':

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -211,4 +211,11 @@ sphinx_gallery_conf = {
     'gallery_dirs' : gallery_dirs,
     'within_subsection_order' : FileNameSortKey,
     'filename_pattern' : '.py',
+    'download_all_examples' : False,
 }
+
+import os
+if os.environ['DGLBACKEND'] == 'mxnet':
+    sphinx_gallery_conf['filename_pattern'] = "/*(?<=mx)\.py"
+if os.environ['DGLBACKEND'] == 'pytorch':
+    sphinx_gallery_conf['filename_pattern'] = "/*(?<!mx)\.py"

--- a/readthedocs.yml
+++ b/readthedocs.yml
@@ -1,0 +1,9 @@
+build:
+  image: latest
+
+formats: []
+
+python:
+  version: 3.6
+  use_system_site_packages: true
+  setup_py_install: false


### PR DESCRIPTION
Same as https://github.com/dmlc/dgl/pull/352. Need to modify conf.py add config file to build.

## Description
<!-- Brief description. Refer to the related issues if existed.
It'll be great if relevant reviewers can be assigned as well.-->
Move file_pattern option from Makefile to conf.py and add doc build config file. This is for further doc autobuild and versioning settings.

## Checklist
Please feel free to remove inapplicable items for your PR.
- [x] The PR title starts with [$CATEGORY] (such as [Model], [Doc], [Feature]])
- [x] Changes are complete (i.e. I finished coding on this PR)


## Changes
<!-- You could use following template
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)
-->
