### PR TITLE
[BugFix] Fix memory leak in DGL edge softmax module

### DIFF
--- a/python/dgl/backend/mxnet/tensor.py
+++ b/python/dgl/backend/mxnet/tensor.py
@@ -310,6 +310,7 @@ class BinaryReduce(mx.autograd.Function):
             zerocopy_to_dgl_ndarray_for_write(grad_rhs), self.lhs_map[1],
             self.rhs_map[1], self.out_map[1])
         grad_rhs = _reduce_grad(grad_rhs, rhs_data_nd.shape)
+        # clear saved tensors explicitly
         self.saved_tensors = None
         return grad_lhs, grad_rhs
 
@@ -352,6 +353,7 @@ class CopyReduce(mx.autograd.Function):
             self.reducer, self.graph, self.target, in_data_nd, out_data_nd,
             grad_out_nd, zerocopy_to_dgl_ndarray_for_write(grad_in),
             self.in_map[1], self.out_map[1])
+        # clear saved tensors explicitly
         self.saved_tensors = None
         return grad_in
 

--- a/python/dgl/backend/mxnet/tensor.py
+++ b/python/dgl/backend/mxnet/tensor.py
@@ -310,6 +310,7 @@ class BinaryReduce(mx.autograd.Function):
             zerocopy_to_dgl_ndarray_for_write(grad_rhs), self.lhs_map[1],
             self.rhs_map[1], self.out_map[1])
         grad_rhs = _reduce_grad(grad_rhs, rhs_data_nd.shape)
+        self.saved_tensors = None
         return grad_lhs, grad_rhs
 
 
@@ -351,6 +352,7 @@ class CopyReduce(mx.autograd.Function):
             self.reducer, self.graph, self.target, in_data_nd, out_data_nd,
             grad_out_nd, zerocopy_to_dgl_ndarray_for_write(grad_in),
             self.in_map[1], self.out_map[1])
+        self.saved_tensors = None
         return grad_in
 
 

--- a/python/dgl/nn/mxnet/softmax.py
+++ b/python/dgl/nn/mxnet/softmax.py
@@ -75,6 +75,7 @@ class EdgeSoftmax(mx.autograd.Function):
         g.apply_edges(fn.e_mul_v(out_name, accum_name, out_name))
         g.ndata.pop(accum_name)
         grad_score = g.edata.pop(grad_score_name) - g.edata.pop(out_name)
+        # clear saved tensors explicitly
         self.saved_tensors = None
         return grad_score
 

--- a/python/dgl/nn/mxnet/softmax.py
+++ b/python/dgl/nn/mxnet/softmax.py
@@ -65,7 +65,7 @@ class EdgeSoftmax(mx.autograd.Function):
         return grad_score.data
         """
         g = self.g
-        out, = self.saved_tensors  # pylint: disable=access-member-before-definition
+        out, = self.saved_tensors  # pylint: disable=access-member-before-definition, unpacking-non-sequence
         # clear saved tensors explicitly
         self.saved_tensors = None
         out_name = utils.get_edata_name(g, 'out')

--- a/python/dgl/nn/mxnet/softmax.py
+++ b/python/dgl/nn/mxnet/softmax.py
@@ -66,6 +66,8 @@ class EdgeSoftmax(mx.autograd.Function):
         """
         g = self.g
         out, = self.saved_tensors
+        # clear saved tensors explicitly
+        self.saved_tensors = None
         out_name = utils.get_edata_name(g, 'out')
         accum_name = utils.get_ndata_name(g, 'accum')
         grad_score_name = utils.get_edata_name(g, 'grad_score')
@@ -75,8 +77,6 @@ class EdgeSoftmax(mx.autograd.Function):
         g.apply_edges(fn.e_mul_v(out_name, accum_name, out_name))
         g.ndata.pop(accum_name)
         grad_score = g.edata.pop(grad_score_name) - g.edata.pop(out_name)
-        # clear saved tensors explicitly
-        self.saved_tensors = None
         return grad_score
 
 

--- a/python/dgl/nn/mxnet/softmax.py
+++ b/python/dgl/nn/mxnet/softmax.py
@@ -65,7 +65,7 @@ class EdgeSoftmax(mx.autograd.Function):
         return grad_score.data
         """
         g = self.g
-        out = self.saved_tensors[0]
+        out, = self.saved_tensors
         out_name = utils.get_edata_name(g, 'out')
         accum_name = utils.get_ndata_name(g, 'accum')
         grad_score_name = utils.get_edata_name(g, 'grad_score')
@@ -75,6 +75,7 @@ class EdgeSoftmax(mx.autograd.Function):
         g.apply_edges(fn.e_mul_v(out_name, accum_name, out_name))
         g.ndata.pop(accum_name)
         grad_score = g.edata.pop(grad_score_name) - g.edata.pop(out_name)
+        self.saved_tensors = None
         return grad_score
 
 

--- a/python/dgl/nn/mxnet/softmax.py
+++ b/python/dgl/nn/mxnet/softmax.py
@@ -65,7 +65,7 @@ class EdgeSoftmax(mx.autograd.Function):
         return grad_score.data
         """
         g = self.g
-        out, = self.saved_tensors
+        out, = self.saved_tensors  # pylint: disable=access-member-before-definition
         # clear saved tensors explicitly
         self.saved_tensors = None
         out_name = utils.get_edata_name(g, 'out')

--- a/python/dgl/nn/pytorch/softmax.py
+++ b/python/dgl/nn/pytorch/softmax.py
@@ -62,6 +62,7 @@ class EdgeSoftmax(th.autograd.Function):
         return grad_score.data
         """
         g, out = ctx.backward_cache
+        ctx.backward_cache = None
         out_name = utils.get_edata_name(g, 'out')
         accum_name = utils.get_ndata_name(g, 'accum')
         grad_score_name = utils.get_edata_name(g, 'grad_score')

--- a/python/dgl/nn/pytorch/softmax.py
+++ b/python/dgl/nn/pytorch/softmax.py
@@ -62,6 +62,7 @@ class EdgeSoftmax(th.autograd.Function):
         return grad_score.data
         """
         g, out = ctx.backward_cache
+        # clear backward cache explicitly
         ctx.backward_cache = None
         out_name = utils.get_edata_name(g, 'out')
         accum_name = utils.get_ndata_name(g, 'accum')


### PR DESCRIPTION
## Description
Current DGL operators leak memory, and this happens for both PyTorch (#637 ) and MXNet backend.

For PyTorch, the cause is we used a separate cache instead of PyTorch's `ctx.save_for_backward` API to save tensors from forward pass but forgot to explicitly clear the cache. And the reason for not using `ctx.save_for_backward` API is we need to save non-tensor type data. Similar problem was mentioned in [this thread](https://discuss.pytorch.org/t/when-should-you-save-for-backward-vs-storing-in-ctx/6522).

For MXNet, the interesting thing is, even if we use its standard `save_for_backward` API, there is still memory leak. 

The Solution is simply explicitly clearing the cache.

## Checklist
Please feel free to remove inapplicable items for your PR.
- [x] The PR title starts with [$CATEGORY] (such as [Model], [Doc], [Feature]])
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage
- [x] Code is well-documented
- [x] To the my best knowledge, examples are either not affected by this change,
      or have been fixed to be compatible with this change
- [x] Related issue is referred in this PR

