### PR TITLE
[Bugfix] Remove unnecessary assert in from_scipy_sparse_matrix

### DIFF
--- a/python/dgl/graph_index.py
+++ b/python/dgl/graph_index.py
@@ -756,8 +756,6 @@ class GraphIndex(object):
         ----------
         adj : scipy sparse matrix
         """
-        assert isinstance(adj, (scipy.sparse.csr_matrix, scipy.sparse.coo_matrix)), \
-                "The input matrix has to be a SciPy sparse matrix."
         if not self.is_readonly():
             self.clear()
         num_nodes = max(adj.shape[0], adj.shape[1])


### PR DESCRIPTION
## Description
graph_index.py `from_scipy_sparse_matrix` function requires input to be either coo or csr sparse matrix. But it's not necessary because code that calls this function guarantees that input is sparse matrix and this function immediately calls `adj.tocoo()`.

Remove this assertion allows user to create DGLGraph from other sparse matrix format.

## Checklist
Please feel free to remove inapplicable items for your PR.
- [x] The PR title starts with [$CATEGORY] (such as [Model], [Doc], [Feature]])
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] To the my best knowledge, examples are either not affected by this change,
      or have been fixed to be compatible with this change

## Changes
- [x] remove unnecessary assertion
