### PR TITLE
[Hotfix] fix cython bug

### DIFF
--- a/python/dgl/nodeflow.py
+++ b/python/dgl/nodeflow.py
@@ -447,8 +447,8 @@ class NodeFlow(DGLBaseGraph):
         # We need to extract two layers.
         layer0_size = self._layer_offsets[block_id + 1] - self._layer_offsets[block_id]
         rst = _CAPI_NodeFlowGetBlockAdj(self._graph._handle, fmt, layer0_size,
-                                        self._layer_offsets[block_id + 1],
-                                        self._layer_offsets[block_id + 2])
+                                        int(self._layer_offsets[block_id + 1]),
+                                        int(self._layer_offsets[block_id + 2]))
         num_rows = self.layer_size(block_id + 1)
         num_cols = self.layer_size(block_id)
 

--- a/python/dgl/nodeflow.py
+++ b/python/dgl/nodeflow.py
@@ -414,8 +414,8 @@ class NodeFlow(DGLBaseGraph):
         """
         layer0_size = self._layer_offsets[block_id + 1] - self._layer_offsets[block_id]
         rst = _CAPI_NodeFlowGetBlockAdj(self._graph._handle, "coo", layer0_size,
-                                        self._layer_offsets[block_id + 1],
-                                        self._layer_offsets[block_id + 2])
+                                        int(self._layer_offsets[block_id + 1]),
+                                        int(self._layer_offsets[block_id + 2]))
         idx = utils.toindex(rst(0)).tousertensor()
         eid = utils.toindex(rst(1))
         num_edges = int(len(idx) / 2)

--- a/python/dgl/nodeflow.py
+++ b/python/dgl/nodeflow.py
@@ -413,7 +413,8 @@ class NodeFlow(DGLBaseGraph):
             The edge ids.
         """
         layer0_size = self._layer_offsets[block_id + 1] - self._layer_offsets[block_id]
-        rst = _CAPI_NodeFlowGetBlockAdj(self._graph._handle, "coo", layer0_size,
+        rst = _CAPI_NodeFlowGetBlockAdj(self._graph._handle, "coo",
+                                        int(layer0_size),
                                         int(self._layer_offsets[block_id + 1]),
                                         int(self._layer_offsets[block_id + 2]))
         idx = utils.toindex(rst(0)).tousertensor()
@@ -446,7 +447,8 @@ class NodeFlow(DGLBaseGraph):
         fmt = F.get_preferred_sparse_format()
         # We need to extract two layers.
         layer0_size = self._layer_offsets[block_id + 1] - self._layer_offsets[block_id]
-        rst = _CAPI_NodeFlowGetBlockAdj(self._graph._handle, fmt, layer0_size,
+        rst = _CAPI_NodeFlowGetBlockAdj(self._graph._handle, fmt,
+                                        int(layer0_size),
                                         int(self._layer_offsets[block_id + 1]),
                                         int(self._layer_offsets[block_id + 2]))
         num_rows = self.layer_size(block_id + 1)

--- a/tests/scripts/build_dgl.sh
+++ b/tests/scripts/build_dgl.sh
@@ -15,5 +15,8 @@ popd
 pushd python
 rm -rf build *.egg-info dist
 pip3 uninstall -y dgl
+# test install
 python3 setup.py install
+# test inplace build (for cython)
+python3 setup.py build_ext --inplace
 popd


### PR DESCRIPTION
## Description
<!-- Brief description. Refer to the related issues if existed.
It'll be great if relevant reviewers can be assigned as well.-->

* Cython cannot distinguish numpy.int and int. So `int()` is recommended when calling CAPI. @zheng-da 
* Update Jenkins to allow cython test.