### PR TITLE
[Feature] add bipartite graph.

### DIFF
--- a/include/dgl/immutable_graph.h
+++ b/include/dgl/immutable_graph.h
@@ -920,6 +920,34 @@ CSR::CSR(int64_t num_vertices, int64_t num_edges,
   }
 }
 
+class ImmutableBiGraph: public ImmutableGraph {
+ public:
+  /*! \brief Construct an immutable graph from the COO format. */
+  explicit ImmutableBiGraph(COOPtr coo, size_t num_src, size_t num_dst): ImmutableGraph(coo) {
+    this->num_src = num_src;
+    this->num_dst = num_dst;
+  }
+  /*! \brief Construct an immutable graph from the CSR format. */
+  ImmutableBiGraph(CSRPtr in_csr, CSRPtr out_csr, size_t num_src, size_t num_dst)
+    : ImmutableGraph(in_csr, out_csr) {
+    CHECK(in_csr_ || out_csr_) << "Both CSR are missing.";
+    this->num_src = num_src;
+    this->num_dst = num_dst;
+  }
+
+  /*! \brief Construct an immutable graph from one CSR. */
+  ImmutableBiGraph(CSRPtr csr, size_t num_src, size_t num_dst): ImmutableGraph(csr) {
+    this->num_src = num_src;
+    this->num_dst = num_dst;
+  }
+
+  std::vector<IdArray> GetAdj(bool transpose, const std::string &fmt) const override;
+
+ private:
+  size_t num_src;
+  size_t num_dst;
+};
+
 }  // namespace dgl
 
 #endif  // DGL_IMMUTABLE_GRAPH_H_

--- a/python/dgl/__init__.py
+++ b/python/dgl/__init__.py
@@ -20,3 +20,4 @@ from .traversal import *
 from .transform import *
 from .propagate import *
 from .udf import NodeBatch, EdgeBatch
+from .bipartite import DGLBipartiteGraph

--- a/python/dgl/bipartite.py
+++ b/python/dgl/bipartite.py
@@ -1870,7 +1870,8 @@ class DGLBipartiteGraph(DGLHeteroGraph):
         parent_nids = {}
         parent_eids = {}
         for key in edges:
-            gidx[key] = self._get_graph(key).edge_subgraph(edges[key])
+            e = utils.toindex(edges[key])
+            gidx[key] = self._get_graph(key).edge_subgraph(e)
             src_type, dst_type, _ = key
             # TODO(zhengda) we need to make sure sampled nodes of
             # the same type are the same.

--- a/python/dgl/bipartite.py
+++ b/python/dgl/bipartite.py
@@ -1417,9 +1417,13 @@ class DGLBipartiteGraph(DGLHeteroGraph):
             reduce_func = self._reduce_funcs
         if apply_node_func == "default":
             apply_node_func = self._apply_node_funcs
+            if len(apply_node_func) == 0:
+                apply_node_func = None
+
         if not isinstance(message_func, dict):
             assert not isinstance(reduce_func, dict)
-            assert not isinstance(apply_node_func, dict)
+            if apply_node_func is not None:
+                assert not isinstance(apply_node_func, dict)
             etype = self._etypes[0]
             message_func = {etype: message_func}
             reduce_func = {etype[1]: reduce_func}

--- a/python/dgl/bipartite.py
+++ b/python/dgl/bipartite.py
@@ -616,12 +616,12 @@ class DGLBipartiteGraph(DGLHeteroGraph):
             # update row
             self._edge_frames[etype].update_rows(eid, data, inplace=inplace)
 
-    def get_e_repr(self, etype, edges=ALL):
+    def get_e_repr(self, etype=ALL, edges=ALL):
         """Get edge(s) representation.
 
         Parameters
         ----------
-        etype : tuple[str, str, str]
+        etype : tuple[str, str, str], optional
             The edge type, characterized by a triplet of source type name,
             destination type name, and edge type name.
         edges : edges
@@ -633,6 +633,9 @@ class DGLBipartiteGraph(DGLHeteroGraph):
         dict
             Representation dict
         """
+        if is_all(etype):
+            etype = self._etype
+
         if len(self.edge_attr_schemes(self._etype)) == 0:
             return dict()
         # parse argument
@@ -983,6 +986,24 @@ class DGLBipartiteGraph(DGLHeteroGraph):
         """
         raise Exception("bipartite graph doesn't support recv for now")
 
+    def _get_func(self, message_func, reduce_func, apply_node_func):
+        if message_func == "default":
+            if self._etype in self._message_funcs:
+                message_func = self._message_funcs[self._etype]
+            else:
+                message_func = None
+        if reduce_func == "default":
+            if self._ntypes[1] in self._reduce_funcs:
+                reduce_func = self._reduce_funcs[self._ntypes[1]]
+            else:
+                reduce_func = None
+        if apply_node_func == "default":
+            if self._ntypes[1] in self._apply_node_funcs:
+                apply_node_func = self._apply_node_funcs[self._ntypes[1]]
+            else:
+                apply_node_func = None
+        return message_func, reduce_func, apply_node_func
+
     def send_and_recv(self,
                       edges,
                       message_func="default",
@@ -1052,13 +1073,8 @@ class DGLBipartiteGraph(DGLHeteroGraph):
         * the edge type of ``edges``, ``message_func`` and ``reduce_func``
           must also be the same.
         """
-        if message_func == "default":
-            message_func = self._message_funcs[self._etype]
-        if reduce_func == "default":
-            reduce_func = self._reduce_funcs[self._ntypes[1]]
-        if apply_node_func == "default":
-            apply_node_func = self._apply_node_funcs[self._ntypes[1]]
-
+        message_func, reduce_func, apply_node_func = self._get_func(message_func, reduce_func,
+                                                                    apply_node_func)
         assert message_func is not None
         assert reduce_func is not None
 
@@ -1151,13 +1167,8 @@ class DGLBipartiteGraph(DGLHeteroGraph):
         * the edge type of ``message_func`` and ``reduce_func`` must also be
           the same.
         """
-        if message_func == "default":
-            message_func = self._message_funcs[self._etype]
-        if reduce_func == "default":
-            reduce_func = self._reduce_funcs[self._ntypes[1]]
-        if apply_node_func == "default":
-            apply_node_func = self._apply_node_funcs[self._ntypes[1]]
-
+        message_func, reduce_func, apply_node_func = self._get_func(message_func, reduce_func,
+                                                                    apply_node_func)
         assert message_func is not None
         assert reduce_func is not None
 
@@ -1290,12 +1301,8 @@ class DGLBipartiteGraph(DGLHeteroGraph):
         * the edge type of ``message_func`` and ``reduce_func`` must also be
           the same.
         """
-        if message_func == "default":
-            message_func = self._message_funcs[self._etype]
-        if reduce_func == "default":
-            reduce_func = self._reduce_funcs[self._ntypes[1]]
-        if apply_node_func == "default":
-            apply_node_func = self._apply_node_funcs[self._ntypes[1]]
+        message_func, reduce_func, apply_node_func = self._get_func(message_func, reduce_func,
+                                                                    apply_node_func)
         assert message_func is not None
         assert reduce_func is not None
 

--- a/python/dgl/bipartite.py
+++ b/python/dgl/bipartite.py
@@ -46,13 +46,6 @@ class DGLBipartiteGraph(DGLHeteroGraph):
         assert metagraph.number_of_edges() == 1
         self._metagraph = metagraph
 
-        self._ntypes = list(number_of_nodes_by_type.keys())
-        assert self._ntypes[0] in number_of_nodes_by_type.keys()
-        assert self._ntypes[1] in number_of_nodes_by_type.keys()
-        self._num_nodes_by_type = number_of_nodes_by_type
-        self._num_nodes = [number_of_nodes_by_type[self._ntypes[0]],
-                           number_of_nodes_by_type[self._ntypes[1]]]
-
         self._one_dir_graphs = {}
         self._graph = None
         self._etypes = list(edge_connections_by_type.keys())
@@ -69,6 +62,13 @@ class DGLBipartiteGraph(DGLHeteroGraph):
                 self._one_dir_graphs[etype] = None
         if len(self._etypes) == 1:
             self._graph = self._one_dir_graphs[self._etypes[0]]
+
+        self._ntypes = list(self._etypes[0])[0:2]
+        assert self._ntypes[0] in number_of_nodes_by_type.keys()
+        assert self._ntypes[1] in number_of_nodes_by_type.keys()
+        self._num_nodes_by_type = number_of_nodes_by_type
+        self._num_nodes = [number_of_nodes_by_type[self._ntypes[0]],
+                           number_of_nodes_by_type[self._ntypes[1]]]
 
         if node_frame is not None:
             assert self._ntypes[0] in node_frame

--- a/python/dgl/bipartite.py
+++ b/python/dgl/bipartite.py
@@ -1,3 +1,4 @@
+"""Bipartite graph class specialized for neural networks on graphs."""
 import numpy as np
 from scipy import sparse as spsp
 
@@ -1620,7 +1621,8 @@ class DGLBipartiteGraph(DGLHeteroGraph):
                 else:
                     raise Exception("The subgraph view doesn't exist")
             elif len(key) == 3:
-                if key[0] == self._ntypes[0] and key[1] == self._ntypes[1] and key[2] == self._etype:
+                if key[0] == self._ntypes[0] and key[1] == self._ntypes[1] \
+                   and key[2] == self._etype:
                     return self
                 else:
                     raise Exception("The subgraph view doesn't exist")

--- a/python/dgl/bipartite.py
+++ b/python/dgl/bipartite.py
@@ -1499,7 +1499,8 @@ class DGLBipartiteGraph(DGLHeteroGraph):
         SparseTensor
             The incidence matrix.
         """
-        pass
+        assert etype == self._etype
+        return self._graph.incidence_matrix(typestr, ctx)[0]
 
     def filter_nodes(self, ntype, predicate, nodes=ALL):
         """Return a tensor of node IDs with the given node type that satisfy

--- a/python/dgl/bipartite.py
+++ b/python/dgl/bipartite.py
@@ -1424,7 +1424,8 @@ class DGLBipartiteGraph(DGLHeteroGraph):
         scipy.sparse.spmatrix
             The scipy representation of adjacency matrix.
         """
-        pass
+        assert etype == self._etype
+        return self._graph.adjacency_matrix_scipy(transpose, fmt)
 
     def adjacency_matrix(self, etype, transpose=False, ctx=F.cpu()):
         """Return the adjacency matrix representation of edges with the
@@ -1451,7 +1452,8 @@ class DGLBipartiteGraph(DGLHeteroGraph):
         SparseTensor
             The adjacency matrix.
         """
-        pass
+        assert etype == self._etype
+        return self._graph.adjacency_matrix(transpose, ctx)[0]
 
     def incidence_matrix(self, etype, typestr, ctx=F.cpu()):
         """Return the incidence matrix representation of edges with the given

--- a/python/dgl/bipartite.py
+++ b/python/dgl/bipartite.py
@@ -1,5 +1,4 @@
 """Bipartite graph class specialized for neural networks on graphs."""
-import sys
 from .graph_index import create_bigraph_index
 from .heterograph import DGLHeteroGraph
 from .base import ALL, is_all

--- a/python/dgl/bipartite.py
+++ b/python/dgl/bipartite.py
@@ -1865,7 +1865,19 @@ class DGLBipartiteGraph(DGLHeteroGraph):
             node/edge ID via `parent_nid` and `parent_eid` properties of the
             subgraph.
         """
-        raise NotImplementedError('not supported')
+        from . import subgraph
+        gidx = {}
+        parent_nids = {}
+        parent_eids = {}
+        for key in edges:
+            gidx[key] = self._get_graph(key).edge_subgraph(edges[key])
+            src_type, dst_type, _ = key
+            # TODO(zhengda) we need to make sure sampled nodes of
+            # the same type are the same.
+            parent_nids[src_type] = gidx[key].induced_nodes[0]
+            parent_nids[dst_type] = gidx[key].induced_nodes[1]
+            parent_eids[key] = gidx[key].induced_edges
+        return subgraph.DGLBiSubGraph(self, parent_nids, parent_eids, gidx)
 
     def adjacency_matrix_scipy(self, etype, transpose=False, fmt='csr'):
         """Return the scipy adjacency matrix representation of edges with the

--- a/python/dgl/bipartite.py
+++ b/python/dgl/bipartite.py
@@ -102,8 +102,13 @@ class DGLBipartiteGraph(DGLHeteroGraph):
     def number_of_nodes(self):
         """Return the number of nodes in the graph.
 
-        Bipartite graph doesn't support number_of_nodes().
-        Please use g['ntype'].number_of_nodes() to get number of nodes.
+        Notes
+        -----
+        An error is raised if the graph contains multiple node types.  Use
+
+            g[ntype].number_of_nodes()
+
+        to get the number of nodes with type ``ntype``.
 
         Returns
         -------
@@ -159,6 +164,13 @@ class DGLBipartiteGraph(DGLHeteroGraph):
     def has_edge_between(self, u, v):
         """Return True if the edge (u, v) is in the graph.
 
+        Only works if the graph has one edge type.  For multiple types,
+        query with
+
+        .. code::
+
+           g['srctype', 'dsttype', 'edgetype'].has_edge_between(u, v)
+
         Parameters
         ----------
         u : int
@@ -178,6 +190,13 @@ class DGLBipartiteGraph(DGLHeteroGraph):
         destination node ID array `v`.
 
         `a[i]` is 1 if the graph contains edge `(u[i], v[i])`, 0 otherwise.
+
+        Only works if the graph has one edge type.  For multiple types,
+        query with
+
+        .. code::
+
+           g['srctype', 'dsttype', 'edgetype'].has_edges_between(u, v)
 
         Parameters
         ----------
@@ -419,6 +438,13 @@ class DGLBipartiteGraph(DGLHeteroGraph):
     def all_edges(self, form='uv', order=None):
         """Return all the edges.
 
+        Only works if the graph has one edge type.  For multiple types,
+        query with
+
+        .. code::
+
+           g['srctype', 'dsttype', 'edgetype'].edge_ids(u, v)
+
         Parameters
         ----------
         form : str, optional
@@ -460,6 +486,13 @@ class DGLBipartiteGraph(DGLHeteroGraph):
     def in_degree(self, v):
         """Return the in-degree of node ``v``.
 
+        Only works if the graph has one edge type.  For multiple types,
+        query with
+
+        .. code::
+
+           g['srctype', 'dsttype', 'edgetype'].edge_ids(u, v)
+
         Parameters
         ----------
         v : int
@@ -477,6 +510,13 @@ class DGLBipartiteGraph(DGLHeteroGraph):
         """Return the array `d` of in-degrees of the node array `v`.
 
         `d[i]` is the in-degree of node `v[i]`.
+
+        Only works if the graph has one edge type.  For multiple types,
+        query with
+
+        .. code::
+
+           g['srctype', 'dsttype', 'edgetype'].edge_ids(u, v)
 
         Parameters
         ----------
@@ -499,6 +539,13 @@ class DGLBipartiteGraph(DGLHeteroGraph):
     def out_degree(self, v):
         """Return the out-degree of node `v`.
 
+        Only works if the graph has one edge type.  For multiple types,
+        query with
+
+        .. code::
+
+           g['srctype', 'dsttype', 'edgetype'].edge_ids(u, v)
+
         Parameters
         ----------
         v : int
@@ -515,6 +562,13 @@ class DGLBipartiteGraph(DGLHeteroGraph):
         """Return the array `d` of out-degrees of the node array `v`.
 
         `d[i]` is the out-degree of node `v[i]`.
+
+        Only works if the graph has one edge type.  For multiple types,
+        query with
+
+        .. code::
+
+           g['srctype', 'dsttype', 'edgetype'].edge_ids(u, v)
 
         Parameters
         ----------
@@ -1258,7 +1312,7 @@ class DGLBipartiteGraph(DGLHeteroGraph):
 
         Parameters
         ----------
-        v : int, container or tensor, optional
+        v : int, container or tensor, dict, optional
             The node(s) to be updated. Default is receiving all the nodes.
 
             If ``apply_node_func`` is not a dict, then ``v`` must not be a

--- a/python/dgl/bipartite.py
+++ b/python/dgl/bipartite.py
@@ -1550,7 +1550,6 @@ class DGLBipartiteGraph(DGLHeteroGraph):
                                               inplace=inplace)
             Runtime.run(prog)
 
-    # pylint: disable=unnecessary-pass
     def push(self,
              u,
              message_func="default",
@@ -1614,7 +1613,22 @@ class DGLBipartiteGraph(DGLHeteroGraph):
         * the edge type of ``message_func`` and ``reduce_func`` must also be
           the same.
         """
