### PR TITLE
[Doc] added index [0] to torch.max comment

### DIFF
--- a/python/dgl/function/reducer.py
+++ b/python/dgl/function/reducer.py
@@ -92,6 +92,6 @@ def max(msg, out):
 
     >>> import torch
     >>> def reduce_func(nodes):
-    >>>     return {'h': torch.max(nodes.mailbox['m'], dim=1)}
+    >>>     return {'h': torch.max(nodes.mailbox['m'], dim=1)[0]}
     """
     return SimpleReduceFunction("max", F.max, msg, out)


### PR DESCRIPTION
## Description
<!-- Very very nitpicky, and it only affects a comment, but torch.max returns a tuple of tensors. The first tensor is the desired one in this case, while the second tensor in the tuple is essentially the argmax tensor.-->
