### PR TITLE
[BUG][Test] Fix occasional assertion failure in sampler test

### DIFF
--- a/tests/compute/test_sampler.py
+++ b/tests/compute/test_sampler.py
@@ -4,6 +4,8 @@ import scipy as sp
 import dgl
 from dgl import utils
 
+np.random.seed(42)
+
 def generate_rand_graph(n):
     arr = (sp.sparse.random(n, n, density=0.1, format='coo') != 0).astype(np.int64)
     return dgl.DGLGraph(arr, readonly=True)


### PR DESCRIPTION
Occasionally the NodeFlow sampler test will fail due to isolated nodes (i.e. zero in-degree or out-degree) in the generated graph.