### PR TITLE
[BugFix] Fix bug in RGCN data processing and use index_select to improve speed

### DIFF
--- a/examples/pytorch/rgcn/link_predict.py
+++ b/examples/pytorch/rgcn/link_predict.py
@@ -149,7 +149,7 @@ def main(args):
 
         # set node/edge feature
         node_id = torch.from_numpy(node_id).view(-1, 1)
-        edge_type = torch.from_numpy(edge_type).view(-1, 1)
+        edge_type = torch.from_numpy(edge_type)
         node_norm = torch.from_numpy(node_norm).view(-1, 1)
         data, labels = torch.from_numpy(data), torch.from_numpy(labels)
         deg = g.in_degrees(range(g.number_of_nodes())).float().view(-1, 1)

--- a/python/dgl/contrib/data/knowledge_graph.py
+++ b/python/dgl/contrib/data/knowledge_graph.py
@@ -410,8 +410,8 @@ def _load_data(dataset_str='aifb', dataset_path=None):
                 dst = nodes_dict[o]
                 assert src < num_node and dst < num_node
                 rel = relations_dict[p]
-                edge_list.append((src, dst, 2 * rel))
-                edge_list.append((dst, src, 2 * rel + 1))
+                edge_list.append((src, dst, 2 * rel + 1))
+                edge_list.append((dst, src, 2 * rel + 2))
 
             # sort indices by destination
             edge_list = sorted(edge_list, key=lambda x: (x[1], x[0], x[2]))

--- a/python/dgl/contrib/data/knowledge_graph.py
+++ b/python/dgl/contrib/data/knowledge_graph.py
@@ -410,7 +410,9 @@ def _load_data(dataset_str='aifb', dataset_path=None):
                 dst = nodes_dict[o]
                 assert src < num_node and dst < num_node
                 rel = relations_dict[p]
+                # relation id 0 is self-relation, so others should start with 1
                 edge_list.append((src, dst, 2 * rel + 1))
+                # reverse relation
                 edge_list.append((dst, src, 2 * rel + 2))
 
             # sort indices by destination


### PR DESCRIPTION
## Description
RGCN entity dataset processing code generates relation type id wrongly. And index_select is much faster than tensor's __getitem__ operator.

## Checklist
- [x] The PR title starts with [$CATEGORY] (such as [Model], [Doc], [Feature]])
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] To the my best knowledge, examples are either not affected by this change,
      or have been fixed to be compatible with this change
