### PR TITLE
[WIP][Feature] Add locking for concurrent data access to the embeddings in the shared-memory graph store

### DIFF
--- a/include/dgl/runtime/c_runtime_api.h
+++ b/include/dgl/runtime/c_runtime_api.h
@@ -457,6 +457,16 @@ DGL_DLL int DGLArrayCopyFromTo(DGLArrayHandle from,
                                DGLArrayHandle to,
                                DGLStreamHandle stream);
 
+DGL_DLL int DGLArraySharedMemGatherRows(DGLArrayHandle from,
+                                        DGLArrayHandle lock,
+                                        DGLArrayHandle idx,
+                                        DGLArrayHandle to);
+
+DGL_DLL int DGLArraySharedMemScatterRows(DGLArrayHandle from,
+                                         DGLArrayHandle lock,
+                                         DGLArrayHandle idx,
+                                         DGLArrayHandle to);
+
 /*!
  * \brief Produce an array from the DLManagedTensor that shares data memory
  * with the DLManagedTensor.

--- a/python/dgl/_ffi/_cython/base.pxi
+++ b/python/dgl/_ffi/_cython/base.pxi
@@ -112,11 +112,11 @@ cdef extern from "dgl/runtime/c_runtime_api.h":
     int DGLArraySharedMemGatherRows(DLTensorHandle from,
                                     DLTensorHandle lock,
                                     DLTensorHandle idx,
-                                    DLTensorHandle to);
+                                    DLTensorHandle to)
     int DGLArraySharedMemScatterRows(DLTensorHandle from,
                                      DLTensorHandle lock,
                                      DLTensorHandle idx,
-                                     DLTensorHandle to);
+                                     DLTensorHandle to)
     int DGLArrayFromDLPack(DLManagedTensor* arr_from,
                            DLTensorHandle* out)
     int DGLArrayToDLPack(DLTensorHandle arr_from,

--- a/python/dgl/_ffi/_cython/base.pxi
+++ b/python/dgl/_ffi/_cython/base.pxi
@@ -109,6 +109,14 @@ cdef extern from "dgl/runtime/c_runtime_api.h":
     int DGLArrayCopyFromTo(DLTensorHandle src,
                            DLTensorHandle to,
                            DGLStreamHandle stream)
+    int DGLArraySharedMemGatherRows(DLTensorHandle from,
+                                    DLTensorHandle lock,
+                                    DLTensorHandle idx,
+                                    DLTensorHandle to);
+    int DGLArraySharedMemScatterRows(DLTensorHandle from,
+                                     DLTensorHandle lock,
+                                     DLTensorHandle idx,
+                                     DLTensorHandle to);
     int DGLArrayFromDLPack(DLManagedTensor* arr_from,
                            DLTensorHandle* out)
     int DGLArrayToDLPack(DLTensorHandle arr_from,

--- a/python/dgl/_ffi/_cython/base.pxi
+++ b/python/dgl/_ffi/_cython/base.pxi
@@ -109,14 +109,14 @@ cdef extern from "dgl/runtime/c_runtime_api.h":
     int DGLArrayCopyFromTo(DLTensorHandle src,
                            DLTensorHandle to,
                            DGLStreamHandle stream)
-    int DGLArraySharedMemGatherRows(DLTensorHandle from,
-                                    DLTensorHandle lock,
-                                    DLTensorHandle idx,
-                                    DLTensorHandle to)
-    int DGLArraySharedMemScatterRows(DLTensorHandle from,
-                                     DLTensorHandle lock,
-                                     DLTensorHandle idx,
-                                     DLTensorHandle to)
+    int DGLArraySharedMemGatherRows(CDGLArrayHandle from,
+                                    CDGLArrayHandle lock,
+                                    CDGLArrayHandle idx,
+                                    CDGLArrayHandle to)
+    int DGLArraySharedMemScatterRows(CDGLArrayHandle from,
+                                     CDGLArrayHandle lock,
+                                     CDGLArrayHandle idx,
+                                     CDGLArrayHandle to)
     int DGLArrayFromDLPack(DLManagedTensor* arr_from,
                            DLTensorHandle* out)
     int DGLArrayToDLPack(DLTensorHandle arr_from,

--- a/python/dgl/_ffi/ndarray.py
+++ b/python/dgl/_ffi/ndarray.py
@@ -149,6 +149,15 @@ def empty_shared_mem(name, is_create, shape, dtype="float32"):
         ctypes.byref(handle)))
     return _make_array(handle, False)
 
+def shared_mem_gather_rows(src_arr, lock_arr, idx_arr):
+    dst_shape = (idx_arr.shape[0], ) + src_arr.shape[1:]
+    dst_arr = empty(dst_shape, src_arr.dtype, src_arr.context)
+    check_call(_LIB.DGLArraySharedMemGatherRows(
+        src_arr.handle, lock_arr.handle, idx_arr, dst_arr))
+
+def shared_mem_scatter_rows(src_arr, lock_arr, idx_arr, dst_arr):
+    check_call(_LIB.DGLArraySharedMemScatterRows(
+        src_arr.handle, lock_arr.handle, idx_arr, dst_arr))
 
 def from_dlpack(dltensor):
     """Produce an array from a DLPack tensor without memory copy.

--- a/python/dgl/_ffi/ndarray.py
+++ b/python/dgl/_ffi/ndarray.py
@@ -150,6 +150,10 @@ def empty_shared_mem(name, is_create, shape, dtype="float32"):
     return _make_array(handle, False)
 
 def shared_mem_gather_rows(src_arr, lock_arr, idx_arr):
+    """Slice rows from the shared-memory tensor.
+
+    When slicing rows, we make sure that we read a row atomically.
+    """
     dst_shape = (idx_arr.shape[0], ) + src_arr.shape[1:]
     dst_arr = empty(dst_shape, src_arr.dtype, src_arr.context)
     check_call(_LIB.DGLArraySharedMemGatherRows(
@@ -157,6 +161,10 @@ def shared_mem_gather_rows(src_arr, lock_arr, idx_arr):
     return dst_arr
 
 def shared_mem_scatter_rows(src_arr, lock_arr, idx_arr, dst_arr):
+    """Scatter data to rows.
+
+    When scattering data, we make sure that a row is written atomically.
+    """
     check_call(_LIB.DGLArraySharedMemScatterRows(
         src_arr.handle, lock_arr.handle, idx_arr.handle, dst_arr.handle))
 

--- a/python/dgl/_ffi/ndarray.py
+++ b/python/dgl/_ffi/ndarray.py
@@ -153,11 +153,12 @@ def shared_mem_gather_rows(src_arr, lock_arr, idx_arr):
     dst_shape = (idx_arr.shape[0], ) + src_arr.shape[1:]
     dst_arr = empty(dst_shape, src_arr.dtype, src_arr.context)
     check_call(_LIB.DGLArraySharedMemGatherRows(
-        src_arr.handle, lock_arr.handle, idx_arr, dst_arr))
+        src_arr.handle, lock_arr.handle, idx_arr.handle, dst_arr.handle))
+    return dst_arr
 
 def shared_mem_scatter_rows(src_arr, lock_arr, idx_arr, dst_arr):
     check_call(_LIB.DGLArraySharedMemScatterRows(
-        src_arr.handle, lock_arr.handle, idx_arr, dst_arr))
+        src_arr.handle, lock_arr.handle, idx_arr.handle, dst_arr.handle))
 
 def from_dlpack(dltensor):
     """Produce an array from a DLPack tensor without memory copy.

--- a/python/dgl/contrib/graph_store.py
+++ b/python/dgl/contrib/graph_store.py
@@ -588,7 +588,7 @@ class SharedMemoryDGLGraph(DGLGraph):
             self._node_frame._frame._warn_and_set_initializer()
         init = self._node_frame.get_initializer(ndata_name)
         init = self._init_manager.serialize(init)
-        self.proxy.init_ndata(init, ndata_name, shape, dtype)
+        self.proxy.init_ndata(init, ndata_name, shape, dtype, True)
         self._init_ndata(ndata_name, shape, dtype)
 
     def init_edata(self, edata_name, shape, dtype):
@@ -612,7 +612,7 @@ class SharedMemoryDGLGraph(DGLGraph):
             self._edge_frame._frame._warn_and_set_initializer()
         init = self._edge_frame.get_initializer(edata_name)
         init = self._init_manager.serialize(init)
-        self.proxy.init_edata(init, edata_name, shape, dtype)
+        self.proxy.init_edata(init, edata_name, shape, dtype, True)
         self._init_edata(edata_name, shape, dtype)
 
 

--- a/python/dgl/frame.py
+++ b/python/dgl/frame.py
@@ -518,7 +518,7 @@ class Frame(MutableMapping):
         if self.num_rows == 0:
             # if no rows in current frame; append is equivalent to
             # directly updating columns.
-            self._columns = {key: self._column_create(data, key) for key, data in other.items()}
+            self._columns = {key: self._column_create(data, None, key) for key, data in other.items()}
         else:
             # pad columns that are not provided in the other frame with initial values
             for key, col in self.items():

--- a/python/dgl/frame.py
+++ b/python/dgl/frame.py
@@ -518,7 +518,8 @@ class Frame(MutableMapping):
         if self.num_rows == 0:
             # if no rows in current frame; append is equivalent to
             # directly updating columns.
-            self._columns = {key: self._column_create(data, None, key) for key, data in other.items()}
+            self._columns = {key: self._column_create(data, None,
+                                                      key) for key, data in other.items()}
         else:
             # pad columns that are not provided in the other frame with initial values
             for key, col in self.items():

--- a/python/dgl/frame.py
+++ b/python/dgl/frame.py
@@ -251,16 +251,6 @@ class SharedMemColumn(Column):
         """
         raise Exception("shared-memory column doesn't support extend")
 
-    @staticmethod
-    def create(data, scheme, data_path, create_lock):
-        """Create a new column using the given data."""
-        if isinstance(data, Column) and scheme is not None:
-            return SharedMemColumn(data.data, data_path, create_lock, scheme)
-        elif isinstance(data, Column):
-            return SharedMemColumn(data.data, data_path, create_lock, data.scheme)
-        else:
-            return SharedMemColumn(data, data_path, create_lock)
-
 class Frame(MutableMapping):
     """The columnar storage for node/edge features.
 
@@ -306,6 +296,15 @@ class Frame(MutableMapping):
         self._default_initializer = None
 
     def set_column_create(self, column_create):
+        """Set the column creator.
+
+        We allow users to define how to create a column.
+
+        Parameters
+        ----------
+        column_create : callable
+            A function to create a column
+        """
         self._column_create = column_create
 
     def _warn_and_set_initializer(self):

--- a/python/dgl/frame.py
+++ b/python/dgl/frame.py
@@ -9,7 +9,7 @@ import numpy as np
 from . import backend as F
 from .base import DGLError, dgl_warning
 from .init import zero_initializer
-from ._ffi.ndarray import empty_shared_mem
+from ._ffi.ndarray import empty_shared_mem, shared_mem_gather_rows, shared_mem_scatter_rows
 from . import utils
 
 class Scheme(namedtuple('Scheme', ['shape', 'dtype'])):
@@ -188,7 +188,7 @@ class SharedMemColumn(Column):
             rows = shared_mem_gather_rows(utils.todgltensor(self.data),
                                           self.locks,
                                           idx.todgltensor())
-            return rows.tousertensor()
+            return utils.tousertensor(rows)
 
     def update(self, idx, feats, inplace):
         feat_scheme = infer_scheme(feats)
@@ -199,7 +199,7 @@ class SharedMemColumn(Column):
         if not inplace:
             raise Exception("shared-memory column only support in-place update.")
         shared_mem_scatter_rows(utils.todgltensor(feats), self.locks,
-                                idx.todgltensor(), utils.todgltensor(data))
+                                idx.todgltensor(), utils.todgltensor(self.data))
 
     def extend(self, feats, feat_scheme=None):
         raise Exception("shared-memory column doesn't support extend")

--- a/python/dgl/frame.py
+++ b/python/dgl/frame.py
@@ -166,7 +166,7 @@ class Column(object):
         self.data = F.cat([self.data, feats], dim=0)
 
     @staticmethod
-    def create(data, scheme, data_name):
+    def create(data, scheme, data_name):  # pylint: disable=unused-argument
         """Create a new column using the given data."""
         if isinstance(data, Column) and scheme is not None:
             return Column(data.data, scheme)

--- a/python/dgl/utils.py
+++ b/python/dgl/utils.py
@@ -244,10 +244,14 @@ def toindex(data):
     return data if isinstance(data, Index) else Index(data)
 
 def todgltensor(data):
+    """Convert data to dgl tensor
+    """
     dlpack = F.zerocopy_to_dlpack(data)
     return nd.from_dlpack(dlpack)
 
 def tousertensor(data):
+    """Convert dgl tensor to the tensor of the underlying framework.
+    """
     dlpack = data.to_dlpack()
     return F.zerocopy_from_dlpack(dlpack)
 

--- a/python/dgl/utils.py
+++ b/python/dgl/utils.py
@@ -243,6 +243,14 @@ def toindex(data):
     """
     return data if isinstance(data, Index) else Index(data)
 
+def todgltensor(data):
+    dlpack = F.zerocopy_to_dlpack(data)
+    return nd.from_dlpack(dlpack)
+
+def tousertensor(data):
+    dlpack = data.to_dlpack()
+    return F.zerocopy_from_dlpack(dlpack)
+
 def zero_index(size):
     """Create a index with provided size initialized to zero
 

--- a/src/runtime/atomic.h
+++ b/src/runtime/atomic.h
@@ -8,15 +8,12 @@
 
 #ifndef _WIN32
 
-#include <stdatomic.h>
-#include <atomic>
-
 namespace dgl {
 
 template<class T>
 T atomic_read(volatile T *val) {
   T ret_val;
-  __atomic_load(val, &ret_val, memory_order_seq_cst);
+  __atomic_load(val, &ret_val, __ATOMIC_SEQ_CST);
   return ret_val;
 }
 
@@ -31,14 +28,14 @@ class ReadWriteLock {
   void enter_write_mode() {
     int prev;
     do {
-      prev = __atomic_fetch_or(lock, 1<<31, memory_order_seq_cst);
+      prev = __atomic_fetch_or(lock, 1<<31, __ATOMIC_SEQ_CST);
       // If the previous value already has write lock set up,
       // we have to wait until the write lock is reset.
     } while (prev < 0);
   }
 
   void leave_write_mode() {
-    int prev = __atomic_fetch_and(lock, ~(1<<31), memory_order_seq_cst);
+    int prev = __atomic_fetch_and(lock, ~(1<<31), __ATOMIC_SEQ_CST);
     // when leaving the write mode, we have to make sure the write lock was
     // set up.
     CHECK_LT(prev, 0);
@@ -67,7 +64,7 @@ class ReadWriteLock {
   }
 
   void WriteUnlock() {
-    __atomic_fetch_add(lock, 1, memory_order_seq_cst);
+    __atomic_fetch_add(lock, 1, __ATOMIC_SEQ_CST);
     leave_write_mode();
   }
 };

--- a/src/runtime/atomic.h
+++ b/src/runtime/atomic.h
@@ -6,12 +6,12 @@
 #ifndef DGL_RUNTIME_ATOMIC_H_
 #define DGL_RUNTIME_ATOMIC_H_
 
+#ifndef _WIN32
+
 #include <stdatomic.h>
 #include <atomic>
 
 namespace dgl {
-
-#ifndef _WIN32
 
 template<class T>
 T atomic_read(volatile T *val) {
@@ -72,8 +72,8 @@ class ReadWriteLock {
   }
 };
 
-#endif  // _WIN32
-
 }  // namespace dgl
+
+#endif  // _WIN32
 
 #endif  // DGL_RUNTIME_ATOMIC_H_

--- a/src/runtime/atomic.h
+++ b/src/runtime/atomic.h
@@ -11,6 +11,8 @@
 
 namespace dgl {
 
+#ifndef _WIN32
+
 template<class T>
 T atomic_read(volatile T *val) {
   T ret_val;
@@ -69,6 +71,8 @@ class ReadWriteLock {
     leave_write_mode();
   }
 };
+
+#endif  // _WIN32
 
 }  // namespace dgl
 

--- a/src/runtime/atomic.h
+++ b/src/runtime/atomic.h
@@ -1,0 +1,73 @@
+/*!
+ *  Copyright (c) 2019 by Contributors
+ * \file c_atomic.h
+ * \brief DGL atomic operations
+ */
+#ifndef DGL_ATOMIC_H_
+#define DGL_ATOMIC_H_
+
+#include <stdatomic.h>
+#include <atomic>
+
+namespace dgl {
+
+template<class T>
+T atomic_read(volatile T *val) {
+  T ret_val;
+  __atomic_load(val, &ret_val, memory_order_seq_cst);
+  return ret_val;
+}
+
+class ReadWriteLock {
+  volatile int &lock;
+  int tmp_val;
+
+  static bool is_write_mode(int lock_val) {
+    return lock_val < 0;
+  }
+
+  void enter_write_mode() {
+    int prev;
+    do {
+      prev = __atomic_fetch_or(&lock, 1<<31, memory_order_seq_cst);
+      // If the previous value already has write lock set up,
+      // we have to wait until the write lock is reset.
+    } while(prev < 0);
+  }
+
+  void leave_write_mode() {
+    int prev = __atomic_fetch_and(&lock, ~(1<<31), memory_order_seq_cst);
+    // when leaving the write mode, we have to make sure the write lock was
+    // set up.
+    CHECK(prev < 0);
+  }
+public:
+  ReadWriteLock(int &_lock): lock(_lock) {
+  }
+
+  void ReadLock() {
+    tmp_val = atomic_read(&lock);
+  }
+
+  bool ReadUnlock() {
+    int tmp_val2 = atomic_read(&lock);
+    // If the first read and the second read has different values,
+    // it means the row has been modified during reading. We should read it again.
+    // Even if they are the same, we still need to check if the lock is in the write mode,
+    // which means another process is locking the row for modification.
+    return tmp_val == tmp_val2 && !is_write_mode(tmp_val);
+  }
+
+  void WriteLock() {
+    enter_write_mode();
+  }
+
+  void WriteUnlock() {
+    __atomic_fetch_add(&lock, 1, memory_order_seq_cst);
+    leave_write_mode();
+  }
+};
+
+}  // namespace dgl
+
+#endif  // DGL_ATOMIC_H_

