### PR TITLE
[Feature] Reduce messages with scatter_add in PyTorch

### DIFF
--- a/python/dgl/backend/pytorch/tensor.py
+++ b/python/dgl/backend/pytorch/tensor.py
@@ -139,7 +139,8 @@ def spmm(x, y):
     dst, src = x._indices()
     dst = dst.view(-1, 1).expand(-1, y.shape[1])
     zeros = y.new_full((x.shape[0], y.shape[1]), 0)
-    return zeros.scatter_add(0, dst, y[src] * x._values().unsqueeze(-1))
+    message = th.index_select(y, 0, src) * x._values().unsqueeze(-1)
+    return zeros.scatter_add(0, dst, message)
 
 def unsorted_1d_segment_sum(input, seg_id, n_segs, dim):
     y = th.zeros(n_segs, *input.shape[1:]).to(input)

--- a/python/dgl/backend/pytorch/tensor.py
+++ b/python/dgl/backend/pytorch/tensor.py
@@ -137,8 +137,7 @@ def ones(shape, dtype, ctx):
 
 def spmm(x, y):
     dst, src = x._indices()
-    dim = 0
-    dst = dst.view(-1, 1).expand_as(-1, y.shape[1])
+    dst = dst.view(-1, 1).expand(-1, y.shape[1])
     zeros = y.new_full((x.shape[0], y.shape[1]), 0)
     return zeros.scatter_add(0, dst, y[src] * x._values().unsqueeze(-1))
 

--- a/python/dgl/backend/pytorch/tensor.py
+++ b/python/dgl/backend/pytorch/tensor.py
@@ -137,10 +137,13 @@ def ones(shape, dtype, ctx):
 
 def spmm(x, y):
     dst, src = x._indices()
-    dst = dst.view(-1, 1).expand(-1, y.shape[1])
-    zeros = y.new_full((x.shape[0], y.shape[1]), 0)
-    message = th.index_select(y, 0, src) * x._values().unsqueeze(-1)
-    return zeros.scatter_add(0, dst, message)
+    # scatter index
+    index = dst.view(-1, 1).expand(-1, y.shape[1])
+    # zero tensor to be scatter_add to
+    out = y.new_full((x.shape[0], y.shape[1]), 0)
+    # look up src features and multiply by edge features
+    feature = th.index_select(y, 0, src) * x._values().unsqueeze(-1)
+    return out.scatter_add(0, index, feature)
 
 def unsorted_1d_segment_sum(input, seg_id, n_segs, dim):
     y = th.zeros(n_segs, *input.shape[1:]).to(input)

--- a/python/dgl/backend/pytorch/tensor.py
+++ b/python/dgl/backend/pytorch/tensor.py
@@ -143,7 +143,7 @@ def spmm(x, y):
     out = y.new_full((x.shape[0], y.shape[1]), 0)
     # look up src features and multiply by edge features
     # Note: using y[src] instead of index_select will lead to terrible
-    #       porformance in backward
+    #       performance in backward
     feature = th.index_select(y, 0, src) * x._values().unsqueeze(-1)
     return out.scatter_add(0, index, feature)
 

--- a/python/dgl/backend/pytorch/tensor.py
+++ b/python/dgl/backend/pytorch/tensor.py
@@ -142,6 +142,8 @@ def spmm(x, y):
     # zero tensor to be scatter_add to
     out = y.new_full((x.shape[0], y.shape[1]), 0)
     # look up src features and multiply by edge features
+    # Note: using y[src] instead of index_select will lead to terrible
+    #       porformance in backward
     feature = th.index_select(y, 0, src) * x._values().unsqueeze(-1)
     return out.scatter_add(0, index, feature)
 


### PR DESCRIPTION
## Description
Spmm with uncoalesced sparse matrix in PyTorch has bad performance because the coalesce step is costly. Although coalesce sparse matrix ahead of time could make the forward pass much faster, the backward phase is still slow. Given expression y=spmat * x, in order to calculate gradient of x, we need to do spmat^T * grad_y. But transpose sparse matrix and then coalesce is again very costly. See profiling results [here](https://docs.google.com/document/d/1VaOksLx4yc76gdGpv2BpozJV4G96-7y07E6f9qwUqWM/edit#heading=h.49fpnq8w33hh).

This PR replaces PyTorch spmm with index_select and scatter_add. This solution is motivated by [pytorch_geometric](https://github.com/rusty1s/pytorch_geometric). See profiling results after improvement [here](https://docs.google.com/document/d/1VaOksLx4yc76gdGpv2BpozJV4G96-7y07E6f9qwUqWM/edit#heading=h.agwmzyovzufy).

## Checklist
Please feel free to remove inapplicable items for your PR.
- [x] The PR title starts with [$CATEGORY] (such as [Model], [Doc], [Feature]])
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage
- [x] To the my best knowledge, examples are either not affected by this change,
      or have been fixed to be compatible with this change

## Changes
- [x] Replace PyTorch spmm with index_select and scatter_add

