### PR TITLE
[BugFix] Fix minigc dataset

### DIFF
--- a/python/dgl/data/minigc.py
+++ b/python/dgl/data/minigc.py
@@ -143,6 +143,6 @@ class MiniGCDataset(object):
     def _gen_circular_ladder(self, n):
         for _ in range(n):
             num_v = np.random.randint(self.min_num_v, self.max_num_v)
-            g = nx.circular_ladder_graph(num_v)
+            g = nx.circular_ladder_graph(num_v // 2)
             self.graphs.append(g)
             self.labels.append(7)


### PR DESCRIPTION
## Description

As described in #568 , when we create `circular_ladder_graph` with `nx.circular_ladder_graph(num_v)`, we will get a graph with `2 * num_v` nodes.

## Checklist
Please feel free to remove inapplicable items for your PR.
- [x] The PR title starts with [$CATEGORY] (such as [Model], [Doc], [Feature]])
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage
- [x] Code is well-documented
- [x] To the my best knowledge, examples are either not affected by this change,
      or have been fixed to be compatible with this change
- [x] Related issue is referred in this PR

## Changes
<!-- You could use following template
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)
-->
