### PR TITLE
[Feature] add edge sampler.

### DIFF
--- a/include/dgl/sampler.h
+++ b/include/dgl/sampler.h
@@ -56,13 +56,15 @@ class SamplerOp {
    * \param num_hops the number of hops to sample neighbors.
    * \param expand_factor the max number of neighbors to sample.
    * \param add_self_loop whether to add self loop to the sampled subgraph
+   * \param exclude_edges a set of edges we should exclude from the sampled NodeFlow.
    * \return a NodeFlow graph.
    */
   static NodeFlow NeighborUniformSample(const ImmutableGraph *graph,
                                         const std::vector<dgl_id_t>& seeds,
                                         const std::string &edge_type,
                                         int num_hops, int expand_factor,
-                                        const bool add_self_loop);
+                                        const bool add_self_loop,
+                                        const std::unordered_set<dgl_id_t> &exclude_edges);
 
   /*!
    * \brief Sample a graph from the seed vertices with layer sampling.

--- a/python/dgl/contrib/sampling/__init__.py
+++ b/python/dgl/contrib/sampling/__init__.py
@@ -1,4 +1,4 @@
-from .sampler import NeighborSampler, LayerSampler
+from .sampler import NeighborSampler, LayerSampler, EdgeNeighborSampler
 from .randomwalk import *
 from .dis_sampler import SamplerSender, SamplerReceiver
 from .dis_sampler import SamplerPool

--- a/python/dgl/contrib/sampling/sampler.py
+++ b/python/dgl/contrib/sampling/sampler.py
@@ -557,11 +557,13 @@ class EdgeNeighborSampler(EdgeSampler):
         for hdl in handles:
             func = _CAPI_GetEdgeBatch(hdl)
 
-            pos_subg_func = _CAPI_GetSubgraph(func(2))
+            pos_subg_hdl = func(2)
+            pos_subg_func = _CAPI_GetSubgraph(pos_subg_hdl)
             pos_subg_idx = SubgraphIndex(GraphIndex(pos_subg_func(0)), self.g._graph,
                                          utils.toindex(pos_subg_func(1)),
                                          utils.toindex(pos_subg_func(2)))
             pos_subg = subgraph.DGLSubGraph(self.g, pos_subg_idx)
+            _CAPI_FreeSubgraph(pos_subg_hdl)
 
             if self._num_hops > 0 and self._expand_factor > 0:
                 nf1 = NodeFlow(self.g, func(0))
@@ -573,12 +575,15 @@ class EdgeNeighborSampler(EdgeSampler):
             if self._negative_mode == "":
                 nflows.append((nf1, nf2, pos_subg))
             else:
-                neg_subg_func = _CAPI_GetSubgraph(func(3))
+                neg_subg_hdl = func(3)
+                neg_subg_func = _CAPI_GetSubgraph(neg_subg_hdl)
                 neg_subg_idx = SubgraphIndex(GraphIndex(neg_subg_func(0)), self.g._graph,
                                              utils.toindex(neg_subg_func(1)),
                                              utils.toindex(neg_subg_func(2)))
                 neg_subg = subgraph.DGLSubGraph(self.g, neg_subg_idx)
                 nflows.append((nf1, nf2, pos_subg, neg_subg))
+                _CAPI_FreeSubgraph(neg_subg_hdl)
+            _CAPI_FreeEdgeBatch(hdl)
 
         return nflows
 

--- a/python/dgl/contrib/sampling/sampler.py
+++ b/python/dgl/contrib/sampling/sampler.py
@@ -11,6 +11,8 @@ from ... import utils
 from ...nodeflow import NodeFlow
 from ... import backend as F
 from ...utils import unwrap_to_ptr_list
+from ...graph_index import SubgraphIndex, GraphIndex
+from ... import subgraph
 
 try:
     import Queue as queue
@@ -491,7 +493,7 @@ class EdgeNeighborSampler(EdgeSampler):
             self,
             g,
             batch_size,
-            expand_factor=None,
+            expand_factor=0,
             num_hops=1,
             neighbor_type='in',
             node_prob=None,
@@ -501,7 +503,9 @@ class EdgeNeighborSampler(EdgeSampler):
             prefetch=False,
             add_self_loop=False,
             exclude_sampled_edges=True,
-            undirected=False):
+            undirected=False,
+            negative_mode="",
+            neg_sample_size=0):
         super(EdgeNeighborSampler, self).__init__(
                 g, batch_size, seed_edges, shuffle, num_workers * 2 if prefetch else 0,
                 ThreadPrefetchingWrapper)
@@ -516,6 +520,8 @@ class EdgeNeighborSampler(EdgeSampler):
         self._neighbor_type = neighbor_type
         self._exclude_edges = exclude_sampled_edges
         self._undirected = undirected
+        self._negative_mode = negative_mode
+        self._neg_sample_size = neg_sample_size
 
     def fetch(self, current_index):
         handles = unwrap_to_ptr_list(_CAPI_UniformEdgeSampling(
@@ -529,11 +535,30 @@ class EdgeNeighborSampler(EdgeSampler):
             self._neighbor_type,
             self._add_self_loop,
             self._exclude_edges,
-            self._undirected))
+            self._undirected,
+            self._negative_mode,
+            self._neg_sample_size))
         nflows = []
         for hdl in handles:
             func = _CAPI_GetEdgeBatch(hdl)
-            nflows.append((NodeFlow(self.g, func(0)), NodeFlow(self.g, func(1)), func(2)))
+
+            pos_subg_func = _CAPI_GetSubgraph(func(2))
+            pos_subg_idx = SubgraphIndex(GraphIndex(pos_subg_func(0)), self.g._graph,
+                                         utils.toindex(pos_subg_func(1)),
+                                         utils.toindex(pos_subg_func(2)))
+            pos_subg = subgraph.DGLSubGraph(self.g, pos_subg_idx)
+
+            if self._negative_mode == "":
+                nflows.append((NodeFlow(self.g, func(0)), NodeFlow(self.g, func(1)), pos_subg))
+            else:
+                neg_subg_func = _CAPI_GetSubgraph(func(3))
+                neg_subg_idx = SubgraphIndex(GraphIndex(neg_subg_func(0)), self.g._graph,
+                                             utils.toindex(neg_subg_func(1)),
+                                             utils.toindex(neg_subg_func(2)))
+                neg_subg = subgraph.DGLSubGraph(self.g, neg_subg_idx)
+                nflows.append((NodeFlow(self.g, func(0)), NodeFlow(self.g, func(1)),
+                               pos_subg, neg_subg))
+
         return nflows
 
 

--- a/python/dgl/contrib/sampling/sampler.py
+++ b/python/dgl/contrib/sampling/sampler.py
@@ -548,16 +548,22 @@ class EdgeNeighborSampler(EdgeSampler):
                                          utils.toindex(pos_subg_func(2)))
             pos_subg = subgraph.DGLSubGraph(self.g, pos_subg_idx)
 
+            if self._num_hops > 0 and self._expand_factor > 0:
+                nf1 = NodeFlow(self.g, func(0))
+                nf2 = NodeFlow(self.g, func(1))
+            else:
+                nf1 = None
+                nf2 = None
+
             if self._negative_mode == "":
-                nflows.append((NodeFlow(self.g, func(0)), NodeFlow(self.g, func(1)), pos_subg))
+                nflows.append((nf1, nf2, pos_subg))
             else:
                 neg_subg_func = _CAPI_GetSubgraph(func(3))
                 neg_subg_idx = SubgraphIndex(GraphIndex(neg_subg_func(0)), self.g._graph,
                                              utils.toindex(neg_subg_func(1)),
                                              utils.toindex(neg_subg_func(2)))
                 neg_subg = subgraph.DGLSubGraph(self.g, neg_subg_idx)
-                nflows.append((NodeFlow(self.g, func(0)), NodeFlow(self.g, func(1)),
-                               pos_subg, neg_subg))
+                nflows.append((nf1, nf2, pos_subg, neg_subg))
 
         return nflows
 

--- a/python/dgl/contrib/sampling/sampler.py
+++ b/python/dgl/contrib/sampling/sampler.py
@@ -19,24 +19,24 @@ except ImportError:
 
 __all__ = ['NeighborSampler', 'LayerSampler']
 
-class NodeFlowSamplerIter(object):
+class SamplerIter(object):
     def __init__(self, sampler):
-        super(NodeFlowSamplerIter, self).__init__()
+        super(SamplerIter, self).__init__()
         self._sampler = sampler
-        self._nflows = []
-        self._nflow_idx = 0
+        self._batches = []
+        self._batch_idx = 0
 
     def prefetch(self):
-        nflows = self._sampler.fetch(self._nflow_idx)
-        self._nflows.extend(nflows)
-        self._nflow_idx += len(nflows)
+        batches = self._sampler.fetch(self._batch_idx)
+        self._batches.extend(batches)
+        self._batch_idx += len(batches)
 
     def __next__(self):
-        if len(self._nflows) == 0:
+        if len(self._batches) == 0:
             self.prefetch()
-        if len(self._nflows) == 0:
+        if len(self._batches) == 0:
             raise StopIteration
-        return self._nflows.pop(0)
+        return self._batches.pop(0)
 
 class PrefetchingWrapper(object):
     """Internal shared prefetcher logic. It can be sub-classed by a Thread-based implementation
@@ -187,7 +187,7 @@ class NodeFlowSampler(object):
         raise NotImplementedError
 
     def __iter__(self):
-        it = NodeFlowSamplerIter(self)
+        it = SamplerIter(self)
         if self._num_prefetch:
             return self._prefetching_wrapper_class(it, self._num_prefetch)
         else:
@@ -405,6 +405,133 @@ class LayerSampler(NodeFlowSampler):
             self._neighbor_type))
         nflows = [NodeFlow(self.g, hdl) for hdl in handles]
         return nflows
+
+
+class EdgeSampler(object):
+    '''Base class that generates NodeFlows for link prediction.
+
+    For a mini-batch, it samples a set of edges. From the source and
+    destination vertices, it creates NodeFlows with node-level sampler
+    (e.g., NeighborSampler, Layer-wise sampler).
+
+    Class properties
+    ----------------
+    immutable_only : bool
+        Whether the sampler only works on immutable graphs.
+        Subclasses can override this property.
+    '''
+    immutable_only = False
+
+    def __init__(
+            self,
+            g,
+            batch_size,
+            seed_edges,
+            shuffle,
+            num_prefetch,
+            prefetching_wrapper_class):
+        self._g = g
+        if self.immutable_only and not g._graph.is_readonly():
+            raise NotImplementedError("This loader only support read-only graphs.")
+
+        self._batch_size = int(batch_size)
+
+        if seed_edges is None:
+            self._seed_edges = F.arange(0, g.number_of_edges())
+        else:
+            self._seed_edges = seed_edges
+        if shuffle:
+            self._seed_edges = F.rand_shuffle(self._seed_edges)
+        self._seed_edges = utils.toindex(self._seed_edges)
+
+        if num_prefetch:
+            self._prefetching_wrapper_class = prefetching_wrapper_class
+        self._num_prefetch = num_prefetch
+
+    def fetch(self, current_index):
+        '''
+        It returns the next "bunch" of NodeFlows.
+
+        Subclasses of EdgeSampler should override this method.
+
+        Parameters
+        ----------
+        current_index : int
+            How many batches the sampler has generated so far.
+
+        Returns
+        -------
+        list[(NodeFlow, GraphIndex, NodeFlow)]
+            Next "bunch" of nodeflows to be processed.
+        '''
+        raise NotImplementedError
+
+    def __iter__(self):
+        it = SamplerIter(self)
+        if self._num_prefetch:
+            return self._prefetching_wrapper_class(it, self._num_prefetch)
+        else:
+            return it
+
+    @property
+    def g(self):
+        return self._g
+
+    @property
+    def seed_edges(self):
+        return self._seed_edges
+
+    @property
+    def batch_size(self):
+        return self._batch_size
+
+
+class EdgeNeighborSampler(EdgeSampler):
+    def __init__(
+            self,
+            g,
+            batch_size,
+            expand_factor=None,
+            num_hops=1,
+            neighbor_type='in',
+            node_prob=None,
+            seed_edges=None,
+            shuffle=False,
+            num_workers=1,
+            prefetch=False,
+            add_self_loop=False):
+        super(EdgeNeighborSampler, self).__init__(
+                g, batch_size, seed_edges, shuffle, num_workers * 2 if prefetch else 0,
+                ThreadPrefetchingWrapper)
+
+        assert node_prob is None, 'non-uniform node probability not supported'
+        assert isinstance(expand_factor, Integral), 'non-int expand_factor not supported'
+
+        self._expand_factor = int(expand_factor)
+        self._num_hops = int(num_hops)
+        self._add_self_loop = add_self_loop
+        self._num_workers = int(num_workers)
+        self._neighbor_type = neighbor_type
+
+    def fetch(self, current_index):
+        handles = unwrap_to_ptr_list(_CAPI_UniformEdgeSampling(
+            self.g.c_handle,
+            self.seed_edges.todgltensor(),
+            current_nodeflow_index, # start batch id
+            self.batch_size,        # batch size
+            self._num_workers,      # num batches
+            self._expand_factor,
+            self._num_hops,
+            self._neighbor_type,
+            self._add_self_loop))
+        assert len(handles) % 2 == 0
+        nflows = []
+        for i in range(len(handles) / 2):
+            hdl1 = handles[i * 2]
+            hdl2 = handles[i * 2 + 1]
+            nflows.append((NodeFlow(self.g, hdl1), NodeFlow(self.g, hdl2)))
+        return nflows
+
 
 def create_full_nodeflow(g, num_layers, add_self_loop=False):
     """Convert a full graph to NodeFlow to run a L-layer GNN model.

--- a/python/dgl/contrib/sampling/sampler.py
+++ b/python/dgl/contrib/sampling/sampler.py
@@ -499,7 +499,8 @@ class EdgeNeighborSampler(EdgeSampler):
             shuffle=False,
             num_workers=1,
             prefetch=False,
-            add_self_loop=False):
+            add_self_loop=False,
+            exclude_sampled_edges=True):
         super(EdgeNeighborSampler, self).__init__(
                 g, batch_size, seed_edges, shuffle, num_workers * 2 if prefetch else 0,
                 ThreadPrefetchingWrapper)
@@ -512,6 +513,7 @@ class EdgeNeighborSampler(EdgeSampler):
         self._add_self_loop = add_self_loop
         self._num_workers = int(num_workers)
         self._neighbor_type = neighbor_type
+        self._exclude_edges = exclude_sampled_edges
 
     def fetch(self, current_index):
         handles = unwrap_to_ptr_list(_CAPI_UniformEdgeSampling(
@@ -523,7 +525,8 @@ class EdgeNeighborSampler(EdgeSampler):
             self._expand_factor,
             self._num_hops,
             self._neighbor_type,
-            self._add_self_loop))
+            self._add_self_loop,
+            self._exclude_edges))
         nflows = []
         for hdl in handles:
             func = _CAPI_GetEdgeBatch(hdl)

--- a/python/dgl/contrib/sampling/sampler.py
+++ b/python/dgl/contrib/sampling/sampler.py
@@ -500,7 +500,8 @@ class EdgeNeighborSampler(EdgeSampler):
             num_workers=1,
             prefetch=False,
             add_self_loop=False,
-            exclude_sampled_edges=True):
+            exclude_sampled_edges=True,
+            undirected=False):
         super(EdgeNeighborSampler, self).__init__(
                 g, batch_size, seed_edges, shuffle, num_workers * 2 if prefetch else 0,
                 ThreadPrefetchingWrapper)
@@ -514,6 +515,7 @@ class EdgeNeighborSampler(EdgeSampler):
         self._num_workers = int(num_workers)
         self._neighbor_type = neighbor_type
         self._exclude_edges = exclude_sampled_edges
+        self._undirected = undirected
 
     def fetch(self, current_index):
         handles = unwrap_to_ptr_list(_CAPI_UniformEdgeSampling(
@@ -526,7 +528,8 @@ class EdgeNeighborSampler(EdgeSampler):
             self._num_hops,
             self._neighbor_type,
             self._add_self_loop,
-            self._exclude_edges))
+            self._exclude_edges,
+            self._undirected))
         nflows = []
         for hdl in handles:
             func = _CAPI_GetEdgeBatch(hdl)

--- a/python/dgl/contrib/sampling/sampler.py
+++ b/python/dgl/contrib/sampling/sampler.py
@@ -17,7 +17,7 @@ try:
 except ImportError:
     import queue
 
-__all__ = ['NeighborSampler', 'LayerSampler']
+__all__ = ['NeighborSampler', 'LayerSampler', 'EdgeNeighborSampler']
 
 class SamplerIter(object):
     def __init__(self, sampler):
@@ -517,19 +517,17 @@ class EdgeNeighborSampler(EdgeSampler):
         handles = unwrap_to_ptr_list(_CAPI_UniformEdgeSampling(
             self.g.c_handle,
             self.seed_edges.todgltensor(),
-            current_nodeflow_index, # start batch id
+            current_index, # start batch id
             self.batch_size,        # batch size
             self._num_workers,      # num batches
             self._expand_factor,
             self._num_hops,
             self._neighbor_type,
             self._add_self_loop))
-        assert len(handles) % 2 == 0
         nflows = []
-        for i in range(len(handles) / 2):
-            hdl1 = handles[i * 2]
-            hdl2 = handles[i * 2 + 1]
-            nflows.append((NodeFlow(self.g, hdl1), NodeFlow(self.g, hdl2)))
+        for hdl in handles:
+            func = _CAPI_GetEdgeBatch(hdl)
+            nflows.append((NodeFlow(self.g, func(0)), NodeFlow(self.g, func(1)), func(2)))
         return nflows
 
 

--- a/src/graph/graph_apis.cc
+++ b/src/graph/graph_apis.cc
@@ -18,7 +18,6 @@ using dgl::runtime::NDArray;
 
 namespace dgl {
 
-namespace {
 // Convert EdgeArray structure to PackedFunc.
 template<class EdgeArray>
 PackedFunc ConvertEdgeArrayToPackedFunc(const EdgeArray& ea) {
@@ -68,8 +67,6 @@ PackedFunc ConvertSubgraphToPackedFunc(const Subgraph& sg) {
     };
   return PackedFunc(body);
 }
-
-}  // namespace
 
 namespace {
 // This namespace contains template functions for batching
@@ -596,5 +593,6 @@ DGL_REGISTER_GLOBAL("transform._CAPI_DGLToBidirectedImmutableGraph")
     GraphHandle bghandle = GraphOp::ToBidirectedImmutableGraph(ptr).Reset();
     *rv = bghandle;
   });
+
 
 }  // namespace dgl

--- a/src/graph/immutable_graph.cc
+++ b/src/graph/immutable_graph.cc
@@ -594,7 +594,7 @@ Subgraph COO::EdgeSubgraph(IdArray eids, bool preserve_nodes) const {
       induced_nodes_data[kv.second] = kv.first;
     }
 
-    COOPtr subcoo(new COO(newid, new_src, new_dst));
+    COOPtr subcoo(new COO(newid, new_src, new_dst, this->IsMultigraph()));
     return Subgraph{subcoo, induced_nodes, eids};
   } else {
     for (int64_t i = 0; i < eids->shape[0]; ++i) {
@@ -610,7 +610,7 @@ Subgraph COO::EdgeSubgraph(IdArray eids, bool preserve_nodes) const {
     for (int64_t i = 0; i < NumVertices(); ++i)
       *(induced_nodes_data++) = i;
 
-    COOPtr subcoo(new COO(NumVertices(), new_src, new_dst));
+    COOPtr subcoo(new COO(NumVertices(), new_src, new_dst, this->IsMultigraph()));
     return Subgraph{subcoo, induced_nodes, eids};
   }
 }

--- a/src/graph/sampler.cc
+++ b/src/graph/sampler.cc
@@ -891,7 +891,7 @@ dgl_id_t global2local_map(dgl_id_t global_id,
 
 Subgraph NegEdgeSubgraph(int64_t num_tot_nodes, const Subgraph &pos_subg,
                          const std::string &neg_mode,
-                         int neg_sample_size) {
+                         int neg_sample_size, bool is_multigraph) {
   unsigned int seed = randseed();
   std::vector<IdArray> adj = pos_subg.graph->GetAdj(false, "coo");
   IdArray coo = adj[0];
@@ -972,7 +972,7 @@ Subgraph NegEdgeSubgraph(int64_t num_tot_nodes, const Subgraph &pos_subg,
   Subgraph neg_subg;
   // We sample negative vertices without replacement.
   // There shouldn't be duplicated edges.
-  COOPtr neg_coo(new COO(num_neg_nodes, neg_src, neg_dst, false));
+  COOPtr neg_coo(new COO(num_neg_nodes, neg_src, neg_dst, is_multigraph));
   neg_subg.graph = GraphPtr(new ImmutableGraph(neg_coo));
   neg_subg.induced_vertices = induced_neg_vid;
   neg_subg.induced_edges = induced_neg_eid;
@@ -1000,7 +1000,6 @@ DGL_REGISTER_GLOBAL("sampling._CAPI_UniformEdgeSampling")
     const ImmutableGraph *gptr = dynamic_cast<const ImmutableGraph*>(ptr);
     CHECK(gptr) << "sampling isn't implemented in mutable graph";
     CHECK(IsValidIdArray(seed_edges));
-    CHECK(!gptr->IsMultigraph()) << "Edge sampling doesn't support multi-graph";
     BuildCsr(*gptr, neigh_type);
     BuildCoo(*gptr);
 
@@ -1052,7 +1051,8 @@ DGL_REGISTER_GLOBAL("sampling._CAPI_UniformEdgeSampling")
       *nflows[i]->pos_subg = gptr->EdgeSubgraph(worker_seeds, false);
       if (neg_mode.size() > 0)
         *nflows[i]->neg_subg = NegEdgeSubgraph(gptr->NumVertices(), *nflows[i]->pos_subg,
-                                               neg_mode, neg_sample_size);
+                                               neg_mode, neg_sample_size,
+                                               gptr->IsMultigraph());
     }
     *rv = WrapVectorReturn(nflows);
   });

--- a/src/graph/sampler.cc
+++ b/src/graph/sampler.cc
@@ -116,6 +116,23 @@ void RandomSample(size_t set_size, size_t num, std::vector<size_t>* out, unsigne
   out->insert(out->end(), sampled_idxs.begin(), sampled_idxs.end());
 }
 
+void RandomSample(size_t set_size, size_t num, const std::vector<size_t> &exclude,
+                  std::vector<size_t>* out, unsigned int* seed) {
+  std::unordered_map<size_t, int> sampled_idxs;
+  for (auto v : exclude) {
+    sampled_idxs.insert(std::pair<size_t, int>(v, 0));
+  }
+  while (sampled_idxs.size() < num + exclude.size()) {
+    sampled_idxs.insert(std::pair<size_t, int>(rand_r(seed) % set_size, 1));
+  }
+  out->clear();
+  for (auto it = sampled_idxs.begin(); it != sampled_idxs.end(); it++) {
+    if (it->second) {
+      out->push_back(it->first);
+    }
+  }
+}
+
 /*
  * For a sparse array whose non-zeros are represented by nz_idxs,
  * negate the sparse array and outputs the non-zeros in the negated array.
@@ -175,8 +192,7 @@ void GetUniformSample(const dgl_id_t* edge_id_list,
   } else {
     std::vector<size_t> negate;
     negate.reserve(ver_len - max_num_neighbor);
-    RandomSample(ver_len, ver_len - max_num_neighbor,
-                 &negate, seed);
+    RandomSample(ver_len, ver_len - max_num_neighbor, &negate, seed);
     std::sort(negate.begin(), negate.end());
     NegateArray(negate, ver_len, &sorted_idxs);
   }
@@ -891,6 +907,8 @@ Subgraph NegEdgeSubgraph(int64_t num_tot_nodes, const Subgraph &pos_subg,
   const dgl_id_t *src_data = static_cast<const dgl_id_t *>(coo->data) + num_pos_edges;
   const dgl_id_t *induced_vid_data = static_cast<const dgl_id_t *>(pos_subg.induced_vertices->data);
   const dgl_id_t *induced_eid_data = static_cast<const dgl_id_t *>(pos_subg.induced_edges->data);
+  size_t num_pos_nodes = pos_subg.graph->NumVertices();
+  std::vector<size_t> pos_nodes(induced_vid_data, induced_vid_data + num_pos_nodes);
 
   dgl_id_t *neg_dst_data = static_cast<dgl_id_t *>(neg_dst->data);
   dgl_id_t *neg_src_data = static_cast<dgl_id_t *>(neg_src->data);
@@ -905,7 +923,7 @@ Subgraph NegEdgeSubgraph(int64_t num_tot_nodes, const Subgraph &pos_subg,
   for (size_t i = 0; i < num_pos_edges; i++) {
     size_t neg_idx = i * neg_sample_size;
     neg_vids.clear();
-    RandomSample(num_tot_nodes, neg_sample_size, &neg_vids, &seed);
+    RandomSample(num_tot_nodes, neg_sample_size, pos_nodes, &neg_vids, &seed);
 
     const dgl_id_t *unchanged;
     dgl_id_t *neg_unchanged;

--- a/src/graph/sampler.cc
+++ b/src/graph/sampler.cc
@@ -852,9 +852,67 @@ DGL_REGISTER_GLOBAL("sampling._CAPI_LayerSampling")
 struct EdgeBatch {
   NodeFlow *src_nf;
   NodeFlow *dst_nf;
-  IdArray eids;
+  Subgraph *pos_subg;
+  Subgraph *neg_subg;
 };
 
+Subgraph NegEdgeSubgraph(const Subgraph &pos_subg, const std::string &neg_mode,
+                         int neg_sample_size) {
+  unsigned int seed = randseed();
+  std::vector<IdArray> adj = pos_subg.graph->GetAdj(false, "coo");
+  IdArray coo = adj[0];
+  int64_t num_nodes = pos_subg.graph->NumVertices();
+  int64_t num_pos_edges = coo->shape[0] / 2;
+  int64_t num_neg_edges = num_pos_edges * neg_sample_size;
+  IdArray neg_dst = IdArray::Empty({num_neg_edges}, coo->dtype, coo->ctx);
+  IdArray neg_src = IdArray::Empty({num_neg_edges}, coo->dtype, coo->ctx);
+  IdArray neg_eid = IdArray::Empty({num_neg_edges}, coo->dtype, coo->ctx);
+  IdArray induced_neg_eid = IdArray::Empty({num_neg_edges}, coo->dtype, coo->ctx);
+  // The negative subgraph should have the same set of vertices.
+  IdArray induced_neg_vid = pos_subg.induced_vertices;
+
+  const dgl_id_t *dst_data = static_cast<const dgl_id_t *>(coo->data);
+  const dgl_id_t *src_data = static_cast<const dgl_id_t *>(coo->data) + num_pos_edges;
+  const dgl_id_t *induced_eid_data = static_cast<const dgl_id_t *>(pos_subg.induced_vertices->data);
+  dgl_id_t *neg_dst_data = static_cast<dgl_id_t *>(neg_dst->data);
+  dgl_id_t *neg_src_data = static_cast<dgl_id_t *>(neg_src->data);
+  dgl_id_t *neg_eid_data = static_cast<dgl_id_t *>(neg_eid->data);
+  dgl_id_t *induced_neg_eid_data = static_cast<dgl_id_t *>(induced_neg_eid->data);
+
+  bool neg_head = (neg_mode == "head");
+  dgl_id_t curr_eid = 0;
+  std::vector<size_t> neg_vids;
+  neg_vids.reserve(neg_sample_size);
+  for (size_t i = 0; i < num_pos_edges; i++) {
+    size_t neg_idx = i * neg_sample_size;
+    neg_vids.clear();
+    RandomSample(num_nodes, neg_sample_size, &neg_vids, &seed);
+    if (neg_head) {
+      for (size_t j = 0; j < neg_sample_size; j++) {
+        neg_dst_data[neg_idx + j] = dst_data[i];
+        neg_eid_data[neg_idx + j] = curr_eid++;
+        neg_src_data[neg_idx + j] = neg_vids[j];
+        // induced negative eid references to the positive one.
+        induced_neg_eid_data[neg_idx + j] = induced_eid_data[i];
+      }
+    } else {
+      for (size_t j = 0; j < neg_sample_size; j++) {
+        neg_src_data[neg_idx + j] = src_data[i];
+        neg_eid_data[neg_idx + j] = curr_eid++;
+        neg_dst_data[neg_idx + j] = neg_vids[j];
+        induced_neg_eid_data[neg_idx + j] = induced_eid_data[i];
+      }
+    }
+  }
+  Subgraph neg_subg;
+  // We sample negative vertices without replacement.
+  // There shouldn't be duplicated edges.
+  COOPtr neg_coo(new COO(num_nodes, neg_src, neg_dst, false));
+  neg_subg.graph = GraphPtr(new ImmutableGraph(neg_coo));
+  neg_subg.induced_vertices = induced_neg_vid;
+  neg_subg.induced_edges = induced_neg_eid;
+  return neg_subg;
+}
 
 DGL_REGISTER_GLOBAL("sampling._CAPI_UniformEdgeSampling")
 .set_body([] (DGLArgs args, DGLRetValue* rv) {
@@ -870,6 +928,8 @@ DGL_REGISTER_GLOBAL("sampling._CAPI_UniformEdgeSampling")
     const bool add_self_loop = args[8];
     const bool exclude_edges = args[9];
     const bool undirected = args[10];
+    const std::string neg_mode = args[11];
+    const int neg_sample_size = args[12];
     // process args
     const GraphInterface *ptr = static_cast<const GraphInterface *>(ghdl);
     const ImmutableGraph *gptr = dynamic_cast<const ImmutableGraph*>(ptr);
@@ -900,6 +960,11 @@ DGL_REGISTER_GLOBAL("sampling._CAPI_UniformEdgeSampling")
       nflows[i] = new EdgeBatch();
       nflows[i]->src_nf = new NodeFlow();
       nflows[i]->dst_nf = new NodeFlow();
+      nflows[i]->pos_subg = new Subgraph();
+      if (neg_mode.size() > 0)
+        nflows[i]->neg_subg = new Subgraph();
+      else
+        nflows[i]->neg_subg = nullptr;
 
       // We need to exclude the edges.
       std::unordered_set<dgl_id_t> exclude;
@@ -914,10 +979,13 @@ DGL_REGISTER_GLOBAL("sampling._CAPI_UniformEdgeSampling")
       }
 
       *nflows[i]->src_nf = SamplerOp::NeighborUniformSample(
-          gptr, src_vec, neigh_type, num_hops, expand_factor, add_self_loop, exclude);
+        gptr, src_vec, neigh_type, num_hops, expand_factor, add_self_loop, exclude);
       *nflows[i]->dst_nf = SamplerOp::NeighborUniformSample(
-          gptr, dst_vec, neigh_type, num_hops, expand_factor, add_self_loop, exclude);
-      nflows[i]->eids = worker_seeds;
+        gptr, dst_vec, neigh_type, num_hops, expand_factor, add_self_loop, exclude);
+      *nflows[i]->pos_subg = gptr->EdgeSubgraph(worker_seeds, true);
+      CHECK_EQ(nflows[i]->pos_subg->graph->NumVertices(), gptr->NumVertices());
+      if (neg_mode.size() > 0)
+        *nflows[i]->neg_subg = NegEdgeSubgraph(*nflows[i]->pos_subg, neg_mode, neg_sample_size);
     }
     *rv = WrapVectorReturn(nflows);
   });
@@ -931,7 +999,10 @@ PackedFunc ConvertEdgeBatchToPackedFunc(const EdgeBatch& eb) {
       } else if (which == 1) {
         *rv = eb.dst_nf;
       } else if (which == 2) {
-        *rv = std::move(eb.eids);
+        *rv = eb.pos_subg;
+      } else if (which == 3) {
+        CHECK(eb.neg_subg);
+        *rv = eb.neg_subg;
       } else {
         LOG(FATAL) << "invalid choice";
       }
@@ -944,6 +1015,15 @@ DGL_REGISTER_GLOBAL("sampling._CAPI_GetEdgeBatch")
     void *ptr = args[0];
     const EdgeBatch *eb = static_cast<const EdgeBatch *>(ptr);
     *rv = ConvertEdgeBatchToPackedFunc(*eb);
+});
+
+PackedFunc ConvertSubgraphToPackedFunc(const Subgraph& sg);
+
+DGL_REGISTER_GLOBAL("sampling._CAPI_GetSubgraph")
+.set_body([] (DGLArgs args, DGLRetValue* rv) {
+    void *ptr = args[0];
+    const Subgraph *eb = static_cast<const Subgraph *>(ptr);
+    *rv = ConvertSubgraphToPackedFunc(*eb);
 });
 
 }  // namespace dgl

--- a/src/graph/sampler.cc
+++ b/src/graph/sampler.cc
@@ -923,8 +923,9 @@ Subgraph NegEdgeSubgraph(int64_t num_tot_nodes, const Subgraph &pos_subg,
   for (int64_t i = 0; i < num_pos_edges; i++) {
     size_t neg_idx = i * neg_sample_size;
     neg_vids.clear();
-    RandomSample(num_tot_nodes, neg_sample_size, pos_nodes, &neg_vids, &seed);
 
+    std::vector<size_t> neighbors;
+    DGLIdIters neigh_it;
     const dgl_id_t *unchanged;
     dgl_id_t *neg_unchanged;
     dgl_id_t *neg_changed;
@@ -932,11 +933,20 @@ Subgraph NegEdgeSubgraph(int64_t num_tot_nodes, const Subgraph &pos_subg,
       unchanged = dst_data;
       neg_unchanged = neg_dst_data;
       neg_changed = neg_src_data;
+      neigh_it = pos_subg.graph->PredVec(unchanged[i]);
     } else {
       unchanged = src_data;
       neg_unchanged = neg_src_data;
       neg_changed = neg_dst_data;
+      neigh_it = pos_subg.graph->SuccVec(unchanged[i]);
     }
+
+    std::vector<size_t> exclude;
+    for (auto it = neigh_it.begin(); it != neigh_it.end(); it++) {
+      dgl_id_t local_vid = *it;
+      exclude.push_back(induced_vid_data[local_vid]);
+    }
+    RandomSample(num_tot_nodes, neg_sample_size, exclude, &neg_vids, &seed);
 
     dgl_id_t global_unchanged = induced_vid_data[unchanged[i]];
     dgl_id_t local_unchanged = global2local_map(global_unchanged, &neg_map);

--- a/src/graph/sampler.cc
+++ b/src/graph/sampler.cc
@@ -891,7 +891,8 @@ dgl_id_t global2local_map(dgl_id_t global_id,
 
 Subgraph NegEdgeSubgraph(int64_t num_tot_nodes, const Subgraph &pos_subg,
                          const std::string &neg_mode,
-                         int neg_sample_size, bool is_multigraph) {
+                         int neg_sample_size, bool is_multigraph,
+                         bool exclude_positive) {
   unsigned int seed = randseed();
   std::vector<IdArray> adj = pos_subg.graph->GetAdj(false, "coo");
   IdArray coo = adj[0];
@@ -941,12 +942,16 @@ Subgraph NegEdgeSubgraph(int64_t num_tot_nodes, const Subgraph &pos_subg,
       neigh_it = pos_subg.graph->SuccVec(unchanged[i]);
     }
 
-    std::vector<size_t> exclude;
-    for (auto it = neigh_it.begin(); it != neigh_it.end(); it++) {
-      dgl_id_t local_vid = *it;
-      exclude.push_back(induced_vid_data[local_vid]);
+    if (exclude_positive) {
+      std::vector<size_t> exclude;
+      for (auto it = neigh_it.begin(); it != neigh_it.end(); it++) {
+        dgl_id_t local_vid = *it;
+        exclude.push_back(induced_vid_data[local_vid]);
+      }
+      RandomSample(num_tot_nodes, neg_sample_size, exclude, &neg_vids, &seed);
+    } else {
+      RandomSample(num_tot_nodes, neg_sample_size, &neg_vids, &seed);
     }
-    RandomSample(num_tot_nodes, neg_sample_size, exclude, &neg_vids, &seed);
 
     dgl_id_t global_unchanged = induced_vid_data[unchanged[i]];
     dgl_id_t local_unchanged = global2local_map(global_unchanged, &neg_map);
@@ -995,6 +1000,7 @@ DGL_REGISTER_GLOBAL("sampling._CAPI_UniformEdgeSampling")
     const bool undirected = args[10];
     const std::string neg_mode = args[11];
     const int neg_sample_size = args[12];
+    const bool exclude_positive = args[13];
     // process args
     const GraphInterface *ptr = static_cast<const GraphInterface *>(ghdl);
     const ImmutableGraph *gptr = dynamic_cast<const ImmutableGraph*>(ptr);
@@ -1052,7 +1058,7 @@ DGL_REGISTER_GLOBAL("sampling._CAPI_UniformEdgeSampling")
       if (neg_mode.size() > 0)
         *nflows[i]->neg_subg = NegEdgeSubgraph(gptr->NumVertices(), *nflows[i]->pos_subg,
                                                neg_mode, neg_sample_size,
-                                               gptr->IsMultigraph());
+                                               gptr->IsMultigraph(), exclude_positive);
     }
     *rv = WrapVectorReturn(nflows);
   });

--- a/src/graph/sampler.cc
+++ b/src/graph/sampler.cc
@@ -731,6 +731,11 @@ void BuildCsr(const ImmutableGraph &g, const std::string neigh_type) {
   }
 }
 
+void BuildCoo(const ImmutableGraph &g) {
+  auto coo = g.GetCOO();
+  assert(coo);
+}
+
 DGL_REGISTER_GLOBAL("sampling._CAPI_UniformSampling")
 .set_body([] (DGLArgs args, DGLRetValue* rv) {
     // arguments
@@ -807,6 +812,57 @@ DGL_REGISTER_GLOBAL("sampling._CAPI_LayerSampling")
       nflows[i] = new NodeFlow();
       *nflows[i] = SamplerOp::LayerUniformSample(
           gptr, worker_seeds, neigh_type, layer_sizes);
+    }
+    *rv = WrapVectorReturn(nflows);
+  });
+
+
+DGL_REGISTER_GLOBAL("sampling._CAPI_UniformEdgeSampling")
+.set_body([] (DGLArgs args, DGLRetValue* rv) {
+    // arguments
+    const GraphHandle ghdl = args[0];
+    IdArray seed_edges = args[1];
+    const int64_t batch_start_id = args[2];
+    const int64_t batch_size = args[3];
+    const int64_t max_num_workers = args[4];
+    const int64_t expand_factor = args[5];
+    const int64_t num_hops = args[6];
+    const std::string neigh_type = args[7];
+    const bool add_self_loop = args[8];
+    // process args
+    const GraphInterface *ptr = static_cast<const GraphInterface *>(ghdl);
+    const ImmutableGraph *gptr = dynamic_cast<const ImmutableGraph*>(ptr);
+    CHECK(gptr) << "sampling isn't implemented in mutable graph";
+    CHECK(IsValidIdArray(seed_edges));
+    CHECK(!gptr->IsMultigraph()) << "Edge sampling doesn't support multi-graph";
+    BuildCsr(*gptr, neigh_type);
+    BuildCoo(*gptr);
+
+    const int64_t num_seeds = seed_edges->shape[0];
+    const int64_t num_workers = std::min(max_num_workers,
+        (num_seeds + batch_size - 1) / batch_size - batch_start_id);
+    // generate node flows
+    std::vector<NodeFlow*> nflows(num_workers * 2);
+#pragma omp parallel for
+    for (int i = 0; i < num_workers; i++) {
+      const int64_t start = (batch_start_id + i) * batch_size;
+      const int64_t end = std::min(start + batch_size, num_seeds);
+      const int64_t num_edges = end - start;
+      IdArray worker_seeds = seed_edges.CreateView({num_edges}, DLDataType{kDLInt, 64, 1},
+                                                   sizeof(dgl_id_t) * start);
+      GraphInterface::EdgeArray arr = gptr->FindEdges(worker_seeds);
+      const dgl_id_t *src_ids = static_cast<const dgl_id_t *>(arr.src->data);
+      const dgl_id_t *dst_ids = static_cast<const dgl_id_t *>(arr.dst->data);
+      std::vector<dgl_id_t> src_vec(src_ids, src_ids + num_edges);
+      std::vector<dgl_id_t> dst_vec(dst_ids, dst_ids + num_edges);
+      // TODO(zhengda) what if there are duplicates in the src and dst vectors.
+      nflows[i * 2] = new NodeFlow();
+      nflows[i * 2 + 1] = new NodeFlow();
+      // TODO(zhengda) we need to remove the edges from NodeFlows.
+      *nflows[i * 2] = SamplerOp::NeighborUniformSample(
+          gptr, src_vec, neigh_type, num_hops, expand_factor, add_self_loop);
+      *nflows[i * 2 + 1] = SamplerOp::NeighborUniformSample(
+          gptr, dst_vec, neigh_type, num_hops, expand_factor, add_self_loop);
     }
     *rv = WrapVectorReturn(nflows);
   });

--- a/src/graph/sampler.cc
+++ b/src/graph/sampler.cc
@@ -856,24 +856,42 @@ struct EdgeBatch {
   Subgraph *neg_subg;
 };
 
-Subgraph NegEdgeSubgraph(const Subgraph &pos_subg, const std::string &neg_mode,
+class Global2LocalMap {
+  std::unordered_map<dgl_id_t, dgl_id_t> map;
+ public:
+};
+
+dgl_id_t global2local_map(dgl_id_t global_id,
+                          std::unordered_map<dgl_id_t, dgl_id_t> *map) {
+  auto it = map->find(global_id);
+  if (it == map->end()) {
+    dgl_id_t local_id = map->size();
+    map->insert(std::pair<dgl_id_t, dgl_id_t>(global_id, local_id));
+    return local_id;
+  } else {
+    return it->second;
+  }
+}
+
+Subgraph NegEdgeSubgraph(int64_t num_tot_nodes, const Subgraph &pos_subg,
+                         const std::string &neg_mode,
                          int neg_sample_size) {
   unsigned int seed = randseed();
   std::vector<IdArray> adj = pos_subg.graph->GetAdj(false, "coo");
   IdArray coo = adj[0];
-  int64_t num_nodes = pos_subg.graph->NumVertices();
   int64_t num_pos_edges = coo->shape[0] / 2;
   int64_t num_neg_edges = num_pos_edges * neg_sample_size;
   IdArray neg_dst = IdArray::Empty({num_neg_edges}, coo->dtype, coo->ctx);
   IdArray neg_src = IdArray::Empty({num_neg_edges}, coo->dtype, coo->ctx);
   IdArray neg_eid = IdArray::Empty({num_neg_edges}, coo->dtype, coo->ctx);
   IdArray induced_neg_eid = IdArray::Empty({num_neg_edges}, coo->dtype, coo->ctx);
-  // The negative subgraph should have the same set of vertices.
-  IdArray induced_neg_vid = pos_subg.induced_vertices;
 
+  // These are vids in the positive subgraph.
   const dgl_id_t *dst_data = static_cast<const dgl_id_t *>(coo->data);
   const dgl_id_t *src_data = static_cast<const dgl_id_t *>(coo->data) + num_pos_edges;
-  const dgl_id_t *induced_eid_data = static_cast<const dgl_id_t *>(pos_subg.induced_vertices->data);
+  const dgl_id_t *induced_vid_data = static_cast<const dgl_id_t *>(pos_subg.induced_vertices->data);
+  const dgl_id_t *induced_eid_data = static_cast<const dgl_id_t *>(pos_subg.induced_edges->data);
+
   dgl_id_t *neg_dst_data = static_cast<dgl_id_t *>(neg_dst->data);
   dgl_id_t *neg_src_data = static_cast<dgl_id_t *>(neg_src->data);
   dgl_id_t *neg_eid_data = static_cast<dgl_id_t *>(neg_eid->data);
@@ -883,31 +901,50 @@ Subgraph NegEdgeSubgraph(const Subgraph &pos_subg, const std::string &neg_mode,
   dgl_id_t curr_eid = 0;
   std::vector<size_t> neg_vids;
   neg_vids.reserve(neg_sample_size);
+  std::unordered_map<dgl_id_t, dgl_id_t> neg_map;
   for (size_t i = 0; i < num_pos_edges; i++) {
     size_t neg_idx = i * neg_sample_size;
     neg_vids.clear();
-    RandomSample(num_nodes, neg_sample_size, &neg_vids, &seed);
+    RandomSample(num_tot_nodes, neg_sample_size, &neg_vids, &seed);
+
+    const dgl_id_t *unchanged;
+    dgl_id_t *neg_unchanged;
+    dgl_id_t *neg_changed;
     if (neg_head) {
-      for (size_t j = 0; j < neg_sample_size; j++) {
-        neg_dst_data[neg_idx + j] = dst_data[i];
-        neg_eid_data[neg_idx + j] = curr_eid++;
-        neg_src_data[neg_idx + j] = neg_vids[j];
-        // induced negative eid references to the positive one.
-        induced_neg_eid_data[neg_idx + j] = induced_eid_data[i];
-      }
+      unchanged = dst_data;
+      neg_unchanged = neg_dst_data;
+      neg_changed = neg_src_data;
     } else {
-      for (size_t j = 0; j < neg_sample_size; j++) {
-        neg_src_data[neg_idx + j] = src_data[i];
-        neg_eid_data[neg_idx + j] = curr_eid++;
-        neg_dst_data[neg_idx + j] = neg_vids[j];
-        induced_neg_eid_data[neg_idx + j] = induced_eid_data[i];
-      }
+      unchanged = src_data;
+      neg_unchanged = neg_src_data;
+      neg_changed = neg_dst_data;
+    }
+
+    dgl_id_t global_unchanged = induced_vid_data[unchanged[i]];
+    dgl_id_t local_unchanged = global2local_map(global_unchanged, &neg_map);
+
+    for (size_t j = 0; j < neg_sample_size; j++) {
+      neg_unchanged[neg_idx + j] = local_unchanged;
+      neg_eid_data[neg_idx + j] = curr_eid++;
+      dgl_id_t local_changed = global2local_map(neg_vids[j], &neg_map);
+      neg_changed[neg_idx + j] = local_changed;
+      // induced negative eid references to the positive one.
+      induced_neg_eid_data[neg_idx + j] = induced_eid_data[i];
     }
   }
+
+  // Now we know the number of vertices in the negative graph.
+  int64_t num_neg_nodes = neg_map.size();
+  IdArray induced_neg_vid = IdArray::Empty({num_neg_nodes}, coo->dtype, coo->ctx);
+  dgl_id_t *induced_neg_vid_data = static_cast<dgl_id_t *>(induced_neg_vid->data);
+  for (auto it = neg_map.begin(); it != neg_map.end(); it++) {
+    induced_neg_vid_data[it->second] = it->first;
+  }
+
   Subgraph neg_subg;
   // We sample negative vertices without replacement.
   // There shouldn't be duplicated edges.
-  COOPtr neg_coo(new COO(num_nodes, neg_src, neg_dst, false));
+  COOPtr neg_coo(new COO(num_neg_nodes, neg_src, neg_dst, false));
   neg_subg.graph = GraphPtr(new ImmutableGraph(neg_coo));
   neg_subg.induced_vertices = induced_neg_vid;
   neg_subg.induced_edges = induced_neg_eid;
@@ -982,10 +1019,10 @@ DGL_REGISTER_GLOBAL("sampling._CAPI_UniformEdgeSampling")
         gptr, src_vec, neigh_type, num_hops, expand_factor, add_self_loop, exclude);
       *nflows[i]->dst_nf = SamplerOp::NeighborUniformSample(
         gptr, dst_vec, neigh_type, num_hops, expand_factor, add_self_loop, exclude);
-      *nflows[i]->pos_subg = gptr->EdgeSubgraph(worker_seeds, true);
-      CHECK_EQ(nflows[i]->pos_subg->graph->NumVertices(), gptr->NumVertices());
+      *nflows[i]->pos_subg = gptr->EdgeSubgraph(worker_seeds, false);
       if (neg_mode.size() > 0)
-        *nflows[i]->neg_subg = NegEdgeSubgraph(*nflows[i]->pos_subg, neg_mode, neg_sample_size);
+        *nflows[i]->neg_subg = NegEdgeSubgraph(gptr->NumVertices(), *nflows[i]->pos_subg,
+                                               neg_mode, neg_sample_size);
     }
     *rv = WrapVectorReturn(nflows);
   });

--- a/src/graph/sampler.cc
+++ b/src/graph/sampler.cc
@@ -817,6 +817,13 @@ DGL_REGISTER_GLOBAL("sampling._CAPI_LayerSampling")
   });
 
 
+struct EdgeBatch {
+  NodeFlow *src_nf;
+  NodeFlow *dst_nf;
+  IdArray eids;
+};
+
+
 DGL_REGISTER_GLOBAL("sampling._CAPI_UniformEdgeSampling")
 .set_body([] (DGLArgs args, DGLRetValue* rv) {
     // arguments
@@ -842,7 +849,7 @@ DGL_REGISTER_GLOBAL("sampling._CAPI_UniformEdgeSampling")
     const int64_t num_workers = std::min(max_num_workers,
         (num_seeds + batch_size - 1) / batch_size - batch_start_id);
     // generate node flows
-    std::vector<NodeFlow*> nflows(num_workers * 2);
+    std::vector<EdgeBatch*> nflows(num_workers);
 #pragma omp parallel for
     for (int i = 0; i < num_workers; i++) {
       const int64_t start = (batch_start_id + i) * batch_size;
@@ -856,15 +863,43 @@ DGL_REGISTER_GLOBAL("sampling._CAPI_UniformEdgeSampling")
       std::vector<dgl_id_t> src_vec(src_ids, src_ids + num_edges);
       std::vector<dgl_id_t> dst_vec(dst_ids, dst_ids + num_edges);
       // TODO(zhengda) what if there are duplicates in the src and dst vectors.
-      nflows[i * 2] = new NodeFlow();
-      nflows[i * 2 + 1] = new NodeFlow();
+      nflows[i] = new EdgeBatch();
+      nflows[i]->src_nf = new NodeFlow();
+      nflows[i]->dst_nf = new NodeFlow();
       // TODO(zhengda) we need to remove the edges from NodeFlows.
-      *nflows[i * 2] = SamplerOp::NeighborUniformSample(
+      // TODO(zhengda) if this is an undirected graph, we need to remove the edges
+      // and their reversed edges from NodeFlows.
+      *nflows[i]->src_nf = SamplerOp::NeighborUniformSample(
           gptr, src_vec, neigh_type, num_hops, expand_factor, add_self_loop);
-      *nflows[i * 2 + 1] = SamplerOp::NeighborUniformSample(
+      *nflows[i]->dst_nf = SamplerOp::NeighborUniformSample(
           gptr, dst_vec, neigh_type, num_hops, expand_factor, add_self_loop);
+      nflows[i]->eids = worker_seeds;
     }
     *rv = WrapVectorReturn(nflows);
   });
+
+// Convert EdgeBatch structure to PackedFunc.
+PackedFunc ConvertEdgeBatchToPackedFunc(const EdgeBatch& eb) {
+  auto body = [eb] (DGLArgs args, DGLRetValue* rv) {
+      const int which = args[0];
+      if (which == 0) {
+        *rv = eb.src_nf;
+      } else if (which == 1) {
+        *rv = eb.dst_nf;
+      } else if (which == 2) {
+        *rv = std::move(eb.eids);
+      } else {
+        LOG(FATAL) << "invalid choice";
+      }
+    };
+  return PackedFunc(body);
+}
+
+DGL_REGISTER_GLOBAL("sampling._CAPI_GetEdgeBatch")
+.set_body([] (DGLArgs args, DGLRetValue* rv) {
+    void *ptr = args[0];
+    const EdgeBatch *eb = static_cast<const EdgeBatch *>(ptr);
+    *rv = ConvertEdgeBatchToPackedFunc(*eb);
+});
 
 }  // namespace dgl

--- a/src/graph/sampler.cc
+++ b/src/graph/sampler.cc
@@ -920,7 +920,7 @@ Subgraph NegEdgeSubgraph(int64_t num_tot_nodes, const Subgraph &pos_subg,
   std::vector<size_t> neg_vids;
   neg_vids.reserve(neg_sample_size);
   std::unordered_map<dgl_id_t, dgl_id_t> neg_map;
-  for (size_t i = 0; i < num_pos_edges; i++) {
+  for (int64_t i = 0; i < num_pos_edges; i++) {
     size_t neg_idx = i * neg_sample_size;
     neg_vids.clear();
     RandomSample(num_tot_nodes, neg_sample_size, pos_nodes, &neg_vids, &seed);
@@ -941,7 +941,7 @@ Subgraph NegEdgeSubgraph(int64_t num_tot_nodes, const Subgraph &pos_subg,
     dgl_id_t global_unchanged = induced_vid_data[unchanged[i]];
     dgl_id_t local_unchanged = global2local_map(global_unchanged, &neg_map);
 
-    for (size_t j = 0; j < neg_sample_size; j++) {
+    for (int64_t j = 0; j < neg_sample_size; j++) {
       neg_unchanged[neg_idx + j] = local_unchanged;
       neg_eid_data[neg_idx + j] = curr_eid++;
       dgl_id_t local_changed = global2local_map(neg_vids[j], &neg_map);
@@ -1033,10 +1033,12 @@ DGL_REGISTER_GLOBAL("sampling._CAPI_UniformEdgeSampling")
         }
       }
 
-      *nflows[i]->src_nf = SamplerOp::NeighborUniformSample(
-        gptr, src_vec, neigh_type, num_hops, expand_factor, add_self_loop, exclude);
-      *nflows[i]->dst_nf = SamplerOp::NeighborUniformSample(
-        gptr, dst_vec, neigh_type, num_hops, expand_factor, add_self_loop, exclude);
+      if (expand_factor > 0 && num_hops > 0) {
+        *nflows[i]->src_nf = SamplerOp::NeighborUniformSample(
+          gptr, src_vec, neigh_type, num_hops, expand_factor, add_self_loop, exclude);
+        *nflows[i]->dst_nf = SamplerOp::NeighborUniformSample(
+          gptr, dst_vec, neigh_type, num_hops, expand_factor, add_self_loop, exclude);
+      }
       *nflows[i]->pos_subg = gptr->EdgeSubgraph(worker_seeds, false);
       if (neg_mode.size() > 0)
         *nflows[i]->neg_subg = NegEdgeSubgraph(gptr->NumVertices(), *nflows[i]->pos_subg,

--- a/tests/compute/test_sampler.py
+++ b/tests/compute/test_sampler.py
@@ -165,7 +165,6 @@ def test_edge_sampler():
     g = generate_rand_graph(100)
     EdgeNeighborSampler = getattr(dgl.contrib.sampling, 'EdgeNeighborSampler')
     for src_nf, dst_nf, edge_subg in EdgeNeighborSampler(g, 50, g.number_of_nodes(), num_hops=2):
-        assert edge_subg.number_of_nodes() == g.number_of_nodes()
         eids = edge_subg.parent_eid
         src, dst = g.find_edges(eids)
         src1 = src_nf.layer_parent_nid(-1)
@@ -218,15 +217,35 @@ def test_negative_sampler():
                                                           num_hops=2,
                                                           negative_mode="head",
                                                           neg_sample_size=10):
-        assert pos_edges.number_of_nodes() == g.number_of_nodes()
-        assert neg_edges.number_of_nodes() == g.number_of_nodes()
+        assert 10 * pos_edges.number_of_edges() == neg_edges.number_of_edges()
+        pos_nid = pos_edges.parent_nid
         pos_eid = pos_edges.parent_eid
-        neg_src, neg_dst = neg_edges.all_edges(order='eid')
-        exist_edges = g.has_edges_between(neg_src, neg_dst)
-        for i, eid in enumerate(neg_edges.parent_eid):
-            assert eid in pos_eid
-            assert not exist_edges[i]
-            # TODO check if only the head is changed.
+        pos_lsrc, pos_ldst, pos_leid = pos_edges.all_edges(form='all', order='eid')
+        pos_src = pos_nid[pos_lsrc]
+        pos_dst = pos_nid[pos_ldst]
+        pos_eid = pos_eid[pos_leid]
+        assert_array_equal(F.asnumpy(pos_eid), F.asnumpy(g.edge_ids(pos_src, pos_dst)))
+
+        pos_map = {}
+        for i in range(len(pos_eid)):
+            pos_d = int(F.asnumpy(pos_dst[i]))
+            pos_e = int(F.asnumpy(pos_eid[i]))
+            pos_map[(pos_d, pos_e)] = int(F.asnumpy(pos_src[i]))
+            print(pos_d, pos_e, F.asnumpy(pos_src[i]))
+
+        neg_lsrc, neg_ldst, neg_leid = neg_edges.all_edges(form='all', order='eid')
+        neg_nid = neg_edges.parent_nid
+        neg_eid = neg_edges.parent_eid
+        neg_src = neg_nid[neg_lsrc]
+        neg_dst = neg_nid[neg_ldst]
+        neg_eid = neg_eid[neg_leid]
+
+        for i in range(len(neg_eid)):
+            neg_d = int(F.asnumpy(neg_dst[i]))
+            neg_e = int(F.asnumpy(neg_eid[i]))
+            print("neg: ", neg_d, neg_e, F.asnumpy(neg_src[i]))
+            assert (neg_d, neg_e) in pos_map
+            assert int(F.asnumpy(neg_src[i])) != pos_map[(neg_d, neg_e)]
 
 
 if __name__ == '__main__':

--- a/tests/compute/test_sampler.py
+++ b/tests/compute/test_sampler.py
@@ -216,7 +216,8 @@ def test_negative_sampler():
     for _, _, pos_edges, neg_edges in EdgeNeighborSampler(g, 50,
                                                           num_hops=2,
                                                           negative_mode="head",
-                                                          neg_sample_size=10):
+                                                          neg_sample_size=10,
+                                                          exclude_positive=True):
         assert 10 * pos_edges.number_of_edges() == neg_edges.number_of_edges()
         pos_nid = pos_edges.parent_nid
         pos_eid = pos_edges.parent_eid

--- a/tests/compute/test_sampler.py
+++ b/tests/compute/test_sampler.py
@@ -3,6 +3,7 @@ import numpy as np
 import scipy as sp
 import dgl
 from dgl import utils
+from numpy.testing import assert_array_equal
 
 np.random.seed(42)
 
@@ -155,6 +156,24 @@ def test_layer_sampler():
     _test_layer_sampler()
     _test_layer_sampler(prefetch=True)
 
+
+def test_edge_sampler():
+    g = generate_rand_graph(100)
+    EdgeNeighborSampler = getattr(dgl.contrib.sampling, 'EdgeNeighborSampler')
+    for src_nf, dst_nf, eids in EdgeNeighborSampler(g, 50, g.number_of_nodes(), num_hops=2):
+        src, dst = g.find_edges(eids)
+        src1 = src_nf.layer_parent_nid(-1)
+        dst1 = dst_nf.layer_parent_nid(-1)
+        #verify_subgraph(g, src_nf, src1)
+        #verify_subgraph(g, dst_nf, dst1)
+
+        src1 = np.unique(F.asnumpy(src1))
+        dst1 = np.unique(F.asnumpy(dst1))
+        src = np.unique(F.asnumpy(src))
+        dst = np.unique(F.asnumpy(dst))
+        assert_array_equal(src, src1)
+        assert_array_equal(dst, dst1)
+
 if __name__ == '__main__':
     test_create_full()
     test_1neighbor_sampler_all()
@@ -162,3 +181,4 @@ if __name__ == '__main__':
     test_1neighbor_sampler()
     test_10neighbor_sampler()
     test_layer_sampler()
+    test_edge_sampler()

--- a/tests/compute/test_sampler.py
+++ b/tests/compute/test_sampler.py
@@ -174,6 +174,13 @@ def test_edge_sampler():
         assert_array_equal(src, src1)
         assert_array_equal(dst, dst1)
 
+        edges = []
+        for i in range(src_nf.num_blocks):
+            edges.append(F.asnumpy(src_nf.block_parent_eid(i)))
+        edges = np.concatenate(edges)
+        for eid in F.asnumpy(eids):
+            assert eid not in edges
+
 if __name__ == '__main__':
     test_create_full()
     test_1neighbor_sampler_all()

--- a/tests/compute/test_sampler.py
+++ b/tests/compute/test_sampler.py
@@ -231,7 +231,6 @@ def test_negative_sampler():
             pos_d = int(F.asnumpy(pos_dst[i]))
             pos_e = int(F.asnumpy(pos_eid[i]))
             pos_map[(pos_d, pos_e)] = int(F.asnumpy(pos_src[i]))
-            print(pos_d, pos_e, F.asnumpy(pos_src[i]))
 
         neg_lsrc, neg_ldst, neg_leid = neg_edges.all_edges(form='all', order='eid')
         neg_nid = neg_edges.parent_nid
@@ -243,7 +242,6 @@ def test_negative_sampler():
         for i in range(len(neg_eid)):
             neg_d = int(F.asnumpy(neg_dst[i]))
             neg_e = int(F.asnumpy(neg_eid[i]))
-            print("neg: ", neg_d, neg_e, F.asnumpy(neg_src[i]))
             assert (neg_d, neg_e) in pos_map
             assert int(F.asnumpy(neg_src[i])) != pos_map[(neg_d, neg_e)]
 

--- a/tests/compute/test_sampler.py
+++ b/tests/compute/test_sampler.py
@@ -164,7 +164,9 @@ def test_layer_sampler():
 def test_edge_sampler():
     g = generate_rand_graph(100)
     EdgeNeighborSampler = getattr(dgl.contrib.sampling, 'EdgeNeighborSampler')
-    for src_nf, dst_nf, eids in EdgeNeighborSampler(g, 50, g.number_of_nodes(), num_hops=2):
+    for src_nf, dst_nf, edge_subg in EdgeNeighborSampler(g, 50, g.number_of_nodes(), num_hops=2):
+        assert edge_subg.number_of_nodes() == g.number_of_nodes()
+        eids = edge_subg.parent_eid
         src, dst = g.find_edges(eids)
         src1 = src_nf.layer_parent_nid(-1)
         dst1 = dst_nf.layer_parent_nid(-1)
@@ -190,14 +192,15 @@ def test_edge_sampler():
     # sample on the undirected graph
     g = generate_rand_graph(100, False)
     EdgeNeighborSampler = getattr(dgl.contrib.sampling, 'EdgeNeighborSampler')
-    for src_nf, dst_nf, eids in EdgeNeighborSampler(g, 50, g.number_of_nodes(),
-                                                    num_hops=2, undirected=True):
+    for src_nf, dst_nf, edge_subg in EdgeNeighborSampler(g, 50, g.number_of_nodes(),
+                                                         num_hops=2, undirected=True):
         edges = []
         for i in range(src_nf.num_blocks):
             edges.append(F.asnumpy(src_nf.block_parent_eid(i)))
         edges = np.concatenate(edges)
 
         # The sampled edges shouldn't be in NodeFlow.
+        eids = edge_subg.parent_eid
         for eid in F.asnumpy(eids):
             assert eid not in edges
 
@@ -208,6 +211,24 @@ def test_edge_sampler():
             assert eid not in edges
 
 
+def test_negative_sampler():
+    g = generate_rand_graph(100)
+    EdgeNeighborSampler = getattr(dgl.contrib.sampling, 'EdgeNeighborSampler')
+    for _, _, pos_edges, neg_edges in EdgeNeighborSampler(g, 50,
+                                                          num_hops=2,
+                                                          negative_mode="head",
+                                                          neg_sample_size=10):
+        assert pos_edges.number_of_nodes() == g.number_of_nodes()
+        assert neg_edges.number_of_nodes() == g.number_of_nodes()
+        pos_eid = pos_edges.parent_eid
+        neg_src, neg_dst = neg_edges.all_edges(order='eid')
+        exist_edges = g.has_edges_between(neg_src, neg_dst)
+        for i, eid in enumerate(neg_edges.parent_eid):
+            assert eid in pos_eid
+            assert not exist_edges[i]
+            # TODO check if only the head is changed.
+
+
 if __name__ == '__main__':
     test_create_full()
     test_1neighbor_sampler_all()
@@ -215,4 +236,5 @@ if __name__ == '__main__':
     test_1neighbor_sampler()
     test_10neighbor_sampler()
     test_layer_sampler()
+    test_negative_sampler()
     test_edge_sampler()


### PR DESCRIPTION
## Description
The edge sampler creates mini-batches for link prediction. Basically, it samples some edges and creates NodeFlows from source and destination vertices. This sampler works on DGLGraph. However, it can also work on bipartite graph.

## Checklist
Please feel free to remove inapplicable items for your PR.
- [ ] The PR title starts with [$CATEGORY] (such as [Model], [Doc], [Feature]])
- [ ] Changes are complete (i.e. I finished coding on this PR)
- [ ] All changes have test coverage
- [ ] Code is well-documented
- [ ] To the my best knowledge, examples are either not affected by this change,
      or have been fixed to be compatible with this change
- [ ] Related issue is referred in this PR

## Changes
<!-- You could use following template
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)
-->
