### PR TITLE
fix self-edge bug in GCN and GAT.

### DIFF
--- a/examples/mxnet/gat/gat_batch.py
+++ b/examples/mxnet/gat/gat_batch.py
@@ -178,9 +178,12 @@ def main(args):
         test_mask = test_mask.as_in_context(ctx)
         val_mask = val_mask.as_in_context(ctx)
     # create graph
-    g = DGLGraph(data.graph)
+    g = data.graph
     # add self-loop
+    g.remove_edges_from(g.selfloop_edges())
+    g = DGLGraph(g)
     g.add_edges(g.nodes(), g.nodes())
+    
 
     # create model
     model = GAT(g,

--- a/examples/mxnet/gat/gat_batch.py
+++ b/examples/mxnet/gat/gat_batch.py
@@ -183,8 +183,6 @@ def main(args):
     g.remove_edges_from(g.selfloop_edges())
     g = DGLGraph(g)
     g.add_edges(g.nodes(), g.nodes())
-    
-
     # create model
     model = GAT(g,
                 args.num_layers,

--- a/examples/mxnet/gcn/train.py
+++ b/examples/mxnet/gcn/train.py
@@ -52,9 +52,11 @@ def main(args):
     test_mask = test_mask.as_in_context(ctx)
 
     # create GCN model
-    g = DGLGraph(data.graph)
+    g = data.graph
     if args.self_loop:
-        g.add_edges(g.nodes(), g.nodes())
+        g.remove_edges_from(g.selfloop_edges())
+        g.add_edges_from(zip(g.nodes(), g.nodes()))
+    g = DGLGraph(g)
     # normalization
     degs = g.in_degrees().astype('float32')
     norm = mx.nd.power(degs, -0.5)

--- a/examples/pytorch/gat/train.py
+++ b/examples/pytorch/gat/train.py
@@ -65,11 +65,12 @@ def main(args):
         val_mask = val_mask.cuda()
         test_mask = test_mask.cuda()
 
-    # create DGL graph
-    g = DGLGraph(data.graph)
-    n_edges = g.number_of_edges()
+    g = data.graph
     # add self loop
+    g.remove_edges_from(g.selfloop_edges())
+    g = DGLGraph(g)
     g.add_edges(g.nodes(), g.nodes())
+    n_edges = g.number_of_edges()
     # create model
     heads = ([args.num_heads] * args.num_layers) + [args.num_out_heads]
     model = GAT(g,

--- a/examples/pytorch/gcn/gcn_mp.py
+++ b/examples/pytorch/gcn/gcn_mp.py
@@ -153,7 +153,6 @@ def main(args):
     # add self loop
     g.add_edges(g.nodes(), g.nodes())
     n_edges = g.number_of_edges()
-    # create model
     # normalization
     degs = g.in_degrees().float()
     norm = torch.pow(degs, -0.5)

--- a/examples/pytorch/gcn/gcn_mp.py
+++ b/examples/pytorch/gcn/gcn_mp.py
@@ -147,10 +147,13 @@ def main(args):
         test_mask = test_mask.cuda()
 
     # graph preprocess and calculate normalization factor
-    g = DGLGraph(data.graph)
-    n_edges = g.number_of_edges()
+    g = data.graph
+    g.remove_edges_from(g.selfloop_edges())
+    g = DGLGraph(g)
     # add self loop
     g.add_edges(g.nodes(), g.nodes())
+    n_edges = g.number_of_edges()
+    # create model
     # normalization
     degs = g.in_degrees().float()
     norm = torch.pow(degs, -0.5)

--- a/examples/pytorch/gcn/train.py
+++ b/examples/pytorch/gcn/train.py
@@ -54,11 +54,13 @@ def main(args):
         test_mask = test_mask.cuda()
 
     # graph preprocess and calculate normalization factor
-    g = DGLGraph(data.graph)
-    n_edges = g.number_of_edges()
+    g = data.graph
     # add self loop
     if args.self_loop:
-        g.add_edges(g.nodes(), g.nodes())
+            g.remove_edges_from(g.selfloop_edges())
+            g.add_edges_from(zip(g.nodes(), g.nodes()))
+    g = DGLGraph(g)
+    n_edges = g.number_of_edges()
     # normalization
     degs = g.in_degrees().float()
     norm = torch.pow(degs, -0.5)


### PR DESCRIPTION
## Description
I find that  some nodes in citation dataset have self-edge orginally, if we use `g.add_edges(g.nodes(), g.nodes())` directly, some nodes will have more than one self-edge.  This PR fixes that. 


