### PR TITLE
[BUG][Test] Fix random BFS traversal test failures

### DIFF
--- a/tests/compute/test_traversal.py
+++ b/tests/compute/test_traversal.py
@@ -31,8 +31,10 @@ def test_bfs(n=1000):
                 edges_nx.append(edge_frontier)
                 frontier = set([v])
                 edge_frontier = set([g.edge_id(u, v)])
-        layers_nx.append(frontier)
-        edges_nx.append(edge_frontier)
+        # avoids case of no successors
+        if len(frontier) > 0 and len(edge_frontier) > 0:
+            layers_nx.append(frontier)
+            edges_nx.append(edge_frontier)
         return layers_nx, edges_nx
 
     g = dgl.DGLGraph()


### PR DESCRIPTION
Sometimes the BFS traversal will fail due to empty frontier being added in networkx code for nodes with 0 successors.