### PR TITLE
Fixing typo in JTNN after interface change

### DIFF
--- a/examples/pytorch/jtnn/jtnn/jtnn_enc.py
+++ b/examples/pytorch/jtnn/jtnn/jtnn_enc.py
@@ -15,7 +15,7 @@ MAX_NB = 8
 def level_order(forest, roots):
     edges = bfs_edges_generator(forest, roots)
     _, leaves = forest.find_edges(edges[-1])
-    edges_back = bfs_edges_generator(forest, roots, reversed=True)
+    edges_back = bfs_edges_generator(forest, roots, reverse=True)
     yield from reversed(edges_back)
     yield from edges
 


### PR DESCRIPTION
## Description
The call in JTNN didn't get updated after changes in traversal interfaces