### PR TITLE
[Build] Switching to msbuild for conda windows

### DIFF
--- a/conda/dgl/bld.bat
+++ b/conda/dgl/bld.bat
@@ -1,11 +1,11 @@
+REM Needs vcvars64.bat to be called
 git submodule init
 git submodule update
 md build
 cd build
-cmake -DCMAKE_CXX_FLAGS="-DDMLC_LOG_STACK_TRACE=0 -DDGL_EXPORTS" -DCMAKE_MAKE_PROGRAM=mingw32-make .. -G "MinGW Makefiles"
-if errorlevel 1 exit 1
-mingw32-make
-if errorlevel 1 exit 1
+cmake -DCMAKE_CXX_FLAGS="/DDGL_EXPORTS" -DCMAKE_CONFIGURATION_TYPES="Release" .. -G "Visual Studio 15 2017 Win64" || EXIT /B 1
+msbuild dgl.sln || EXIT /B 1
+COPY Release\dgl.dll .
 cd ..\python
-"%PYTHON%" setup.py install --single-version-externally-managed --record=record.txt
-if errorlevel 1 exit 1
+"%PYTHON%" setup.py install --single-version-externally-managed --record=record.txt || EXIT /B 1
+EXIT /B

--- a/conda/dgl/meta.yaml
+++ b/conda/dgl/meta.yaml
@@ -3,7 +3,7 @@ package:
   version: "0.2"
 
 source:
-  git_rev: 0.1.x
+  git_rev: 0.2.x
   git_url: https://github.com/dmlc/dgl.git
 
 requirements:
@@ -12,8 +12,7 @@ requirements:
     - setuptools
     - cmake
     - git
-    - m2w64-gcc         # [win]
-    - m2w64-make        # [win]
+    - cython
   run:
     - python
     - numpy


### PR DESCRIPTION
0.2.x+ on Windows no longer needs mingw to build.

Note that currently the Windows packages are already built with MSBuild.