-        pass
+        message_func, reduce_func, apply_node_func = self._get_func(message_func, reduce_func,
+                                                                    apply_node_func)
+        assert message_func is not None
+        assert reduce_func is not None
+
+        u = utils.toindex(u)
+        if len(u) == 0:
+            return
+        with ir.prog() as prog:
+            scheduler.schedule_bipartite_push(graph=self,
+                                              u=u,
+                                              message_func=message_func,
+                                              reduce_func=reduce_func,
+                                              apply_func=apply_node_func,
+                                              inplace=inplace)
+            Runtime.run(prog)
 
     def update_all(self,
                    message_func="default",

--- a/python/dgl/bipartite.py
+++ b/python/dgl/bipartite.py
@@ -1550,6 +1550,7 @@ class DGLBipartiteGraph(DGLHeteroGraph):
                                               inplace=inplace)
             Runtime.run(prog)
 
+    # pylint: disable=unnecessary-pass
     def push(self,
              u,
              message_func="default",
@@ -1699,6 +1700,7 @@ class DGLBipartiteGraph(DGLHeteroGraph):
         """
         raise NotImplementedError('not supported')
 
+    # pylint: disable=unnecessary-pass
     def subgraph(self, nodes):
         """Return the subgraph induced on given nodes.
 
@@ -1723,6 +1725,7 @@ class DGLBipartiteGraph(DGLHeteroGraph):
         """
         pass
 
+    # pylint: disable=unnecessary-pass
     def subgraphs(self, nodes):
         """Return a list of subgraphs, each induced in the corresponding given
         nodes in the list.
@@ -1745,6 +1748,7 @@ class DGLBipartiteGraph(DGLHeteroGraph):
         """
         pass
 
+    # pylint: disable=unnecessary-pass
     def edge_subgraph(self, edges):
         """Return the subgraph induced on given edges.
 
@@ -1875,6 +1879,7 @@ class DGLBipartiteGraph(DGLHeteroGraph):
         assert etype == self._etype
         return self._graph.incidence_matrix(typestr, ctx)[0]
 
+    # pylint: disable=unnecessary-pass
     def filter_nodes(self, ntype, predicate, nodes=ALL):
         """Return a tensor of node IDs with the given node type that satisfy
         the given predicate.
@@ -1899,6 +1904,7 @@ class DGLBipartiteGraph(DGLHeteroGraph):
         """
         pass
 
+    # pylint: disable=unnecessary-pass
     def filter_edges(self, etype, predicate, edges=ALL):
         """Return a tensor of edge IDs with the given edge type that satisfy
         the given predicate.
@@ -1925,6 +1931,7 @@ class DGLBipartiteGraph(DGLHeteroGraph):
         """
         pass
 
+    # pylint: disable=unnecessary-pass
     def readonly(self, readonly_state=True):
         """Set this graph's readonly state in-place.
 
@@ -1935,6 +1942,7 @@ class DGLBipartiteGraph(DGLHeteroGraph):
         """
         pass
 
+    # pylint: disable=unnecessary-pass
     def __repr__(self):
         pass
 

--- a/python/dgl/bipartite.py
+++ b/python/dgl/bipartite.py
@@ -102,13 +102,8 @@ class DGLBipartiteGraph(DGLHeteroGraph):
     def number_of_nodes(self):
         """Return the number of nodes in the graph.
 
-        Notes
-        -----
-        An error is raised if the graph contains multiple node types.  Use
-
-            g[ntype].number_of_nodes()
-
-        to get the number of nodes with type ``ntype``.
+        Bipartite graph doesn't support number_of_nodes().
+        Please use g['ntype'].number_of_nodes() to get number of nodes.
 
         Returns
         -------
@@ -164,13 +159,6 @@ class DGLBipartiteGraph(DGLHeteroGraph):
     def has_edge_between(self, u, v):
         """Return True if the edge (u, v) is in the graph.
 
-        Only works if the graph has one edge type.  For multiple types,
-        query with
-
-        .. code::
-
-           g['srctype', 'dsttype', 'edgetype'].has_edge_between(u, v)
-
         Parameters
         ----------
         u : int
@@ -190,13 +178,6 @@ class DGLBipartiteGraph(DGLHeteroGraph):
         destination node ID array `v`.
 
         `a[i]` is 1 if the graph contains edge `(u[i], v[i])`, 0 otherwise.
-
-        Only works if the graph has one edge type.  For multiple types,
-        query with
-
-        .. code::
-
-           g['srctype', 'dsttype', 'edgetype'].has_edges_between(u, v)
 
         Parameters
         ----------
@@ -438,13 +419,6 @@ class DGLBipartiteGraph(DGLHeteroGraph):
     def all_edges(self, form='uv', order=None):
         """Return all the edges.
 
-        Only works if the graph has one edge type.  For multiple types,
-        query with
-
-        .. code::
-
-           g['srctype', 'dsttype', 'edgetype'].edge_ids(u, v)
-
         Parameters
         ----------
         form : str, optional
@@ -486,13 +460,6 @@ class DGLBipartiteGraph(DGLHeteroGraph):
     def in_degree(self, v):
         """Return the in-degree of node ``v``.
 
-        Only works if the graph has one edge type.  For multiple types,
-        query with
-
-        .. code::
-
-           g['srctype', 'dsttype', 'edgetype'].edge_ids(u, v)
-
         Parameters
         ----------
         v : int
@@ -510,13 +477,6 @@ class DGLBipartiteGraph(DGLHeteroGraph):
         """Return the array `d` of in-degrees of the node array `v`.
 
         `d[i]` is the in-degree of node `v[i]`.
-
-        Only works if the graph has one edge type.  For multiple types,
-        query with
-
-        .. code::
-
-           g['srctype', 'dsttype', 'edgetype'].edge_ids(u, v)
 
         Parameters
         ----------
@@ -539,13 +499,6 @@ class DGLBipartiteGraph(DGLHeteroGraph):
     def out_degree(self, v):
         """Return the out-degree of node `v`.
 
-        Only works if the graph has one edge type.  For multiple types,
-        query with
-
-        .. code::
-
-           g['srctype', 'dsttype', 'edgetype'].edge_ids(u, v)
-
         Parameters
         ----------
         v : int
@@ -562,13 +515,6 @@ class DGLBipartiteGraph(DGLHeteroGraph):
         """Return the array `d` of out-degrees of the node array `v`.
 
         `d[i]` is the out-degree of node `v[i]`.
-
-        Only works if the graph has one edge type.  For multiple types,
-        query with
-
-        .. code::
-
-           g['srctype', 'dsttype', 'edgetype'].edge_ids(u, v)
 
         Parameters
         ----------
@@ -1312,7 +1258,7 @@ class DGLBipartiteGraph(DGLHeteroGraph):
 
         Parameters
         ----------
-        v : int, container or tensor, dict, optional
+        v : int, container or tensor, optional
             The node(s) to be updated. Default is receiving all the nodes.
 
             If ``apply_node_func`` is not a dict, then ``v`` must not be a

--- a/python/dgl/bipartite.py
+++ b/python/dgl/bipartite.py
@@ -1,4 +1,5 @@
 """Bipartite graph class specialized for neural networks on graphs."""
+import sys
 from .graph_index import create_bigraph_index
 from .heterograph import DGLHeteroGraph
 from .base import ALL, is_all
@@ -56,6 +57,8 @@ class DGLBipartiteGraph(DGLHeteroGraph):
         # TODO(zhengda) this is a hack way of constructing a bipartite graph.
         if len(edge_connections_by_type) > 1:
             raise Exception("Bipartite graph only support one type of edges")
+        print(self._etype, file=sys.stderr)
+        print(edge_connections_by_type.keys(), file=sys.stderr)
         assert self._etype in edge_connections_by_type.keys()
         edges = edge_connections_by_type[self._etype]
 

--- a/python/dgl/bipartite.py
+++ b/python/dgl/bipartite.py
@@ -46,7 +46,7 @@ class DGLBipartiteGraph(DGLHeteroGraph):
             raise Exception("Bipartite graph should have only two node types")
         assert metagraph.number_of_edges() == 1
         self._metagraph = metagraph
-        self._etype = list(metagraph.edges)[0]
+        self._etype = list(edge_connections_by_type.keys())[0]
         self._ntypes = [self._etype[0], self._etype[1]]
         assert self._ntypes[0] in number_of_nodes_by_type.keys()
         assert self._ntypes[1] in number_of_nodes_by_type.keys()
@@ -57,9 +57,6 @@ class DGLBipartiteGraph(DGLHeteroGraph):
         # TODO(zhengda) this is a hack way of constructing a bipartite graph.
         if len(edge_connections_by_type) > 1:
             raise Exception("Bipartite graph only support one type of edges")
-        print(self._etype, file=sys.stderr)
-        print(edge_connections_by_type.keys(), file=sys.stderr)
-        assert self._etype in edge_connections_by_type.keys()
         edges = edge_connections_by_type[self._etype]
 
         self._graph = create_bigraph_index(edges, self._num_nodes, False, readonly)

--- a/python/dgl/bipartite.py
+++ b/python/dgl/bipartite.py
@@ -980,7 +980,7 @@ class DGLBipartiteGraph(DGLHeteroGraph):
             # update row
             self._edge_frames[etype].update_rows(eid, data, inplace=inplace)
 
-    def get_e_repr(self, etype, edges=ALL):
+    def get_e_repr(self, etype=None, edges=ALL):
         """Get edge(s) representation.
 
         Parameters
@@ -997,6 +997,8 @@ class DGLBipartiteGraph(DGLHeteroGraph):
         dict
             Representation dict
         """
+        if etype is None:
+            etype = self._etypes[0]
         if len(self.edge_attr_schemes(etype)) == 0:
             return dict()
         # parse argument

--- a/python/dgl/bipartite.py
+++ b/python/dgl/bipartite.py
@@ -7,6 +7,7 @@ from .frame import FrameRef, Frame
 from .view import HeteroEdgeView, HeteroNodeView
 from . import utils
 from .runtime import ir, scheduler, Runtime
+from .udf import NodeBatch, EdgeBatch
 
 __all__ = ['DGLBipartiteGraph']
 

--- a/python/dgl/graph_index.py
+++ b/python/dgl/graph_index.py
@@ -1358,40 +1358,12 @@ def from_bigraph_coo(num_nodes, src, dst, is_multigraph, readonly):
     handle = _CAPI_DGLBiGraphCreate(
         src.todgltensor(),
         dst.todgltensor(),
-        int(multigraph),
+        int(is_multigraph),
         int(num_nodes[0]),
         int(num_nodes[1]),
-        _readonly)
+        readonly)
     return BiGraphIndex(handle, num_nodes)
 
-
-def from_bigraph_csr(indptr, indices, num_nodes, edge_dir, shared_mem_name=""):
-    """Load a bipartite graph from the CSR matrix.
-
-    Parameters
-    ----------
-    indptr : a 1D tensor
-        index pointer in the CSR format
-    indices : a 1D tensor
-        column index array in the CSR format
-    edge_dir : string
-        the edge direction. The supported option is "in" and "out".
-    shared_mem_name : string
-        the name of shared memory
-    """
-    indptr = utils.toindex(indptr)
-    assert len(indptr) == num_nodes[0] + num_nodes[1] + 1
-    indices = utils.toindex(indices)
-    edge_ids = utils.toindex(F.arange(0, len(indices)))
-    handle = _CAPI_DGLBiGraphCSRCreate(
-        indptr.todgltensor(),
-        indices.todgltensor(),
-        edge_ids.todgltensor(),
-        num_nodes[0],
-        num_nodes[1],
-        shared_mem_name,
-        multigraph,
-        edge_dir)
 
 def create_bigraph_index(graph_data=None, num_nodes=(0, 0), multigraph=False, readonly=False):
     """Create a graph index object.

--- a/python/dgl/graph_index.py
+++ b/python/dgl/graph_index.py
@@ -1294,6 +1294,67 @@ class BiGraphIndex(GraphIndex):
         else:
             raise Exception("unknown format")
 
+    @utils.cached_member(cache='_cache', prefix='inc')
+    def incidence_matrix(self, typestr, ctx):
+        """Return the incidence matrix representation of this graph.
+
+        An incidence matrix is an n x m sparse matrix, where n is
+        the number of nodes and m is the number of edges. Each nnz
+        value indicating whether the edge is incident to the node
+        or not.
+
+        There are three types of an incidence matrix `I`:
+        * "in":
+          - I[v, e] = 1 if e is the in-edge of v (or v is the dst node of e);
+          - I[v, e] = 0 otherwise.
+        * "out":
+          - I[v, e] = 1 if e is the out-edge of v (or v is the src node of e);
+          - I[v, e] = 0 otherwise.
+
+        Parameters
+        ----------
+        typestr : str
+            Can be either "in" or "out"
+        ctx : context
+            The context of returned incidence matrix.
+
+        Returns
+        -------
+        SparseTensor
+            The incidence matrix.
+        utils.Index
+            A index for data shuffling due to sparse format change. Return None
+            if shuffle is not required.
+        """
+        src, dst, eid = self.edges()
+        src = src.tousertensor(ctx)  # the index of the ctx will be cached
+        dst = dst.tousertensor(ctx)  # the index of the ctx will be cached
+        eid = eid.tousertensor(ctx)  # the index of the ctx will be cached
+        m = self.number_of_edges()
+        if typestr == 'in':
+            n = self._num_nodes[1]
+            dst = dst - self._num_nodes[0]
+            print(dst)
+            print(eid)
+            row = F.unsqueeze(dst, 0)
+            col = F.unsqueeze(eid, 0)
+            idx = F.cat([row, col], dim=0)
+            # FIXME(minjie): data type
+            dat = F.ones((m,), dtype=F.float32, ctx=ctx)
+            inc, shuffle_idx = F.sparse_matrix(dat, ('coo', idx), (n, m))
+        elif typestr == 'out':
+            n = self._num_nodes[0]
+            row = F.unsqueeze(src, 0)
+            col = F.unsqueeze(eid, 0)
+            idx = F.cat([row, col], dim=0)
+            # FIXME(minjie): data type
+            dat = F.ones((m,), dtype=F.float32, ctx=ctx)
+            inc, shuffle_idx = F.sparse_matrix(dat, ('coo', idx), (n, m))
+        else:
+            raise DGLError('Invalid incidence matrix type: %s' % str(typestr))
+        shuffle_idx = utils.toindex(shuffle_idx) if shuffle_idx is not None else None
+        return inc, shuffle_idx
+
 
 def create_bigraph_index(graph_data=None, num_nodes=(0, 0), multigraph=False, readonly=False):
     """Create a graph index object.

--- a/python/dgl/graph_index.py
+++ b/python/dgl/graph_index.py
@@ -1166,6 +1166,18 @@ class BiGraphIndex(GraphIndex):
         self._num_nodes = num_nodes
 
     def number_of_nodes(self, idx):
+        """Return the number of nodes.
+
+        Parameters
+        ----------
+        idx : int
+            The index of node types.
+
+        Returns
+        -------
+        int
+            The number of nodes
+        """
         return self._num_nodes[idx]
 
     def _conv_right1(self, v):
@@ -1180,53 +1192,233 @@ class BiGraphIndex(GraphIndex):
         return utils.toindex(v)
 
     def has_edge_between(self, u, v):
+        """Return true if the edge exists.
+
+        Parameters
+        ----------
+        u : int
+            The src node.
+        v : int
+            The dst node.
+
+        Returns
+        -------
+        bool
+            True if the edge exists, False otherwise
+        """
         v = self._conv_right1(v)
         return super(BiGraphIndex, self).has_edge_between(u, v)
 
     def has_edges_between(self, u, v):
+        """Return true if the edge exists.
+
+        Parameters
+        ----------
+        u : utils.Index
+            The src nodes.
+        v : utils.Index
+            The dst nodes.
+
+        Returns
+        -------
+        utils.Index
+            0-1 array indicating existence
+        """
         v = self._conv_right(v)
         return super(BiGraphIndex, self).has_edges_between(u, v)
 
     def predecessors(self, v):
+        """Return the predecessors of the node.
+
+        Parameters
+        ----------
+        v : int
+            The node.
+        radius : int, optional
+            The radius of the neighborhood.
+
+        Returns
+        -------
+        utils.Index
+            Array of predecessors
+        """
         v = self._conv_right1(v)
         return super(BiGraphIndex, self).predecessors(v)
 
     def successors(self, v):
+        """Return the successors of the node.
+
+        Parameters
+        ----------
+        v : int
+            The node.
+        radius : int, optional
+            The radius of the neighborhood.
+
+        Returns
+        -------
+        utils.Index
+            Array of successors
+        """
         return self._conv_right_back(super(BiGraphIndex, self).successors(v))
 
     def edge_id(self, u, v):
+        """Return the id array of all edges between u and v.
+
+        Parameters
+        ----------
+        u : int
+            The src node.
+        v : int
+            The dst node.
+
+        Returns
+        -------
+        utils.Index
+            The edge id array.
+        """
         return super(BiGraphIndex, self).edge_id(u, self._conv_right1(v))
 
     def edge_ids(self, u, v):
+        """Return a triplet of arrays that contains the edge IDs.
+
+        Parameters
+        ----------
+        u : utils.Index
+            The src nodes.
+        v : utils.Index
+            The dst nodes.
+
+        Returns
+        -------
+        utils.Index
+            The src nodes.
+        utils.Index
+            The dst nodes.
+        utils.Index
+            The edge ids.
+        """
         src, dst, eid = super(BiGraphIndex, self).edge_ids(u, self._conv_right(v))
         dst = self._conv_right_back(dst)
         return src, dst, eid
 
     def find_edges(self, eid):
+        """Return a triplet of arrays that contains the edge IDs.
+
+        Parameters
+        ----------
+        eid : utils.Index
+            The edge ids.
+
+        Returns
+        -------
+        utils.Index
+            The src nodes.
+        utils.Index
+            The dst nodes.
+        utils.Index
+            The edge ids.
+        """
         src, dst, eid = super(BiGraphIndex, self).find_edges(eid)
         dst = self._conv_right_back(dst)
         return src, dst, eid
 
     def in_edges(self, v):
+        """Return the in edges of the node(s).
+
+        Parameters
+        ----------
+        v : utils.Index
+            The node(s).
+
+        Returns
+        -------
+        utils.Index
+            The src nodes.
+        utils.Index
+            The dst nodes.
+        utils.Index
+            The edge ids.
+        """
         src, dst, eid = super(BiGraphIndex, self).in_edges(self._conv_right(v))
         dst = self._conv_right_back(dst)
         return src, dst, eid
 
     def out_edges(self, v):
+        """Return the out edges of the node(s).
+
+        Parameters
+        ----------
+        v : utils.Index
+            The node(s).
+
+        Returns
+        -------
+        utils.Index
+            The src nodes.
+        utils.Index
+            The dst nodes.
+        utils.Index
+            The edge ids.
+        """
         src, dst, eid = super(BiGraphIndex, self).out_edges(v)
         dst = self._conv_right_back(dst)
         return src, dst, eid
 
     def edges(self, order=None):
+        """Return all the edges
+
+        Parameters
+        ----------
+        order : string
+            The order of the returned edges. Currently support:
+
+            - 'srcdst' : sorted by their src and dst ids.
+            - 'eid'    : sorted by edge Ids.
+            - None     : the arbitrary order.
+
+        Returns
+        -------
+        utils.Index
+            The src nodes.
+        utils.Index
+            The dst nodes.
+        utils.Index
+            The edge ids.
+        """
         src, dst, eid = super(BiGraphIndex, self).edges(order)
         dst = self._conv_right_back(dst)
         return src, dst, eid
 
     def in_degree(self, v):
+        """Return the in degree of the node.
+
+        Parameters
+        ----------
+        v : int
+            The node.
+
+        Returns
+        -------
+        int
+            The in degree.
+        """
         v = self._conv_right1(v)
         return super(BiGraphIndex, self).in_degree(v)
 
     def in_degrees(self, v):
+        """Return the in degrees of the nodes.
+
+        Parameters
+        ----------
+        v : utils.Index
+            The nodes.
+
+        Returns
+        -------
+        int
+            The in degree array.
+        """
         v = self._conv_right(v)
         return super(BiGraphIndex, self).in_degrees(v)
 

--- a/python/dgl/graph_index.py
+++ b/python/dgl/graph_index.py
@@ -1147,4 +1147,21 @@ def create_graph_index(graph_data, multigraph, readonly):
                            % type(graph_data))
         return gidx
 
+def create_bigraph_index(graph_data=None, num_nodes=[0, 0], multigraph=False, readonly=False):
+    if isinstance(graph_data, list) or isinstance(graph_data, tuple):
+        assert len(graph_data) == 2
+        src_nodes, dst_nodes = graph_data
+        num_edges = len(src_nodes)
+        dst_nodes = dst_nodes + num_nodes[0]
+        # TODO(zhengda) let's use scipy coo first.
+        data = np.zeros((num_edges,))
+        spm = scipy.sparse.coo_matrix((data, (src_nodes, dst_nodes)))
+        return create_graph_index(spm, False, readonly)
+    elif isinstance(graph_data, scipy.sparse.spmatrix):
+        coo = graph_data.tocoo()
+        return create_bigraph_index([coo.row, coo.col], num_nodes, multigraph, readonly)
+    else:
+        raise Exception("cannot create a bipartite graph from an unknown format")
+
+
 _init_api("dgl.graph_index")

--- a/python/dgl/graph_index.py
+++ b/python/dgl/graph_index.py
@@ -27,6 +27,10 @@ class GraphIndex(object):
     ----------
     handle : GraphIndexHandle
         Handler
+    multigraph : bool, optional
+        whether the graph is a multigraph
+    readonly : bool, optional
+        whether the graph is readonly.
     """
     def __init__(self, handle):
         self._handle = handle
@@ -1148,7 +1152,20 @@ def create_graph_index(graph_data, multigraph, readonly):
         return gidx
 
 class BiGraphIndex(GraphIndex):
-    def __init__(self, handle=None, num_nodes=[0, 0], multigraph=None, readonly=None):
+    """Bipartite graph index object.
+
+    Parameters
+    ----------
+    handle : GraphIndexHandle
+        Handler
+    num_nodes : tuple
+        The number of nodes of each type.
+    multigraph : bool, optional
+        whether the graph is a multigraph
+    readonly : bool, optional
+        whether the graph is readonly.
+    """
+    def __init__(self, handle=None, num_nodes=(0, 0), multigraph=None, readonly=None):
         super(BiGraphIndex, self).__init__(handle, multigraph, readonly)
         self._num_nodes = num_nodes
 
@@ -1168,7 +1185,7 @@ class BiGraphIndex(GraphIndex):
         """
         assert self.is_readonly()
         indptr = utils.toindex(indptr)
-        assert(len(indptr) == self._num_nodes[0] + self._num_nodes[1] + 1)
+        assert len(indptr) == self._num_nodes[0] + self._num_nodes[1] + 1
         indices = utils.toindex(indices)
         edge_ids = utils.toindex(F.arange(0, len(indices)))
         self._handle = _CAPI_DGLBiGraphCSRCreate(
@@ -1229,7 +1246,7 @@ class BiGraphIndex(GraphIndex):
             indptr = utils.toindex(rst(0)).tonumpy()
             indices = utils.toindex(rst(1)).tonumpy()
             shuffle = utils.toindex(rst(2)).tonumpy()
-            assert len(indptr) ==  nrows + 1
+            assert len(indptr) == nrows + 1
             return scipy.sparse.csr_matrix((shuffle, indices, indptr), shape=(nrows, ncols))
         elif fmt == 'coo':
             idx = utils.toindex(rst(0)).tonumpy()
@@ -1371,7 +1388,6 @@ def create_bigraph_index(graph_data=None, num_nodes=(0, 0), multigraph=False, re
     if isinstance(graph_data, list) or isinstance(graph_data, tuple):
         assert len(graph_data) == 2
         src_nodes, dst_nodes = graph_data
-        num_edges = len(src_nodes)
         dst_nodes = dst_nodes + num_nodes[0]
         src_nodes = utils.toindex(src_nodes)
         dst_nodes = utils.toindex(dst_nodes)

--- a/python/dgl/graph_index.py
+++ b/python/dgl/graph_index.py
@@ -1385,7 +1385,7 @@ def create_bigraph_index(graph_data=None, num_nodes=(0, 0), multigraph=False, re
     multigraph : bool, optional
         Whether the graph is multigraph (default is False)
     """
-    if isinstance(graph_data, list) or isinstance(graph_data, tuple):
+    if isinstance(graph_data, (list, tuple)):
         assert len(graph_data) == 2
         src_nodes, dst_nodes = graph_data
         dst_nodes = dst_nodes + num_nodes[0]

--- a/python/dgl/heterograph.py
+++ b/python/dgl/heterograph.py
@@ -807,7 +807,7 @@ class DGLBaseHeteroGraph(object):
 
         .. code::
 
-           g['srctype', 'dsttype', 'edgetype'].edge_ids(u, v)
+           g['srctype', 'dsttype', 'edgetype'].in_degree(v)
 
         Parameters
         ----------
@@ -841,7 +841,7 @@ class DGLBaseHeteroGraph(object):
 
         .. code::
 
-           g['srctype', 'dsttype', 'edgetype'].edge_ids(u, v)
+           g['srctype', 'dsttype', 'edgetype'].in_degrees(v)
 
         Parameters
         ----------
@@ -876,7 +876,7 @@ class DGLBaseHeteroGraph(object):
 
         .. code::
 
-           g['srctype', 'dsttype', 'edgetype'].edge_ids(u, v)
+           g['srctype', 'dsttype', 'edgetype'].out_degree(v)
 
         Parameters
         ----------
@@ -910,7 +910,7 @@ class DGLBaseHeteroGraph(object):
 
         .. code::
 
-           g['srctype', 'dsttype', 'edgetype'].edge_ids(u, v)
+           g['srctype', 'dsttype', 'edgetype'].out_degrees(v)
 
         Parameters
         ----------

--- a/python/dgl/heterograph.py
+++ b/python/dgl/heterograph.py
@@ -162,6 +162,14 @@ class DGLBaseHeteroGraph(object):
     def number_of_nodes(self):
         """Return the number of nodes in the graph.
 
+        Notes
+        -----
+        An error is raised if the graph contains multiple node types.  Use
+
+            g[ntype].number_of_nodes()
+
+        to get the number of nodes with type ``ntype``.
+
         Returns
         -------
         int
@@ -934,11 +942,7 @@ class DGLBaseHeteroGraphView(DGLBaseHeteroGraph):
     """View on a heterogeneous graph, constructed from
     DGLBaseHeteroGraph.__getitem__().
 
-    It is semantically the same as a subgraph, except that
-
-    * The subgraph itself is not materialized until the user explicitly
-    queries the subgraph structure (e.g. calling ``in_edges``, but not
-    ``update_all``).
+    It is semantically the same as a subgraph.
     """
     pass
 

--- a/python/dgl/heterograph.py
+++ b/python/dgl/heterograph.py
@@ -807,7 +807,7 @@ class DGLBaseHeteroGraph(object):
 
         .. code::
 
-           g['srctype', 'dsttype', 'edgetype'].in_degree(v)
+           g['srctype', 'dsttype', 'edgetype'].edge_ids(u, v)
 
         Parameters
         ----------
@@ -841,7 +841,7 @@ class DGLBaseHeteroGraph(object):
 
         .. code::
 
-           g['srctype', 'dsttype', 'edgetype'].in_degrees(v)
+           g['srctype', 'dsttype', 'edgetype'].edge_ids(u, v)
 
         Parameters
         ----------
@@ -876,7 +876,7 @@ class DGLBaseHeteroGraph(object):
 
         .. code::
 
-           g['srctype', 'dsttype', 'edgetype'].out_degree(v)
+           g['srctype', 'dsttype', 'edgetype'].edge_ids(u, v)
 
         Parameters
         ----------
@@ -910,7 +910,7 @@ class DGLBaseHeteroGraph(object):
 
         .. code::
 
-           g['srctype', 'dsttype', 'edgetype'].out_degrees(v)
+           g['srctype', 'dsttype', 'edgetype'].edge_ids(u, v)
 
         Parameters
         ----------

--- a/python/dgl/heterograph.py
+++ b/python/dgl/heterograph.py
@@ -115,6 +115,7 @@ class DGLBaseHeteroGraph(object):
             edge_connections_by_type):
         super(DGLBaseHeteroGraph, self).__init__()
 
+    # pylint: disable=unnecessary-pass
     def __getitem__(self, key):
         """Returns a view on the heterogeneous graph with given node/edge
         type:

--- a/python/dgl/heterograph.py
+++ b/python/dgl/heterograph.py
@@ -2,6 +2,7 @@
 from .base import ALL
 from . import backend as F
 
+# pylint: disable=unnecessary-pass
 class DGLBaseHeteroGraph(object):
     """Base Heterogeneous graph class.
 
@@ -115,7 +116,6 @@ class DGLBaseHeteroGraph(object):
             edge_connections_by_type):
         super(DGLBaseHeteroGraph, self).__init__()
 
-    # pylint: disable=unnecessary-pass
     def __getitem__(self, key):
         """Returns a view on the heterogeneous graph with given node/edge
         type:
@@ -939,6 +939,7 @@ class DGLBaseHeteroGraph(object):
         pass
 
 
+# pylint: disable=unnecessary-pass
 class DGLBaseHeteroGraphView(DGLBaseHeteroGraph):
     """View on a heterogeneous graph, constructed from
     DGLBaseHeteroGraph.__getitem__().
@@ -948,6 +949,7 @@ class DGLBaseHeteroGraphView(DGLBaseHeteroGraph):
     pass
 
 
+# pylint: disable=unnecessary-pass
 class DGLHeteroGraph(DGLBaseHeteroGraph):
     """Base heterogeneous graph class.
 

--- a/python/dgl/runtime/scheduler.py
+++ b/python/dgl/runtime/scheduler.py
@@ -241,8 +241,8 @@ def schedule_update_all(graph,
         def uv_getter():
             src, dst, _ = graph._graph.edges('eid')
             return var.IDX(src), var.IDX(dst)
-        adj_creator = lambda: spmv.build_bipartite_adj_matrix_graph(graph)
-        inc_creator = lambda: spmv.build_bipartite_inc_matrix_graph(graph)
+        adj_creator = lambda: spmv.build_adj_matrix_graph(graph)
+        inc_creator = lambda: spmv.build_inc_matrix_graph(graph)
         reduced_feat = _gen_send_reduce(graph, graph._node_frame, graph._node_frame,
                                         graph._edge_frame, message_func, reduce_func,
                                         var_eid, var_recv_nodes,
@@ -285,7 +285,9 @@ def schedule_bipartite_update_all(graph,
         def uv_getter():
             src, dst = graph.all_edges(order='eid')
             return var.IDX(utils.toindex(src)), var.IDX(utils.toindex(dst))
+        # The adjacency matrix creator for a bipartite graph is the same as a regular graph.
         adj_creator = lambda: spmv.build_adj_matrix_graph(graph)
+        # The incidence matrix creator for a bipartite graph is the same as a regular graph.
         inc_creator = lambda: spmv.build_inc_matrix_graph(graph)
         reduced_feat = _gen_send_reduce(graph, graph._get_node_frame(0), graph._get_node_frame(1),
                                         graph._get_edge_frame(0), message_func, reduce_func,
@@ -639,7 +641,7 @@ def schedule_bipartite_pull(graph,
         var_eid = var.IDX(eid)
         # generate send and reduce schedule
         uv_getter = lambda: (var_u, var_v)
-        adj_creator = lambda: spmv.build_adj_matrix_uv((u, v), pull_nodes, graph.number_of_nodes())
+        adj_creator = lambda: spmv.build_adj_matrix_uv((u, v), pull_nodes, graph._number_of_nodes(0))
         inc_creator = lambda: spmv.build_inc_matrix_dst(v, pull_nodes)
         reduced_feat = _gen_send_reduce(graph, graph._get_node_frame(0), graph._get_node_frame(1),
                                         graph._get_edge_frame(0), message_func, reduce_func,

--- a/python/dgl/runtime/scheduler.py
+++ b/python/dgl/runtime/scheduler.py
@@ -564,7 +564,10 @@ def schedule_bipartite_push(graph,
     inplace: bool
         If True, the update will be done in place
     """
-    u, v, eid = graph._graph.out_edges(u)
+    u, v, eid = graph.out_edges(u)
+    u = utils.toindex(u)
+    v = utils.toindex(v)
+    eid = utils.toindex(eid)
     if len(eid) == 0:
         # All the pushing nodes have no out edges. No computation is scheduled.
         return

--- a/python/dgl/runtime/scheduler.py
+++ b/python/dgl/runtime/scheduler.py
@@ -564,7 +564,7 @@ def schedule_bipartite_push(graph,
     inplace: bool
         If True, the update will be done in place
     """
-    u, v, eid = graph.out_edges(u)
+    u, v, eid = graph.out_edges(u, 'all')
     u = utils.toindex(u)
     v = utils.toindex(v)
     eid = utils.toindex(eid)

--- a/python/dgl/runtime/scheduler.py
+++ b/python/dgl/runtime/scheduler.py
@@ -541,6 +541,36 @@ def schedule_push(graph,
     schedule_snr(graph, (u, v, eid),
                  message_func, reduce_func, apply_func, inplace)
 
+def schedule_bipartite_push(graph,
+                            u,
+                            message_func,
+                            reduce_func,
+                            apply_func,
+                            inplace):
+    """get push schedule on a bipartite graph
+
+    Parameters
+    ----------
+    graph: DGLBipartiteGraph
+        The DGLBipartiteGraph to use
+    u : utils.Index
+        Source nodes for push
+    message_func: callable or list of callable
+        The message function
+    reduce_func: callable or list of callable
+        The reduce function
+    apply_func: callable
+        The apply node function
+    inplace: bool
+        If True, the update will be done in place
+    """
+    u, v, eid = graph._graph.out_edges(u)
+    if len(eid) == 0:
+        # All the pushing nodes have no out edges. No computation is scheduled.
+        return
+    schedule_bipartite_snr(graph, (u, v, eid),
+                           message_func, reduce_func, apply_func, inplace)
+
 def schedule_pull(graph,
                   pull_nodes,
                   message_func,

--- a/python/dgl/runtime/scheduler.py
+++ b/python/dgl/runtime/scheduler.py
@@ -640,8 +640,9 @@ def schedule_bipartite_pull(graph,
         var_v = var.IDX(v)
         var_eid = var.IDX(eid)
         # generate send and reduce schedule
+        num_src = graph._number_of_nodes(0)
         uv_getter = lambda: (var_u, var_v)
-        adj_creator = lambda: spmv.build_adj_matrix_uv((u, v), pull_nodes, graph._number_of_nodes(0))
+        adj_creator = lambda: spmv.build_adj_matrix_uv((u, v), pull_nodes, num_src)
         inc_creator = lambda: spmv.build_inc_matrix_dst(v, pull_nodes)
         reduced_feat = _gen_send_reduce(graph, graph._get_node_frame(0), graph._get_node_frame(1),
                                         graph._get_edge_frame(0), message_func, reduce_func,

--- a/python/dgl/runtime/scheduler.py
+++ b/python/dgl/runtime/scheduler.py
@@ -165,12 +165,12 @@ def schedule_bipartite_snr(graph,
                            reduce_func,
                            apply_func,
                            inplace):
-    """Schedule send_and_recv.
+    """Schedule send_and_recv on a bipartite graph.
 
     Parameters
     ----------
-    graph: DGLGraph
-        The DGLGraph to use
+    graph: DGLBipartiteGraph
+        The DGLBipartiteGraph to use
     edge_tuple: tuple
         A tuple of (src ids, dst ids, edge ids) representing edges to perform
         send_and_recv
@@ -255,12 +255,12 @@ def schedule_bipartite_update_all(graph,
                                   message_func,
                                   reduce_func,
                                   apply_func):
-    """get send and recv schedule
+    """get send and recv schedule on a bipartite graph.
 
     Parameters
     ----------
-    graph: DGLGraph
-        The DGLGraph to use
+    graph: DGLBipartiteGraph
+        The DGLBipartiteGraph to use
     message_func: callable or list of callable
         The message function
     reduce_func: callable or list of callable
@@ -472,8 +472,8 @@ def schedule_bipartite_apply_edges(graph,
 
     Parameters
     ----------
-    graph: NodeFlow
-        The NodeFlow to use
+    graph: DGLBipartiteGraph
+        The DGLBipartiteGraph to use
     u : utils.Index
         Source nodes of edges to apply
     v : utils.Index
@@ -602,12 +602,12 @@ def schedule_bipartite_pull(graph,
                             reduce_func,
                             apply_func,
                             inplace):
-    """get pull schedule
+    """get pull schedule on a bipartite graph
 
     Parameters
     ----------
-    graph: DGLGraph
-        The DGLGraph to use
+    graph: DGLBipartiteGraph
+        The DGLBipartiteGraph to use
     pull_nodes : utils.Index
         Destination nodes for pull
     message_func: callable or list of callable

--- a/python/dgl/subgraph.py
+++ b/python/dgl/subgraph.py
@@ -3,6 +3,7 @@ from __future__ import absolute_import
 
 from .frame import Frame, FrameRef
 from .graph import DGLGraph
+from .bipartite import DGLBipartiteGraph
 from . import utils
 from .graph_index import map_to_subgraph_nid
 
@@ -139,4 +140,172 @@ class DGLSubGraph(DGLGraph):
         tensor
             The node ID array in the subgraph.
         """
-        return map_to_subgraph_nid(self._graph, utils.toindex(parent_vids)).tousertensor()
+        return map_to_subgraph_nid(self._parent_nid,
+                                   utils.toindex(parent_vids)).tousertensor()
+
+class DGLBiSubGraph(DGLBipartiteGraph):
+    """The subgraph class.
+
+    There are two subgraph modes: shared and non-shared.
+
+    For the "non-shared" mode, the user needs to explicitly call
+    ``copy_from_parent`` to copy node/edge features from its parent graph.
+    * If the user tries to get node/edge features before ``copy_from_parent``,
+      s/he will get nothing.
+    * If the subgraph already has its own node/edge features, ``copy_from_parent``
+      will override them.
+    * Any update on the subgraph's node/edge features will not be seen
+      by the parent graph. As such, the memory consumption is of the order
+      of the subgraph size.
+    * To write the subgraph's node/edge features back to parent graph. There are two options:
+      (1) Use ``copy_to_parent`` API to write node/edge features back.
+      (2) [TODO] Use ``dgl.merge`` to merge multiple subgraphs back to one parent.
+
+    The "shared" mode is currently not supported.
+
+    The subgraph is read-only on structure; graph mutation is not allowed.
+
+    Parameters
+    ----------
+    parent : DGLGraph
+        The parent graph
+    parent_nid : dict of utils.Index
+        The induced parent node ids in this subgraph.
+    parent_eid : dict of utils.Index
+        The induced parent edge ids in this subgraph.
+    graph_idx : GraphIndex
+        The graph index.
+    shared : bool, optional
+        Whether the subgraph shares node/edge features with the parent graph.
+    """
+    def __init__(self, parent, parent_nid, parent_eid, graph_idx, shared=False):
+        num_nodes_by_type = {name: len(parent_nid[name]) for name in parent_nid}
+        for key in graph_idx:
+            readonly = graph_idx[key].is_readonly()
+            break
+        assert isinstance(graph_idx, dict)
+        assert isinstance(parent_nid, dict)
+        assert isinstance(parent_eid, dict)
+        #TODO(zhengda) we need to reconstruct metagraph. But why do we need it?
+        super(DGLBiSubGraph, self).__init__(parent.metagraph,
+                                            num_nodes_by_type,
+                                            graph_idx,
+                                            readonly=readonly)
+        self._one_dir_graphs = graph_idx
+        if len(graph_idx) == 1:
+            self._graph = self._one_dir_graphs[self._etypes[0]]
+
+        if shared:
+            raise DGLError('Shared mode is not yet supported.')
+        self._parent = parent
+        self._parent_nid = parent_nid
+        self._parent_eid = parent_eid
+
+    # override APIs
+    def add_nodes(self, num, data=None):
+        """Add nodes. Disabled because BatchedDGLGraph is read-only."""
+        raise DGLError('Readonly graph. Mutation is not allowed.')
+
+    def add_edge(self, u, v, data=None):
+        """Add one edge. Disabled because BatchedDGLGraph is read-only."""
+        raise DGLError('Readonly graph. Mutation is not allowed.')
+
+    def add_edges(self, u, v, data=None):
+        """Add many edges. Disabled because BatchedDGLGraph is read-only."""
+        raise DGLError('Readonly graph. Mutation is not allowed.')
+
+    def parent_nid(self, ntype):
+        """Get the parent node ids.
+
+        The returned tensor can be used as a map from the node id
+        in this subgraph to the node id in the parent graph.
+
+        Parameters
+        ----------
+        ntype : str
+            The node type
+
+        Returns
+        -------
+        Tensor
+            The parent node id array.
+        """
+        return self._parent_nid[ntype].tousertensor()
+
+    def _get_parent_eid(self, etype):
+        # The parent eid might be lazily evaluated and thus may not
+        # be an index. Instead, it's a lambda function that returns
+        # an index.
+        parent_eid = self._parent_eid[etype]
+        if isinstance(parent_eid, utils.Index):
+            return parent_eid
+        else:
+            return parent_eid()
+
+    def parent_eid(self, etype):
+        """Get the parent edge ids.
+
+        The returned tensor can be used as a map from the edge id
+        in this subgraph to the edge id in the parent graph.
+
+        Parameters
+        ----------
+        etype : str
+            The edge type
+
+        Returns
+        -------
+        Tensor
+            The parent edge id array.
+        """
+        return self._get_parent_eid(etype).tousertensor()
+
+    def copy_to_parent(self, inplace=False):
+        """Write node/edge features to the parent graph.
+
+        Parameters
+        ----------
+        inplace : bool
+            If true, use inplace write (no gradient but faster)
+        """
+        for idx, ntype in enumerate(self._ntypes):
+            self._parent._get_node_frame(idx).update_rows(
+                self._parent_nid[ntype], self._get_node_frame(idx), inplace=inplace)
+        for idx, etype in enumerate(self._etypes):
+            if self._parent._get_edge_frame(idx).num_rows != 0:
+                self._parent._get_edge_frame(idx).update_rows(
+                    self._get_parent_eid(etype), self._get_edge_frame(idx), inplace=inplace)
+
+    def copy_from_parent(self):
+        """Copy node/edge features from the parent graph.
+
+        All old features will be removed.
+        """
+        for idx, ntype in enumerate(self._ntypes):
+            if self._parent._get_node_frame(idx).num_rows != 0:
+                self._node_frame_vec[idx] = FrameRef(Frame(
+                    self._parent._get_node_frame(idx)[self._parent_nid[ntype]]))
+                self._node_frames[ntype] = self._node_frame_vec[idx]
+        for idx, etype in enumerate(self._etypes):
+            if self._parent._get_edge_frame(idx).num_rows != 0:
+                self._edge_frame_vec[idx] = FrameRef(Frame(
+                    self._parent._get_edge_frame(idx)[self._get_parent_eid(etype)]))
+                self._edge_frames[etype] = self._edge_frame_vec[idx]
+
+    def map_to_subgraph_nid(self, ntype, parent_vids):
+        """Map the node Ids in the parent graph to the node Ids in the subgraph.
+
+        Parameters
+        ----------
+        ntype : str
+            The node type
+        parent_vids : list, tensor
+            The node ID array in the parent graph.
+
+        Returns
+        -------
+        tensor
+            The node ID array in the subgraph.
+        """
+        return map_to_subgraph_nid(self._parent_nid[ntype],
+                                   utils.toindex(parent_vids)).tousertensor()

--- a/python/dgl/view.py
+++ b/python/dgl/view.py
@@ -242,3 +242,141 @@ class BlockDataView(MutableMapping):
     def __repr__(self):
         data = self._graph._edge_frames[self._flow]
         return repr({key : data[key] for key in data})
+
+class HeteroNodeView(object):
+    """A NodeView class to act as G.nodes for a DGLGraph.
+
+    Can be used to get a list of current nodes and get and set node data.
+
+    See Also
+    --------
+    dgl.DGLGraph.nodes
+    """
+    __slots__ = ['_graph', '_ntype']
+
+    def __init__(self, graph, ntype):
+        self._graph = graph
+        self._ntype = ntype
+
+    def __len__(self):
+        return self._graph._number_of_nodes(self._ntype)
+
+    def __getitem__(self, nodes):
+        if isinstance(nodes, slice):
+            # slice
+            if not (nodes.start is None and nodes.stop is None
+                    and nodes.step is None):
+                raise DGLError('Currently only full slice ":" is supported')
+            return NodeSpace(data=HeteroNodeDataView(self._graph, self._ntype, ALL))
+        else:
+            return NodeSpace(data=HeteroNodeDataView(self._graph, self._ntype, nodes))
+
+    def __call__(self):
+        """Return the nodes."""
+        return F.arange(0, len(self))
+
+class HeteroNodeDataView(MutableMapping):
+    """The data view class when G.nodes[...].data is called.
+
+    See Also
+    --------
+    dgl.DGLGraph.nodes
+    """
+    __slots__ = ['_graph', '_nodes', '_ntype']
+
+    def __init__(self, graph, ntype, nodes):
+        self._graph = graph
+        self._nodes = nodes
+        self._ntype = ntype
+
+    def __getitem__(self, key):
+        return self._graph.get_n_repr(self._ntype, self._nodes)[key]
+
+    def __setitem__(self, key, val):
+        self._graph.set_n_repr({key : val}, self._ntype, self._nodes)
+
+    def __delitem__(self, key):
+        if not is_all(self._nodes):
+            raise DGLError('Delete feature data is not supported on only a subset'
+                           ' of nodes. Please use `del G.ndata[key]` instead.')
+        self._graph.pop_n_repr(self._ntype, key)
+
+    def __len__(self):
+        return len(self._graph._node_frames[self._ntype])
+
+    def __iter__(self):
+        return iter(self._graph._node_frames[self._ntype])
+
+    def __repr__(self):
+        data = self._graph.get_n_repr(self._ntype, self._nodes)
+        return repr({key : data[key] for key in self._graph._node_frames[self._ntype]})
+
+class HeteroEdgeView(object):
+    """A EdgeView class to act as G.edges for a DGLGraph.
+
+    Can be used to get a list of current edges and get and set edge data.
+
+    See Also
+    --------
+    dgl.DGLGraph.edges
+    """
+    __slots__ = ['_graph', '_etype']
+
+    def __init__(self, graph, etype):
+        self._graph = graph
+        self._etype = etype
+
+    def __len__(self):
+        return self._graph._number_of_edges(etype)
+
+    def __getitem__(self, edges):
+        if isinstance(edges, slice):
+            # slice
+            if not (edges.start is None and edges.stop is None
+                    and edges.step is None):
+                raise DGLError('Currently only full slice ":" is supported')
+            return EdgeSpace(data=HeteroEdgeDataView(self._graph, self._etype, ALL))
+        else:
+            return EdgeSpace(data=HeteroEdgeDataView(self._graph, self._etype, edges))
+
+    def __call__(self, *args, **kwargs):
+        """Return all the edges."""
+        # TODO(zhengda) is this right?
+        args = (self._etype,) + args
+        return self._graph._all_edges(*args, **kwargs)
+
+class HeteroEdgeDataView(MutableMapping):
+    """The data view class when G.edges[...].data is called.
+
+    See Also
+    --------
+    dgl.DGLGraph.edges
+    """
+    __slots__ = ['_graph', '_edges', '_etype']
+
+    def __init__(self, graph, etype, edges):
+        self._graph = graph
+        self._etype = etype
+        self._edges = edges
+
+    def __getitem__(self, key):
+        return self._graph.get_e_repr(self._etype, self._edges)[key]
+
+    def __setitem__(self, key, val):
+        self._graph.set_e_repr({key : val}, self._etype, self._edges)
+
+    def __delitem__(self, key):
+        if not is_all(self._edges):
+            raise DGLError('Delete feature data is not supported on only a subset'
+                           ' of nodes. Please use `del G.edata[key]` instead.')
+        self._graph.pop_e_repr(self._etype, key)
+
+    def __len__(self):
+        return len(self._graph._edge_frames[self._etype])
+
+    def __iter__(self):
+        return iter(self._graph._edge_frames[self._etype])
+
+    def __repr__(self):
+        data = self._graph.get_e_repr(self._etype, self._edges)
+        return repr({key : data[key] for key in self._graph._edge_frames[self._etype]})

--- a/src/graph/graph_apis.cc
+++ b/src/graph/graph_apis.cc
@@ -212,6 +212,54 @@ DGL_REGISTER_GLOBAL("graph_index._CAPI_DGLGraphCSRCreateMMap")
     *rv = ghandle;
   });
 
+DGL_REGISTER_GLOBAL("graph_index._CAPI_DGLBiGraphCreate")
+.set_body([] (DGLArgs args, DGLRetValue* rv) {
+    const IdArray src_ids = args[0];
+    const IdArray dst_ids = args[1];
+    const bool multigraph = static_cast<bool>(args[2]);
+    const int64_t num_src_nodes = static_cast<int64_t>(args[3]);
+    const int64_t num_dst_nodes = static_cast<int64_t>(args[4]);
+    const bool readonly = static_cast<bool>(args[5]);
+    GraphHandle ghandle;
+    CHECK(readonly) << "We only support readonly bipartite graph for now";
+    // TODO(minjie): The array copy here is unnecessary and adds extra overhead.
+    //   However, with MXNet backend, the memory would be corrupted if we directly
+    //   save the passed-in ndarrays into DGL's graph object. We hope MXNet team
+    //   could help look into this.
+    COOPtr coo(new COO(num_src_nodes + num_dst_nodes,
+                       Clone(src_ids), Clone(dst_ids), multigraph));
+    ghandle = new ImmutableBiGraph(coo, num_src_nodes, num_dst_nodes);
+    *rv = ghandle;
+  });
+
+DGL_REGISTER_GLOBAL("graph_index._CAPI_DGLBiGraphCSRCreate")
+.set_body([] (DGLArgs args, DGLRetValue* rv) {
+    const IdArray indptr = args[0];
+    const IdArray indices = args[1];
+    const IdArray edge_ids = args[2];
+    const int64_t num_src_nodes = args[3];
+    const int64_t num_dst_nodes = args[4];
+    const std::string shared_mem_name = args[5];
+    const bool multigraph = static_cast<bool>(args[6]);
+    const std::string edge_dir = args[7];
+    CSRPtr csr;
+    if (shared_mem_name.empty())
+      // TODO(minjie): The array copy here is unnecessary and adds extra overhead.
+      //   However, with MXNet backend, the memory would be corrupted if we directly
+      //   save the passed-in ndarrays into DGL's graph object. We hope MXNet team
+      //   could help look into this.
+      csr.reset(new CSR(Clone(indptr), Clone(indices), Clone(edge_ids), multigraph));
+    else
+      csr.reset(new CSR(indptr, indices, edge_ids, multigraph, shared_mem_name));
+
+    GraphHandle ghandle;
+    if (edge_dir == "in")
+      ghandle = new ImmutableBiGraph(csr, nullptr, num_src_nodes, num_dst_nodes);
+    else
+      ghandle = new ImmutableBiGraph(nullptr, csr, num_src_nodes, num_dst_nodes);
+    *rv = ghandle;
+  });
+
 DGL_REGISTER_GLOBAL("graph_index._CAPI_DGLGraphFree")
 .set_body([] (DGLArgs args, DGLRetValue* rv) {
     GraphHandle ghandle = args[0];

--- a/src/graph/immutable_graph.cc
+++ b/src/graph/immutable_graph.cc
@@ -533,17 +533,22 @@ Subgraph COO::EdgeSubgraph(IdArray eids) const {
   dgl_id_t newid = 0;
   std::unordered_map<dgl_id_t, dgl_id_t> oldv2newv;
 
+  // All source nodes have node Ids smaller than destination nodes.
   for (int64_t i = 0; i < eids->shape[0]; ++i) {
     const dgl_id_t eid = eids_data[i];
     const dgl_id_t src = src_data[eid];
-    const dgl_id_t dst = dst_data[eid];
     if (!oldv2newv.count(src)) {
       oldv2newv[src] = newid++;
     }
+    *(new_src_data++) = oldv2newv[src];
+  }
+
+  for (int64_t i = 0; i < eids->shape[0]; ++i) {
+    const dgl_id_t eid = eids_data[i];
+    const dgl_id_t dst = dst_data[eid];
     if (!oldv2newv.count(dst)) {
       oldv2newv[dst] = newid++;
     }
-    *(new_src_data++) = oldv2newv[src];
     *(new_dst_data++) = oldv2newv[dst];
   }
 

--- a/tests/compute/test_bipartite.py
+++ b/tests/compute/test_bipartite.py
@@ -130,8 +130,10 @@ def test_query():
         assert g.out_degree(9) == 2
         assert F.allclose(g.out_degrees([8, 9]), F.tensor([0, 2]))
 
-        #assert np.array_equal(F.sparse_to_numpy(g.adjacency_matrix()), scipy_coo_input().toarray().T)
-        #assert np.array_equal(F.sparse_to_numpy(g.adjacency_matrix(transpose=True)), scipy_coo_input().toarray())
+        assert np.array_equal(F.sparse_to_numpy(g.adjacency_matrix(('src', 'dst', 'e'))),
+                              scipy_coo_input().toarray().T)
+        assert np.array_equal(F.sparse_to_numpy(g.adjacency_matrix(('src', 'dst', 'e'), transpose=True)),
+                              scipy_coo_input().toarray())
 
     def _test(g):
         # test twice to see whether the cached format works or not
@@ -211,8 +213,10 @@ def test_query():
         assert g.out_degree(9) == 2
         assert F.allclose(g.out_degrees([8, 9]), F.tensor([0, 2]))
 
-        #assert np.array_equal(F.sparse_to_numpy(g.adjacency_matrix()), scipy_coo_input().toarray().T)
-        #assert np.array_equal(F.sparse_to_numpy(g.adjacency_matrix(transpose=True)), scipy_coo_input().toarray())
+        assert np.array_equal(F.sparse_to_numpy(g.adjacency_matrix(('src', 'dst', 'e'))),
+                              scipy_coo_input().toarray().T)
+        assert np.array_equal(F.sparse_to_numpy(g.adjacency_matrix(('src', 'dst', 'e'), transpose=True)),
+                              scipy_coo_input().toarray())
 
     def _test_csr(g):
         # test twice to see whether the cached format works or not
@@ -251,28 +255,21 @@ def test_mutation():
     assert F.allclose(F.zeros((g.number_of_edges(), 3)), g.edata['h2'])
 
 def test_scipy_adjmat():
-    g = dgl.DGLGraph()
-    g.add_nodes(10)
-    g.add_edges(range(9), range(1, 10))
+    g = gen_from_edgelist()
+    coo = scipy_coo_input()
+    coo_t = coo.transpose()
 
-    adj_0 = g.adjacency_matrix_scipy()
-    adj_1 = g.adjacency_matrix_scipy(fmt='coo')
+    adj_0 = g.adjacency_matrix_scipy(('src', 'dst', 'e'))
+    adj_1 = g.adjacency_matrix_scipy(('src', 'dst', 'e'), fmt='coo')
+    assert np.array_equal(coo_t.row, adj_1.row)
+    assert np.array_equal(coo_t.col, adj_1.col)
     assert np.array_equal(adj_0.toarray(), adj_1.toarray())
 
-    adj_t0 = g.adjacency_matrix_scipy(transpose=True)
-    adj_t_1 = g.adjacency_matrix_scipy(transpose=True, fmt='coo')
-    assert np.array_equal(adj_0.toarray(), adj_1.toarray())
-
-    g.readonly()
-    adj_2 = g.adjacency_matrix_scipy()
-    adj_3 = g.adjacency_matrix_scipy(fmt='coo')
-    assert np.array_equal(adj_2.toarray(), adj_3.toarray())
-    assert np.array_equal(adj_0.toarray(), adj_2.toarray())
-
-    adj_t2 = g.adjacency_matrix_scipy(transpose=True)
-    adj_t3 = g.adjacency_matrix_scipy(transpose=True, fmt='coo')
-    assert np.array_equal(adj_t2.toarray(), adj_t3.toarray())
-    assert np.array_equal(adj_t0.toarray(), adj_t2.toarray())
+    adj_t0 = g.adjacency_matrix_scipy(('src', 'dst', 'e'), transpose=True)
+    adj_t_1 = g.adjacency_matrix_scipy(('src', 'dst', 'e'), transpose=True, fmt='coo')
+    assert np.array_equal(coo.row, adj_t_1.row)
+    assert np.array_equal(coo.col, adj_t_1.col)
+    assert np.array_equal(adj_t0.toarray(), adj_t_1.toarray())
 
 def test_incmat():
     g = dgl.DGLGraph()
@@ -486,7 +483,7 @@ def test_update_routines():
 if __name__ == '__main__':
     test_query()
     #test_mutation()
-    #test_scipy_adjmat()
+    test_scipy_adjmat()
     #test_incmat()
     #test_readonly()
     #test_find_edges()

--- a/tests/compute/test_bipartite.py
+++ b/tests/compute/test_bipartite.py
@@ -1,0 +1,497 @@
+import time
+import math
+import numpy as np
+import scipy.sparse as sp
+import networkx as nx
+import dgl
+import backend as F
+from dgl import DGLError
+
+D = 5
+
+# graph generation: a random bipartite graph with 10 left nodes and 11 right nodes.
+#  and 21 edges.
+#  - has self loop
+#  - no multi edge
+def edge_pair_input(sort=False):
+    if sort:
+        src = [0, 0, 0, 1, 1, 2, 2, 3, 3, 4, 4, 4, 4, 5, 5, 6, 7, 7, 7, 9, 9]
+        dst = [4, 6, 9, 3, 5, 3, 7, 5, 8, 1, 3, 4, 9, 1, 9, 6, 2, 8, 9, 2, 10]
+        return src, dst
+    else:
+        src = [0, 0, 4, 5, 0, 4, 7, 4, 4, 3, 2, 7, 7, 5, 3, 2, 1, 9, 6, 1, 9]
+        dst = [9, 6, 3, 9, 4, 4, 9, 9, 1, 8, 3, 2, 8, 1, 5, 7, 3, 2, 6, 5, 10]
+        return src, dst
+
+def gen_from_edgelist():
+    src, dst = edge_pair_input()
+    num_typed_nodes = {'src': max(src) + 1, 'dst': max(dst) + 1}
+    src = np.array(src, np.int64)
+    dst = np.array(dst, np.int64)
+    metagraph = nx.MultiGraph([('src', 'dst', 'e')])
+    g = dgl.DGLBipartiteGraph(metagraph, num_typed_nodes,
+                              {('src', 'dst', 'e'): (src, dst)}, readonly=True)
+    return g
+
+def scipy_coo_input():
+    src, dst = edge_pair_input()
+    return sp.coo_matrix((np.ones((len(src),)), (src, dst)), shape=(10,11))
+
+def scipy_csr_input():
+    src, dst = edge_pair_input()
+    csr = sp.coo_matrix((np.ones((len(src),)), (src, dst)), shape=(10,11)).tocsr()
+    csr.sort_indices()
+    coo = csr.tocoo()
+    # src = [0 0 0 1 1 2 2 3 3 4 4 4 4 5 5 6 7 7 7 9]
+    # dst = [4 6 9 3 5 3 7 5 8 1 3 4 9 1 9 6 2 8 9 2]
+    return csr
+
+#def gen_by_mutation():
+#    g = dgl.DGLGraph()
+#    src, dst = edge_pair_input()
+#    g.add_nodes(10)
+#    g.add_edges(src, dst)
+#    return g
+
+def gen_from_data(data, readonly):
+    num_typed_nodes = {'src': data.shape[0], 'dst': data.shape[1]}
+    metagraph = nx.MultiGraph([('src', 'dst', 'e')])
+    g = dgl.DGLBipartiteGraph(metagraph, num_typed_nodes,
+                              {('src', 'dst', 'e'): data}, readonly=readonly)
+    return g
+
+def test_query():
+    def _test_one(g):
+        assert g['src'].number_of_nodes() == 10
+        assert g['dst'].number_of_nodes() == 11
+        assert g.number_of_edges() == 21
+        assert not g.is_multigraph
+
+        for i in range(10):
+            assert g['src'].has_node(i)
+            assert i in g['src']
+        for i in range(11):
+            assert g['dst'].has_node(i)
+            assert i in g['dst']
+        assert not g['src'].has_node(11)
+        assert not g['dst'].has_nodes(12)
+        assert not g['src'].has_node(-1)
+        assert not g['dst'].has_node(-1)
+        assert not -1 in g['src']
+        assert F.allclose(g['src'].has_nodes([-1,0,2,10,11]), F.tensor([0,1,1,0,0]))
+
+        src, dst = edge_pair_input()
+        for u, v in zip(src, dst):
+            assert g.has_edge_between(u, v)
+        assert not g.has_edge_between(0, 0)
+        assert F.allclose(g.has_edges_between([0, 0, 3], [0, 9, 8]), F.tensor([0,1,1]))
+        assert set(F.asnumpy(g.predecessors(9))) == set([0,5,7,4])
+        assert set(F.asnumpy(g.successors(2))) == set([7,3])
+
+        assert g.edge_id(4,4) == 5
+        assert F.allclose(g.edge_ids([4,0], [4,9]), F.tensor([5,0]))
+
+        src, dst = g.find_edges([3, 6, 5])
+        assert F.allclose(src, F.tensor([5, 7, 4]))
+        assert F.allclose(dst, F.tensor([9, 9, 4]))
+
+        src, dst, eid = g.in_edges(9, form='all')
+        tup = list(zip(F.asnumpy(src), F.asnumpy(dst), F.asnumpy(eid)))
+        assert set(tup) == set([(0,9,0),(5,9,3),(7,9,6),(4,9,7)])
+        src, dst, eid = g.in_edges([9,0,8], form='all')  # test node#0 has no in edges
+        tup = list(zip(F.asnumpy(src), F.asnumpy(dst), F.asnumpy(eid)))
+        assert set(tup) == set([(0,9,0),(5,9,3),(7,9,6),(4,9,7),(3,8,9),(7,8,12)])
+
+        src, dst, eid = g.out_edges(0, form='all')
+        tup = list(zip(F.asnumpy(src), F.asnumpy(dst), F.asnumpy(eid)))
+        assert set(tup) == set([(0,9,0),(0,6,1),(0,4,4)])
+        src, dst, eid = g.out_edges([0,4,8], form='all')  # test node#8 has no out edges
+        tup = list(zip(F.asnumpy(src), F.asnumpy(dst), F.asnumpy(eid)))
+        assert set(tup) == set([(0,9,0),(0,6,1),(0,4,4),(4,3,2),(4,4,5),(4,9,7),(4,1,8)])
+
+        src, dst, eid = g.edges('all', 'eid')
+        t_src, t_dst = edge_pair_input()
+        t_tup = list(zip(t_src, t_dst, list(range(21))))
+        tup = list(zip(F.asnumpy(src), F.asnumpy(dst), F.asnumpy(eid)))
+        assert set(tup) == set(t_tup)
+        assert list(F.asnumpy(eid)) == list(range(21))
+
+        src, dst, eid = g.edges('all', 'srcdst')
+        t_src, t_dst = edge_pair_input()
+        t_tup = list(zip(t_src, t_dst, list(range(21))))
+        tup = list(zip(F.asnumpy(src), F.asnumpy(dst), F.asnumpy(eid)))
+        assert set(tup) == set(t_tup)
+        assert list(F.asnumpy(src)) == sorted(list(F.asnumpy(src)))
+
+        assert g.in_degree(0) == 0
+        assert g.in_degree(9) == 4
+        assert F.allclose(g.in_degrees([0, 9]), F.tensor([0, 4]))
+        assert g.out_degree(8) == 0
+        assert g.out_degree(9) == 2
+        assert F.allclose(g.out_degrees([8, 9]), F.tensor([0, 2]))
+
+        #assert np.array_equal(F.sparse_to_numpy(g.adjacency_matrix()), scipy_coo_input().toarray().T)
+        #assert np.array_equal(F.sparse_to_numpy(g.adjacency_matrix(transpose=True)), scipy_coo_input().toarray())
+
+    def _test(g):
+        # test twice to see whether the cached format works or not
+        _test_one(g)
+        _test_one(g)
+
+    def _test_csr_one(g):
+        assert g['src'].number_of_nodes() == 10
+        assert g['dst'].number_of_nodes() == 11
+        assert g.number_of_edges() == 21
+        assert len(g['src']) == 10
+        assert len(g['dst']) == 11
+        assert not g.is_multigraph
+
+        for i in range(10):
+            assert g['src'].has_node(i)
+            assert i in g['src']
+        for i in range(11):
+            assert g['dst'].has_node(i)
+            assert i in g['dst']
+        assert not g['src'].has_node(11)
+        assert not g['dst'].has_node(12)
+        assert not g['src'].has_node(-1)
+        assert not -1 in g['src']
+        assert F.allclose(g['src'].has_nodes([-1,0,2,10,11]), F.tensor([0,1,1,0,0]))
+
+        src, dst = edge_pair_input(sort=True)
+        for u, v in zip(src, dst):
+            assert g.has_edge_between(u, v)
+        assert not g.has_edge_between(0, 0)
+        assert F.allclose(g.has_edges_between([0, 0, 3], [0, 9, 8]), F.tensor([0,1,1]))
+        assert set(F.asnumpy(g.predecessors(9))) == set([0,5,7,4])
+        assert set(F.asnumpy(g.successors(2))) == set([7,3])
+
+        # src = [0 0 0 1 1 2 2 3 3 4 4 4 4 5 5 6 7 7 7 9]
+        # dst = [4 6 9 3 5 3 7 5 8 1 3 4 9 1 9 6 2 8 9 2]
+        # eid = [0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9]
+        assert g.edge_id(4,4) == 11
+        assert F.allclose(g.edge_ids([4,0], [4,9]), F.tensor([11,2]))
+
+        src, dst = g.find_edges([3, 6, 5])
+        assert F.allclose(src, F.tensor([1, 2, 2]))
+        assert F.allclose(dst, F.tensor([3, 7, 3]))
+
+        src, dst, eid = g.in_edges(9, form='all')
+        tup = list(zip(F.asnumpy(src), F.asnumpy(dst), F.asnumpy(eid)))
+        assert set(tup) == set([(0,9,2),(5,9,14),(7,9,18),(4,9,12)])
+        src, dst, eid = g.in_edges([9,0,8], form='all')  # test node#0 has no in edges
+        tup = list(zip(F.asnumpy(src), F.asnumpy(dst), F.asnumpy(eid)))
+        assert set(tup) == set([(0,9,2),(5,9,14),(7,9,18),(4,9,12),(3,8,8),(7,8,17)])
+
+        src, dst, eid = g.out_edges(0, form='all')
+        tup = list(zip(F.asnumpy(src), F.asnumpy(dst), F.asnumpy(eid)))
+        assert set(tup) == set([(0,9,2),(0,6,1),(0,4,0)])
+        src, dst, eid = g.out_edges([0,4,8], form='all')  # test node#8 has no out edges
+        tup = list(zip(F.asnumpy(src), F.asnumpy(dst), F.asnumpy(eid)))
+        assert set(tup) == set([(0,9,2),(0,6,1),(0,4,0),(4,3,10),(4,4,11),(4,9,12),(4,1,9)])
+
+        src, dst, eid = g.edges('all', 'eid')
+        t_src, t_dst = edge_pair_input(sort=True)
+        t_tup = list(zip(t_src, t_dst, list(range(21))))
+        tup = list(zip(F.asnumpy(src), F.asnumpy(dst), F.asnumpy(eid)))
+        assert set(tup) == set(t_tup)
+        assert list(F.asnumpy(eid)) == list(range(21))
+
+        src, dst, eid = g.edges('all', 'srcdst')
+        t_src, t_dst = edge_pair_input(sort=True)
+        t_tup = list(zip(t_src, t_dst, list(range(21))))
+        tup = list(zip(F.asnumpy(src), F.asnumpy(dst), F.asnumpy(eid)))
+        assert set(tup) == set(t_tup)
+        assert list(F.asnumpy(src)) == sorted(list(F.asnumpy(src)))
+
+        assert g.in_degree(0) == 0
+        assert g.in_degree(9) == 4
+        assert F.allclose(g.in_degrees([0, 9]), F.tensor([0, 4]))
+        assert g.out_degree(8) == 0
+        assert g.out_degree(9) == 2
+        assert F.allclose(g.out_degrees([8, 9]), F.tensor([0, 2]))
+
+        #assert np.array_equal(F.sparse_to_numpy(g.adjacency_matrix()), scipy_coo_input().toarray().T)
+        #assert np.array_equal(F.sparse_to_numpy(g.adjacency_matrix(transpose=True)), scipy_coo_input().toarray())
+
+    def _test_csr(g):
+        # test twice to see whether the cached format works or not
+        _test_csr_one(g)
+        _test_csr_one(g)
+
+    _test(gen_from_edgelist())
+    #_test(gen_from_data(scipy_coo_input(), False))
+    _test(gen_from_data(scipy_coo_input(), True))
+
+    #_test_csr(gen_from_data(scipy_csr_input(), False))
+    _test_csr(gen_from_data(scipy_csr_input(), True))
+
+def test_mutation():
+    g = dgl.DGLGraph()
+    # test add nodes with data
+    g.add_nodes(5)
+    g.add_nodes(5, {'h' : F.ones((5, 2))})
+    ans = F.cat([F.zeros((5, 2)), F.ones((5, 2))], 0)
+    assert F.allclose(ans, g.ndata['h'])
+    g.ndata['w'] = 2 * F.ones((10, 2))
+    assert F.allclose(2 * F.ones((10, 2)), g.ndata['w'])
+    # test add edges with data
+    g.add_edges([2, 3], [3, 4])
+    g.add_edges([0, 1], [1, 2], {'m' : F.ones((2, 2))})
+    ans = F.cat([F.zeros((2, 2)), F.ones((2, 2))], 0)
+    assert F.allclose(ans, g.edata['m'])
+    # test clear and add again
+    g.clear()
+    g.add_nodes(5)
+    g.ndata['h'] = 3 * F.ones((5, 2))
+    assert F.allclose(3 * F.ones((5, 2)), g.ndata['h'])
+    g.init_ndata('h1', (g.number_of_nodes(), 3), 'float32')
+    assert F.allclose(F.zeros((g.number_of_nodes(), 3)), g.ndata['h1'])
+    g.init_edata('h2', (g.number_of_edges(), 3), 'float32')
+    assert F.allclose(F.zeros((g.number_of_edges(), 3)), g.edata['h2'])
+
+def test_scipy_adjmat():
+    g = dgl.DGLGraph()
+    g.add_nodes(10)
+    g.add_edges(range(9), range(1, 10))
+
+    adj_0 = g.adjacency_matrix_scipy()
+    adj_1 = g.adjacency_matrix_scipy(fmt='coo')
+    assert np.array_equal(adj_0.toarray(), adj_1.toarray())
+
+    adj_t0 = g.adjacency_matrix_scipy(transpose=True)
+    adj_t_1 = g.adjacency_matrix_scipy(transpose=True, fmt='coo')
+    assert np.array_equal(adj_0.toarray(), adj_1.toarray())
+
+    g.readonly()
+    adj_2 = g.adjacency_matrix_scipy()
+    adj_3 = g.adjacency_matrix_scipy(fmt='coo')
+    assert np.array_equal(adj_2.toarray(), adj_3.toarray())
+    assert np.array_equal(adj_0.toarray(), adj_2.toarray())
+
+    adj_t2 = g.adjacency_matrix_scipy(transpose=True)
+    adj_t3 = g.adjacency_matrix_scipy(transpose=True, fmt='coo')
+    assert np.array_equal(adj_t2.toarray(), adj_t3.toarray())
+    assert np.array_equal(adj_t0.toarray(), adj_t2.toarray())
+
+def test_incmat():
+    g = dgl.DGLGraph()
+    g.add_nodes(4)
+    g.add_edge(0, 1) # 0
+    g.add_edge(0, 2) # 1
+    g.add_edge(0, 3) # 2
+    g.add_edge(2, 3) # 3
+    g.add_edge(1, 1) # 4
+    inc_in = F.sparse_to_numpy(g.incidence_matrix('in'))
+    inc_out = F.sparse_to_numpy(g.incidence_matrix('out'))
+    inc_both = F.sparse_to_numpy(g.incidence_matrix('both'))
+    print(inc_in)
+    print(inc_out)
+    print(inc_both)
+    assert np.allclose(
+            inc_in,
+            np.array([[0., 0., 0., 0., 0.],
+                      [1., 0., 0., 0., 1.],
+                      [0., 1., 0., 0., 0.],
+                      [0., 0., 1., 1., 0.]]))
+    assert np.allclose(
+            inc_out,
+            np.array([[1., 1., 1., 0., 0.],
+                      [0., 0., 0., 0., 1.],
+                      [0., 0., 0., 1., 0.],
+                      [0., 0., 0., 0., 0.]]))
+    assert np.allclose(
+            inc_both,
+            np.array([[-1., -1., -1., 0., 0.],
+                      [1., 0., 0., 0., 0.],
+                      [0., 1., 0., -1., 0.],
+                      [0., 0., 1., 1., 0.]]))
+
+def test_readonly():
+    g = dgl.DGLGraph()
+    g.add_nodes(5)
+    g.add_edges([0, 1, 2, 3], [1, 2, 3, 4])
+    g.ndata['x'] = F.zeros((5, 3))
+    g.edata['x'] = F.zeros((4, 4))
+
+    g.readonly(False)
+    assert g._graph.is_readonly() == False
+    assert g.number_of_nodes() == 5
+    assert g.number_of_edges() == 4
+
+    g.readonly()
+    assert g._graph.is_readonly() == True 
+    assert g.number_of_nodes() == 5
+    assert g.number_of_edges() == 4
+
+    try:
+        g.add_nodes(5)
+        fail = False
+    except DGLError:
+        fail = True
+    finally:
+        assert fail
+
+    g.readonly()
+    assert g._graph.is_readonly() == True 
+    assert g.number_of_nodes() == 5
+    assert g.number_of_edges() == 4
+
+    try:
+        g.add_nodes(5)
+        fail = False
+    except DGLError:
+        fail = True
+    finally:
+        assert fail
+
+    g.readonly(False)
+    assert g._graph.is_readonly() == False
+    assert g.number_of_nodes() == 5
+    assert g.number_of_edges() == 4
+
+    try:
+        g.add_nodes(10)
+        g.add_edges([4, 5, 6, 7, 8, 9, 10, 11, 12, 13],
+                    [5, 6, 7, 8, 9, 10, 11, 12, 13, 14])
+        fail = False
+    except DGLError:
+        fail = True
+    finally:
+        assert not fail
+        assert g.number_of_nodes() == 15
+        assert F.shape(g.ndata['x']) == (15, 3)
+        assert g.number_of_edges() == 14
+        assert F.shape(g.edata['x']) == (14, 4)
+
+def test_find_edges():
+    g = dgl.DGLGraph()
+    g.add_nodes(10)
+    g.add_edges(range(9), range(1, 10))
+    e = g.find_edges([1, 3, 2, 4])
+    assert e[0][0] == 1 and e[0][1] == 3 and e[0][2] == 2 and e[0][3] == 4
+    assert e[1][0] == 2 and e[1][1] == 4 and e[1][2] == 3 and e[1][3] == 5
+
+    try:
+        g.find_edges([10])
+        fail = False
+    except DGLError:
+        fail = True
+    finally:
+        assert fail
+
+    g.readonly()
+    e = g.find_edges([1, 3, 2, 4])
+    assert e[0][0] == 1 and e[0][1] == 3 and e[0][2] == 2 and e[0][3] == 4
+    assert e[1][0] == 2 and e[1][1] == 4 and e[1][2] == 3 and e[1][3] == 5
+
+    try:
+        g.find_edges([10])
+        fail = False
+    except DGLError:
+        fail = True
+    finally:
+        assert fail
+
+def check_apply_nodes(g, ntype):
+    def _upd(nodes):
+        return {'h' : nodes.data['h'] * 2}
+    g[ntype].ndata['h'] = F.randn((g[ntype].number_of_nodes(), D))
+    g[ntype].register_apply_node_func(_upd)
+    old = g[ntype].ndata['h']
+    g[ntype].apply_nodes()
+    assert F.allclose(old * 2, g[ntype].ndata['h'])
+    u = F.tensor([0, 3, 4, 6])
+    g[ntype].apply_nodes(lambda nodes : {'h' : nodes.data['h'] * 0.}, u)
+    assert F.allclose(F.gather_row(g[ntype].ndata['h'], u), F.zeros((4, D)))
+
+def test_apply_nodes():
+    g = gen_from_edgelist()
+    check_apply_nodes(g, 'src')
+    check_apply_nodes(g, 'dst')
+
+def test_apply_edges():
+    def _upd(edges):
+        return {'w' : edges.data['w'] * 2}
+    g = gen_from_edgelist()
+    g.edata['w'] = F.randn((g.number_of_edges(), D))
+    g.register_apply_edge_func(_upd)
+    old = g.edata['w']
+    g.apply_edges()
+    assert F.allclose(old * 2, g.edata['w'])
+    u = F.tensor([0, 0, 0, 4, 5, 6])
+    v = F.tensor([4, 6, 9, 3, 9, 6])
+    g.apply_edges(lambda edges : {'w' : edges.data['w'] * 0.}, (u, v))
+    eid = g.edge_ids(u, v)
+    assert F.allclose(F.gather_row(g.edata['w'], eid), F.zeros((6, D)))
+
+reduce_msg_shapes = set()
+
+def message_func(edges):
+    assert F.ndim(edges.src['h']) == 2
+    assert F.shape(edges.src['h'])[1] == D
+    return {'m' : edges.src['h']}
+
+def reduce_func(nodes):
+    msgs = nodes.mailbox['m']
+    reduce_msg_shapes.add(tuple(msgs.shape))
+    assert F.ndim(msgs) == 3
+    assert F.shape(msgs)[2] == D
+    return {'accum' : F.sum(msgs, 1)}
+
+def apply_node_func(nodes):
+    return {'h' : nodes.data['h'] + nodes.data['accum']}
+
+def test_update_routines():
+    g = gen_from_edgelist()
+    g.register_message_func(message_func)
+    g['dst'].register_reduce_func(reduce_func)
+    g['dst'].register_apply_node_func(apply_node_func)
+    g['src'].ndata['h'] = F.randn((g['src'].number_of_nodes(), D))
+    g['dst'].ndata['h'] = F.randn((g['dst'].number_of_nodes(), D))
+
+    # send_and_recv
+    reduce_msg_shapes.clear()
+    u = [0, 0, 0, 4, 5, 6]
+    v = [4, 6, 9, 3, 9, 6]
+    g.send_and_recv((u, v))
+    assert(reduce_msg_shapes == {(2, 2, D), (2, 1, D)})
+    reduce_msg_shapes.clear()
+    try:
+        g.send_and_recv([u, v])
+        assert False
+    except:
+        pass
+
+    # pull
+    v = F.tensor([1, 2, 3, 9])
+    reduce_msg_shapes.clear()
+    g.pull(v)
+    assert(reduce_msg_shapes == {(2, 2, D), (1, 3, D), (1, 4, D)})
+    reduce_msg_shapes.clear()
+
+    # push
+    #v = F.tensor([0, 1, 2, 3])
+    #reduce_msg_shapes.clear()
+    #g.push(v)
+    #assert(reduce_msg_shapes == {(1, 3, D), (8, 1, D)})
+    #reduce_msg_shapes.clear()
+
+    # update_all
+    reduce_msg_shapes.clear()
+    g.update_all()
+    assert(reduce_msg_shapes == {(1, 3, D), (2, 1, D), (6, 2, D), (1, 4, D)})
+    reduce_msg_shapes.clear()
+
+if __name__ == '__main__':
+    test_query()
+    #test_mutation()
+    #test_scipy_adjmat()
+    #test_incmat()
+    #test_readonly()
+    #test_find_edges()
+    test_apply_nodes()
+    test_apply_edges()
+    test_update_routines()
+    #TODO(zhengda) test builtin
+

--- a/tests/compute/test_bipartite.py
+++ b/tests/compute/test_bipartite.py
@@ -466,7 +466,7 @@ def test_update_routines():
     v = F.tensor([0, 1, 2, 3])
     reduce_msg_shapes.clear()
     g.push(v)
-    assert(reduce_msg_shapes == {(1, 3, D), (8, 1, D)})
+    assert(reduce_msg_shapes == {(2, 2, D), (5, 1, D)})
     reduce_msg_shapes.clear()
 
     # update_all

--- a/tests/compute/test_bipartite.py
+++ b/tests/compute/test_bipartite.py
@@ -486,5 +486,4 @@ if __name__ == '__main__':
     test_apply_nodes()
     test_apply_edges()
     test_update_routines()
-    #TODO(zhengda) test builtin
 

--- a/tests/compute/test_bipartite.py
+++ b/tests/compute/test_bipartite.py
@@ -272,19 +272,18 @@ def test_scipy_adjmat():
     assert np.array_equal(adj_t0.toarray(), adj_t_1.toarray())
 
 def test_incmat():
-    g = dgl.DGLGraph()
-    g.add_nodes(4)
-    g.add_edge(0, 1) # 0
-    g.add_edge(0, 2) # 1
-    g.add_edge(0, 3) # 2
-    g.add_edge(2, 3) # 3
-    g.add_edge(1, 1) # 4
-    inc_in = F.sparse_to_numpy(g.incidence_matrix('in'))
-    inc_out = F.sparse_to_numpy(g.incidence_matrix('out'))
-    inc_both = F.sparse_to_numpy(g.incidence_matrix('both'))
+    src = [0, 0, 0, 2, 1]
+    dst = [1, 2, 3, 3, 1]
+    num_typed_nodes = {'src': max(src) + 1, 'dst': max(dst) + 1}
+    src = np.array(src, np.int64)
+    dst = np.array(dst, np.int64)
+    metagraph = nx.MultiGraph([('src', 'dst', 'e')])
+    g = dgl.DGLBipartiteGraph(metagraph, num_typed_nodes,
+                              {('src', 'dst', 'e'): (src, dst)}, readonly=True)
+    inc_in = F.sparse_to_numpy(g.incidence_matrix(('src', 'dst', 'e'), 'in'))
+    inc_out = F.sparse_to_numpy(g.incidence_matrix(('src', 'dst', 'e'), 'out'))
     print(inc_in)
     print(inc_out)
-    print(inc_both)
     assert np.allclose(
             inc_in,
             np.array([[0., 0., 0., 0., 0.],
@@ -295,14 +294,7 @@ def test_incmat():
             inc_out,
             np.array([[1., 1., 1., 0., 0.],
                       [0., 0., 0., 0., 1.],
-                      [0., 0., 0., 1., 0.],
-                      [0., 0., 0., 0., 0.]]))
-    assert np.allclose(
-            inc_both,
-            np.array([[-1., -1., -1., 0., 0.],
-                      [1., 0., 0., 0., 0.],
-                      [0., 1., 0., -1., 0.],
-                      [0., 0., 1., 1., 0.]]))
+                      [0., 0., 0., 1., 0.]]))
 
 def test_readonly():
     g = dgl.DGLGraph()
@@ -484,7 +476,7 @@ if __name__ == '__main__':
     test_query()
     #test_mutation()
     test_scipy_adjmat()
-    #test_incmat()
+    test_incmat()
     #test_readonly()
     #test_find_edges()
     test_apply_nodes()

--- a/tests/compute/test_bipartite.py
+++ b/tests/compute/test_bipartite.py
@@ -572,6 +572,15 @@ def test_update_routines():
                                        apply_node_func)
     assert(reduce_msg_shapes == {(2, 2, D), (2, 1, D)})
 
+    g['dst', 'src', 'e'].send_and_recv((v, u),
+                                       message_func,
+                                       reduce_func,
+                                       apply_node_func)
+    print(reduce_msg_shapes)
+    print(g['src'].ndata['res'])
+    #assert(reduce_msg_shapes == {(2, 2, D), (2, 1, D)})
+    #assert F.allclose(g['src'].ndata['res'], comp_res)
+
     reduce_msg_shapes.clear()
     try:
         g.send_and_recv([u, v])
@@ -588,7 +597,7 @@ def test_update_routines():
            {'dst': apply_node_func})
     assert(reduce_msg_shapes == {(2, 2, D), (1, 3, D), (1, 4, D)})
     reduce_msg_shapes.clear()
-    F.allclose(g['dst'].ndata['res'][v], comp_res[v])
+    assert F.allclose(g['dst'].ndata['res'][v], comp_res[v])
 
     g['src', 'dst', 'e'].pull(v,
                               message_func,
@@ -596,7 +605,7 @@ def test_update_routines():
                               apply_node_func)
     assert(reduce_msg_shapes == {(2, 2, D), (1, 3, D), (1, 4, D)})
     reduce_msg_shapes.clear()
-    F.allclose(g['dst'].ndata['res'][v], comp_res[v])
+    assert F.allclose(g['dst'].ndata['res'][v], comp_res[v])
 
     # push
     v = F.tensor([0, 1, 2, 3])
@@ -622,14 +631,14 @@ def test_update_routines():
                  {'dst': apply_node_func})
     assert(reduce_msg_shapes == {(1, 3, D), (2, 1, D), (6, 2, D), (1, 4, D)})
     reduce_msg_shapes.clear()
-    F.allclose(g['dst'].ndata['res'], comp_res)
+    assert F.allclose(g['dst'].ndata['res'], comp_res)
 
     g['src', 'dst', 'e'].update_all(message_func,
                                     reduce_func,
                                     apply_node_func)
     assert(reduce_msg_shapes == {(1, 3, D), (2, 1, D), (6, 2, D), (1, 4, D)})
     reduce_msg_shapes.clear()
-    F.allclose(g['dst'].ndata['res'], comp_res)
+    assert F.allclose(g['dst'].ndata['res'], comp_res)
 
 def test_filter():
     g = gen_from_edgelist(False)

--- a/tests/compute/test_bipartite.py
+++ b/tests/compute/test_bipartite.py
@@ -463,11 +463,11 @@ def test_update_routines():
     F.allclose(g['dst'].ndata['res'][v], comp_res[v])
 
     # push
-    #v = F.tensor([0, 1, 2, 3])
-    #reduce_msg_shapes.clear()
-    #g.push(v)
-    #assert(reduce_msg_shapes == {(1, 3, D), (8, 1, D)})
-    #reduce_msg_shapes.clear()
+    v = F.tensor([0, 1, 2, 3])
+    reduce_msg_shapes.clear()
+    g.push(v)
+    assert(reduce_msg_shapes == {(1, 3, D), (8, 1, D)})
+    reduce_msg_shapes.clear()
 
     # update_all
     reduce_msg_shapes.clear()

--- a/tests/compute/test_bipartite_specialization.py
+++ b/tests/compute/test_bipartite_specialization.py
@@ -1,0 +1,577 @@
+import numpy as np
+import networkx as nx
+import scipy.sparse as sp
+import dgl
+import dgl.function as fn
+import backend as F
+
+D = 5
+
+# graph generation: a random bipartite graph with 10 left nodes and 11 right nodes.
+#  and 21 edges.
+#  - has self loop
+#  - no multi edge
+def edge_pair_input(sort=False):
+    if sort:
+        src = [0, 0, 0, 1, 1, 2, 2, 3, 3, 4, 4, 4, 4, 5, 5, 6, 7, 7, 7, 9, 9]
+        dst = [4, 6, 9, 3, 5, 3, 7, 5, 8, 1, 3, 4, 9, 1, 9, 6, 2, 8, 9, 2, 10]
+        return src, dst
+    else:
+        src = [0, 0, 4, 5, 0, 4, 7, 4, 4, 3, 2, 7, 7, 5, 3, 2, 1, 9, 6, 1, 9]
+        dst = [9, 6, 3, 9, 4, 4, 9, 9, 1, 8, 3, 2, 8, 1, 5, 7, 3, 2, 6, 5, 10]
+        return src, dst
+
+def generate_graph():
+    src, dst = edge_pair_input()
+    num_nodes = {'src': max(src) + 1, 'dst': max(dst) + 1}
+    src = np.array(src, np.int64)
+    dst = np.array(dst, np.int64)
+    metagraph = nx.MultiGraph([('src', 'dst', 'e')])
+    g = dgl.DGLBipartiteGraph(metagraph, num_nodes,
+                              {('src', 'dst', 'e'): (src, dst)}, readonly=True)
+    g.set_n_repr({'f1' : F.randn((num_nodes['src'],)),
+                  'f2' : F.randn((num_nodes['src'], D))},
+                 'src')
+    g.set_n_repr({'f1' : F.randn((num_nodes['dst'],)),
+                  'f2' : F.randn((num_nodes['dst'], D))},
+                 'dst')
+    weights = F.randn((g.number_of_edges(),))
+    g.set_e_repr({'e1': weights, 'e2': F.unsqueeze(weights, 1)}, ('src', 'dst', 'e'))
+    return g
+
+def test_v2v_update_all():
+    def _test(fld):
+        def message_func(edges):
+            return {'m' : edges.src[fld]}
+
+        def message_func_edge(edges):
+            if len(edges.src[fld].shape) == 1:
+                return {'m' : edges.src[fld] * edges.data['e1']}
+            else:
+                return {'m' : edges.src[fld] * edges.data['e2']}
+
+        def reduce_func(nodes):
+            return {fld : F.sum(nodes.mailbox['m'], 1)}
+
+        def apply_func(nodes):
+            return {fld : 2 * nodes.data[fld]}
+        g = generate_graph()
+        # update all
+        g.update_all(fn.copy_src(src=fld, out='m'), fn.sum(msg='m', out=fld), apply_func)
+        v2 = g['dst'].ndata[fld]
+        g.update_all(message_func, reduce_func, apply_func)
+        v3 = g['dst'].ndata[fld]
+        assert F.allclose(v2, v3)
+
+        # update all with edge weights
+        g.update_all(fn.src_mul_edge(src=fld, edge='e1', out='m'),
+                fn.sum(msg='m', out=fld), apply_func)
+        v2 = g['dst'].ndata[fld]
+        g.update_all(fn.src_mul_edge(src=fld, edge='e2', out='m'),
+                fn.sum(msg='m', out=fld), apply_func)
+        v3 = g['dst'].ndata[fld]
+        g.update_all(message_func_edge, reduce_func, apply_func)
+        v4 = g['dst'].ndata[fld]
+        assert F.allclose(v2, v3)
+        assert F.allclose(v3, v4)
+    # test 1d node features
+    _test('f1')
+    # test 2d node features
+    _test('f2')
+
+def test_v2v_snr():
+    u = F.tensor([0, 0, 0, 3, 4, 9])
+    v = F.tensor([1, 2, 3, 9, 9, 0])
+    def _test(fld):
+        def message_func(edges):
+            return {'m' : edges.src[fld]}
+
+        def message_func_edge(edges):
+            if len(edges.src[fld].shape) == 1:
+                return {'m' : edges.src[fld] * edges.data['e1']}
+            else:
+                return {'m' : edges.src[fld] * edges.data['e2']}
+
+        def reduce_func(nodes):
+            return {fld : F.sum(nodes.mailbox['m'], 1)}
+
+        def apply_func(nodes):
+            return {fld : 2 * nodes.data[fld]}
+        g = generate_graph()
+        # send and recv
+        g.send_and_recv((u, v), fn.copy_src(src=fld, out='m'),
+                fn.sum(msg='m', out=fld), apply_func)
+        v2 = g['dst'].ndata[fld]
+        g.send_and_recv((u, v), message_func, reduce_func, apply_func)
+        v3 = g['dst'].ndata[fld]
+        assert F.allclose(v2, v3)
+
+        # send and recv with edge weights
+        g.send_and_recv((u, v), fn.src_mul_edge(src=fld, edge='e1', out='m'),
+                fn.sum(msg='m', out=fld), apply_func)
+        v2 = g['dst'].ndata[fld]
+        g.send_and_recv((u, v), fn.src_mul_edge(src=fld, edge='e2', out='m'),
+                fn.sum(msg='m', out=fld), apply_func)
+        v3 = g['dst'].ndata[fld]
+        g.send_and_recv((u, v), message_func_edge, reduce_func, apply_func)
+        v4 = g['dst'].ndata[fld]
+        assert F.allclose(v2, v3)
+        assert F.allclose(v3, v4)
+    # test 1d node features
+    _test('f1')
+    # test 2d node features
+    _test('f2')
+
+
+def test_v2v_pull():
+    nodes = F.tensor([1, 2, 3, 9])
+    def _test(fld):
+        def message_func(edges):
+            return {'m' : edges.src[fld]}
+
+        def message_func_edge(edges):
+            if len(edges.src[fld].shape) == 1:
+                return {'m' : edges.src[fld] * edges.data['e1']}
+            else:
+                return {'m' : edges.src[fld] * edges.data['e2']}
+
+        def reduce_func(nodes):
+            return {fld : F.sum(nodes.mailbox['m'], 1)}
+
+        def apply_func(nodes):
+            return {fld : 2 * nodes.data[fld]}
+        g = generate_graph()
+        # send and recv
+        g.pull(nodes, fn.copy_src(src=fld, out='m'), fn.sum(msg='m', out=fld), apply_func)
+        v2 = g['dst'].ndata[fld]
+        g.pull(nodes, message_func, reduce_func, apply_func)
+        v3 = g['dst'].ndata[fld]
+        assert F.allclose(v2, v3)
+        # send and recv with edge weights
+        g.pull(nodes, fn.src_mul_edge(src=fld, edge='e1', out='m'),
+               fn.sum(msg='m', out=fld), apply_func)
+        v2 = g['dst'].ndata[fld]
+        g.pull(nodes, fn.src_mul_edge(src=fld, edge='e2', out='m'),
+               fn.sum(msg='m', out=fld), apply_func)
+        v3 = g['dst'].ndata[fld]
+        g.pull(nodes, message_func_edge, reduce_func, apply_func)
+        v4 = g['dst'].ndata[fld]
+        assert F.allclose(v2, v3)
+        assert F.allclose(v3, v4)
+    # test 1d node features
+    _test('f1')
+    # test 2d node features
+    _test('f2')
+
+def test_v2v_update_all_multi_fn():
+    def message_func(edges):
+        return {'m2': edges.src['f2']}
+
+    def message_func_edge(edges):
+        return {'m2': edges.src['f2'] * edges.data['e2']}
+
+    def reduce_func(nodes):
+        return {'v1': F.sum(nodes.mailbox['m2'], 1)}
+
+    g = generate_graph()
+    #g.set_n_repr({'v1' : F.zeros((10,)), 'v2' : F.zeros((10,))})
+    fld = 'f2'
+
+    g.update_all(message_func, reduce_func)
+    v1 = g['dst'].ndata['v1']
+
+    # 1 message, 2 reduces
+    g.update_all(fn.copy_src(src=fld, out='m'), [fn.sum(msg='m', out='v2'), fn.sum(msg='m', out='v3')])
+    v2 = g['dst'].ndata['v2']
+    v3 = g['dst'].ndata['v3']
+    assert F.allclose(v1, v2)
+    assert F.allclose(v1, v3)
+
+    # update all with edge weights, 2 message, 3 reduces
+    g.update_all([fn.src_mul_edge(src=fld, edge='e1', out='m1'), fn.src_mul_edge(src=fld, edge='e2', out='m2')],
+                 [fn.sum(msg='m1', out='v1'), fn.sum(msg='m2', out='v2'), fn.sum(msg='m1', out='v3')],
+                 None)
+    v1 = g['dst'].ndata['v1']
+    v2 = g['dst'].ndata['v2']
+    v3 = g['dst'].ndata['v3']
+    assert F.allclose(v1, v2)
+    assert F.allclose(v1, v3)
+
+    # run UDF with single message and reduce
+    g.update_all(message_func_edge, reduce_func, None)
+    v2 = g['dst'].ndata['v2']
+    assert F.allclose(v1, v2)
+
+def test_v2v_snr_multi_fn():
+    u = F.tensor([0, 0, 0, 3, 4, 9])
+    v = F.tensor([1, 2, 3, 9, 9, 0])
+
+    def message_func(edges):
+        return {'m2': edges.src['f2']}
+
+    def message_func_edge(edges):
+        return {'m2': edges.src['f2'] * edges.data['e2']}
+
+    def reduce_func(nodes):
+        return {'v1' : F.sum(nodes.mailbox['m2'], 1)}
+
+    g = generate_graph()
+    fld = 'f2'
+
+    g.send_and_recv((u, v), message_func, reduce_func)
+    v1 = g['dst'].ndata['v1']
+
+    # 1 message, 2 reduces
+    g.send_and_recv((u, v),
+            fn.copy_src(src=fld, out='m'),
+            [fn.sum(msg='m', out='v2'), fn.sum(msg='m', out='v3')],
+            None)
+    v2 = g['dst'].ndata['v2']
+    v3 = g['dst'].ndata['v3']
+    assert F.allclose(v1, v2)
+    assert F.allclose(v1, v3)
+
+    # send and recv with edge weights, 2 message, 3 reduces
+    g.send_and_recv((u, v),
+                    [fn.src_mul_edge(src=fld, edge='e1', out='m1'), fn.src_mul_edge(src=fld, edge='e2', out='m2')],
+                    [fn.sum(msg='m1', out='v1'), fn.sum(msg='m2', out='v2'), fn.sum(msg='m1', out='v3')],
+                    None)
+    v1 = g['dst'].ndata['v1']
+    v2 = g['dst'].ndata['v2']
+    v3 = g['dst'].ndata['v3']
+    assert F.allclose(v1, v2)
+    assert F.allclose(v1, v3)
+
+    # run UDF with single message and reduce
+    g.send_and_recv((u, v), message_func_edge,
+            reduce_func, None)
+    v2 = g['dst'].ndata['v2']
+    assert F.allclose(v1, v2)
+
+def test_e2v_update_all_multi_fn():
+    def _test(fld):
+        def message_func(edges):
+            return {'m1' : edges.src[fld] + edges.dst[fld],
+                    'm2' : edges.src[fld] * edges.dst[fld]}
+
+        def reduce_func(nodes):
+            return {'final' : F.sum(nodes.mailbox['m1'] + nodes.mailbox['m2'], 1)}
+
+        def apply_func(nodes):
+            return {'final' : 2 * nodes.data['final']}
+
+        def apply_func_2(nodes):
+            return {'final' : 2 * nodes.data['r1'] + 2 * nodes.data['r2']}
+
+        g = generate_graph()
+        # update all
+        # no specialization
+        g.update_all(message_func, reduce_func, apply_func)
+        v2 = g.get_n_repr('dst')['final']
+
+        # user break reduce func into 2 builtin
+        g.update_all(message_func,
+                     [fn.sum(msg='m1', out='r1'), fn.sum(msg='m2', out='r2')],
+                     apply_func_2)
+        v3 = g.get_n_repr('dst')['final']
+
+        assert F.allclose(v2, v3)
+
+    # test 1d node features
+    _test('f1')
+    # test 2d node features
+    _test('f2')
+
+def test_e2v_snr_multi_fn():
+    u = F.tensor([0, 0, 0, 3, 4, 9])
+    v = F.tensor([1, 2, 3, 9, 9, 0])
+    def _test(fld):
+        def message_func(edges):
+            return {'m1' : edges.src[fld] + edges.dst[fld],
+                    'm2' : edges.src[fld] * edges.dst[fld]}
+
+        def reduce_func(nodes):
+            return {'final' : F.sum(nodes.mailbox['m1'] + nodes.mailbox['m2'], 1)}
+
+        def apply_func(nodes):
+            return {'final' : 2 * nodes.data['final']}
+
+        def apply_func_2(nodes):
+            return {'final' : 2 * nodes.data['r1'] + 2 * nodes.data['r2']}
+
+        g = generate_graph()
+        # send_and_recv
+        # no specialization
+        g.send_and_recv((u, v), message_func, reduce_func, apply_func)
+        v2 = g.get_n_repr('dst')['final']
+
+        # user break reduce func into 2 builtin
+        g.send_and_recv((u, v), message_func,
+                        [fn.sum(msg='m1', out='r1'), fn.sum(msg='m2', out='r2')],
+                        apply_func_2)
+        v3 = g.get_n_repr('dst')['final']
+
+        assert F.allclose(v2, v3)
+
+    # test 1d node features
+    _test('f1')
+    # test 2d node features
+    _test('f2')
+
+def test_e2v_recv_multi_fn():
+    u = F.tensor([0, 0, 0, 3, 4, 9])
+    v = F.tensor([1, 2, 3, 9, 9, 0])
+    def _test(fld):
+        def message_func(edges):
+            return {'m1' : edges.src[fld] + edges.dst[fld],
+                    'm2' : edges.src[fld] * edges.dst[fld]}
+
+        def reduce_func(nodes):
+            return {fld : F.sum(nodes.mailbox['m1'] + nodes.mailbox['m2'], 1)}
+
+        def apply_func(nodes):
+            return {fld : 2 * nodes.data[fld]}
+
+        def apply_func_2(nodes):
+            return {fld : 2 * nodes.data['r1'] + 2 * nodes.data['r2']}
+
+        g = generate_graph()
+        # recv
+        v1 = g.get_n_repr()[fld]
+        # no specialization
+        g.send((u, v), message_func)
+        g.recv([0,1,2,3,9], reduce_func, apply_func)
+        v2 = g.get_n_repr()[fld]
+
+        # user break reduce func into 2 builtin
+        g.set_n_repr({fld : v1})
+        g.send((u, v), message_func)
+        g.recv([0,1,2,3,9],
+               [fn.sum(msg='m1', out='r1'), fn.sum(msg='m2', out='r2')],
+               apply_func_2)
+        v3 = g.get_n_repr()[fld]
+
+        assert F.allclose(v2, v3)
+
+    # test 1d node features
+    _test('f1')
+    # test 2d node features
+    _test('f2')
+
+def test_update_all_multi_fallback():
+    # create a graph with zero in degree nodes
+    g = generate_graph()
+    g['src'].ndata['h'] = F.randn((g['src'].number_of_nodes(), D))
+    g.edata['w1'] = F.randn((g.number_of_edges(),))
+    g.edata['w2'] = F.randn((g.number_of_edges(), D))
+    def _mfunc_hxw1(edges):
+        return {'m1' : edges.src['h'] * F.unsqueeze(edges.data['w1'], 1)}
+    def _mfunc_hxw2(edges):
+        return {'m2' : edges.src['h'] * edges.data['w2']}
+    def _rfunc_m1(nodes):
+        return {'o1' : F.sum(nodes.mailbox['m1'], 1)}
+    def _rfunc_m2(nodes):
+        return {'o2' : F.sum(nodes.mailbox['m2'], 1)}
+    def _rfunc_m1max(nodes):
+        return {'o3' : F.max(nodes.mailbox['m1'], 1)}
+    def _afunc(nodes):
+        ret = {}
+        for k, v in nodes.data.items():
+            if k.startswith('o'):
+                ret[k] = 2 * v
+        return ret
+    # compute ground truth
+    g.update_all(_mfunc_hxw1, _rfunc_m1, _afunc)
+    o1 = g['dst'].ndata.pop('o1')
+    g.update_all(_mfunc_hxw2, _rfunc_m2, _afunc)
+    o2 = g['dst'].ndata.pop('o2')
+    g.update_all(_mfunc_hxw1, _rfunc_m1max, _afunc)
+    o3 = g['dst'].ndata.pop('o3')
+    # v2v spmv
+    g.update_all(fn.src_mul_edge(src='h', edge='w1', out='m1'),
+                 fn.sum(msg='m1', out='o1'),
+                 _afunc)
+    assert F.allclose(o1, g['dst'].ndata.pop('o1'))
+    # v2v fallback to e2v
+    g.update_all(fn.src_mul_edge(src='h', edge='w2', out='m2'),
+                 fn.sum(msg='m2', out='o2'),
+                 _afunc)
+    assert F.allclose(o2, g['dst'].ndata.pop('o2'))
+    # v2v fallback to degree bucketing
+    g.update_all(fn.src_mul_edge(src='h', edge='w1', out='m1'),
+                 fn.max(msg='m1', out='o3'),
+                 _afunc)
+    assert F.allclose(o3, g['dst'].ndata.pop('o3'))
+    # multi builtins, both v2v spmv
+    g.update_all([fn.src_mul_edge(src='h', edge='w1', out='m1'), fn.src_mul_edge(src='h', edge='w1', out='m2')],
+                 [fn.sum(msg='m1', out='o1'), fn.sum(msg='m2', out='o2')],
+                 _afunc)
+    assert F.allclose(o1, g['dst'].ndata.pop('o1'))
+    assert F.allclose(o1, g['dst'].ndata.pop('o2'))
+    # multi builtins, one v2v spmv, one fallback to e2v
+    g.update_all([fn.src_mul_edge(src='h', edge='w1', out='m1'), fn.src_mul_edge(src='h', edge='w2', out='m2')],
+                 [fn.sum(msg='m1', out='o1'), fn.sum(msg='m2', out='o2')],
+                 _afunc)
+    assert F.allclose(o1, g['dst'].ndata.pop('o1'))
+    assert F.allclose(o2, g['dst'].ndata.pop('o2'))
+    # multi builtins, one v2v spmv, one fallback to e2v, one fallback to degree-bucketing
+    g.update_all([fn.src_mul_edge(src='h', edge='w1', out='m1'),
+                  fn.src_mul_edge(src='h', edge='w2', out='m2'),
+                  fn.src_mul_edge(src='h', edge='w1', out='m3')],
+                 [fn.sum(msg='m1', out='o1'),
+                  fn.sum(msg='m2', out='o2'),
+                  fn.max(msg='m3', out='o3')],
+                 _afunc)
+    assert F.allclose(o1, g['dst'].ndata.pop('o1'))
+    assert F.allclose(o2, g['dst'].ndata.pop('o2'))
+    assert F.allclose(o3, g['dst'].ndata.pop('o3'))
+
+
+def test_pull_multi_fallback():
+    # create a graph with zero in degree nodes
+    g = generate_graph()
+    g['src'].ndata['h'] = F.randn((g['src'].number_of_nodes(), D))
+    g.edata['w1'] = F.randn((g.number_of_edges(),))
+    g.edata['w2'] = F.randn((g.number_of_edges(), D))
+    def _mfunc_hxw1(edges):
+        return {'m1' : edges.src['h'] * F.unsqueeze(edges.data['w1'], 1)}
+    def _mfunc_hxw2(edges):
+        return {'m2' : edges.src['h'] * edges.data['w2']}
+    def _rfunc_m1(nodes):
+        return {'o1' : F.sum(nodes.mailbox['m1'], 1)}
+    def _rfunc_m2(nodes):
+        return {'o2' : F.sum(nodes.mailbox['m2'], 1)}
+    def _rfunc_m1max(nodes):
+        return {'o3' : F.max(nodes.mailbox['m1'], 1)}
+    def _afunc(nodes):
+        ret = {}
+        for k, v in nodes.data.items():
+            if k.startswith('o'):
+                ret[k] = 2 * v
+        return ret
+    # nodes to pull
+    def _pull_nodes(nodes):
+        # compute ground truth
+        g.pull(nodes, _mfunc_hxw1, _rfunc_m1, _afunc)
+        o1 = g['dst'].ndata.pop('o1')
+        g.pull(nodes, _mfunc_hxw2, _rfunc_m2, _afunc)
+        o2 = g['dst'].ndata.pop('o2')
+        g.pull(nodes, _mfunc_hxw1, _rfunc_m1max, _afunc)
+        o3 = g['dst'].ndata.pop('o3')
+        # v2v spmv
+        g.pull(nodes, fn.src_mul_edge(src='h', edge='w1', out='m1'),
+                     fn.sum(msg='m1', out='o1'),
+                     _afunc)
+        assert F.allclose(o1, g['dst'].ndata.pop('o1'))
+        # v2v fallback to e2v
+        g.pull(nodes, fn.src_mul_edge(src='h', edge='w2', out='m2'),
+                     fn.sum(msg='m2', out='o2'),
+                     _afunc)
+        assert F.allclose(o2, g['dst'].ndata.pop('o2'))
+        # v2v fallback to degree bucketing
+        g.pull(nodes, fn.src_mul_edge(src='h', edge='w1', out='m1'),
+                     fn.max(msg='m1', out='o3'),
+                     _afunc)
+        assert F.allclose(o3, g['dst'].ndata.pop('o3'))
+        # multi builtins, both v2v spmv
+        g.pull(nodes,
+               [fn.src_mul_edge(src='h', edge='w1', out='m1'), fn.src_mul_edge(src='h', edge='w1', out='m2')],
+               [fn.sum(msg='m1', out='o1'), fn.sum(msg='m2', out='o2')],
+               _afunc)
+        assert F.allclose(o1, g['dst'].ndata.pop('o1'))
+        assert F.allclose(o1, g['dst'].ndata.pop('o2'))
+        # multi builtins, one v2v spmv, one fallback to e2v
+        g.pull(nodes,
+               [fn.src_mul_edge(src='h', edge='w1', out='m1'), fn.src_mul_edge(src='h', edge='w2', out='m2')],
+               [fn.sum(msg='m1', out='o1'), fn.sum(msg='m2', out='o2')],
+               _afunc)
+        assert F.allclose(o1, g['dst'].ndata.pop('o1'))
+        assert F.allclose(o2, g['dst'].ndata.pop('o2'))
+        # multi builtins, one v2v spmv, one fallback to e2v, one fallback to degree-bucketing
+        g.pull(nodes,
+               [fn.src_mul_edge(src='h', edge='w1', out='m1'),
+                fn.src_mul_edge(src='h', edge='w2', out='m2'),
+                fn.src_mul_edge(src='h', edge='w1', out='m3')],
+               [fn.sum(msg='m1', out='o1'),
+                fn.sum(msg='m2', out='o2'),
+                fn.max(msg='m3', out='o3')],
+               _afunc)
+        assert F.allclose(o1, g['dst'].ndata.pop('o1'))
+        assert F.allclose(o2, g['dst'].ndata.pop('o2'))
+        assert F.allclose(o3, g['dst'].ndata.pop('o3'))
+    # test#1: non-0deg nodes
+    nodes = [1, 2, 9]
+    _pull_nodes(nodes)
+    # test#2: 0deg nodes + non-0deg nodes
+    nodes = [0, 1, 2, 9]
+    _pull_nodes(nodes)
+
+def test_spmv_3d_feat():
+    def src_mul_edge_udf(edges):
+        return {'sum': edges.src['h'] * F.unsqueeze(F.unsqueeze(edges.data['h'], 1), 1)}
+
+    def sum_udf(nodes):
+        return {'h': F.sum(nodes.mailbox['sum'], 1)}
+
+    n = 100
+    p = 0.1
+    a = sp.random(n, n + 10, p, data_rvs=lambda n: np.ones(n))
+    num_nodes = {'src': n, 'dst': n + 10}
+    metagraph = nx.MultiGraph([('src', 'dst', 'e')])
+    g = dgl.DGLBipartiteGraph(metagraph, num_nodes,
+                              {('src', 'dst', 'e'): a}, readonly=True)
+    m = g.number_of_edges()
+
+    # test#1: v2v with adj data
+    h = F.randn((n, 5, 5))
+    e = F.randn((m,))
+
+    g['src'].ndata['h'] = h
+    g.edata['h'] = e
+    g.update_all(message_func=fn.src_mul_edge('h', 'h', 'sum'), reduce_func=fn.sum('sum', 'h')) # 1
+    ans = g['dst'].ndata['h']
+
+    g['src'].ndata['h'] = h
+    g.edata['h'] = e
+    g.update_all(message_func=src_mul_edge_udf, reduce_func=fn.sum('sum', 'h')) # 2
+    assert F.allclose(g['dst'].ndata['h'], ans)
+
+    g['src'].ndata['h'] = h
+    g.edata['h'] = e
+    g.update_all(message_func=src_mul_edge_udf, reduce_func=sum_udf) # 3
+    assert F.allclose(g['dst'].ndata['h'], ans)
+
+    # test#2: e2v
+    def src_mul_edge_udf(edges):
+        return {'sum': edges.src['h'] * edges.data['h']}
+
+    h = F.randn((n, 5, 5))
+    e = F.randn((m, 5, 5))
+
+    g['src'].ndata['h'] = h
+    g.edata['h'] = e
+    g.update_all(message_func=fn.src_mul_edge('h', 'h', 'sum'), reduce_func=fn.sum('sum', 'h')) # 1
+    ans = g['dst'].ndata['h']
+
+    g['src'].ndata['h'] = h
+    g.edata['h'] = e
+    g.update_all(message_func=src_mul_edge_udf, reduce_func=fn.sum('sum', 'h')) # 2
+    assert F.allclose(g['dst'].ndata['h'], ans)
+
+    g['src'].ndata['h'] = h
+    g.edata['h'] = e
+    g.update_all(message_func=src_mul_edge_udf, reduce_func=sum_udf) # 3
+    assert F.allclose(g['dst'].ndata['h'], ans)
+
+if __name__ == '__main__':
+    test_v2v_update_all()
+    test_v2v_snr()
+    test_v2v_pull()
+    test_v2v_update_all_multi_fn()
+    test_v2v_snr_multi_fn()
+    test_e2v_update_all_multi_fn()
+    test_e2v_snr_multi_fn()
+    #test_e2v_recv_multi_fn()
+    test_update_all_multi_fallback()
+    test_pull_multi_fallback()
+    test_spmv_3d_feat()

--- a/tests/compute/test_bipartite_specialization.py
+++ b/tests/compute/test_bipartite_specialization.py
@@ -318,6 +318,7 @@ def test_e2v_snr_multi_fn():
     # test 2d node features
     _test('f2')
 
+"""
 def test_e2v_recv_multi_fn():
     u = F.tensor([0, 0, 0, 3, 4, 9])
     v = F.tensor([1, 2, 3, 9, 9, 0])
@@ -357,6 +358,7 @@ def test_e2v_recv_multi_fn():
     _test('f1')
     # test 2d node features
     _test('f2')
+"""
 
 def test_update_all_multi_fallback():
     # create a graph with zero in degree nodes

--- a/tests/compute/test_graph.py
+++ b/tests/compute/test_graph.py
@@ -273,9 +273,6 @@ def test_incmat():
     inc_in = F.sparse_to_numpy(g.incidence_matrix('in'))
     inc_out = F.sparse_to_numpy(g.incidence_matrix('out'))
     inc_both = F.sparse_to_numpy(g.incidence_matrix('both'))
-    print(inc_in)
-    print(inc_out)
-    print(inc_both)
     assert np.allclose(
             inc_in,
             np.array([[0., 0., 0., 0., 0.],


### PR DESCRIPTION
## Description
This PR implements DGLBipartiteGraph with the hetero graph API for bipartite graph. The edges in DGLBipartiteGraph have to go from one side of nodes to the other side. If we want to support a bipartite graph with bidirectional edges, we need to use two DGLBipartiteGraph.

In addition, this implementation reuses the original graph structure for bipartite graphs. To support bipartite graph, we put nodes of the two sides into the same space. To be more specific, the source nodes have Ids between [0, #source nodes - 1] and the destination nodes have Ids between [#source nodes, #source nodes + #destination nodes - 1]. We'll improve this graph structure in the future and make it more specific for bipartite graphs.

## Checklist
Please feel free to remove inapplicable items for your PR.
- [ ] The PR title starts with [$CATEGORY] (such as [Model], [Doc], [Feature]])
- [ ] Changes are complete (i.e. I finished coding on this PR)
- [ ] All changes have test coverage
- [ ] Code is well-documented
- [ ] To the my best knowledge, examples are either not affected by this change,
      or have been fixed to be compatible with this change
- [ ] Related issue is referred in this PR

## Changes
<!-- You could use following template
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)
-->
