### PR TITLE
[Kernel][Bugfix] fix nodeflow bug

### DIFF
--- a/python/dgl/backend/pytorch/tensor.py
+++ b/python/dgl/backend/pytorch/tensor.py
@@ -250,6 +250,7 @@ class CopyReduce(th.autograd.Function):
         out_data = in_data.new_empty((out_size,) + in_data.shape[1:])
         in_data_nd = zerocopy_to_dgl_ndarray(in_data)
         out_data_nd = zerocopy_to_dgl_ndarray(out_data)
+        u, v, eid = graph.copy_to(nd.cpu(0)).asbits(64).edges()
         K.copy_reduce(
             reducer, graph, target, in_data_nd, out_data_nd, in_map[0],
             out_map[0])

--- a/python/dgl/kernel.py
+++ b/python/dgl/kernel.py
@@ -212,13 +212,9 @@ def copy_reduce(reducer, graph, target,
         in_mapping = empty([])
     if out_mapping is None:
         out_mapping = empty([])
-    print("before calling kernel, in_data value:")
-    print(in_data)
     _CAPI_DGLKernelCopyReduce(
         reducer, graph._handle, int(target),
         in_data, out_data, in_mapping, out_mapping)
-    print("after calling kernel, in_data value:")
-    print(in_data)
 
 def backward_copy_reduce(reducer, graph, target,
                          in_data, out_data,

--- a/src/kernel/binary_reduce.cc
+++ b/src/kernel/binary_reduce.cc
@@ -112,9 +112,10 @@ BcastInfo CalcBcastInfo(NDArray lhs, NDArray rhs) {
 }
 
 std::string IdArrayToStr(IdArray arr) {
+  arr = arr.CopyTo(DLContext{kDLCPU, 0});
   int64_t len = arr->shape[0];
   std::ostringstream oss;
-  oss << "[";
+  oss << "(" << len << ")[";
   if (arr->dtype.bits == 32) {
     int32_t* data = static_cast<int32_t*>(arr->data);
     for (int64_t i = 0; i < len; ++i) {
@@ -125,6 +126,18 @@ std::string IdArrayToStr(IdArray arr) {
     for (int64_t i = 0; i < len; ++i) {
       oss << data[i] << " ";
     }
+  }
+  oss << "]";
+  return oss.str();
+}
+
+std::string NDArrayToStr(NDArray arr, size_t num) {
+  arr = arr.CopyTo(DLContext{kDLCPU, 0});
+  std::ostringstream oss;
+  oss << "[";
+  float* arr_data = (float*)(arr->data);
+  for (size_t i = 0; i < num; ++i) {
+    oss << arr_data[i] << " ";
   }
   oss << "]";
   return oss.str();
@@ -383,6 +396,7 @@ void CopyReduce(
     NDArray in_data, NDArray out_data,
     NDArray in_mapping, NDArray out_mapping) {
   const auto& ctx = graph->Context();
+  const auto incsr = graph->GetInCSR();
   // sanity check
   CheckCtx(ctx,
       {in_data, out_data, in_mapping, out_mapping},

--- a/src/kernel/binary_reduce.cc
+++ b/src/kernel/binary_reduce.cc
@@ -131,18 +131,6 @@ std::string IdArrayToStr(IdArray arr) {
   return oss.str();
 }
 
-std::string NDArrayToStr(NDArray arr, size_t num) {
-  arr = arr.CopyTo(DLContext{kDLCPU, 0});
-  std::ostringstream oss;
-  oss << "[";
-  float* arr_data = (float*)(arr->data);
-  for (size_t i = 0; i < num; ++i) {
-    oss << arr_data[i] << " ";
-  }
-  oss << "]";
-  return oss.str();
-}
-
 inline void CheckCtx(
     const DLContext& ctx,
     const std::vector<NDArray>& arrays,

--- a/src/kernel/binary_reduce_impl.h
+++ b/src/kernel/binary_reduce_impl.h
@@ -35,6 +35,7 @@ GData<Idx, DType> AllocGData(
   // GData
   GData<Idx, DType> gdata;
   gdata.x_length = x_len;
+  gdata.out_size = out_data->shape[0];
   gdata.lhs_data = static_cast<DType*>(lhs_data->data);
   gdata.rhs_data = static_cast<DType*>(rhs_data->data);
   gdata.out_data = static_cast<DType*>(out_data->data);
@@ -137,6 +138,7 @@ BackwardGData<Idx, DType> AllocBackwardGData(
   // GData
   BackwardGData<Idx, DType> gdata;
   gdata.x_length = x_len;
+  gdata.out_size = out_data->shape[0];
   gdata.lhs_data = static_cast<DType*>(lhs_data->data);
   gdata.rhs_data = static_cast<DType*>(rhs_data->data);
   gdata.out_data = static_cast<DType*>(out_data->data);

--- a/src/kernel/binary_reduce_impl_decl.h
+++ b/src/kernel/binary_reduce_impl_decl.h
@@ -28,8 +28,10 @@ struct BcastInfo;
 
 template <typename Idx, typename DType>
 struct GData {
-  // length along x dimension
+  // length along x(feature) dimension
   int64_t x_length{0};
+  // number of rows of the output tensor
+  int64_t out_size{0};
   // input data
   DType *lhs_data{nullptr}, *rhs_data{nullptr};
   // output data
@@ -59,8 +61,10 @@ void BinaryReduceImpl(
 
 template <typename Idx, typename DType>
 struct BackwardGData {
-  // length along x dimension
+  // length along x(feature) dimension
   int64_t x_length{0};
+  // number of rows of the output tensor
+  int64_t out_size{0};
   // input data
   DType *lhs_data{nullptr}, *rhs_data{nullptr}, *out_data{nullptr};
   DType *grad_out_data{nullptr};

--- a/tests/compute/test_nodeflow.py
+++ b/tests/compute/test_nodeflow.py
@@ -8,6 +8,7 @@ import dgl.function as fn
 from functools import partial
 import itertools
 
+np.random.seed(40)
 
 def generate_rand_graph(n, connect_more=False, complete=False):
     if complete:
@@ -153,7 +154,7 @@ def check_flow_compute(create_node_flow):
     for i in range(num_layers):
         nf.block_compute(i, fn.copy_src(src='h', out='m'), fn.sum(msg='m', out='t'),
                          lambda nodes: {'h' : nodes.data['t'] + 1})
-        exit()
+
         g.update_all(fn.copy_src(src='h', out='m'), fn.sum(msg='m', out='t'),
                      lambda nodes: {'h' : nodes.data['t'] + 1})
         assert F.allclose(nf.layers[i + 1].data['h'],


### PR DESCRIPTION
## Description
Fix the bug in using cusparse when the sparse matrix is actually a bipartite graph.

## Checklist
Please feel free to remove inapplicable items for your PR.
- [x] The PR title starts with [$CATEGORY] (such as [Model], [Doc], [Feature]])
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage
- [x] Code is well-documented
- [x] To the my best knowledge, examples are either not affected by this change,
      or have been fixed to be compatible with this change
- [x] Related issue is referred in this PR