--- a/src/runtime/atomic.h
+++ b/src/runtime/atomic.h
@@ -43,7 +43,7 @@ class ReadWriteLock {
   }
 
  public:
-  ReadWriteLock(int *_lock) {
+  explicit ReadWriteLock(int *_lock) {
     this->lock = _lock;
   }
 

--- a/src/runtime/ndarray.cc
+++ b/src/runtime/ndarray.cc
@@ -241,7 +241,7 @@ void SharedMemGatherRows(DLTensor *from, DLTensor *lock, DLTensor *idx, DLTensor
     bool success;
     do {
       row_lock.ReadLock();
-      memcpy(from_data + row_idx * row_size, to_data + i * row_size, row_size);
+      memcpy(to_data + i * row_size, from_data + row_idx * row_size, row_size);
       success = row_lock.ReadUnlock();
     } while (!success);
   }
@@ -268,7 +268,7 @@ void SharedMemScatterRows(DLTensor *from, DLTensor *lock, DLTensor *idx, DLTenso
     size_t row_idx = idx_data[i];
     ReadWriteLock row_lock(lock_data[row_idx]);
     row_lock.WriteLock();
-    memcpy(from_data + i * row_size, to_data + row_idx * row_size, row_size);
+    memcpy(to_data + row_idx * row_size, from_data + i * row_size, row_size);
     row_lock.WriteUnlock();
   }
 }

