### PR TITLE
[Doc] fix the comment error of edge_id in graph.h

### DIFF
--- a/include/dgl/graph.h
+++ b/include/dgl/graph.h
@@ -386,7 +386,7 @@ class Graph: public GraphInterface {
   struct EdgeList {
     /*! \brief successor vertex list */
     std::vector<dgl_id_t> succ;
-    /*! \brief predecessor vertex list */
+    /*! \brief out edge list */
     std::vector<dgl_id_t> edge_id;
   };
   typedef std::vector<EdgeList> AdjacencyList;


### PR DESCRIPTION
## Description
<!-- Brief description. Refer to the related issues if existed.
It'll be great if relevant reviewers can be assigned as well.-->
I think `edge_id` is not the predecessor vertex list. It is the out edge list.
## Checklist
Please feel free to remove inapplicable items for your PR.
- [ ] The PR title starts with [$CATEGORY] (such as [Model], [Doc], [Feature]])
- [ ] Changes are complete (i.e. I finished coding on this PR)
- [ ] All changes have test coverage
- [ ] Code is well-documented
- [ ] To the my best knowledge, examples are either not affected by this change,
      or have been fixed to be compatible with this change
- [ ] Related issue is referred in this PR

## Changes
<!-- You could use following template
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)
-->
