### PR TITLE
[Refactor] Sampler code refactor

### DIFF
--- a/python/dgl/graph.py
+++ b/python/dgl/graph.py
@@ -38,6 +38,10 @@ class DGLBaseGraph(object):
     def __init__(self, graph):
         self._graph = graph
 
+    @property
+    def c_handle(self):
+        return self._graph._handle
+
     def number_of_nodes(self):
         """Return the number of nodes in the graph.
 

--- a/python/dgl/graph.py
+++ b/python/dgl/graph.py
@@ -40,6 +40,7 @@ class DGLBaseGraph(object):
 
     @property
     def c_handle(self):
+        """The C handle for the graph."""
         return self._graph._handle
 
     def number_of_nodes(self):

--- a/tutorials/models/1_gnn/8_sse_mx.py
+++ b/tutorials/models/1_gnn/8_sse_mx.py
@@ -483,12 +483,15 @@ def train_on_subgraphs(g, label_nodes, batch_size,
     # The first phase samples from all vertices in the graph.
     sampler = dgl.contrib.sampling.NeighborSampler(
             g, batch_size, g.number_of_nodes(), num_hops=1)
+    sampler_iter = iter(sampler)
  
     # The second phase only samples from labeled vertices.
     sampler_train = dgl.contrib.sampling.NeighborSampler(
             g, batch_size, g.number_of_nodes(), seed_nodes=label_nodes, num_hops=1)
+    sampler_train_iter = iter(sampler_train)
+
     for i in range(n_embedding_updates):
-        subg = next(sampler)
+        subg = next(sampler_iter)
         # Currently, subgraphing does not copy or share features
         # automatically.  Therefore, we need to copy the node
         # embeddings of the subgraph from the parent graph with
@@ -499,7 +502,7 @@ def train_on_subgraphs(g, label_nodes, batch_size,
         g.ndata['h'][subg.layer_parent_nid(-1)] = subg.layers[-1].data['h']
     for i in range(n_parameter_updates):
         try:
-            subg = next(sampler_train)
+            subg = next(sampler_train_iter)
         except:
             break
         # Again we need to copy features from parent graph


### PR DESCRIPTION
## Description
Current neighbor sampler and layerwise sampler code breaks Python code convention: the functions "pretend" to be classes by having CamelCase names.

Also layerwise sampling and neighbor sampling are mangled in the same `SubgraphSampler` class via if-else blocks, which is not very friendly when new samplers are added.

Tested with `examples/mxnet/gcn_ns_sc.py` and it didn't break.

## Checklist
Please feel free to remove inapplicable items for your PR.
- [x] The PR title starts with [$CATEGORY] (such as [Model], [Doc], [Feature]])
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage
- [x] Code is well-documented
- [x] To the my best knowledge, examples are either not affected by this change,
      or have been fixed to be compatible with this change