### PR TITLE
[bugfix] fix bug in repr function of GraphConv

### DIFF
--- a/python/dgl/nn/pytorch/conv.py
+++ b/python/dgl/nn/pytorch/conv.py
@@ -149,5 +149,6 @@ class GraphConv(nn.Module):
         """
         summary = 'in={_in_feats}, out={_out_feats}'
         summary += ', normalization={_norm}'
-        summary += ', activation={_activation}'
+        if '_activation' in self.__dict__:
+            summary += ', activation={_activation}'
         return summary.format(**self.__dict__)


### PR DESCRIPTION
## Description
To fix the bug described in #617 .

## Checklist
Please feel free to remove inapplicable items for your PR.
- [x] The PR title starts with [$CATEGORY] (such as [Model], [Doc], [Feature]])
- [x] Changes are complete (i.e. I finished coding on this PR)
- [ ] All changes have test coverage
- [x] Code is well-documented
- [x] To the my best knowledge, examples are either not affected by this change,
      or have been fixed to be compatible with this change
- [x] Related issue is referred in this PR

## Behavior
Input:
```python
import dgl
from dgl.nn.pytorch.conv import GraphConv
import torch.nn as nn
import torch.nn.functional as F
model_0 = GraphConv(2,2,activation=nn.PReLU())
model_1 = GraphConv(2,2, activation=F.relu)
print(model_0)
print(model_1)
```
Output:
```
GraphConv(
  in=2, out=2, normalization=True
  (_activation): PReLU(num_parameters=1)
)
GraphConv(in=2, out=2, normalization=True, activation=<function relu at 0x119d84bf8>)
```