### PR TITLE
[Build] Find OpenMP in CMake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -43,10 +43,12 @@ else(MSVC)
   check_cxx_compiler_flag("-std=c++11"    SUPPORT_CXX11)
   set(CMAKE_C_FLAGS "-O2 -Wall -fPIC ${CMAKE_C_FLAGS}")
   set(CMAKE_CXX_FLAGS "-O2 -Wall -fPIC -std=c++11 ${CMAKE_CXX_FLAGS}")
-  if (${CMAKE_SYSTEM_NAME} MATCHES "Linux")
-    set(CMAKE_C_FLAGS "-fopenmp ${CMAKE_C_FLAGS}")
-    set(CMAKE_CXX_FLAGS "-fopenmp ${CMAKE_CXX_FLAGS}")
-  endif()
+
+  include(FindOpenMP)
+  if(OPENMP_FOUND)
+    set(CMAKE_C_FLAGS "${OpenMP_C_FLAGS} ${CMAKE_C_FLAGS}")
+    set(CMAKE_CXX_FLAGS "${OpenMP_CXX_FLAGS} ${CMAKE_CXX_FLAGS}")
+  endif(OPENMP_FOUND)
 endif(MSVC)
 
 # Source file lists

--- a/src/graph/sampler.cc
+++ b/src/graph/sampler.cc
@@ -9,7 +9,7 @@
 #include <algorithm>
 #include <cstdlib>
 #include <cmath>
-#include <omp.h>
+#include <dmlc/omp.h>
 
 #ifdef _MSC_VER
 // rand in MS compiler works well in multi-threading.


### PR DESCRIPTION
## Description
Organically find OpenMP in CMake instead of hard-coding.

Also changes `omp.h` to `dmlc/omp.h`.