### PR TITLE
[BugFix] Fix performance bug in EdgeSoftmax

### DIFF
--- a/python/dgl/nn/pytorch/softmax.py
+++ b/python/dgl/nn/pytorch/softmax.py
@@ -84,7 +84,7 @@ class EdgeSoftmax(nn.Module):
         graph.apply_edges(
             lambda edges: {self._logits_name : th.exp(edges.data[self._logits_name] -
                                                       edges.dst[self._max_logits_name])})
-        # pop out temporary feature _max_logits, otherwise get_ndata_name will have huge overhead
+        # pop out temporary feature _max_logits, otherwise get_ndata_name could have huge overhead
         graph.ndata.pop(self._max_logits_name)
         # compute normalizer
         graph.update_all(fn.copy_edge(self._logits_name, self._logits_name),

--- a/python/dgl/nn/pytorch/softmax.py
+++ b/python/dgl/nn/pytorch/softmax.py
@@ -84,6 +84,8 @@ class EdgeSoftmax(nn.Module):
         graph.apply_edges(
             lambda edges: {self._logits_name : th.exp(edges.data[self._logits_name] -
                                                       edges.dst[self._max_logits_name])})
+        # pop out temporary feature _max_logits, otherwise get_ndata_name will have huge overhead
+        graph.ndata.pop(self._max_logits_name)
         # compute normalizer
         graph.update_all(fn.copy_edge(self._logits_name, self._logits_name),
                          fn.sum(self._logits_name, self._normalizer_name))


### PR DESCRIPTION
## Description
`EdgeSoftmax` module did not pop the temporary max feature. In GAT model, this bug leads to huge slow down in `get_ndata_name` function because GAT uses one single graph, and after `n` epochs, there are `n` max feature in `g.ndata`, and `get_ndata_name` has to retry `n` times to find a usable feature name. Also, the bug leads to extra memory consumption because the reference to tensor is still kept by DGLGraph.

This explains why when running GAT models, the training time of one epoch keeps increasing.

## Checklist
Please feel free to remove inapplicable items for your PR.
- [x] The PR title starts with [$CATEGORY] (such as [Model], [Doc], [Feature]])
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] Code is well-documented
- [x] To the my best knowledge, examples are either not affected by this change,
      or have been fixed to be compatible with this change
