### PR TITLE
[Test] Disable unittest for shared memory temporarily

### DIFF
--- a/tests/mxnet/test_shared_mem_store.py
+++ b/tests/mxnet/test_shared_mem_store.py
@@ -5,6 +5,7 @@ from multiprocessing import Process
 from scipy import sparse as spsp
 import mxnet as mx
 import backend as F
+import unittest
 
 num_nodes = 100
 num_edges = int(num_nodes * num_nodes * 0.1)

--- a/tests/mxnet/test_shared_mem_store.py
+++ b/tests/mxnet/test_shared_mem_store.py
@@ -48,6 +48,7 @@ def server_func(num_workers):
     g.edata['feat'] = mx.nd.arange(num_edges * 10).reshape((num_edges, 10))
     g.run()
 
+@unittest.skip("disable shared memory test temporarily")
 def test_worker_server():
     serv_p = Process(target=server_func, args=(2,))
     work_p1 = Process(target=worker_func, args=(0,))


### PR DESCRIPTION
## Description
It seems RPC calls fail sometimes. It might take a while to investigate the problem. Let's disable the unittest for shared memory for now.

## Checklist
Please feel free to remove inapplicable items for your PR.
- [ ] The PR title starts with [$CATEGORY] (such as [Model], [Doc], [Feature]])
- [ ] Changes are complete (i.e. I finished coding on this PR)
- [ ] All changes have test coverage
- [ ] Code is well-documented
- [ ] To the my best knowledge, examples are either not affected by this change,
      or have been fixed to be compatible with this change
- [ ] Related issue is referred in this PR

## Changes
<!-- You could use following template
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)
-->
