### PR TITLE
[Docker]Roll back CI to use MXNet nightly build 20190523

### DIFF
--- a/docker/install/ubuntu_install_mxnet_cpu.sh
+++ b/docker/install/ubuntu_install_mxnet_cpu.sh
@@ -1,1 +1,1 @@
-pip3 install mxnet==1.5.0b20190528
+pip3 install mxnet==1.5.0b20190523

--- a/docker/install/ubuntu_install_mxnet_gpu.sh
+++ b/docker/install/ubuntu_install_mxnet_gpu.sh
@@ -1,1 +1,1 @@
-pip3 install mxnet-cu90==1.5.0b20190528
+pip3 install mxnet-cu90==1.5.0b20190523

--- a/python/dgl/backend/mxnet/tensor.py
+++ b/python/dgl/backend/mxnet/tensor.py
@@ -11,7 +11,7 @@ MX_VERSION = LooseVersion(mx.__version__)
 # After MXNet 1.5, empty tensors aren't supprted by default.
 # after we turn on the numpy compatible flag, MXNet supports empty NDArray.
 if MX_VERSION.version[0] == 1 and MX_VERSION.version[1] >= 5:
-    mx.set_np_shape(True)
+    mx.set_np_compat(True)
 
 def data_type_dict():
     return {'float16' : np.float16,

--- a/tests/compute/test_dis_sampler.py
+++ b/tests/compute/test_dis_sampler.py
@@ -1,4 +1,4 @@
-from dgl import backend as F
+import backend as F
 import numpy as np
 import scipy as sp
 import dgl


### PR DESCRIPTION
## Description
Latest mxnet has a bug in its NDArray::Save function, which breaks DGL code. Rollback CI to use MXNet nightly build on 20190523