### PR TITLE
[BugFix] Fix getting src and dst id of ALL edges in NodeFlow.apply_block

### DIFF
--- a/python/dgl/nodeflow.py
+++ b/python/dgl/nodeflow.py
@@ -721,8 +721,8 @@ class NodeFlow(DGLBaseGraph):
         block_id : int
             The specified block to update edge embeddings.
         func : callable or None, optional
-            Apply function on the nodes. The function should be
-            a :mod:`Node UDF <dgl.udf>`.
+            Apply function on the edges. The function should be
+            an :mod:`Edge UDF <dgl.udf>`.
         edges : a list of edge Ids or ALL.
             The edges to run the edge update function.
         inplace : bool, optional
@@ -732,12 +732,10 @@ class NodeFlow(DGLBaseGraph):
             func = self._apply_edge_funcs[block_id]
         assert func is not None
 
-        def _layer_local_nid(layer_id):
-            return F.arange(0, self.layer_size(layer_id))
-
         if is_all(edges):
-            u = utils.toindex(_layer_local_nid(block_id))
-            v = utils.toindex(_layer_local_nid(block_id + 1))
+            u, v, _ = self.block_edges(block_id)
+            u = utils.toindex(u)
+            v = utils.toindex(v)
             eid = utils.toindex(slice(0, self.block_size(block_id)))
         elif isinstance(edges, tuple):
             u, v = edges


### PR DESCRIPTION
## Description
When use `NodeFlow.apply_block` with `edges=ALL`(default), it will produce an error. 

More details can be found in #513 

## Checklist
Please feel free to remove inapplicable items for your PR.
- [x] The PR title starts with [$CATEGORY] (such as [Model], [Doc], [Feature]])
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage
- [x] Code is well-documented
- [x] To the my best knowledge, examples are either not affected by this change,
      or have been fixed to be compatible with this change
- [x] Related issue is referred in this PR

## Changes
<!-- You could use following template
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)
-->