--- a/src/runtime/ndarray.cc
+++ b/src/runtime/ndarray.cc
@@ -237,7 +237,7 @@ void SharedMemGatherRows(DLTensor *from, DLTensor *lock, DLTensor *idx, DLTensor
 #pragma omp parallel for
   for (size_t i = 0; i < num_rows; i++) {
     size_t row_idx = idx_data[i];
-    ReadWriteLock row_lock(lock_data[row_idx]);
+    ReadWriteLock row_lock(&lock_data[row_idx]);
     bool success;
     do {
       row_lock.ReadLock();
@@ -266,7 +266,7 @@ void SharedMemScatterRows(DLTensor *from, DLTensor *lock, DLTensor *idx, DLTenso
 #pragma omp parallel for
   for (size_t i = 0; i < num_rows; i++) {
     size_t row_idx = idx_data[i];
-    ReadWriteLock row_lock(lock_data[row_idx]);
+    ReadWriteLock row_lock(&lock_data[row_idx]);
     row_lock.WriteLock();
     memcpy(to_data + row_idx * row_size, from_data + i * row_size, row_size);
     row_lock.WriteUnlock();

--- a/src/runtime/ndarray.cc
+++ b/src/runtime/ndarray.cc
@@ -218,6 +218,8 @@ void NDArray::CopyFromTo(DLTensor* from,
     from_size, from->ctx, to->ctx, from->dtype, stream);
 }
 
+#ifndef _WIN32
+
 void SharedMemGatherRows(DLTensor *from, DLTensor *lock, DLTensor *idx, DLTensor *to) {
   CHECK_EQ(idx->ndim, 1);
   CHECK_EQ(lock->ndim, 1);
@@ -272,6 +274,8 @@ void SharedMemScatterRows(DLTensor *from, DLTensor *lock, DLTensor *idx, DLTenso
     row_lock.WriteUnlock();
   }
 }
+
+#endif  // _WIN32
 
 }  // namespace runtime
 }  // namespace dgl
@@ -343,7 +347,11 @@ int DGLArraySharedMemGatherRows(DGLArrayHandle from,
                                 DGLArrayHandle idx,
                                 DGLArrayHandle to) {
   API_BEGIN();
+#ifndef _WIN32
   SharedMemGatherRows(from, lock, idx, to);
+#else
+  LOG(FATAL) << "Windows doesn't support NDArray with shared memory";
+#endif  // _WIN32
   API_END();
 }
 
@@ -352,7 +360,11 @@ int DGLArraySharedMemScatterRows(DGLArrayHandle from,
                                  DGLArrayHandle idx,
                                  DGLArrayHandle to) {
   API_BEGIN();
+#ifndef _WIN32
   SharedMemScatterRows(from, lock, idx, to);
+#else
+  LOG(FATAL) << "Windows doesn't support NDArray with shared memory";
+#endif  // _WIN32
   API_END();
 }
 

--- a/tests/mxnet/test_shared_mem_store.py
+++ b/tests/mxnet/test_shared_mem_store.py
@@ -144,9 +144,7 @@ def test_concurrent():
     work_p2.join()
     work_p3.join()
     work_p4.join()
-    print('wait for s')
     serv_p.join()
-    print('end')
 
 if __name__ == '__main__':
     test_test_init()

--- a/tests/mxnet/test_shared_mem_store.py
+++ b/tests/mxnet/test_shared_mem_store.py
@@ -97,6 +97,58 @@ def test_update_all():
     work_p1.join()
     work_p2.join()
 
+def server_func1(num_workers):
+    print("server starts")
+    np.random.seed(0)
+    csr = (spsp.random(10, 10, density=0.1, format='csr') != 0).astype(np.int64)
+
+    g = dgl.contrib.graph_store.create_graph_store_server(csr, "cgraph", "shared_mem",
+                                                          num_workers, False, edge_dir="in")
+    g.ndata['feat'] = mx.nd.zeros(shape=(g._graph.number_of_nodes(), 10))
+    g.run()
+
+def read_func(worker_id):
+    time.sleep(3)
+    print('reader runs: ' + str(worker_id))
+    g = dgl.contrib.graph_store.create_graph_from_store("cgraph", "shared_mem")
+    for i in range(100000):
+        idx = dgl.utils.toindex(np.random.randint(0, g.number_of_nodes(), size=10))
+        rows = g._node_frame._frame['feat'][idx].asnumpy()
+        for j in range(len(rows)):
+            assert np.all(rows[j] == rows[j][0])
+    print('reader ends: ' + str(worker_id))
+
+def write_func(worker_id):
+    time.sleep(3)
+    print('writer runs: ' + str(worker_id))
+    g = dgl.contrib.graph_store.create_graph_from_store("cgraph", "shared_mem")
+    rows = mx.nd.ones(shape=(10, 10))
+    for i in range(100000):
+        idx = dgl.utils.toindex(np.random.randint(0, g.number_of_nodes(), size=10))
+        rows = rows + random.randint(0, 100)
+        g._node_frame._frame['feat'].update(idx, rows, inplace=True)
+    print('writer ends: ' + str(worker_id))
+
+def test_concurrent():
+    serv_p = Process(target=server_func1, args=(4,))
+    work_p1 = Process(target=read_func, args=(0,))
+    work_p2 = Process(target=read_func, args=(1,))
+    work_p3 = Process(target=write_func, args=(2,))
+    work_p4 = Process(target=write_func, args=(3,))
+    serv_p.start()
+    work_p1.start()
+    work_p2.start()
+    work_p3.start()
+    work_p4.start()
+    work_p1.join()
+    work_p2.join()
+    work_p3.join()
+    work_p4.join()
+    print('wait for s')
+    serv_p.join()
+    print('end')
+
 if __name__ == '__main__':
     test_test_init()
     test_update_all()
+    test_concurrent()


### PR DESCRIPTION
## Description
The concurrent data access to the embeddings in the shared-memory graph store should be protected by locks. In this design, the embedding of each vertex has a lock to prevent from concurrent access.

## Checklist
Please feel free to remove inapplicable items for your PR.
- [ ] The PR title starts with [$CATEGORY] (such as [Model], [Doc], [Feature]])
- [ ] Changes are complete (i.e. I finished coding on this PR)
- [ ] All changes have test coverage
- [ ] Code is well-documented
- [ ] To the my best knowledge, examples are either not affected by this change,
      or have been fixed to be compatible with this change
- [ ] Related issue is referred in this PR

## Changes
<!-- You could use following template
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)
-->
