### PR TITLE
[Refactor] Use object system for all CAPIs

### DIFF
--- a/include/dgl/graph.h
+++ b/include/dgl/graph.h
@@ -20,7 +20,7 @@ namespace dgl {
 
 class Graph;
 class GraphOp;
-typedef std::shared_ptr<Graph> MGraphPtr;
+typedef std::shared_ptr<Graph> MutableGraphPtr;
 
 /*! \brief Mutable graph based on adjacency list. */
 class Graph: public GraphInterface {
@@ -350,12 +350,12 @@ class Graph: public GraphInterface {
   std::vector<IdArray> GetAdj(bool transpose, const std::string &fmt) const override;
 
   /*! \brief Create an empty graph */
-  static MGraphPtr Create(bool multigraph = false) {
+  static MutableGraphPtr Create(bool multigraph = false) {
     return std::make_shared<Graph>(multigraph);
   }
 
   /*! \brief Create from coo */
-  static MGraphPtr CreateFromCOO(
+  static MutableGraphPtr CreateFromCOO(
       int64_t num_nodes, IdArray src_ids, IdArray dst_ids, bool multigraph = false) {
     return std::make_shared<Graph>(src_ids, dst_ids, num_nodes, multigraph);
   }

--- a/include/dgl/graph_interface.h
+++ b/include/dgl/graph_interface.h
@@ -57,7 +57,7 @@ typedef struct {
 
 // forward declaration
 struct Subgraph;
-class BaseGraphRef;
+class GraphRef;
 class GraphInterface;
 typedef std::shared_ptr<GraphInterface> GraphPtr;
 
@@ -301,15 +301,6 @@ class GraphInterface : public runtime::Object {
   virtual Subgraph EdgeSubgraph(IdArray eids, bool preserve_nodes = false) const = 0;
 
   /*!
-   * \brief Return a new graph with all the edges reversed.
-   *
-   * The returned graph preserves the vertex and edge index in the original graph.
-   *
-   * \return the reversed graph
-   */
-  virtual GraphPtr Reverse() const = 0;
-
-  /*!
    * \brief Return the successor vector
    * \param vid The vertex id.
    * \return the successor vector iterator pair.
@@ -355,22 +346,30 @@ class GraphInterface : public runtime::Object {
    */
   virtual std::vector<IdArray> GetAdj(bool transpose, const std::string &fmt) const = 0;
 
-  static constexpr const char* _type_key = "graph.BaseGraph";
-  DGL_DECLARE_BASE_OBJECT_INFO(GraphInterface, runtime::Object);
+  static constexpr const char* _type_key = "graph.Graph";
+  DGL_DECLARE_OBJECT_TYPE_INFO(GraphInterface, runtime::Object);
 };
 
 /*! \brief Base graph reference */
-class BaseGraphRef : public runtime::ObjectRef {
+class GraphRef : public runtime::ObjectRef {
  public:
   /*! \brief empty reference */
-  BaseGraphRef() {}
-  explicit BaseGraphRef(std::shared_ptr<runtime::Object> obj): runtime::ObjectRef(obj) {}
+  GraphRef() {}
+  explicit GraphRef(std::shared_ptr<runtime::Object> obj): runtime::ObjectRef(obj) {}
+
   const GraphInterface* operator->() const {
     return static_cast<const GraphInterface*>(obj_.get());
   }
+
   GraphInterface* operator->() {
     return static_cast<GraphInterface*>(obj_.get());
   }
+
+  /*! \brief get shared pointer */
+  std::shared_ptr<GraphInterface> sptr() const {
+    return CHECK_NOTNULL(std::dynamic_pointer_cast<GraphInterface>(obj_));
+  }
+
   using ContainerType = GraphInterface;
 };
 

--- a/include/dgl/graph_interface.h
+++ b/include/dgl/graph_interface.h
@@ -350,28 +350,8 @@ class GraphInterface : public runtime::Object {
   DGL_DECLARE_OBJECT_TYPE_INFO(GraphInterface, runtime::Object);
 };
 
-/*! \brief Base graph reference */
-class GraphRef : public runtime::ObjectRef {
- public:
-  /*! \brief empty reference */
-  GraphRef() {}
-  explicit GraphRef(std::shared_ptr<runtime::Object> obj): runtime::ObjectRef(obj) {}
-
-  const GraphInterface* operator->() const {
-    return static_cast<const GraphInterface*>(obj_.get());
-  }
-
-  GraphInterface* operator->() {
-    return static_cast<GraphInterface*>(obj_.get());
-  }
-
-  /*! \brief get shared pointer */
-  std::shared_ptr<GraphInterface> sptr() const {
-    return CHECK_NOTNULL(std::dynamic_pointer_cast<GraphInterface>(obj_));
-  }
-
-  using ContainerType = GraphInterface;
-};
+// Define GraphRef
+DGL_DEFINE_OBJECT_REF(GraphRef, GraphInterface);
 
 /*! \brief Subgraph data structure */
 struct Subgraph {

--- a/include/dgl/graph_op.h
+++ b/include/dgl/graph_op.h
@@ -25,7 +25,7 @@ class GraphOp {
    * \param backtracking Whether the backtracking edges are included or not
    * \return the line graph
    */
-  static Graph LineGraph(const Graph* graph, bool backtracking);
+  static GraphRef LineGraph(GraphRef graph, bool backtracking);
 
   /*!
    * \brief Return a disjoint union of the input graphs.
@@ -39,7 +39,7 @@ class GraphOp {
    * \param graphs A list of input graphs to be unioned.
    * \return the disjoint union of the graphs
    */
-  static Graph DisjointUnion(std::vector<const Graph*> graphs);
+  static GraphRef DisjointUnion(std::vector<GraphRef> graphs);
 
   /*!
    * \brief Partition the graph into several subgraphs.
@@ -52,7 +52,7 @@ class GraphOp {
    * \param num The number of partitions.
    * \return a list of partitioned graphs
    */
-  static std::vector<Graph> DisjointPartitionByNum(const Graph* graph, int64_t num);
+  static std::vector<GraphRef> DisjointPartitionByNum(GraphRef graph, int64_t num);
 
   /*!
    * \brief Partition the graph into several subgraphs.
@@ -65,7 +65,7 @@ class GraphOp {
    * \param sizes The number of partitions.
    * \return a list of partitioned graphs
    */
-  static std::vector<Graph> DisjointPartitionBySizes(const Graph* graph, IdArray sizes);
+  static std::vector<GraphRef> DisjointPartitionBySizes(GraphRef graph, IdArray sizes);
 
   /*!
   * \brief Return a readonly disjoint union of the input graphs.
@@ -79,7 +79,7 @@ class GraphOp {
   * \param ImmutableGraph A list of input graphs to be unioned.
   * \return the disjoint union of the ImmutableGraph
   */
-  static ImmutableGraph DisjointUnion(std::vector<const ImmutableGraph*> graphs);
+  static ImmutableGraphRef DisjointUnion(std::vector<ImmutableGraphRef> graphs);
 
    /*!
    * \brief Partition the ImmutableGraph into several immutable subgraphs.
@@ -92,8 +92,8 @@ class GraphOp {
    * \param num The number of partitions.
    * \return a list of partitioned ImmutableGraph
    */
-  static std::vector<ImmutableGraph> DisjointPartitionByNum(const ImmutableGraph *graph,
-          int64_t num);
+  static std::vector<ImmutableGraphRef> DisjointPartitionByNum(
+      ImmutableGraphRef graph, int64_t num);
 
   /*!
   * \brief Partition the ImmutableGraph into several immutable subgraphs.
@@ -106,8 +106,8 @@ class GraphOp {
   * \param sizes The number of partitions.
   * \return a list of partitioned ImmutableGraph
   */
-  static std::vector<ImmutableGraph> DisjointPartitionBySizes(const ImmutableGraph *batched_graph,
-          IdArray sizes);
+  static std::vector<ImmutableGraphRef> DisjointPartitionBySizes(
+      ImmutableGraphRef batched_graph, IdArray sizes);
 
   /*!
    * \brief Map vids in the parent graph to the vids in the subgraph.
@@ -143,7 +143,7 @@ class GraphOp {
    * \param graph The input graph.
    * \return a new immutable simple graph with no multi-edge.
    */
-  static ImmutableGraph ToSimpleGraph(const GraphInterface* graph);
+  static ImmutableGraphRef ToSimpleGraph(BaseGraphRef graph);
 
   /*!
    * \brief Convert the graph to a mutable bidirected graph.
@@ -155,14 +155,14 @@ class GraphOp {
    * \param graph The input graph.
    * \return a new mutable bidirected graph.
    */
-  static Graph ToBidirectedMutableGraph(const GraphInterface* graph);
+  static GraphRef ToBidirectedMutableGraph(BaseGraphRef graph);
 
   /*!
    * \brief Same as BidirectedMutableGraph except that the returned graph is immutable.
    * \param graph The input graph.
    * \return a new immutable bidirected graph.
    */
-  static ImmutableGraph ToBidirectedImmutableGraph(const GraphInterface* graph);
+  static ImmutableGraphRef ToBidirectedImmutableGraph(BaseGraphRef graph);
 };
 
 }  // namespace dgl

--- a/include/dgl/graph_op.h
+++ b/include/dgl/graph_op.h
@@ -15,6 +15,15 @@ namespace dgl {
 class GraphOp {
  public:
   /*!
+   * \brief Return a new graph with all the edges reversed.
+   *
+   * The returned graph preserves the vertex and edge index in the original graph.
+   *
+   * \return the reversed graph
+   */
+  static GraphPtr Reverse(GraphPtr graph);
+
+  /*!
    * \brief Return the line graph.
    *
    * If i~j and j~i are two edges in original graph G, then
@@ -25,7 +34,7 @@ class GraphOp {
    * \param backtracking Whether the backtracking edges are included or not
    * \return the line graph
    */
-  static GraphRef LineGraph(GraphRef graph, bool backtracking);
+  static GraphPtr LineGraph(GraphPtr graph, bool backtracking);
 
   /*!
    * \brief Return a disjoint union of the input graphs.
@@ -36,10 +45,13 @@ class GraphOp {
    * they have 5, 6, 7 nodes respectively. Then node#2 of g2 will become node#7
    * in the result graph. Edge ids are re-assigned similarly.
    *
+   * The input list must be either ALL mutable graphs or ALL immutable graphs.
+   * The returned graph type is also determined by the input graph type.
+   *
    * \param graphs A list of input graphs to be unioned.
    * \return the disjoint union of the graphs
    */
-  static GraphRef DisjointUnion(std::vector<GraphRef> graphs);
+  static GraphPtr DisjointUnion(std::vector<GraphPtr> graphs);
 
   /*!
    * \brief Partition the graph into several subgraphs.
@@ -47,12 +59,15 @@ class GraphOp {
    * This is a reverse operation of DisjointUnion. The graph will be partitioned
    * into num graphs. This requires the given number of partitions to evenly
    * divides the number of nodes in the graph.
+   *
+   * If the input graph is mutable, the result graphs are mutable.
+   * If the input graph is immutable, the result graphs are immutable.
    * 
    * \param graph The graph to be partitioned.
    * \param num The number of partitions.
    * \return a list of partitioned graphs
    */
-  static std::vector<GraphRef> DisjointPartitionByNum(GraphRef graph, int64_t num);
+  static std::vector<GraphPtr> DisjointPartitionByNum(GraphPtr graph, int64_t num);
 
   /*!
    * \brief Partition the graph into several subgraphs.
@@ -60,54 +75,15 @@ class GraphOp {
    * This is a reverse operation of DisjointUnion. The graph will be partitioned
    * based on the given sizes. This requires the sum of the given sizes is equal
    * to the number of nodes in the graph.
+   *
+   * If the input graph is mutable, the result graphs are mutable.
+   * If the input graph is immutable, the result graphs are immutable.
    * 
    * \param graph The graph to be partitioned.
    * \param sizes The number of partitions.
    * \return a list of partitioned graphs
    */
-  static std::vector<GraphRef> DisjointPartitionBySizes(GraphRef graph, IdArray sizes);
-
-  /*!
-  * \brief Return a readonly disjoint union of the input graphs.
-  *
-  * The new readonly graph will include all the nodes/edges in the given graphs.
-  * Nodes/Edges will be relabled in the given sequence order by batching over CSR Graphs.
-  * For example, giving input [g1, g2, g3], where
-  * they have 5, 6, 7 nodes respectively. Then node#2 of g2 will become node#7
-  * in the result graph. Edge ids are re-assigned similarly.
-  *
-  * \param ImmutableGraph A list of input graphs to be unioned.
-  * \return the disjoint union of the ImmutableGraph
-  */
-  static ImmutableGraphRef DisjointUnion(std::vector<ImmutableGraphRef> graphs);
-
-   /*!
-   * \brief Partition the ImmutableGraph into several immutable subgraphs.
-   *
-   * This is a reverse operation of DisjointUnion. The graph will be partitioned
-   * into num graphs. This requires the given number of partitions to evenly
-   * divides the number of nodes in the graph.
-   *
-   * \param graph The ImmutableGraph to be partitioned.
-   * \param num The number of partitions.
-   * \return a list of partitioned ImmutableGraph
-   */
-  static std::vector<ImmutableGraphRef> DisjointPartitionByNum(
-      ImmutableGraphRef graph, int64_t num);
-
-  /*!
-  * \brief Partition the ImmutableGraph into several immutable subgraphs.
-  *
-  * This is a reverse operation of DisjointUnion. The graph will be partitioned
-  * based on the given sizes. This requires the sum of the given sizes is equal
-  * to the number of nodes in the graph.
-  *
-  * \param graph The ImmutableGraph to be partitioned.
-  * \param sizes The number of partitions.
-  * \return a list of partitioned ImmutableGraph
-  */
-  static std::vector<ImmutableGraphRef> DisjointPartitionBySizes(
-      ImmutableGraphRef batched_graph, IdArray sizes);
+  static std::vector<GraphPtr> DisjointPartitionBySizes(GraphPtr graph, IdArray sizes);
 
   /*!
    * \brief Map vids in the parent graph to the vids in the subgraph.
@@ -143,7 +119,7 @@ class GraphOp {
    * \param graph The input graph.
    * \return a new immutable simple graph with no multi-edge.
    */
-  static ImmutableGraphRef ToSimpleGraph(BaseGraphRef graph);
+  static GraphPtr ToSimpleGraph(GraphPtr graph);
 
   /*!
    * \brief Convert the graph to a mutable bidirected graph.
@@ -155,14 +131,14 @@ class GraphOp {
    * \param graph The input graph.
    * \return a new mutable bidirected graph.
    */
-  static GraphRef ToBidirectedMutableGraph(BaseGraphRef graph);
+  static GraphPtr ToBidirectedMutableGraph(GraphPtr graph);
 
   /*!
    * \brief Same as BidirectedMutableGraph except that the returned graph is immutable.
    * \param graph The input graph.
    * \return a new immutable bidirected graph.
    */
-  static ImmutableGraphRef ToBidirectedImmutableGraph(BaseGraphRef graph);
+  static GraphPtr ToBidirectedImmutableGraph(GraphPtr graph);
 };
 
 }  // namespace dgl

--- a/include/dgl/heterograph_interface.h
+++ b/include/dgl/heterograph_interface.h
@@ -38,14 +38,6 @@ typedef std::shared_ptr<HeteroGraphInterface> HeteroGraphPtr;
  */
 class HeteroGraphInterface {
  public:
-  /* \brief structure used to represent a list of edges */
-  // TODO(minjie): move this data structure outside of class definition so
-  // it can be shared by Graph and HeteroGraph.
-  typedef struct {
-    /* \brief the two endpoints and the id of the edge */
-    IdArray src, dst, id;
-  } EdgeArray;
-
   virtual ~HeteroGraphInterface() = default;
 
   ////////////////////////// query/operations on meta graph ////////////////////////
@@ -112,7 +104,7 @@ class HeteroGraphInterface {
   /*! \return a 0-1 array indicating whether the given vertices are in the graph.*/
   virtual BoolArray HasVertices(dgl_type_t vtype, IdArray vids) const {
     const auto len = vids->shape[0];
-    BoolArray rst = NewBoolArray(len);
+    BoolArray rst = aten::NewBoolArray(len);
     const dgl_id_t* vid_data = static_cast<dgl_id_t*>(vids->data);
     dgl_id_t* rst_data = static_cast<dgl_id_t*>(rst->data);
     for (int64_t i = 0; i < len; ++i) {
@@ -129,7 +121,7 @@ class HeteroGraphInterface {
     const auto srclen = src_ids->shape[0];
     const auto dstlen = dst_ids->shape[0];
     const auto rstlen = std::max(srclen, dstlen);
-    BoolArray rst = NewBoolArray(rstlen);
+    BoolArray rst = aten::NewBoolArray(rstlen);
     dgl_id_t* rst_data = static_cast<dgl_id_t*>(rst->data);
     const dgl_id_t* src_data = static_cast<dgl_id_t*>(src_ids->data);
     const dgl_id_t* dst_data = static_cast<dgl_id_t*>(dst_ids->data);
@@ -340,12 +332,6 @@ class HeteroGraphInterface {
    * \return the in edge id vector iterator pair.
    */
   virtual DGLIdIters InEdgeVec(dgl_type_t etype, dgl_id_t vid) const = 0;
-
-  /*!
-   * \brief Reset the data in the graph and move its data to the returned graph object.
-   * \return a raw pointer to the graph object.
-   */
-  virtual HeteroGraphInterface *Reset() = 0;
 
   /*!
    * \brief Get the adjacency matrix of the graph.

--- a/include/dgl/immutable_graph.h
+++ b/include/dgl/immutable_graph.h
@@ -24,7 +24,7 @@ typedef std::shared_ptr<CSR> CSRPtr;
 typedef std::shared_ptr<COO> COOPtr;
 
 class ImmutableGraph;
-typedef std::shared_ptr<ImmutableGraph> ImGraphPtr;
+typedef std::shared_ptr<ImmutableGraph> ImmutableGraphPtr;
 
 /*!
  * \brief Graph class stored using CSR structure.
@@ -880,32 +880,32 @@ class ImmutableGraph: public GraphInterface {
   COOPtr GetCOO() const;
 
   /*! \brief Create an immutable graph from CSR. */
-  static ImGraphPtr CreateFromCSR(
+  static ImmutableGraphPtr CreateFromCSR(
       IdArray indptr, IdArray indices, IdArray edge_ids, const std::string &edge_dir);
 
-  static ImGraphPtr CreateFromCSR(
+  static ImmutableGraphPtr CreateFromCSR(
       IdArray indptr, IdArray indices, IdArray edge_ids,
       bool multigraph, const std::string &edge_dir);
 
-  static ImGraphPtr CreateFromCSR(
+  static ImmutableGraphPtr CreateFromCSR(
       IdArray indptr, IdArray indices, IdArray edge_ids,
       const std::string &edge_dir, const std::string &shared_mem_name);
 
-  static ImGraphPtr CreateFromCSR(
+  static ImmutableGraphPtr CreateFromCSR(
       IdArray indptr, IdArray indices, IdArray edge_ids,
       bool multigraph, const std::string &edge_dir,
       const std::string &shared_mem_name);
 
-  static ImGraphPtr CreateFromCSR(
+  static ImmutableGraphPtr CreateFromCSR(
       const std::string &shared_mem_name, size_t num_vertices,
       size_t num_edges, bool multigraph,
       const std::string &edge_dir);
 
   /*! \brief Create an immutable graph from COO. */
-  static ImGraphPtr CreateFromCOO(
+  static ImmutableGraphPtr CreateFromCOO(
       int64_t num_vertices, IdArray src, IdArray dst);
 
-  static ImGraphPtr CreateFromCOO(
+  static ImmutableGraphPtr CreateFromCOO(
       int64_t num_vertices, IdArray src, IdArray dst, bool multigraph);
 
   /*!
@@ -917,14 +917,14 @@ class ImmutableGraph: public GraphInterface {
    * \param graph The input graph.
    * \return an immutable graph object.
    */
-  static ImGraphPtr ToImmutable(GraphPtr graph);
+  static ImmutableGraphPtr ToImmutable(GraphPtr graph);
 
   /*!
    * \brief Copy the data to another context.
    * \param ctx The target context.
    * \return The graph under another context.
    */
-  static ImGraphPtr CopyTo(ImGraphPtr g, const DLContext& ctx);
+  static ImmutableGraphPtr CopyTo(ImmutableGraphPtr g, const DLContext& ctx);
 
   /*!
    * \brief Copy data to shared memory.
@@ -932,15 +932,15 @@ class ImmutableGraph: public GraphInterface {
    * \param name The name of the shared memory.
    * \return The graph in the shared memory
    */
-  static ImGraphPtr CopyToSharedMem(
-      ImGraphPtr g, const std::string &edge_dir, const std::string &name);
+  static ImmutableGraphPtr CopyToSharedMem(
+      ImmutableGraphPtr g, const std::string &edge_dir, const std::string &name);
 
   /*!
    * \brief Convert the graph to use the given number of bits for storage.
    * \param bits The new number of integer bits (32 or 64).
    * \return The graph with new bit size storage.
    */
-  static ImGraphPtr AsNumBits(ImGraphPtr g, uint8_t bits);
+  static ImmutableGraphPtr AsNumBits(ImmutableGraphPtr g, uint8_t bits);
 
   /*!
    * \brief Return a new graph with all the edges reversed.
@@ -949,7 +949,7 @@ class ImmutableGraph: public GraphInterface {
    *
    * \return the reversed graph
    */
-  ImGraphPtr Reverse() const;
+  ImmutableGraphPtr Reverse() const;
 
  protected:
   /* !\brief internal default constructor */

--- a/include/dgl/lazy.h
+++ b/include/dgl/lazy.h
@@ -17,16 +17,16 @@ namespace dgl {
  * The object is currently not threaad safe.
  */
 template <typename T>
-class LazyObject {
+class Lazy {
  public:
   /*!\brief default constructor to construct a lazy object */
-  LazyObject() {}
+  Lazy() {}
 
   /*!\brief constructor to construct an object with given value (non-lazy case) */
-  explicit LazyObject(const T& val): ptr_(new T(val)) {}
+  explicit Lazy(const T& val): ptr_(new T(val)) {}
 
   /*!\brief destructor */
-  ~LazyObject() = default;
+  ~Lazy() = default;
 
   /*!
    * \brief Get the value of this object. If the object has not been instantiated,

--- a/include/dgl/nodeflow.h
+++ b/include/dgl/nodeflow.h
@@ -9,6 +9,7 @@
 #include <vector>
 #include <string>
 
+#include "./runtime/object.h"
 #include "graph_interface.h"
 
 namespace dgl {
@@ -23,7 +24,7 @@ class ImmutableGraph;
  * in a more compact format. We store extra information,
  * such as the node and edge mapping from the NodeFlow graph to the parent graph.
  */
-struct NodeFlow {
+struct NodeFlowObject : public runtime::Object {
   /*! \brief The graph. */
   GraphPtr graph;
   /*!
@@ -42,6 +43,31 @@ struct NodeFlow {
    * \brief The edge mapping from the NodeFlow graph to the parent graph.
    */
   IdArray edge_mapping;
+
+  static constexpr const char* _type_key = "graph.NodeFlow";
+  DGL_DECLARE_OBJECT_TYPE_INFO(NodeFlowObject, runtime::Object);
+};
+
+class NodeFlow : public runtime::ObjectRef {
+ public:
+  /*! \brief empty reference */
+  NodeFlow() {}
+  explicit NodeFlow(std::shared_ptr<runtime::Object> obj): runtime::ObjectRef(obj) {}
+
+  const NodeFlowObject* operator->() const {
+    return static_cast<const NodeFlowObject*>(obj_.get());
+  }
+
+  NodeFlowObject* operator->() {
+    return static_cast<NodeFlowObject*>(obj_.get());
+  }
+
+  using ContainerType = NodeFlowObject;
+
+  /*! \brief create a new nodeflow reference */
+  static NodeFlow Create() {
+    return NodeFlow(std::make_shared<NodeFlowObject>());
+  }
 };
 
 /*!

--- a/include/dgl/nodeflow.h
+++ b/include/dgl/nodeflow.h
@@ -48,21 +48,10 @@ struct NodeFlowObject : public runtime::Object {
   DGL_DECLARE_OBJECT_TYPE_INFO(NodeFlowObject, runtime::Object);
 };
 
+// Define NodeFlow as the reference class of NodeFlowObject
 class NodeFlow : public runtime::ObjectRef {
  public:
-  /*! \brief empty reference */
-  NodeFlow() {}
-  explicit NodeFlow(std::shared_ptr<runtime::Object> obj): runtime::ObjectRef(obj) {}
-
-  const NodeFlowObject* operator->() const {
-    return static_cast<const NodeFlowObject*>(obj_.get());
-  }
-
-  NodeFlowObject* operator->() {
-    return static_cast<NodeFlowObject*>(obj_.get());
-  }
-
-  using ContainerType = NodeFlowObject;
+  DGL_DEFINE_OBJECT_REF_METHODS(NodeFlow, runtime::ObjectRef, NodeFlowObject);
 
   /*! \brief create a new nodeflow reference */
   static NodeFlow Create() {

--- a/include/dgl/runtime/container.h
+++ b/include/dgl/runtime/container.h
@@ -314,6 +314,10 @@ class List : public ObjectRef {
   inline bool empty() const {
     return size() == 0;
   }
+  /*! \brief Copy the content to a vector */
+  inline std::vector<T> ToVector() const {
+    return std::vector<T>(begin(), end());
+  }
   /*! \brief specify container obj */
   using ContainerType = ListObject;
 

--- a/include/dgl/runtime/object.h
+++ b/include/dgl/runtime/object.h
@@ -192,10 +192,10 @@ class ObjectRef {
  * For example:
  *
  * // This class is an abstract class and cannot create instances
- * class SomeBaseClass : public Node {
+ * class SomeBaseClass : public Object {
  *  public:
  *   static constexpr const char* _type_key = "some_base";
- *   DGL_DECLARE_BASE_OBJECT_INFO(SomeBaseClass, Node);
+ *   DGL_DECLARE_BASE_OBJECT_INFO(SomeBaseClass, Object);
  * };
  *
  * // Child class that allows instantiation

--- a/include/dgl/runtime/object.h
+++ b/include/dgl/runtime/object.h
@@ -219,6 +219,29 @@ class ObjectRef {
     return Parent::_DerivedFrom(tid);                                   \
   }
 
+/*! \brief Macro to generate common object reference class method definition */
+#define DGL_DEFINE_OBJECT_REF_METHODS(TypeName, BaseTypeName, ObjectName)        \
+  TypeName() {}                                                                  \
+  explicit TypeName(std::shared_ptr<runtime::Object> obj): BaseTypeName(obj) {}  \
+  const ObjectName* operator->() const {                                         \
+    return static_cast<const ObjectName*>(obj_.get());                           \
+  }                                                                              \
+  ObjectName* operator->() {                                                     \
+    return static_cast<ObjectName*>(obj_.get());                                 \
+  }                                                                              \
+  std::shared_ptr<ObjectName> sptr() const {                                     \
+    return CHECK_NOTNULL(std::dynamic_pointer_cast<ObjectName>(obj_));           \
+  }                                                                              \
+  operator bool() const { return this->defined(); }                              \
+  using ContainerType = ObjectName;
+
+/*! \brief Macro to generate object reference class definition */
+#define DGL_DEFINE_OBJECT_REF(TypeName, ObjectName)                                  \
+  class TypeName : public ::dgl::runtime::ObjectRef {                                \
+   public:                                                                           \
+    DGL_DEFINE_OBJECT_REF_METHODS(TypeName, ::dgl::runtime::ObjectRef, ObjectName);  \
+  };
+
 // implementations of inline functions after this
 template<typename T>
 inline bool Object::is_type() const {

--- a/python/dgl/_ffi/_ctypes/object.py
+++ b/python/dgl/_ffi/_ctypes/object.py
@@ -61,11 +61,6 @@ class ObjectBase(object):
                 "'%s' object has no attribute '%s'" % (str(type(self)), name))
         return RETURN_SWITCH[ret_type_code.value](ret_val)
 
-    def __setattr__(self, name, value):
-        if name != 'handle':
-            raise AttributeError('Set attribute is not allowed for DGL object.')
-        object.__setattr__(self, name, value)
-
     def __init_handle_by_constructor__(self, fconstructor, *args):
         """Initialize the handle by calling constructor function.
 

--- a/python/dgl/contrib/sampling/randomwalk.py
+++ b/python/dgl/contrib/sampling/randomwalk.py
@@ -35,7 +35,7 @@ def random_walk(g, seeds, num_traces, num_hops):
     if len(seeds) == 0:
         return utils.toindex([]).tousertensor()
     seeds = utils.toindex(seeds).todgltensor()
-    traces = _CAPI_DGLRandomWalk(g._graph._handle,
+    traces = _CAPI_DGLRandomWalk(g._graph,
             seeds, int(num_traces), int(num_hops))
     return F.zerocopy_from_dlpack(traces.to_dlpack())
 
@@ -109,7 +109,7 @@ def random_walk_with_restart(
         return []
     seeds = utils.toindex(seeds).todgltensor()
     traces = _CAPI_DGLRandomWalkWithRestart(
-            g._graph._handle, seeds, restart_prob, int(max_nodes_per_seed),
+            g._graph, seeds, restart_prob, int(max_nodes_per_seed),
             int(max_visit_counts), int(max_frequent_visited_nodes))
     return _split_traces(traces)
 
@@ -161,7 +161,7 @@ def bipartite_single_sided_random_walk_with_restart(
         return []
     seeds = utils.toindex(seeds).todgltensor()
     traces = _CAPI_DGLBipartiteSingleSidedRandomWalkWithRestart(
-            g._graph._handle, seeds, restart_prob, int(max_nodes_per_seed),
+            g._graph, seeds, restart_prob, int(max_nodes_per_seed),
             int(max_visit_counts), int(max_frequent_visited_nodes))
     return _split_traces(traces)
 

--- a/python/dgl/contrib/sampling/sampler.py
+++ b/python/dgl/contrib/sampling/sampler.py
@@ -310,7 +310,7 @@ class NeighborSampler(NodeFlowSampler):
 
     def fetch(self, current_nodeflow_index):
         nfobjs = _CAPI_UniformSampling(
-            self.g.c_handle,
+            self.g._graph,
             self.seed_nodes.todgltensor(),
             current_nodeflow_index, # start batch id
             self.batch_size,        # batch size
@@ -395,7 +395,7 @@ class LayerSampler(NodeFlowSampler):
 
     def fetch(self, current_nodeflow_index):
         nfobjs = _CAPI_LayerSampling(
-            self.g.c_handle,
+            self.g._graph,
             self.seed_nodes.todgltensor(),
             current_nodeflow_index,  # start batch id
             self.batch_size,         # batch size

--- a/python/dgl/contrib/sampling/sampler.py
+++ b/python/dgl/contrib/sampling/sampler.py
@@ -10,7 +10,6 @@ from ..._ffi.function import _init_api
 from ... import utils
 from ...nodeflow import NodeFlow
 from ... import backend as F
-from ...utils import unwrap_to_ptr_list
 
 try:
     import Queue as queue
@@ -310,7 +309,7 @@ class NeighborSampler(NodeFlowSampler):
         self._neighbor_type = neighbor_type
 
     def fetch(self, current_nodeflow_index):
-        handles = unwrap_to_ptr_list(_CAPI_UniformSampling(
+        nfobjs = _CAPI_UniformSampling(
             self.g.c_handle,
             self.seed_nodes.todgltensor(),
             current_nodeflow_index, # start batch id
@@ -319,8 +318,8 @@ class NeighborSampler(NodeFlowSampler):
             self._expand_factor,
             self._num_hops,
             self._neighbor_type,
-            self._add_self_loop))
-        nflows = [NodeFlow(self.g, hdl) for hdl in handles]
+            self._add_self_loop)
+        nflows = [NodeFlow(self.g, obj) for obj in nfobjs]
         return nflows
 
 
@@ -395,15 +394,15 @@ class LayerSampler(NodeFlowSampler):
         self._layer_sizes = utils.toindex(layer_sizes)
 
     def fetch(self, current_nodeflow_index):
-        handles = unwrap_to_ptr_list(_CAPI_LayerSampling(
+        nfobjs = _CAPI_LayerSampling(
             self.g.c_handle,
             self.seed_nodes.todgltensor(),
             current_nodeflow_index,  # start batch id
             self.batch_size,         # batch size
             self._num_workers,       # num batches
             self._layer_sizes.todgltensor(),
-            self._neighbor_type))
-        nflows = [NodeFlow(self.g, hdl) for hdl in handles]
+            self._neighbor_type)
+        nflows = [NodeFlow(self.g, obj) for obj in nfobjs]
         return nflows
 
 def create_full_nodeflow(g, num_layers, add_self_loop=False):

--- a/python/dgl/graph.py
+++ b/python/dgl/graph.py
@@ -38,11 +38,6 @@ class DGLBaseGraph(object):
     def __init__(self, graph):
         self._graph = graph
 
-    @property
-    def c_handle(self):
-        """The C handle for the graph."""
-        return self._graph._handle
-
     def number_of_nodes(self):
         """Return the number of nodes in the graph.
 

--- a/python/dgl/graph_index.py
+++ b/python/dgl/graph_index.py
@@ -1,13 +1,11 @@
 """Module for graph index class definition."""
 from __future__ import absolute_import
 
-import ctypes
 import numpy as np
 import networkx as nx
 import scipy
 
 from ._ffi.object import register_object, ObjectBase
-from ._ffi.base import c_array
 from ._ffi.function import _init_api
 from .base import DGLError
 from . import backend as F

--- a/python/dgl/graph_index.py
+++ b/python/dgl/graph_index.py
@@ -6,13 +6,12 @@ import numpy as np
 import networkx as nx
 import scipy
 
+from ._ffi.object import register_object, ObjectBase
 from ._ffi.base import c_array
 from ._ffi.function import _init_api
 from .base import DGLError
 from . import backend as F
 from . import utils
-
-GraphIndexHandle = ctypes.c_void_p
 
 class BoolFlag(object):
     """Bool flag with unknown value"""
@@ -20,24 +19,28 @@ class BoolFlag(object):
     BOOL_FALSE = 0
     BOOL_TRUE = 1
 
-class GraphIndex(object):
+@register_object('graph.Graph')
+class GraphIndex(ObjectBase):
     """Graph index object.
 
-    Parameters
-    ----------
-    handle : GraphIndexHandle
-        Handler
-    """
-    def __init__(self, handle):
-        self._handle = handle
-        self._multigraph = None  # python-side cache of the flag
-        self._readonly = None  # python-side cache of the flag
-        self._cache = {}
+    Note
+    ----
+    Do not create GraphIndex directly, you can create graph index object using
+    following functions:
 
-    def __del__(self):
-        """Free this graph index object."""
-        if hasattr(self, '_handle'):
-            _CAPI_DGLGraphFree(self._handle)
+    - `dgl.graph_index.from_edge_list`
+    - `dgl.graph_index.from_scipy_sparse_matrix`
+    - `dgl.graph_index.from_networkx`
+    - `dgl.graph_index.from_shared_mem_csr_matrix`
+    - `dgl.graph_index.from_csr`
+    - `dgl.graph_index.from_coo`
+    """
+    def __new__(cls):
+        obj = ObjectBase.__new__(cls)
+        obj._multigraph = None  # python-side cache of the flag
+        obj._readonly = None  # python-side cache of the flag
+        obj._cache = {}
+        return obj
 
     def __getstate__(self):
         src, dst, _ = self.edges()
@@ -59,17 +62,13 @@ class GraphIndex(object):
         self._readonly = readonly
         if multigraph is None:
             multigraph = BoolFlag.BOOL_UNKNOWN
-        self._handle = _CAPI_DGLGraphCreate(
+        self.__init_handle_by_constructor__(
+            _CAPI_DGLGraphCreate,
             src.todgltensor(),
             dst.todgltensor(),
             int(multigraph),
             int(num_nodes),
             readonly)
-
-    @property
-    def handle(self):
-        """Get the CAPI handle."""
-        return self._handle
 
     def add_nodes(self, num):
         """Add nodes.
@@ -79,7 +78,7 @@ class GraphIndex(object):
         num : int
             Number of nodes to be added.
         """
-        _CAPI_DGLGraphAddVertices(self._handle, int(num))
+        _CAPI_DGLGraphAddVertices(self, int(num))
         self.clear_cache()
 
     def add_edge(self, u, v):
@@ -92,7 +91,7 @@ class GraphIndex(object):
         v : int
             The dst node.
         """
-        _CAPI_DGLGraphAddEdge(self._handle, u, v)
+        _CAPI_DGLGraphAddEdge(self, u, v)
         self.clear_cache()
 
     def add_edges(self, u, v):
@@ -107,12 +106,12 @@ class GraphIndex(object):
         """
         u_array = u.todgltensor()
         v_array = v.todgltensor()
-        _CAPI_DGLGraphAddEdges(self._handle, u_array, v_array)
+        _CAPI_DGLGraphAddEdges(self, u_array, v_array)
         self.clear_cache()
 
     def clear(self):
         """Clear the graph."""
-        _CAPI_DGLGraphClear(self._handle)
+        _CAPI_DGLGraphClear(self)
         self.clear_cache()
 
     def clear_cache(self):
@@ -128,7 +127,7 @@ class GraphIndex(object):
             True if it is a multigraph, False otherwise.
         """
         if self._multigraph is None:
-            self._multigraph = bool(_CAPI_DGLGraphIsMultigraph(self._handle))
+            self._multigraph = bool(_CAPI_DGLGraphIsMultigraph(self))
         return self._multigraph
 
     def is_readonly(self):
@@ -140,7 +139,7 @@ class GraphIndex(object):
             True if it is a read-only graph, False otherwise.
         """
         if self._readonly is None:
-            self._readonly = bool(_CAPI_DGLGraphIsReadonly(self._handle))
+            self._readonly = bool(_CAPI_DGLGraphIsReadonly(self))
         return self._readonly
 
     def readonly(self, readonly_state=True):
@@ -165,7 +164,7 @@ class GraphIndex(object):
         int
             The number of nodes
         """
-        return _CAPI_DGLGraphNumVertices(self._handle)
+        return _CAPI_DGLGraphNumVertices(self)
 
     def number_of_edges(self):
         """Return the number of edges.
@@ -175,7 +174,7 @@ class GraphIndex(object):
         int
             The number of edges
         """
-        return _CAPI_DGLGraphNumEdges(self._handle)
+        return _CAPI_DGLGraphNumEdges(self)
 
     def has_node(self, vid):
         """Return true if the node exists.
@@ -190,7 +189,7 @@ class GraphIndex(object):
         bool
             True if the node exists, False otherwise.
         """
-        return bool(_CAPI_DGLGraphHasVertex(self._handle, int(vid)))
+        return bool(_CAPI_DGLGraphHasVertex(self, int(vid)))
 
     def has_nodes(self, vids):
         """Return true if the nodes exist.
@@ -206,7 +205,7 @@ class GraphIndex(object):
             0-1 array indicating existence
         """
         vid_array = vids.todgltensor()
-        return utils.toindex(_CAPI_DGLGraphHasVertices(self._handle, vid_array))
+        return utils.toindex(_CAPI_DGLGraphHasVertices(self, vid_array))
 
     def has_edge_between(self, u, v):
         """Return true if the edge exists.
@@ -223,7 +222,7 @@ class GraphIndex(object):
         bool
             True if the edge exists, False otherwise
         """
-        return bool(_CAPI_DGLGraphHasEdgeBetween(self._handle, int(u), int(v)))
+        return bool(_CAPI_DGLGraphHasEdgeBetween(self, int(u), int(v)))
 
     def has_edges_between(self, u, v):
         """Return true if the edge exists.
@@ -242,7 +241,7 @@ class GraphIndex(object):
         """
         u_array = u.todgltensor()
         v_array = v.todgltensor()
-        return utils.toindex(_CAPI_DGLGraphHasEdgesBetween(self._handle, u_array, v_array))
+        return utils.toindex(_CAPI_DGLGraphHasEdgesBetween(self, u_array, v_array))
 
     def predecessors(self, v, radius=1):
         """Return the predecessors of the node.
@@ -260,7 +259,7 @@ class GraphIndex(object):
             Array of predecessors
         """
         return utils.toindex(_CAPI_DGLGraphPredecessors(
-            self._handle, int(v), int(radius)))
+            self, int(v), int(radius)))
 
     def successors(self, v, radius=1):
         """Return the successors of the node.
@@ -278,7 +277,7 @@ class GraphIndex(object):
             Array of successors
         """
         return utils.toindex(_CAPI_DGLGraphSuccessors(
-            self._handle, int(v), int(radius)))
+            self, int(v), int(radius)))
 
     def edge_id(self, u, v):
         """Return the id array of all edges between u and v.
@@ -295,7 +294,7 @@ class GraphIndex(object):
         utils.Index
             The edge id array.
         """
-        return utils.toindex(_CAPI_DGLGraphEdgeId(self._handle, int(u), int(v)))
+        return utils.toindex(_CAPI_DGLGraphEdgeId(self, int(u), int(v)))
 
     def edge_ids(self, u, v):
         """Return a triplet of arrays that contains the edge IDs.
@@ -318,7 +317,7 @@ class GraphIndex(object):
         """
         u_array = u.todgltensor()
         v_array = v.todgltensor()
-        edge_array = _CAPI_DGLGraphEdgeIds(self._handle, u_array, v_array)
+        edge_array = _CAPI_DGLGraphEdgeIds(self, u_array, v_array)
 
         src = utils.toindex(edge_array(0))
         dst = utils.toindex(edge_array(1))
@@ -344,7 +343,7 @@ class GraphIndex(object):
             The edge ids.
         """
         eid_array = eid.todgltensor()
-        edge_array = _CAPI_DGLGraphFindEdges(self._handle, eid_array)
+        edge_array = _CAPI_DGLGraphFindEdges(self, eid_array)
 
         src = utils.toindex(edge_array(0))
         dst = utils.toindex(edge_array(1))
@@ -370,10 +369,10 @@ class GraphIndex(object):
             The edge ids.
         """
         if len(v) == 1:
-            edge_array = _CAPI_DGLGraphInEdges_1(self._handle, int(v[0]))
+            edge_array = _CAPI_DGLGraphInEdges_1(self, int(v[0]))
         else:
             v_array = v.todgltensor()
-            edge_array = _CAPI_DGLGraphInEdges_2(self._handle, v_array)
+            edge_array = _CAPI_DGLGraphInEdges_2(self, v_array)
         src = utils.toindex(edge_array(0))
         dst = utils.toindex(edge_array(1))
         eid = utils.toindex(edge_array(2))
@@ -397,10 +396,10 @@ class GraphIndex(object):
             The edge ids.
         """
         if len(v) == 1:
-            edge_array = _CAPI_DGLGraphOutEdges_1(self._handle, int(v[0]))
+            edge_array = _CAPI_DGLGraphOutEdges_1(self, int(v[0]))
         else:
             v_array = v.todgltensor()
-            edge_array = _CAPI_DGLGraphOutEdges_2(self._handle, v_array)
+            edge_array = _CAPI_DGLGraphOutEdges_2(self, v_array)
         src = utils.toindex(edge_array(0))
         dst = utils.toindex(edge_array(1))
         eid = utils.toindex(edge_array(2))
@@ -430,7 +429,7 @@ class GraphIndex(object):
         """
         if order is None:
             order = ""
-        edge_array = _CAPI_DGLGraphEdges(self._handle, order)
+        edge_array = _CAPI_DGLGraphEdges(self, order)
         src = edge_array(0)
         dst = edge_array(1)
         eid = edge_array(2)
@@ -452,7 +451,7 @@ class GraphIndex(object):
         int
             The in degree.
         """
-        return _CAPI_DGLGraphInDegree(self._handle, int(v))
+        return _CAPI_DGLGraphInDegree(self, int(v))
 
     def in_degrees(self, v):
         """Return the in degrees of the nodes.
@@ -468,7 +467,7 @@ class GraphIndex(object):
             The in degree array.
         """
         v_array = v.todgltensor()
-        return utils.toindex(_CAPI_DGLGraphInDegrees(self._handle, v_array))
+        return utils.toindex(_CAPI_DGLGraphInDegrees(self, v_array))
 
     def out_degree(self, v):
         """Return the out degree of the node.
@@ -483,7 +482,7 @@ class GraphIndex(object):
         int
             The out degree.
         """
-        return _CAPI_DGLGraphOutDegree(self._handle, int(v))
+        return _CAPI_DGLGraphOutDegree(self, int(v))
 
     def out_degrees(self, v):
         """Return the out degrees of the nodes.
@@ -499,7 +498,7 @@ class GraphIndex(object):
             The out degree array.
         """
         v_array = v.todgltensor()
-        return utils.toindex(_CAPI_DGLGraphOutDegrees(self._handle, v_array))
+        return utils.toindex(_CAPI_DGLGraphOutDegrees(self, v_array))
 
     def node_subgraph(self, v):
         """Return the induced node subgraph.
@@ -515,9 +514,9 @@ class GraphIndex(object):
             The subgraph index.
         """
         v_array = v.todgltensor()
-        rst = _CAPI_DGLGraphVertexSubgraph(self._handle, v_array)
+        rst = _CAPI_DGLGraphVertexSubgraph(self, v_array)
         induced_edges = utils.toindex(rst(2))
-        gidx = GraphIndex(rst(0))
+        gidx = rst(0)
         return SubgraphIndex(gidx, self, v, induced_edges)
 
     def node_subgraphs(self, vs_arr):
@@ -556,9 +555,9 @@ class GraphIndex(object):
             The subgraph index.
         """
         e_array = e.todgltensor()
-        rst = _CAPI_DGLGraphEdgeSubgraph(self._handle, e_array, preserve_nodes)
+        rst = _CAPI_DGLGraphEdgeSubgraph(self, e_array, preserve_nodes)
         induced_nodes = utils.toindex(rst(1))
-        gidx = GraphIndex(rst(0))
+        gidx = rst(0)
         return SubgraphIndex(gidx, self, induced_nodes, e)
 
     @utils.cached_member(cache='_cache', prefix='scipy_adj')
@@ -588,7 +587,7 @@ class GraphIndex(object):
         if not isinstance(transpose, bool):
             raise DGLError('Expect bool value for "transpose" arg,'
                            ' but got %s.' % (type(transpose)))
-        rst = _CAPI_DGLGraphGetAdj(self._handle, transpose, fmt)
+        rst = _CAPI_DGLGraphGetAdj(self, transpose, fmt)
         if fmt == "csr":
             indptr = utils.toindex(rst(0)).tonumpy()
             indices = utils.toindex(rst(1)).tonumpy()
@@ -631,9 +630,9 @@ class GraphIndex(object):
             The first element of the tuple is the shuffle order for outward graph
             The second element of the tuple is the shuffle order for inward graph
         """
-        csr = _CAPI_DGLGraphGetAdj(self._handle, True, "csr")
+        csr = _CAPI_DGLGraphGetAdj(self, True, "csr")
         order = csr(2)
-        rev_csr = _CAPI_DGLGraphGetAdj(self._handle, False, "csr")
+        rev_csr = _CAPI_DGLGraphGetAdj(self, False, "csr")
         rev_order = rev_csr(2)
         return utils.toindex(order), utils.toindex(rev_order)
 
@@ -665,7 +664,7 @@ class GraphIndex(object):
             raise DGLError('Expect bool value for "transpose" arg,'
                            ' but got %s.' % (type(transpose)))
         fmt = F.get_preferred_sparse_format()
-        rst = _CAPI_DGLGraphGetAdj(self._handle, transpose, fmt)
+        rst = _CAPI_DGLGraphGetAdj(self, transpose, fmt)
         if fmt == "csr":
             indptr = F.copy_to(utils.toindex(rst(0)).tousertensor(), ctx)
             indices = F.copy_to(utils.toindex(rst(1)).tousertensor(), ctx)
@@ -794,8 +793,7 @@ class GraphIndex(object):
         GraphIndex
             The line graph of this graph.
         """
-        handle = _CAPI_DGLGraphLineGraph(self._handle, backtracking)
-        return GraphIndex(handle)
+        return _CAPI_DGLGraphLineGraph(self, backtracking)
 
     def to_immutable(self):
         """Convert this graph index to an immutable one.
@@ -805,8 +803,7 @@ class GraphIndex(object):
         GraphIndex
             An immutable graph index.
         """
-        handle = _CAPI_DGLToImmutable(self._handle)
-        return GraphIndex(handle)
+        return _CAPI_DGLToImmutable(self)
 
     def ctx(self):
         """Return the context of this graph index.
@@ -816,7 +813,7 @@ class GraphIndex(object):
         DGLContext
             The context of the graph.
         """
-        return _CAPI_DGLGraphContext(self._handle)
+        return _CAPI_DGLGraphContext(self)
 
     def copy_to(self, ctx):
         """Copy this immutable graph index to the given device context.
@@ -833,8 +830,7 @@ class GraphIndex(object):
         GraphIndex
             The graph index on the given device context.
         """
-        handle = _CAPI_DGLImmutableGraphCopyTo(self._handle, ctx.device_type, ctx.device_id)
-        return GraphIndex(handle)
+        return _CAPI_DGLImmutableGraphCopyTo(self, ctx.device_type, ctx.device_id)
 
     def copyto_shared_mem(self, edge_dir, shared_mem_name):
         """Copy this immutable graph index to shared memory.
@@ -853,8 +849,7 @@ class GraphIndex(object):
         GraphIndex
             The graph index on the given device context.
         """
-        handle = _CAPI_DGLImmutableGraphCopyToSharedMem(self._handle, edge_dir, shared_mem_name)
-        return GraphIndex(handle)
+        return _CAPI_DGLImmutableGraphCopyToSharedMem(self, edge_dir, shared_mem_name)
 
     def nbits(self):
         """Return the number of integer bits used in the storage (32 or 64).
@@ -864,7 +859,7 @@ class GraphIndex(object):
         int
             The number of bits.
         """
-        return _CAPI_DGLGraphNumBits(self._handle)
+        return _CAPI_DGLGraphNumBits(self)
 
     def bits_needed(self):
         """Return the number of integer bits needed to represent the graph
@@ -894,8 +889,7 @@ class GraphIndex(object):
         GraphIndex
             The graph index stored using the given number of bits.
         """
-        handle = _CAPI_DGLImmutableGraphAsNumBits(self._handle, int(bits))
-        return GraphIndex(handle)
+        return _CAPI_DGLImmutableGraphAsNumBits(self, int(bits))
 
 class SubgraphIndex(object):
     """Internal subgraph data structure.
@@ -955,19 +949,17 @@ def from_coo(num_nodes, src, dst, is_multigraph, readonly):
     if is_multigraph is None:
         is_multigraph = BoolFlag.BOOL_UNKNOWN
     if readonly:
-        handle = _CAPI_DGLGraphCreate(
+        gidx = _CAPI_DGLGraphCreate(
             src.todgltensor(),
             dst.todgltensor(),
             int(is_multigraph),
             int(num_nodes),
             readonly)
-        gidx = GraphIndex(handle)
     else:
         if is_multigraph is BoolFlag.BOOL_UNKNOWN:
             # TODO(minjie): better behavior in the future
             is_multigraph = BoolFlag.BOOL_FALSE
-        handle = _CAPI_DGLGraphCreateMutable(bool(is_multigraph))
-        gidx = GraphIndex(handle)
+        gidx = _CAPI_DGLGraphCreateMutable(bool(is_multigraph))
         gidx.add_nodes(num_nodes)
         gidx.add_edges(src, dst)
     return gidx
@@ -993,13 +985,13 @@ def from_csr(indptr, indices, is_multigraph,
     indices = utils.toindex(indices)
     if is_multigraph is None:
         is_multigraph = BoolFlag.BOOL_UNKNOWN
-    handle = _CAPI_DGLGraphCSRCreate(
+    gidx = _CAPI_DGLGraphCSRCreate(
         indptr.todgltensor(),
         indices.todgltensor(),
         shared_mem_name,
         int(is_multigraph),
         direction)
-    return GraphIndex(handle)
+    return gidx
 
 def from_shared_mem_csr_matrix(shared_mem_name,
                                num_nodes, num_edges, edge_dir,
@@ -1017,12 +1009,12 @@ def from_shared_mem_csr_matrix(shared_mem_name,
     edge_dir : string
         the edge direction. The supported option is "in" and "out".
     """
-    handle = _CAPI_DGLGraphCSRCreateMMap(
+    gidx = _CAPI_DGLGraphCSRCreateMMap(
         shared_mem_name,
         int(num_nodes), int(num_edges),
         is_multigraph,
         edge_dir)
-    return GraphIndex(handle)
+    return gidx
 
 def from_networkx(nx_graph, readonly):
     """Convert from networkx graph.
@@ -1175,10 +1167,7 @@ def disjoint_union(graphs):
     GraphIndex
         The disjoint union
     """
-    inputs = c_array(GraphIndexHandle, [gr._handle for gr in graphs])
-    inputs = ctypes.cast(inputs, ctypes.c_void_p)
-    handle = _CAPI_DGLDisjointUnion(inputs, len(graphs))
-    return GraphIndex(handle)
+    return _CAPI_DGLDisjointUnion(list(graphs))
 
 def disjoint_partition(graph, num_or_size_splits):
     """Partition the graph disjointly.
@@ -1202,17 +1191,13 @@ def disjoint_partition(graph, num_or_size_splits):
     """
     if isinstance(num_or_size_splits, utils.Index):
         rst = _CAPI_DGLDisjointPartitionBySizes(
-            graph._handle,
+            graph,
             num_or_size_splits.todgltensor())
     else:
         rst = _CAPI_DGLDisjointPartitionByNum(
-            graph._handle,
+            graph,
             int(num_or_size_splits))
-    graphs = []
-    for val in rst.asnumpy():
-        handle = ctypes.cast(int(val), ctypes.c_void_p)
-        graphs.append(GraphIndex(handle))
-    return graphs
+    return rst
 
 def create_graph_index(graph_data, multigraph, readonly):
     """Create a graph index object.
@@ -1236,8 +1221,7 @@ def create_graph_index(graph_data, multigraph, readonly):
             raise Exception("can't create an empty immutable graph")
         if multigraph is None:
             multigraph = False
-        handle = _CAPI_DGLGraphCreateMutable(multigraph)
-        return GraphIndex(handle)
+        return _CAPI_DGLGraphCreateMutable(multigraph)
     elif isinstance(graph_data, (list, tuple)):
         # edge list
         return from_edge_list(graph_data, multigraph, readonly)

--- a/python/dgl/kernel.py
+++ b/python/dgl/kernel.py
@@ -139,7 +139,7 @@ def binary_op_reduce(reducer, op, G, A_target, B_target, A, B, out,
     if out_rows is None:
         out_rows = empty([])
     _CAPI_DGLKernelBinaryOpReduce(
-        reducer, op, G._handle,
+        reducer, op, G,
         int(A_target), int(B_target),
         A, B, out,
         A_rows, B_rows, out_rows)
@@ -203,7 +203,7 @@ def backward_lhs_binary_op_reduce(
     if out_rows is None:
         out_rows = empty([])
     _CAPI_DGLKernelBackwardLhsBinaryOpReduce(
-        reducer, op, G._handle,
+        reducer, op, G,
         int(A_target), int(B_target),
         A_rows, B_rows, out_rows,
         A, B, out,
@@ -268,7 +268,7 @@ def backward_rhs_binary_op_reduce(
     if out_rows is None:
         out_rows = empty([])
     _CAPI_DGLKernelBackwardRhsBinaryOpReduce(
-        reducer, op, G._handle,
+        reducer, op, G,
         int(A_target), int(B_target),
         A_rows, B_rows, out_rows,
         A, B, out,
@@ -365,7 +365,7 @@ def copy_reduce(reducer, G, target,
     if out_rows is None:
         out_rows = empty([])
     _CAPI_DGLKernelCopyReduce(
-        reducer, G._handle, int(target),
+        reducer, G, int(target),
         X, out, X_rows, out_rows)
 
 # pylint: disable=invalid-name
@@ -407,7 +407,7 @@ def backward_copy_reduce(reducer, G, target,
     if out_rows is None:
         out_rows = empty([])
     _CAPI_DGLKernelBackwardCopyReduce(
-        reducer, G._handle, int(target),
+        reducer, G, int(target),
         X, out, grad_out, grad_X,
         X_rows, out_rows)
 

--- a/python/dgl/network.py
+++ b/python/dgl/network.py
@@ -63,14 +63,14 @@ def _send_nodeflow(sender, nodeflow, recv_id):
     recv_id : int
         Receiver ID
     """
-    graph_handle = nodeflow._graph._handle
+    gidx = nodeflow._graph
     node_mapping = nodeflow._node_mapping.todgltensor()
     edge_mapping = nodeflow._edge_mapping.todgltensor()
     layers_offsets = utils.toindex(nodeflow._layer_offsets).todgltensor()
     flows_offsets = utils.toindex(nodeflow._block_offsets).todgltensor()
     _CAPI_SenderSendSubgraph(sender,
                              int(recv_id),
-                             graph_handle,
+                             gidx,
                              node_mapping,
                              edge_mapping,
                              layers_offsets,
@@ -136,5 +136,5 @@ def _recv_nodeflow(receiver, graph):
         else:
             raise RuntimeError('Got unexpected control code {}'.format(res))
     else:
-        # res is of type NodeFlowObject
-        return NodeFlow(graph, res)
+        # res is of type List<NodeFlowObject>
+        return NodeFlow(graph, res[0])

--- a/python/dgl/network.py
+++ b/python/dgl/network.py
@@ -3,7 +3,6 @@ from __future__ import absolute_import
 
 from ._ffi.function import _init_api
 from .nodeflow import NodeFlow
-from .utils import unwrap_to_ptr_list
 from . import utils
 
 _init_api("dgl.network")
@@ -137,5 +136,5 @@ def _recv_nodeflow(receiver, graph):
         else:
             raise RuntimeError('Got unexpected control code {}'.format(res))
     else:
-        hdl = unwrap_to_ptr_list(res)
-        return NodeFlow(graph, hdl[0])
+        # res is of type NodeFlowObject
+        return NodeFlow(graph, res)

--- a/python/dgl/nodeflow.py
+++ b/python/dgl/nodeflow.py
@@ -28,7 +28,7 @@ class NodeFlowObject(ObjectBase):
         -------
         GraphIndex
         """
-        return _CAPI_NodeFlowGetGraph(self.handle)
+        return _CAPI_NodeFlowGetGraph(self)
 
     @property
     def layer_offsets(self):
@@ -38,7 +38,7 @@ class NodeFlowObject(ObjectBase):
         -------
         NDArray
         """
-        return _CAPI_NodeFlowGetLayerOffsets(self.handle)
+        return _CAPI_NodeFlowGetLayerOffsets(self)
 
     @property
     def block_offsets(self):
@@ -48,7 +48,7 @@ class NodeFlowObject(ObjectBase):
         -------
         NDArray
         """
-        return _CAPI_NodeFlowGetBlockOffsets(self.handle)
+        return _CAPI_NodeFlowGetBlockOffsets(self)
 
     @property
     def node_mapping(self):
@@ -58,7 +58,7 @@ class NodeFlowObject(ObjectBase):
         -------
         NDArray
         """
-        return _CAPI_NodeFlowGetNodeMapping(self.handle)
+        return _CAPI_NodeFlowGetNodeMapping(self)
 
     @property
     def edge_mapping(self):
@@ -68,7 +68,7 @@ class NodeFlowObject(ObjectBase):
         -------
         NDArray
         """
-        return _CAPI_NodeFlowGetEdgeMapping(self.handle)
+        return _CAPI_NodeFlowGetEdgeMapping(self)
 
 class NodeFlow(DGLBaseGraph):
     """The NodeFlow class stores the sampling results of Neighbor
@@ -337,6 +337,7 @@ class NodeFlow(DGLBaseGraph):
             The parent node id array.
         """
         nid = utils.toindex(nid)
+        # TODO(minjie): should not directly use []
         return self._node_mapping.tousertensor()[nid.tousertensor()]
 
     def map_to_parent_eid(self, eid):
@@ -353,6 +354,7 @@ class NodeFlow(DGLBaseGraph):
             The parent edge id array.
         """
         eid = utils.toindex(eid)
+        # TODO(minjie): should not directly use []
         return self._edge_mapping.tousertensor()[eid.tousertensor()]
 
     def map_from_parent_nid(self, layer_id, parent_nids, remap_local=False):
@@ -462,6 +464,7 @@ class NodeFlow(DGLBaseGraph):
         assert layer_id + 1 < len(self._layer_offsets)
         start = self._layer_offsets[layer_id]
         end = self._layer_offsets[layer_id + 1]
+        # TODO(minjie): should not directly use []
         return self._node_mapping.tousertensor()[start:end]
 
     def block_eid(self, block_id):
@@ -500,6 +503,7 @@ class NodeFlow(DGLBaseGraph):
         block_id = self._get_block_id(block_id)
         start = self._block_offsets[block_id]
         end = self._block_offsets[block_id + 1]
+        # TODO(minjie): should not directly use []
         ret = self._edge_mapping.tousertensor()[start:end]
         # If `add_self_loop` is enabled, the returned parent eid can be -1.
         # We have to make sure this case doesn't happen.
@@ -531,7 +535,7 @@ class NodeFlow(DGLBaseGraph):
         """
         block_id = self._get_block_id(block_id)
         layer0_size = self._layer_offsets[block_id + 1] - self._layer_offsets[block_id]
-        rst = _CAPI_NodeFlowGetBlockAdj(self._graph._handle, "coo",
+        rst = _CAPI_NodeFlowGetBlockAdj(self._graph, "coo",
                                         int(layer0_size),
                                         int(self._layer_offsets[block_id + 1]),
                                         int(self._layer_offsets[block_id + 2]),
@@ -567,7 +571,7 @@ class NodeFlow(DGLBaseGraph):
         fmt = F.get_preferred_sparse_format()
         # We need to extract two layers.
         layer0_size = self._layer_offsets[block_id + 1] - self._layer_offsets[block_id]
-        rst = _CAPI_NodeFlowGetBlockAdj(self._graph._handle, fmt,
+        rst = _CAPI_NodeFlowGetBlockAdj(self._graph, fmt,
                                         int(layer0_size),
                                         int(self._layer_offsets[block_id + 1]),
                                         int(self._layer_offsets[block_id + 2]),

--- a/python/dgl/nodeflow.py
+++ b/python/dgl/nodeflow.py
@@ -1,15 +1,13 @@
 """Class for NodeFlow data structure."""
 from __future__ import absolute_import
 
-import ctypes
-
 from ._ffi.object import register_object, ObjectBase
 from ._ffi.function import _init_api
 from .base import ALL, is_all, DGLError
 from . import backend as F
 from .frame import Frame, FrameRef
 from .graph import DGLBaseGraph
-from .graph_index import GraphIndex, transform_ids
+from .graph_index import transform_ids
 from .runtime import ir, scheduler, Runtime
 from . import utils
 from .view import LayerView, BlockView

--- a/python/dgl/transform.py
+++ b/python/dgl/transform.py
@@ -1,7 +1,6 @@
 """Module for graph transformation methods."""
 from ._ffi.function import _init_api
 from .graph import DGLGraph
-from .graph_index import GraphIndex
 from .batched_graph import BatchedDGLGraph
 
 __all__ = ['line_graph', 'reverse', 'to_simple_graph', 'to_bidirected']

--- a/python/dgl/transform.py
+++ b/python/dgl/transform.py
@@ -121,8 +121,8 @@ def to_simple_graph(g):
     DGLGraph
         A simple graph.
     """
-    newgidx = GraphIndex(_CAPI_DGLToSimpleGraph(g._graph.handle))
-    return DGLGraph(newgidx, readonly=True)
+    gidx = _CAPI_DGLToSimpleGraph(g._graph)
+    return DGLGraph(gidx, readonly=True)
 
 def to_bidirected(g, readonly=True):
     """Convert the graph to a bidirected graph.
@@ -165,9 +165,9 @@ def to_bidirected(g, readonly=True):
     (tensor([0, 1, 1, 0, 0]), tensor([0, 0, 0, 1, 1]))
     """
     if readonly:
-        newgidx = GraphIndex(_CAPI_DGLToBidirectedImmutableGraph(g._graph.handle))
+        newgidx = _CAPI_DGLToBidirectedImmutableGraph(g._graph)
     else:
-        newgidx = GraphIndex(_CAPI_DGLToBidirectedMutableGraph(g._graph.handle))
+        newgidx = _CAPI_DGLToBidirectedMutableGraph(g._graph)
     return DGLGraph(newgidx)
 
 _init_api("dgl.transform")

--- a/python/dgl/traversal.py
+++ b/python/dgl/traversal.py
@@ -39,9 +39,9 @@ def bfs_nodes_generator(graph, source, reverse=False):
     >>> list(dgl.bfs_nodes_generator(g, 0))
     [tensor([0]), tensor([1]), tensor([2, 3]), tensor([4, 5])]
     """
-    ghandle = graph._graph._handle
+    gidx = graph._graph
     source = utils.toindex(source)
-    ret = _CAPI_DGLBFSNodes(ghandle, source.todgltensor(), reverse)
+    ret = _CAPI_DGLBFSNodes(gidx, source.todgltensor(), reverse)
     all_nodes = utils.toindex(ret(0)).tousertensor()
     # TODO(minjie): how to support directly creating python list
     sections = utils.toindex(ret(1)).tonumpy().tolist()
@@ -79,9 +79,9 @@ def bfs_edges_generator(graph, source, reverse=False):
     >>> list(dgl.bfs_edges_generator(g, 0))
     [tensor([0]), tensor([1, 2]), tensor([4, 5])]
     """
-    ghandle = graph._graph._handle
+    gidx = graph._graph
     source = utils.toindex(source)
-    ret = _CAPI_DGLBFSEdges(ghandle, source.todgltensor(), reverse)
+    ret = _CAPI_DGLBFSEdges(gidx, source.todgltensor(), reverse)
     all_edges = utils.toindex(ret(0)).tousertensor()
     # TODO(minjie): how to support directly creating python list
     sections = utils.toindex(ret(1)).tonumpy().tolist()
@@ -116,8 +116,8 @@ def topological_nodes_generator(graph, reverse=False):
     >>> list(dgl.topological_nodes_generator(g))
     [tensor([0]), tensor([1]), tensor([2]), tensor([3, 4]), tensor([5])]
     """
-    ghandle = graph._graph._handle
-    ret = _CAPI_DGLTopologicalNodes(ghandle, reverse)
+    gidx = graph._graph
+    ret = _CAPI_DGLTopologicalNodes(gidx, reverse)
     all_nodes = utils.toindex(ret(0)).tousertensor()
     # TODO(minjie): how to support directly creating python list
     sections = utils.toindex(ret(1)).tonumpy().tolist()
@@ -160,9 +160,9 @@ def dfs_edges_generator(graph, source, reverse=False):
     >>> list(dgl.dfs_edges_generator(g, 0))
     [tensor([0]), tensor([1]), tensor([3]), tensor([5]), tensor([4])]
     """
-    ghandle = graph._graph._handle
+    gidx = graph._graph
     source = utils.toindex(source)
-    ret = _CAPI_DGLDFSEdges(ghandle, source.todgltensor(), reverse)
+    ret = _CAPI_DGLDFSEdges(gidx, source.todgltensor(), reverse)
     all_edges = utils.toindex(ret(0)).tousertensor()
     # TODO(minjie): how to support directly creating python list
     sections = utils.toindex(ret(1)).tonumpy().tolist()
@@ -231,10 +231,10 @@ def dfs_labeled_edges_generator(
     (tensor([0]), tensor([1]), tensor([3]), tensor([5]), tensor([4]), tensor([2])),
     (tensor([0]), tensor([0]), tensor([0]), tensor([0]), tensor([0]), tensor([2]))
     """
-    ghandle = graph._graph._handle
+    gidx = graph._graph
     source = utils.toindex(source)
     ret = _CAPI_DGLDFSLabeledEdges(
-        ghandle,
+        gidx,
         source.todgltensor(),
         reverse,
         has_reverse_edge,

--- a/python/dgl/utils.py
+++ b/python/dgl/utils.py
@@ -1,12 +1,10 @@
 """Utility module."""
 from __future__ import absolute_import, division
 
-import ctypes
 from collections.abc import Mapping, Iterable
 from functools import wraps
 import numpy as np
 
-from . import _api_internal
 from .base import DGLError
 from . import backend as F
 from . import ndarray as nd

--- a/python/dgl/utils.py
+++ b/python/dgl/utils.py
@@ -534,30 +534,6 @@ def get_edata_name(g, name):
         name += '_'
     return name
 
-def unwrap_to_ptr_list(wrapper):
-    """Convert the internal vector wrapper to a python list of ctypes.c_void_p.
-
-    The wrapper will be destroyed after this function.
-
-    Parameters
-    ----------
-    wrapper : ctypes.c_void_p
-        The handler to the wrapper.
-
-    Returns
-    -------
-    list of ctypes.c_void_p
-        A python list of void pointers.
-    """
-    size = _api_internal._GetVectorWrapperSize(wrapper)
-    if size == 0:
-        return []
-    data = _api_internal._GetVectorWrapperData(wrapper)
-    data = ctypes.cast(data, ctypes.POINTER(ctypes.c_void_p * size))
-    rst = [ctypes.c_void_p(x) for x in data.contents]
-    _api_internal._FreeVectorWrapper(wrapper)
-    return rst
-
 def to_dgl_context(ctx):
     """Convert a backend context to DGLContext"""
     device_type = nd.DGLContext.STR2MASK[F.device_type(ctx)]

--- a/src/c_api_common.cc
+++ b/src/c_api_common.cc
@@ -25,25 +25,4 @@ PackedFunc ConvertNDArrayVectorToPackedFunc(const std::vector<NDArray>& vec) {
     return PackedFunc(body);
 }
 
-DGL_REGISTER_GLOBAL("_GetVectorWrapperSize")
-.set_body([] (DGLArgs args, DGLRetValue* rv) {
-    void* ptr = args[0];
-    const CAPIVectorWrapper* wrapper = static_cast<const CAPIVectorWrapper*>(ptr);
-    *rv = static_cast<int64_t>(wrapper->pointers.size());
-  });
-
-DGL_REGISTER_GLOBAL("_GetVectorWrapperData")
-.set_body([] (DGLArgs args, DGLRetValue* rv) {
-    void* ptr = args[0];
-    CAPIVectorWrapper* wrapper = static_cast<CAPIVectorWrapper*>(ptr);
-    *rv = static_cast<void*>(wrapper->pointers.data());
-  });
-
-DGL_REGISTER_GLOBAL("_FreeVectorWrapper")
-.set_body([] (DGLArgs args, DGLRetValue* rv) {
-    void* ptr = args[0];
-    CAPIVectorWrapper* wrapper = static_cast<CAPIVectorWrapper*>(ptr);
-    delete wrapper;
-  });
-
 }  // namespace dgl

--- a/src/c_api_common.h
+++ b/src/c_api_common.h
@@ -70,29 +70,6 @@ dgl::runtime::NDArray CopyVectorToNDArray(
   return a;
 }
 
-/* A structure used to return a vector of void* pointers. */
-struct CAPIVectorWrapper {
-  // The pointer vector.
-  std::vector<void*> pointers;
-};
-
-/*!
- * \brief A helper function used to return vector of pointers from C to frontend.
- *
- * Note that the function will move the given vector memory into the returned
- * wrapper object.
- * 
- * \param vec The given pointer vectors.
- * \return A wrapper object containing the given data.
- */
-template<typename PType>
-CAPIVectorWrapper* WrapVectorReturn(std::vector<PType*> vec) {
-  CAPIVectorWrapper* wrapper = new CAPIVectorWrapper;
-  wrapper->pointers.reserve(vec.size());
-  wrapper->pointers.insert(wrapper->pointers.end(), vec.begin(), vec.end());
-  return wrapper;
-}
-
 }  // namespace dgl
 
 #endif  // DGL_C_API_COMMON_H_

--- a/src/c_api_common.h
+++ b/src/c_api_common.h
@@ -34,9 +34,6 @@ inline std::ostream& operator << (std::ostream& os, const DLContext& ctx) {
 
 namespace dgl {
 
-// Graph handler type
-typedef void* GraphHandle;
-
 // Communicator handler type
 typedef void* CommunicatorHandle;
 

--- a/src/graph/graph.cc
+++ b/src/graph/graph.cc
@@ -585,9 +585,4 @@ std::vector<IdArray> Graph::GetAdj(bool transpose, const std::string &fmt) const
   }
 }
 
-GraphPtr Graph::Reverse() const {
-  LOG(FATAL) << "not implemented";
-  return nullptr;
-}
-
 }  // namespace dgl

--- a/src/graph/graph.cc
+++ b/src/graph/graph.cc
@@ -200,7 +200,7 @@ IdArray Graph::EdgeId(dgl_id_t src, dgl_id_t dst) const {
 }
 
 // O(E*k) pretty slow
-Graph::EdgeArray Graph::EdgeIds(IdArray src_ids, IdArray dst_ids) const {
+EdgeArray Graph::EdgeIds(IdArray src_ids, IdArray dst_ids) const {
   CHECK(IsValidIdArray(src_ids)) << "Invalid src id array.";
   CHECK(IsValidIdArray(dst_ids)) << "Invalid dst id array.";
   const auto srclen = src_ids->shape[0];
@@ -246,7 +246,7 @@ Graph::EdgeArray Graph::EdgeIds(IdArray src_ids, IdArray dst_ids) const {
   return EdgeArray{rst_src, rst_dst, rst_eid};
 }
 
-Graph::EdgeArray Graph::FindEdges(IdArray eids) const {
+EdgeArray Graph::FindEdges(IdArray eids) const {
   CHECK(IsValidIdArray(eids)) << "Invalid edge id array";
   int64_t len = eids->shape[0];
 
@@ -272,7 +272,7 @@ Graph::EdgeArray Graph::FindEdges(IdArray eids) const {
 }
 
 // O(E)
-Graph::EdgeArray Graph::InEdges(dgl_id_t vid) const {
+EdgeArray Graph::InEdges(dgl_id_t vid) const {
   CHECK(HasVertex(vid)) << "invalid vertex: " << vid;
   const int64_t len = reverse_adjlist_[vid].succ.size();
   IdArray src = IdArray::Empty({len}, DLDataType{kDLInt, 64, 1}, DLContext{kDLCPU, 0});
@@ -290,7 +290,7 @@ Graph::EdgeArray Graph::InEdges(dgl_id_t vid) const {
 }
 
 // O(E)
-Graph::EdgeArray Graph::InEdges(IdArray vids) const {
+EdgeArray Graph::InEdges(IdArray vids) const {
   CHECK(IsValidIdArray(vids)) << "Invalid vertex id array.";
   const auto len = vids->shape[0];
   const int64_t* vid_data = static_cast<int64_t*>(vids->data);
@@ -318,7 +318,7 @@ Graph::EdgeArray Graph::InEdges(IdArray vids) const {
 }
 
 // O(E)
-Graph::EdgeArray Graph::OutEdges(dgl_id_t vid) const {
+EdgeArray Graph::OutEdges(dgl_id_t vid) const {
   CHECK(HasVertex(vid)) << "invalid vertex: " << vid;
   const int64_t len = adjlist_[vid].succ.size();
   IdArray src = IdArray::Empty({len}, DLDataType{kDLInt, 64, 1}, DLContext{kDLCPU, 0});
@@ -336,7 +336,7 @@ Graph::EdgeArray Graph::OutEdges(dgl_id_t vid) const {
 }
 
 // O(E)
-Graph::EdgeArray Graph::OutEdges(IdArray vids) const {
+EdgeArray Graph::OutEdges(IdArray vids) const {
   CHECK(IsValidIdArray(vids)) << "Invalid vertex id array.";
   const auto len = vids->shape[0];
   const int64_t* vid_data = static_cast<int64_t*>(vids->data);
@@ -364,7 +364,7 @@ Graph::EdgeArray Graph::OutEdges(IdArray vids) const {
 }
 
 // O(E*log(E)) if sort is required; otherwise, O(E)
-Graph::EdgeArray Graph::Edges(const std::string &order) const {
+EdgeArray Graph::Edges(const std::string &order) const {
   const int64_t len = num_edges_;
   IdArray src = IdArray::Empty({len}, DLDataType{kDLInt, 64, 1}, DLContext{kDLCPU, 0});
   IdArray dst = IdArray::Empty({len}, DLDataType{kDLInt, 64, 1}, DLContext{kDLCPU, 0});

--- a/src/graph/graph_apis.cc
+++ b/src/graph/graph_apis.cc
@@ -94,7 +94,7 @@ DGL_REGISTER_GLOBAL("graph_index._CAPI_DGLGraphCreate")
       }
     } else {
       CHECK_NE(multigraph, kBoolUnknown);
-      *rv = GraphRef(ImmutableGraph::CreateFromCOO(num_nodes, src_ids, dst_ids, multigraph));
+      *rv = GraphRef(Graph::CreateFromCOO(num_nodes, src_ids, dst_ids, multigraph));
     }
   });
 

--- a/src/graph/graph_apis.cc
+++ b/src/graph/graph_apis.cc
@@ -115,7 +115,8 @@ DGL_REGISTER_GLOBAL("graph_index._CAPI_DGLGraphCSRCreate")
       if (multigraph == kBoolUnknown) {
         *rv = GraphRef(ImmutableGraph::CreateFromCSR(indptr, indices, edge_ids, edge_dir));
       } else {
-        *rv = GraphRef(ImmutableGraph::CreateFromCSR(indptr, indices, edge_ids, multigraph, edge_dir));
+        *rv = GraphRef(ImmutableGraph::CreateFromCSR(
+            indptr, indices, edge_ids, multigraph, edge_dir));
       }
     } else {
       if (multigraph == kBoolUnknown) {

--- a/src/graph/graph_apis.cc
+++ b/src/graph/graph_apis.cc
@@ -55,9 +55,7 @@ PackedFunc ConvertSubgraphToPackedFunc(const Subgraph& sg) {
   auto body = [sg] (DGLArgs args, DGLRetValue* rv) {
       const int which = args[0];
       if (which == 0) {
-        GraphInterface* gptr = sg.graph->Reset();
-        GraphHandle ghandle = gptr;
-        *rv = ghandle;
+        *rv = sg.graph;
       } else if (which == 1) {
         *rv = std::move(sg.induced_vertices);
       } else if (which == 2) {
@@ -122,9 +120,8 @@ void DGLDisjointPartitionBySizes(const T *gptr, const IdArray sizes, DGLRetValue
 
 DGL_REGISTER_GLOBAL("graph_index._CAPI_DGLGraphCreateMutable")
 .set_body([] (DGLArgs args, DGLRetValue* rv) {
-    bool multigraph = static_cast<bool>(args[0]);
-    GraphHandle ghandle = new Graph(multigraph);
-    *rv = ghandle;
+    bool multigraph = args[0];
+    *rv = GraphRef::Create(multigraph);
   });
 
 
@@ -135,20 +132,16 @@ DGL_REGISTER_GLOBAL("graph_index._CAPI_DGLGraphCreate")
     const int multigraph = args[2];
     const int64_t num_nodes = args[3];
     const bool readonly = args[4];
-    GraphHandle ghandle;
     if (readonly) {
       if (multigraph == kBoolUnknown) {
-        COOPtr coo(new COO(num_nodes, src_ids, dst_ids));
-        ghandle = new ImmutableGraph(coo);
+        *rv = ImmutableGraphRef::CreateFromCOO(num_nodes, src_ids, dst_ids);
       } else {
-        COOPtr coo(new COO(num_nodes, src_ids, dst_ids, multigraph));
-        ghandle = new ImmutableGraph(coo);
+        *rv = ImmutableGraphRef::CreateFromCOO(num_nodes, src_ids, dst_ids, multigraph);
       }
     } else {
       CHECK_NE(multigraph, kBoolUnknown);
-      ghandle = new Graph(src_ids, dst_ids, num_nodes, multigraph);
+      *rv = GraphRef::CreateFromCOO(num_nodes, src_ids, dst_ids, multigraph);
     }
-    *rv = ghandle;
   });
 
 DGL_REGISTER_GLOBAL("graph_index._CAPI_DGLGraphCSRCreate")
@@ -164,26 +157,21 @@ DGL_REGISTER_GLOBAL("graph_index._CAPI_DGLGraphCSRCreate")
     int64_t *edge_data = static_cast<int64_t *>(edge_ids->data);
     for (size_t i = 0; i < edge_ids->shape[0]; i++)
       edge_data[i] = i;
-    ImmutableGraph *g = nullptr;
     if (shared_mem_name.empty()) {
       if (multigraph == kBoolUnknown) {
-        g = new ImmutableGraph(ImmutableGraph::CreateFromCSR(indptr, indices, edge_ids,
-                                                             edge_dir));
+        *rv = ImmutableGraphRef::CreateFromCSR(indptr, indices, edge_ids, edge_dir);
       } else {
-        g = new ImmutableGraph(ImmutableGraph::CreateFromCSR(indptr, indices, edge_ids,
-                                                             multigraph, edge_dir));
+        *rv = ImmutableGraphRef::CreateFromCSR(indptr, indices, edge_ids, multigraph, edge_dir);
       }
     } else {
       if (multigraph == kBoolUnknown) {
-        g = new ImmutableGraph(ImmutableGraph::CreateFromCSR(indptr, indices, edge_ids,
-                                                             edge_dir, shared_mem_name));
+        *rv = ImmutableGraphRef::CreateFromCSR(
+            indptr, indices, edge_ids, edge_dir, shared_mem_name);
       } else {
-        g = new ImmutableGraph(ImmutableGraph::CreateFromCSR(indptr, indices, edge_ids,
-                                                             multigraph, edge_dir,
-                                                             shared_mem_name));
+        *rv = ImmutableGraphRef::CreateFromCSR(indptr, indices, edge_ids,
+            multigraph, edge_dir, shared_mem_name);
       }
     }
-    *rv = g;
   });
 
 DGL_REGISTER_GLOBAL("graph_index._CAPI_DGLGraphCSRCreateMMap")
@@ -194,95 +182,75 @@ DGL_REGISTER_GLOBAL("graph_index._CAPI_DGLGraphCSRCreateMMap")
     const bool multigraph = args[3];
     const std::string edge_dir = args[4];
     // TODO(minjie): how to know multigraph
-    GraphHandle ghandle = new ImmutableGraph(ImmutableGraph::CreateFromCSR(
-      shared_mem_name, num_vertices, num_edges, multigraph, edge_dir));
-    *rv = ghandle;
-  });
-
-DGL_REGISTER_GLOBAL("graph_index._CAPI_DGLGraphFree")
-.set_body([] (DGLArgs args, DGLRetValue* rv) {
-    GraphHandle ghandle = args[0];
-    GraphInterface* gptr = static_cast<GraphInterface*>(ghandle);
-    delete gptr;
+    *rv = ImmutableGraphRef::CreateFromCSR(
+      shared_mem_name, num_vertices, num_edges, multigraph, edge_dir);
   });
 
 DGL_REGISTER_GLOBAL("graph_index._CAPI_DGLGraphAddVertices")
 .set_body([] (DGLArgs args, DGLRetValue* rv) {
-    GraphHandle ghandle = args[0];
-    GraphInterface* gptr = static_cast<GraphInterface*>(ghandle);
+    BaseGraphRef g = args[0];
     uint64_t num_vertices = args[1];
-    gptr->AddVertices(num_vertices);
+    g->AddVertices(num_vertices);
   });
 
 DGL_REGISTER_GLOBAL("graph_index._CAPI_DGLGraphAddEdge")
 .set_body([] (DGLArgs args, DGLRetValue* rv) {
-    GraphHandle ghandle = args[0];
-    GraphInterface* gptr = static_cast<GraphInterface*>(ghandle);
+    BaseGraphRef g = args[0];
     const dgl_id_t src = args[1];
     const dgl_id_t dst = args[2];
-    gptr->AddEdge(src, dst);
+    g->AddEdge(src, dst);
   });
 
 DGL_REGISTER_GLOBAL("graph_index._CAPI_DGLGraphAddEdges")
 .set_body([] (DGLArgs args, DGLRetValue* rv) {
-    GraphHandle ghandle = args[0];
-    GraphInterface* gptr = static_cast<GraphInterface*>(ghandle);
+    BaseGraphRef g = args[0];
     const IdArray src = args[1];
     const IdArray dst = args[2];
-    gptr->AddEdges(src, dst);
+    g->AddEdges(src, dst);
   });
 
 DGL_REGISTER_GLOBAL("graph_index._CAPI_DGLGraphClear")
 .set_body([] (DGLArgs args, DGLRetValue* rv) {
-    GraphHandle ghandle = args[0];
-    GraphInterface* gptr = static_cast<GraphInterface*>(ghandle);
-    gptr->Clear();
+    BaseGraphRef g = args[0];
+    g->Clear();
   });
 
 DGL_REGISTER_GLOBAL("graph_index._CAPI_DGLGraphIsMultigraph")
 .set_body([] (DGLArgs args, DGLRetValue *rv) {
-    GraphHandle ghandle = args[0];
-    // NOTE: not const since we have caches
-    const GraphInterface* gptr = static_cast<GraphInterface*>(ghandle);
-    *rv = gptr->IsMultigraph();
+    BaseGraphRef g = args[0];
+    *rv = g->IsMultigraph();
   });
 
 DGL_REGISTER_GLOBAL("graph_index._CAPI_DGLGraphIsReadonly")
 .set_body([] (DGLArgs args, DGLRetValue *rv) {
-    GraphHandle ghandle = args[0];
-    // NOTE: not const since we have caches
-    const GraphInterface* gptr = static_cast<GraphInterface*>(ghandle);
-    *rv = gptr->IsReadonly();
+    BaseGraphRef g = args[0];
+    *rv = g->IsReadonly();
   });
 
 DGL_REGISTER_GLOBAL("graph_index._CAPI_DGLGraphNumVertices")
 .set_body([] (DGLArgs args, DGLRetValue* rv) {
-    GraphHandle ghandle = args[0];
-    const GraphInterface* gptr = static_cast<GraphInterface*>(ghandle);
-    *rv = static_cast<int64_t>(gptr->NumVertices());
+    BaseGraphRef g = args[0];
+    *rv = static_cast<int64_t>(g->NumVertices());
   });
 
 DGL_REGISTER_GLOBAL("graph_index._CAPI_DGLGraphNumEdges")
 .set_body([] (DGLArgs args, DGLRetValue* rv) {
-    GraphHandle ghandle = args[0];
-    const GraphInterface* gptr = static_cast<GraphInterface*>(ghandle);
-    *rv = static_cast<int64_t>(gptr->NumEdges());
+    BaseGraphRef g = args[0];
+    *rv = static_cast<int64_t>(g->NumEdges());
   });
 
 DGL_REGISTER_GLOBAL("graph_index._CAPI_DGLGraphHasVertex")
 .set_body([] (DGLArgs args, DGLRetValue* rv) {
-    GraphHandle ghandle = args[0];
-    const GraphInterface* gptr = static_cast<GraphInterface*>(ghandle);
+    BaseGraphRef g = args[0];
     const dgl_id_t vid = args[1];
-    *rv = gptr->HasVertex(vid);
+    *rv = g->HasVertex(vid);
   });
 
 DGL_REGISTER_GLOBAL("graph_index._CAPI_DGLGraphHasVertices")
 .set_body([] (DGLArgs args, DGLRetValue* rv) {
-    GraphHandle ghandle = args[0];
-    const GraphInterface* gptr = static_cast<GraphInterface*>(ghandle);
+    BaseGraphRef g = args[0];
     const IdArray vids = args[1];
-    *rv = gptr->HasVertices(vids);
+    *rv = g->HasVertices(vids);
   });
 
 DGL_REGISTER_GLOBAL("graph_index._CAPI_DGLMapSubgraphNID")
@@ -294,307 +262,156 @@ DGL_REGISTER_GLOBAL("graph_index._CAPI_DGLMapSubgraphNID")
 
 DGL_REGISTER_GLOBAL("graph_index._CAPI_DGLGraphHasEdgeBetween")
 .set_body([] (DGLArgs args, DGLRetValue* rv) {
-    GraphHandle ghandle = args[0];
-    const GraphInterface* gptr = static_cast<GraphInterface*>(ghandle);
+    BaseGraphRef g = args[0];
     const dgl_id_t src = args[1];
     const dgl_id_t dst = args[2];
-    *rv = gptr->HasEdgeBetween(src, dst);
+    *rv = g->HasEdgeBetween(src, dst);
   });
 
 DGL_REGISTER_GLOBAL("graph_index._CAPI_DGLGraphHasEdgesBetween")
 .set_body([] (DGLArgs args, DGLRetValue* rv) {
-    GraphHandle ghandle = args[0];
-    const GraphInterface* gptr = static_cast<GraphInterface*>(ghandle);
+    BaseGraphRef g = args[0];
     const IdArray src = args[1];
     const IdArray dst = args[2];
-    *rv = gptr->HasEdgesBetween(src, dst);
+    *rv = g->HasEdgesBetween(src, dst);
   });
 
 DGL_REGISTER_GLOBAL("graph_index._CAPI_DGLGraphPredecessors")
 .set_body([] (DGLArgs args, DGLRetValue* rv) {
-    GraphHandle ghandle = args[0];
-    const GraphInterface* gptr = static_cast<GraphInterface*>(ghandle);
+    BaseGraphRef g = args[0];
     const dgl_id_t vid = args[1];
     const uint64_t radius = args[2];
-    *rv = gptr->Predecessors(vid, radius);
+    *rv = g->Predecessors(vid, radius);
   });
 
 DGL_REGISTER_GLOBAL("graph_index._CAPI_DGLGraphSuccessors")
 .set_body([] (DGLArgs args, DGLRetValue* rv) {
-    GraphHandle ghandle = args[0];
-    const GraphInterface* gptr = static_cast<GraphInterface*>(ghandle);
+    BaseGraphRef g = args[0];
     const dgl_id_t vid = args[1];
     const uint64_t radius = args[2];
-    *rv = gptr->Successors(vid, radius);
+    *rv = g->Successors(vid, radius);
   });
 
 DGL_REGISTER_GLOBAL("graph_index._CAPI_DGLGraphEdgeId")
 .set_body([] (DGLArgs args, DGLRetValue* rv) {
-    GraphHandle ghandle = args[0];
-    const GraphInterface* gptr = static_cast<GraphInterface*>(ghandle);
+    BaseGraphRef g = args[0];
     const dgl_id_t src = args[1];
     const dgl_id_t dst = args[2];
-    *rv = gptr->EdgeId(src, dst);
+    *rv = g->EdgeId(src, dst);
   });
 
 DGL_REGISTER_GLOBAL("graph_index._CAPI_DGLGraphEdgeIds")
 .set_body([] (DGLArgs args, DGLRetValue* rv) {
-    GraphHandle ghandle = args[0];
-    const GraphInterface* gptr = static_cast<GraphInterface*>(ghandle);
+    BaseGraphRef g = args[0];
     const IdArray src = args[1];
     const IdArray dst = args[2];
-    *rv = ConvertEdgeArrayToPackedFunc(gptr->EdgeIds(src, dst));
+    *rv = ConvertEdgeArrayToPackedFunc(g->EdgeIds(src, dst));
   });
 
 DGL_REGISTER_GLOBAL("graph_index._CAPI_DGLGraphFindEdges")
 .set_body([] (DGLArgs args, DGLRetValue* rv) {
-    GraphHandle ghandle = args[0];
-    const GraphInterface* gptr = static_cast<GraphInterface*>(ghandle);
+    BaseGraphRef g = args[0];
     const IdArray eids = args[1];
-    *rv = ConvertEdgeArrayToPackedFunc(gptr->FindEdges(eids));
+    *rv = ConvertEdgeArrayToPackedFunc(g->FindEdges(eids));
   });
 
 DGL_REGISTER_GLOBAL("graph_index._CAPI_DGLGraphInEdges_1")
 .set_body([] (DGLArgs args, DGLRetValue* rv) {
-    GraphHandle ghandle = args[0];
-    const GraphInterface* gptr = static_cast<GraphInterface*>(ghandle);
+    BaseGraphRef g = args[0];
     const dgl_id_t vid = args[1];
-    *rv = ConvertEdgeArrayToPackedFunc(gptr->InEdges(vid));
+    *rv = ConvertEdgeArrayToPackedFunc(g->InEdges(vid));
   });
 
 DGL_REGISTER_GLOBAL("graph_index._CAPI_DGLGraphInEdges_2")
 .set_body([] (DGLArgs args, DGLRetValue* rv) {
-    GraphHandle ghandle = args[0];
-    const GraphInterface* gptr = static_cast<GraphInterface*>(ghandle);
+    BaseGraphRef g = args[0];
     const IdArray vids = args[1];
-    *rv = ConvertEdgeArrayToPackedFunc(gptr->InEdges(vids));
+    *rv = ConvertEdgeArrayToPackedFunc(g->InEdges(vids));
   });
 
 DGL_REGISTER_GLOBAL("graph_index._CAPI_DGLGraphOutEdges_1")
 .set_body([] (DGLArgs args, DGLRetValue* rv) {
-    GraphHandle ghandle = args[0];
-    const GraphInterface* gptr = static_cast<GraphInterface*>(ghandle);
+    BaseGraphRef g = args[0];
     const dgl_id_t vid = args[1];
-    *rv = ConvertEdgeArrayToPackedFunc(gptr->OutEdges(vid));
+    *rv = ConvertEdgeArrayToPackedFunc(g->OutEdges(vid));
   });
 
 DGL_REGISTER_GLOBAL("graph_index._CAPI_DGLGraphOutEdges_2")
 .set_body([] (DGLArgs args, DGLRetValue* rv) {
-    GraphHandle ghandle = args[0];
-    const GraphInterface* gptr = static_cast<GraphInterface*>(ghandle);
+    BaseGraphRef g = args[0];
     const IdArray vids = args[1];
-    *rv = ConvertEdgeArrayToPackedFunc(gptr->OutEdges(vids));
+    *rv = ConvertEdgeArrayToPackedFunc(g->OutEdges(vids));
   });
 
 DGL_REGISTER_GLOBAL("graph_index._CAPI_DGLGraphEdges")
 .set_body([] (DGLArgs args, DGLRetValue* rv) {
-    GraphHandle ghandle = args[0];
-    const GraphInterface* gptr = static_cast<GraphInterface*>(ghandle);
+    BaseGraphRef g = args[0];
     std::string order = args[1];
-    *rv = ConvertEdgeArrayToPackedFunc(gptr->Edges(order));
+    *rv = ConvertEdgeArrayToPackedFunc(g->Edges(order));
   });
 
 DGL_REGISTER_GLOBAL("graph_index._CAPI_DGLGraphInDegree")
 .set_body([] (DGLArgs args, DGLRetValue* rv) {
-    GraphHandle ghandle = args[0];
-    const GraphInterface* gptr = static_cast<GraphInterface*>(ghandle);
+    BaseGraphRef g = args[0];
     const dgl_id_t vid = args[1];
-    *rv = static_cast<int64_t>(gptr->InDegree(vid));
+    *rv = static_cast<int64_t>(g->InDegree(vid));
   });
 
 DGL_REGISTER_GLOBAL("graph_index._CAPI_DGLGraphInDegrees")
 .set_body([] (DGLArgs args, DGLRetValue* rv) {
-    GraphHandle ghandle = args[0];
-    const GraphInterface* gptr = static_cast<GraphInterface*>(ghandle);
+    BaseGraphRef g = args[0];
     const IdArray vids = args[1];
-    *rv = gptr->InDegrees(vids);
+    *rv = g->InDegrees(vids);
   });
 
 DGL_REGISTER_GLOBAL("graph_index._CAPI_DGLGraphOutDegree")
 .set_body([] (DGLArgs args, DGLRetValue* rv) {
-    GraphHandle ghandle = args[0];
-    const GraphInterface* gptr = static_cast<GraphInterface*>(ghandle);
+    BaseGraphRef g = args[0];
     const dgl_id_t vid = args[1];
-    *rv = static_cast<int64_t>(gptr->OutDegree(vid));
+    *rv = static_cast<int64_t>(g->OutDegree(vid));
   });
 
 DGL_REGISTER_GLOBAL("graph_index._CAPI_DGLGraphOutDegrees")
 .set_body([] (DGLArgs args, DGLRetValue* rv) {
-    GraphHandle ghandle = args[0];
-    const GraphInterface* gptr = static_cast<GraphInterface*>(ghandle);
+    BaseGraphRef g = args[0];
     const IdArray vids = args[1];
-    *rv = gptr->OutDegrees(vids);
+    *rv = g->OutDegrees(vids);
   });
 
 DGL_REGISTER_GLOBAL("graph_index._CAPI_DGLGraphVertexSubgraph")
 .set_body([] (DGLArgs args, DGLRetValue* rv) {
-    GraphHandle ghandle = args[0];
-    const GraphInterface* gptr = static_cast<GraphInterface*>(ghandle);
+    BaseGraphRef g = args[0];
     const IdArray vids = args[1];
-    *rv = ConvertSubgraphToPackedFunc(gptr->VertexSubgraph(vids));
+    *rv = ConvertSubgraphToPackedFunc(g->VertexSubgraph(vids));
   });
 
 DGL_REGISTER_GLOBAL("graph_index._CAPI_DGLGraphEdgeSubgraph")
 .set_body([] (DGLArgs args, DGLRetValue* rv) {
-    GraphHandle ghandle = args[0];
-    const GraphInterface *gptr = static_cast<GraphInterface*>(ghandle);
+    BaseGraphRef g = args[0];
     const IdArray eids = args[1];
     bool preserve_nodes = args[2];
-    *rv = ConvertSubgraphToPackedFunc(gptr->EdgeSubgraph(eids, preserve_nodes));
-  });
-
-DGL_REGISTER_GLOBAL("graph_index._CAPI_DGLDisjointUnion")
-.set_body([] (DGLArgs args, DGLRetValue* rv) {
-    void* list = args[0];
-    GraphHandle* inhandles = static_cast<GraphHandle*>(list);
-    int list_size = args[1];
-    const GraphInterface *ptr = static_cast<const GraphInterface *>(inhandles[0]);
-    const ImmutableGraph *im_gr = dynamic_cast<const ImmutableGraph *>(ptr);
-    const Graph *gr = dynamic_cast<const Graph *>(ptr);
-    if (gr) {
-      DGLDisjointUnion<Graph>(inhandles, list_size, rv);
-    } else {
-      CHECK(im_gr) << "Args[0] is not a list of valid DGLGraph";
-      DGLDisjointUnion<ImmutableGraph>(inhandles, list_size, rv);
-    }
-  });
-
-DGL_REGISTER_GLOBAL("graph_index._CAPI_DGLDisjointPartitionByNum")
-.set_body([] (DGLArgs args, DGLRetValue* rv) {
-    GraphHandle ghandle = args[0];
-    const GraphInterface *ptr = static_cast<const GraphInterface *>(ghandle);
-    const Graph* gptr = dynamic_cast<const Graph*>(ptr);
-    const ImmutableGraph* im_gptr = dynamic_cast<const ImmutableGraph*>(ptr);
-    if (gptr) {
-      DGLDisjointPartitionByNum(gptr, args, rv);
-    } else {
-      CHECK(im_gptr) << "Args[0] is not a valid DGLGraph";
-      DGLDisjointPartitionByNum(im_gptr, args, rv);
-    }
-  });
-
-DGL_REGISTER_GLOBAL("graph_index._CAPI_DGLDisjointPartitionBySizes")
-.set_body([] (DGLArgs args, DGLRetValue* rv) {
-    GraphHandle ghandle = args[0];
-    const IdArray sizes = args[1];
-    const GraphInterface *ptr = static_cast<const GraphInterface *>(ghandle);
-    const Graph* gptr = dynamic_cast<const Graph*>(ptr);
-    const ImmutableGraph* im_gptr = dynamic_cast<const ImmutableGraph*>(ptr);
-    if (gptr) {
-      DGLDisjointPartitionBySizes(gptr, sizes, rv);
-    } else {
-      CHECK(im_gptr) << "Args[0] is not a valid DGLGraph";
-      DGLDisjointPartitionBySizes(im_gptr, sizes, rv);
-    }
-});
-
-DGL_REGISTER_GLOBAL("graph_index._CAPI_DGLGraphLineGraph")
-.set_body([] (DGLArgs args, DGLRetValue* rv) {
-    GraphHandle ghandle = args[0];
-    bool backtracking = args[1];
-    const GraphInterface *ptr = static_cast<const GraphInterface *>(ghandle);
-    const Graph* gptr = dynamic_cast<const Graph*>(ptr);
-    CHECK(gptr) << "_CAPI_DGLGraphLineGraph isn't implemented in immutable graph";
-    Graph* lgptr = new Graph();
-    *lgptr = GraphOp::LineGraph(gptr, backtracking);
-    GraphHandle lghandle = lgptr;
-    *rv = lghandle;
+    *rv = ConvertSubgraphToPackedFunc(g->EdgeSubgraph(eids, preserve_nodes));
   });
 
 DGL_REGISTER_GLOBAL("graph_index._CAPI_DGLGraphGetAdj")
 .set_body([] (DGLArgs args, DGLRetValue* rv) {
-    GraphHandle ghandle = args[0];
+    GraphRef g = args[0];
     bool transpose = args[1];
     std::string format = args[2];
-    const GraphInterface *ptr = static_cast<const GraphInterface *>(ghandle);
-    auto res = ptr->GetAdj(transpose, format);
+    auto res = g->GetAdj(transpose, format);
     *rv = ConvertAdjToPackedFunc(res);
-  });
-
-DGL_REGISTER_GLOBAL("graph_index._CAPI_DGLToImmutable")
-.set_body([] (DGLArgs args, DGLRetValue* rv) {
-    GraphHandle ghandle = args[0];
-    const GraphInterface *ptr = static_cast<GraphInterface *>(ghandle);
-    GraphHandle newhandle = new ImmutableGraph(ImmutableGraph::ToImmutable(ptr));
-    *rv = newhandle;
   });
 
 DGL_REGISTER_GLOBAL("graph_index._CAPI_DGLGraphContext")
 .set_body([] (DGLArgs args, DGLRetValue* rv) {
-    GraphHandle ghandle = args[0];
-    const GraphInterface *ptr = static_cast<GraphInterface *>(ghandle);
-    *rv = ptr->Context();
-  });
-
-DGL_REGISTER_GLOBAL("graph_index._CAPI_DGLImmutableGraphCopyTo")
-.set_body([] (DGLArgs args, DGLRetValue* rv) {
-    GraphHandle ghandle = args[0];
-    const int device_type = args[1];
-    const int device_id = args[2];
-    DLContext ctx;
-    ctx.device_type = static_cast<DLDeviceType>(device_type);
-    ctx.device_id = device_id;
-    const GraphInterface *ptr = static_cast<GraphInterface *>(ghandle);
-    const ImmutableGraph *ig = dynamic_cast<const ImmutableGraph*>(ptr);
-    CHECK(ig) << "Invalid argument: must be an immutable graph object.";
-    GraphHandle newhandle = new ImmutableGraph(ig->CopyTo(ctx));
-    *rv = newhandle;
-  });
-
-DGL_REGISTER_GLOBAL("graph_index._CAPI_DGLImmutableGraphCopyToSharedMem")
-.set_body([] (DGLArgs args, DGLRetValue* rv) {
-    GraphHandle ghandle = args[0];
-    std::string edge_dir = args[1];
-    std::string name = args[2];
-    const GraphInterface *ptr = static_cast<GraphInterface *>(ghandle);
-    const ImmutableGraph *ig = dynamic_cast<const ImmutableGraph*>(ptr);
-    CHECK(ig) << "Invalid argument: must be an immutable graph object.";
-    GraphHandle newhandle = new ImmutableGraph(ig->CopyToSharedMem(edge_dir, name));
-    *rv = newhandle;
+    GraphRef g = args[0];
+    *rv = g->Context();
   });
 
 DGL_REGISTER_GLOBAL("graph_index._CAPI_DGLGraphNumBits")
 .set_body([] (DGLArgs args, DGLRetValue* rv) {
-    GraphHandle ghandle = args[0];
-    const GraphInterface *ptr = static_cast<GraphInterface *>(ghandle);
-    *rv = ptr->NumBits();
-  });
-
-DGL_REGISTER_GLOBAL("graph_index._CAPI_DGLImmutableGraphAsNumBits")
-.set_body([] (DGLArgs args, DGLRetValue* rv) {
-    GraphHandle ghandle = args[0];
-    int bits = args[1];
-    const GraphInterface *ptr = static_cast<GraphInterface *>(ghandle);
-    const ImmutableGraph *ig = dynamic_cast<const ImmutableGraph*>(ptr);
-    CHECK(ig) << "Invalid argument: must be an immutable graph object.";
-    GraphHandle newhandle = new ImmutableGraph(ig->AsNumBits(bits));
-    *rv = newhandle;
-  });
-
-DGL_REGISTER_GLOBAL("transform._CAPI_DGLToSimpleGraph")
-.set_body([] (DGLArgs args, DGLRetValue* rv) {
-    GraphHandle ghandle = args[0];
-    const GraphInterface *ptr = static_cast<const GraphInterface *>(ghandle);
-    GraphHandle ret = GraphOp::ToSimpleGraph(ptr).Reset();
-    *rv = ret;
-  });
-
-DGL_REGISTER_GLOBAL("transform._CAPI_DGLToBidirectedMutableGraph")
-.set_body([] (DGLArgs args, DGLRetValue* rv) {
-    GraphHandle ghandle = args[0];
-    const GraphInterface *ptr = static_cast<const GraphInterface *>(ghandle);
-    Graph* bgptr = new Graph();
-    *bgptr = GraphOp::ToBidirectedMutableGraph(ptr);
-    GraphHandle bghandle = bgptr;
-    *rv = bghandle;
-  });
-
-DGL_REGISTER_GLOBAL("transform._CAPI_DGLToBidirectedImmutableGraph")
-.set_body([] (DGLArgs args, DGLRetValue* rv) {
-    GraphHandle ghandle = args[0];
-    const GraphInterface *ptr = static_cast<const GraphInterface *>(ghandle);
-    GraphHandle bghandle = GraphOp::ToBidirectedImmutableGraph(ptr).Reset();
-    *rv = bghandle;
+    GraphRef g = args[0];
+    *rv = g->NumBits();
   });
 
 }  // namespace dgl

--- a/src/graph/graph_op.cc
+++ b/src/graph/graph_op.cc
@@ -8,6 +8,10 @@
 #include <algorithm>
 #include "../c_api_common.h"
 
+using dgl::runtime::DGLArgs;
+using dgl::runtime::DGLArgValue;
+using dgl::runtime::DGLRetValue;
+
 namespace dgl {
 namespace {
 // generate consecutive dgl ids
@@ -40,15 +44,15 @@ class RangeIter : public std::iterator<std::input_iterator_tag, dgl_id_t> {
 };
 }  // namespace
 
-Graph GraphOp::LineGraph(const Graph* g, bool backtracking) {
-  Graph lg;
-  lg.AddVertices(g->NumEdges());
+GraphRef GraphOp::LineGraph(GraphRef g, bool backtracking) {
+  GraphRef lg = GraphRef::Create();
+  lg->AddVertices(g->NumEdges());
   for (size_t i = 0; i < g->all_edges_src_.size(); ++i) {
     const auto u = g->all_edges_src_[i];
     const auto v = g->all_edges_dst_[i];
     for (size_t j = 0; j < g->adjlist_[v].succ.size(); ++j) {
       if (backtracking || (!backtracking && g->adjlist_[v].succ[j] != u)) {
-        lg.AddEdge(i, g->adjlist_[v].edge_id[j]);
+        lg->AddEdge(i, g->adjlist_[v].edge_id[j]);
       }
     }
   }
@@ -56,20 +60,20 @@ Graph GraphOp::LineGraph(const Graph* g, bool backtracking) {
   return lg;
 }
 
-Graph GraphOp::DisjointUnion(std::vector<const Graph*> graphs) {
-  Graph rst;
+GraphRef GraphOp::DisjointUnion(std::vector<GraphRef> graphs) {
+  GraphRef rst = GraphRef::Create();
   uint64_t cumsum = 0;
-  for (const Graph* gr : graphs) {
-    rst.AddVertices(gr->NumVertices());
+  for (GraphRef gr : graphs) {
+    rst->AddVertices(gr->NumVertices());
     for (uint64_t i = 0; i < gr->NumEdges(); ++i) {
-      rst.AddEdge(gr->all_edges_src_[i] + cumsum, gr->all_edges_dst_[i] + cumsum);
+      rst->AddEdge(gr->all_edges_src_[i] + cumsum, gr->all_edges_dst_[i] + cumsum);
     }
     cumsum += gr->NumVertices();
   }
   return rst;
 }
 
-std::vector<Graph> GraphOp::DisjointPartitionByNum(const Graph* graph, int64_t num) {
+std::vector<GraphRef> GraphOp::DisjointPartitionByNum(GraphRef graph, int64_t num) {
   CHECK(num != 0 && graph->NumVertices() % num == 0)
     << "Number of partitions must evenly divide the number of nodes.";
   IdArray sizes = IdArray::Empty({num}, DLDataType{kDLInt, 64, 1}, DLContext{kDLCPU, 0});
@@ -78,7 +82,7 @@ std::vector<Graph> GraphOp::DisjointPartitionByNum(const Graph* graph, int64_t n
   return DisjointPartitionBySizes(graph, sizes);
 }
 
-std::vector<Graph> GraphOp::DisjointPartitionBySizes(const Graph* graph, IdArray sizes) {
+std::vector<GraphRef> GraphOp::DisjointPartitionBySizes(GraphRef graph, IdArray sizes) {
   const int64_t len = sizes->shape[0];
   const int64_t* sizes_data = static_cast<int64_t*>(sizes->data);
   std::vector<int64_t> cumsum;
@@ -89,41 +93,41 @@ std::vector<Graph> GraphOp::DisjointPartitionBySizes(const Graph* graph, IdArray
   CHECK_EQ(cumsum[len], graph->NumVertices())
     << "Sum of the given sizes must equal to the number of nodes.";
   dgl_id_t node_offset = 0, edge_offset = 0;
-  std::vector<Graph> rst(len);
+  std::vector<GraphRef> rst(len);
   for (int64_t i = 0; i < len; ++i) {
     // copy adj
-    rst[i].adjlist_.insert(rst[i].adjlist_.end(),
+    rst[i]->adjlist_.insert(rst[i]->adjlist_.end(),
         graph->adjlist_.begin() + node_offset,
         graph->adjlist_.begin() + node_offset + sizes_data[i]);
-    rst[i].reverse_adjlist_.insert(rst[i].reverse_adjlist_.end(),
+    rst[i]->reverse_adjlist_.insert(rst[i]->reverse_adjlist_.end(),
         graph->reverse_adjlist_.begin() + node_offset,
         graph->reverse_adjlist_.begin() + node_offset + sizes_data[i]);
     // relabel adjs
     size_t num_edges = 0;
-    for (auto& elist : rst[i].adjlist_) {
+    for (auto& elist : rst[i]->adjlist_) {
       for (size_t j = 0; j < elist.succ.size(); ++j) {
         elist.succ[j] -= node_offset;
         elist.edge_id[j] -= edge_offset;
       }
       num_edges += elist.succ.size();
     }
-    for (auto& elist : rst[i].reverse_adjlist_) {
+    for (auto& elist : rst[i]->reverse_adjlist_) {
       for (size_t j = 0; j < elist.succ.size(); ++j) {
         elist.succ[j] -= node_offset;
         elist.edge_id[j] -= edge_offset;
       }
     }
     // copy edges
-    rst[i].all_edges_src_.reserve(num_edges);
-    rst[i].all_edges_dst_.reserve(num_edges);
-    rst[i].num_edges_ = num_edges;
+    rst[i]->all_edges_src_.reserve(num_edges);
+    rst[i]->all_edges_dst_.reserve(num_edges);
+    rst[i]->num_edges_ = num_edges;
     for (size_t j = edge_offset; j < edge_offset + num_edges; ++j) {
-      rst[i].all_edges_src_.push_back(graph->all_edges_src_[j] - node_offset);
-      rst[i].all_edges_dst_.push_back(graph->all_edges_dst_[j] - node_offset);
+      rst[i]->all_edges_src_.push_back(graph->all_edges_src_[j] - node_offset);
+      rst[i]->all_edges_dst_.push_back(graph->all_edges_dst_[j] - node_offset);
     }
     // update offset
-    CHECK_EQ(rst[i].NumVertices(), sizes_data[i]);
-    CHECK_EQ(rst[i].NumEdges(), num_edges);
+    CHECK_EQ(rst[i]->NumVertices(), sizes_data[i]);
+    CHECK_EQ(rst[i]->NumEdges(), num_edges);
     node_offset += sizes_data[i];
     edge_offset += num_edges;
   }
@@ -131,10 +135,10 @@ std::vector<Graph> GraphOp::DisjointPartitionBySizes(const Graph* graph, IdArray
 }
 
 
-ImmutableGraph GraphOp::DisjointUnion(std::vector<const ImmutableGraph *> graphs) {
+ImmutableGraphRef GraphOp::DisjointUnion(std::vector<ImmutableGraphRef> graphs) {
   int64_t num_nodes = 0;
   int64_t num_edges = 0;
-  for (const ImmutableGraph *gr : graphs) {
+  for (ImmutableGraphRef gr : graphs) {
     num_nodes += gr->NumVertices();
     num_edges += gr->NumEdges();
   }
@@ -148,7 +152,8 @@ ImmutableGraph GraphOp::DisjointUnion(std::vector<const ImmutableGraph *> graphs
   indptr[0] = 0;
   dgl_id_t cum_num_nodes = 0;
   dgl_id_t cum_num_edges = 0;
-  for (const ImmutableGraph *gr : graphs) {
+  for (ImmutableGraphRef gr : graphs) {
+    // TODO(minjie): why in csr?
     const CSRPtr g_csrptr = gr->GetInCSR();
     const int64_t g_num_nodes = g_csrptr->NumVertices();
     const int64_t g_num_edges = g_csrptr->NumEdges();
@@ -169,12 +174,11 @@ ImmutableGraph GraphOp::DisjointUnion(std::vector<const ImmutableGraph *> graphs
     cum_num_edges += g_num_edges;
   }
 
-  CSRPtr batched_csr_ptr = CSRPtr(new CSR(indptr_arr, indices_arr, edge_ids_arr));
-  return ImmutableGraph(batched_csr_ptr, nullptr);
+  return ImmutableGraphRef::CreateFromCSR(indptr_arr, indices_arr, edge_ids_arr, "in");
 }
 
-std::vector<ImmutableGraph> GraphOp::DisjointPartitionByNum(const ImmutableGraph *graph,
-        int64_t num) {
+std::vector<ImmutableGraphRef> GraphOp::DisjointPartitionByNum(
+    ImmutableGraphRef graph, int64_t num) {
   CHECK(num != 0 && graph->NumVertices() % num == 0)
     << "Number of partitions must evenly divide the number of nodes.";
   IdArray sizes = IdArray::Empty({num}, DLDataType{kDLInt, 64, 1}, DLContext{kDLCPU, 0});
@@ -183,8 +187,8 @@ std::vector<ImmutableGraph> GraphOp::DisjointPartitionByNum(const ImmutableGraph
   return DisjointPartitionBySizes(graph, sizes);
 }
 
-std::vector<ImmutableGraph> GraphOp::DisjointPartitionBySizes(const ImmutableGraph *batched_graph,
-        IdArray sizes) {
+std::vector<ImmutableGraphRef> GraphOp::DisjointPartitionBySizes(
+    ImmutableGraphRef batched_graph, IdArray sizes) {
   // TODO(minjie): use array views to speedup this operation
   const int64_t len = sizes->shape[0];
   const int64_t *sizes_data = static_cast<int64_t *>(sizes->data);
@@ -196,7 +200,8 @@ std::vector<ImmutableGraph> GraphOp::DisjointPartitionBySizes(const ImmutableGra
   }
   CHECK_EQ(cumsum[len], batched_graph->NumVertices())
     << "Sum of the given sizes must equal to the number of nodes.";
-  std::vector<ImmutableGraph> rst;
+  std::vector<ImmutableGraphRef> rst;
+  // TODO(minjie): why in csr?
   CSRPtr in_csr_ptr = batched_graph->GetInCSR();
   const dgl_id_t* indptr = static_cast<dgl_id_t*>(in_csr_ptr->indptr()->data);
   const dgl_id_t* indices = static_cast<dgl_id_t*>(in_csr_ptr->indices()->data);
@@ -229,8 +234,9 @@ std::vector<ImmutableGraph> GraphOp::DisjointPartitionBySizes(const ImmutableGra
     }
 
     cum_sum_edges += g_num_edges;
-    CSRPtr g_in_csr_ptr = CSRPtr(new CSR(indptr_arr, indices_arr, edge_ids_arr));
-    rst.emplace_back(g_in_csr_ptr, nullptr);
+    ImmutableGraphRef r = ImmutableGraphRef::CreateFromCSR(
+        indptr_arr, indices_arr, edge_ids_arr, "in");
+    rst.push_back(r);
   }
   return rst;
 }
@@ -297,7 +303,7 @@ IdArray GraphOp::ExpandIds(IdArray ids, IdArray offset) {
   return rst;
 }
 
-ImmutableGraph GraphOp::ToSimpleGraph(const GraphInterface* graph) {
+ImmutableGraphRef GraphOp::ToSimpleGraph(BaseGraphRef graph) {
   std::vector<dgl_id_t> indptr(graph->NumVertices() + 1), indices;
   indptr[0] = 0;
   for (dgl_id_t src = 0; src < graph->NumVertices(); ++src) {
@@ -312,10 +318,10 @@ ImmutableGraph GraphOp::ToSimpleGraph(const GraphInterface* graph) {
   }
   CSRPtr csr(new CSR(graph->NumVertices(), indices.size(),
         indptr.begin(), indices.begin(), RangeIter(0), false));
-  return ImmutableGraph(csr);
+  return ImmutableGraphRef(std::make_shared<ImmutableGraph>(csr));
 }
 
-Graph GraphOp::ToBidirectedMutableGraph(const GraphInterface* g) {
+GraphRef GraphOp::ToBidirectedMutableGraph(BaseGraphRef g) {
   std::unordered_map<int, std::unordered_map<int, int>> n_e;
   for (dgl_id_t u = 0; u < g->NumVertices(); ++u) {
     for (const dgl_id_t v : g->SuccVec(u)) {
@@ -323,8 +329,8 @@ Graph GraphOp::ToBidirectedMutableGraph(const GraphInterface* g) {
     }
   }
 
-  Graph bg;
-  bg.AddVertices(g->NumVertices());
+  GraphRef bg;
+  bg->AddVertices(g->NumVertices());
   for (dgl_id_t u = 0; u < g->NumVertices(); ++u) {
     for (dgl_id_t v = u; v < g->NumVertices(); ++v) {
       const auto new_n_e = std::max(n_e[u][v], n_e[v][u]);
@@ -333,13 +339,13 @@ Graph GraphOp::ToBidirectedMutableGraph(const GraphInterface* g) {
         dgl_id_t* us_data = static_cast<dgl_id_t*>(us->data);
         std::fill(us_data, us_data + new_n_e, u);
         if (u == v) {
-          bg.AddEdges(us, us);
+          bg->AddEdges(us, us);
         } else {
           IdArray vs = aten::NewIdArray(new_n_e);
           dgl_id_t* vs_data = static_cast<dgl_id_t*>(vs->data);
           std::fill(vs_data, vs_data + new_n_e, v);
-          bg.AddEdges(us, vs);
-          bg.AddEdges(vs, us);
+          bg->AddEdges(us, vs);
+          bg->AddEdges(vs, us);
         }
       }
     }
@@ -347,7 +353,7 @@ Graph GraphOp::ToBidirectedMutableGraph(const GraphInterface* g) {
   return bg;
 }
 
-ImmutableGraph GraphOp::ToBidirectedImmutableGraph(const GraphInterface* g) {
+ImmutableGraphRef GraphOp::ToBidirectedImmutableGraph(BaseGraphRef g) {
   std::unordered_map<int, std::unordered_map<int, int>> n_e;
   for (dgl_id_t u = 0; u < g->NumVertices(); ++u) {
     for (const dgl_id_t v : g->SuccVec(u)) {
@@ -383,7 +389,100 @@ ImmutableGraph GraphOp::ToBidirectedImmutableGraph(const GraphInterface* g) {
   IdArray srcs_array = aten::VecToIdArray(srcs);
   IdArray dsts_array = aten::VecToIdArray(dsts);
   COOPtr coo(new COO(g->NumVertices(), srcs_array, dsts_array, g->IsMultigraph()));
-  return ImmutableGraph(coo);
+  return ImmutableGraphRef::CreateFromCOO(
+      g->NumVertices(), srcs_array, dsts_array, g->IsMultigraph());
 }
+
+DGL_REGISTER_GLOBAL("graph_index._CAPI_DGLDisjointUnion")
+.set_body([] (DGLArgs args, DGLRetValue* rv) {
+    void* list = args[0];
+    GraphHandle* inhandles = static_cast<GraphHandle*>(list);
+    int list_size = args[1];
+    const GraphInterface *ptr = static_cast<const GraphInterface *>(inhandles[0]);
+    const ImmutableGraph *im_gr = dynamic_cast<const ImmutableGraph *>(ptr);
+    const Graph *gr = dynamic_cast<const Graph *>(ptr);
+    if (gr) {
+      DGLDisjointUnion<Graph>(inhandles, list_size, rv);
+    } else {
+      CHECK(im_gr) << "Args[0] is not a list of valid DGLGraph";
+      DGLDisjointUnion<ImmutableGraph>(inhandles, list_size, rv);
+    }
+  });
+
+DGL_REGISTER_GLOBAL("graph_index._CAPI_DGLDisjointPartitionByNum")
+.set_body([] (DGLArgs args, DGLRetValue* rv) {
+    GraphHandle ghandle = args[0];
+    const GraphInterface *ptr = static_cast<const GraphInterface *>(ghandle);
+    const Graph* gptr = dynamic_cast<const Graph*>(ptr);
+    const ImmutableGraph* im_gptr = dynamic_cast<const ImmutableGraph*>(ptr);
+    if (gptr) {
+      DGLDisjointPartitionByNum(gptr, args, rv);
+    } else {
+      CHECK(im_gptr) << "Args[0] is not a valid DGLGraph";
+      DGLDisjointPartitionByNum(im_gptr, args, rv);
+    }
+  });
+
+DGL_REGISTER_GLOBAL("graph_index._CAPI_DGLDisjointPartitionBySizes")
+.set_body([] (DGLArgs args, DGLRetValue* rv) {
+    GraphHandle ghandle = args[0];
+    const IdArray sizes = args[1];
+    const GraphInterface *ptr = static_cast<const GraphInterface *>(ghandle);
+    const Graph* gptr = dynamic_cast<const Graph*>(ptr);
+    const ImmutableGraph* im_gptr = dynamic_cast<const ImmutableGraph*>(ptr);
+    if (gptr) {
+      DGLDisjointPartitionBySizes(gptr, sizes, rv);
+    } else {
+      CHECK(im_gptr) << "Args[0] is not a valid DGLGraph";
+      DGLDisjointPartitionBySizes(im_gptr, sizes, rv);
+    }
+});
+
+DGL_REGISTER_GLOBAL("graph_index._CAPI_DGLGraphLineGraph")
+.set_body([] (DGLArgs args, DGLRetValue* rv) {
+    GraphHandle ghandle = args[0];
+    bool backtracking = args[1];
+    const GraphInterface *ptr = static_cast<const GraphInterface *>(ghandle);
+    const Graph* gptr = dynamic_cast<const Graph*>(ptr);
+    CHECK(gptr) << "_CAPI_DGLGraphLineGraph isn't implemented in immutable graph";
+    Graph* lgptr = new Graph();
+    *lgptr = GraphOp::LineGraph(gptr, backtracking);
+    GraphHandle lghandle = lgptr;
+    *rv = lghandle;
+  });
+
+DGL_REGISTER_GLOBAL("graph_index._CAPI_DGLToImmutable")
+.set_body([] (DGLArgs args, DGLRetValue* rv) {
+    GraphHandle ghandle = args[0];
+    const GraphInterface *ptr = static_cast<GraphInterface *>(ghandle);
+    GraphHandle newhandle = new ImmutableGraph(ImmutableGraph::ToImmutable(ptr));
+    *rv = newhandle;
+  });
+
+DGL_REGISTER_GLOBAL("transform._CAPI_DGLToSimpleGraph")
+.set_body([] (DGLArgs args, DGLRetValue* rv) {
+    GraphHandle ghandle = args[0];
+    const GraphInterface *ptr = static_cast<const GraphInterface *>(ghandle);
+    GraphHandle ret = GraphOp::ToSimpleGraph(ptr).Reset();
+    *rv = ret;
+  });
+
+DGL_REGISTER_GLOBAL("transform._CAPI_DGLToBidirectedMutableGraph")
+.set_body([] (DGLArgs args, DGLRetValue* rv) {
+    GraphHandle ghandle = args[0];
+    const GraphInterface *ptr = static_cast<const GraphInterface *>(ghandle);
+    Graph* bgptr = new Graph();
+    *bgptr = GraphOp::ToBidirectedMutableGraph(ptr);
+    GraphHandle bghandle = bgptr;
+    *rv = bghandle;
+  });
+
+DGL_REGISTER_GLOBAL("transform._CAPI_DGLToBidirectedImmutableGraph")
+.set_body([] (DGLArgs args, DGLRetValue* rv) {
+    GraphHandle ghandle = args[0];
+    const GraphInterface *ptr = static_cast<const GraphInterface *>(ghandle);
+    GraphHandle bghandle = GraphOp::ToBidirectedImmutableGraph(ptr).Reset();
+    *rv = bghandle;
+  });
 
 }  // namespace dgl

--- a/src/graph/graph_op.cc
+++ b/src/graph/graph_op.cc
@@ -5,12 +5,12 @@
  */
 #include <dgl/graph_op.h>
 #include <dgl/immutable_graph.h>
+#include <dgl/packed_func_ext.h>
+#include <dgl/runtime/container.h>
 #include <algorithm>
 #include "../c_api_common.h"
 
-using dgl::runtime::DGLArgs;
-using dgl::runtime::DGLArgValue;
-using dgl::runtime::DGLRetValue;
+using namespace dgl::runtime;
 
 namespace dgl {
 namespace {
@@ -42,38 +42,103 @@ class RangeIter : public std::iterator<std::input_iterator_tag, dgl_id_t> {
  private:
   dgl_id_t cur_;
 };
+
+bool IsMutable(GraphPtr g) {
+  MGraphPtr mg = std::dynamic_pointer_cast<Graph>(g);
+  return mg != nullptr;
+}
+
 }  // namespace
 
-GraphRef GraphOp::LineGraph(GraphRef g, bool backtracking) {
-  GraphRef lg = GraphRef::Create();
+GraphPtr GraphOp::Reverse(GraphPtr g) {
+  ImGraphPtr ig = std::dynamic_pointer_cast<ImmutableGraph>(g);
+  CHECK(ig) << "Reverse is only supported on immutable graph";
+  return ig->Reverse();
+}
+
+GraphPtr GraphOp::LineGraph(GraphPtr g, bool backtracking) {
+  MGraphPtr mg = std::dynamic_pointer_cast<Graph>(g);
+  CHECK(mg) << "Line graph transformation is only supported on mutable graph";
+  MGraphPtr lg = Graph::Create();
   lg->AddVertices(g->NumEdges());
-  for (size_t i = 0; i < g->all_edges_src_.size(); ++i) {
-    const auto u = g->all_edges_src_[i];
-    const auto v = g->all_edges_dst_[i];
-    for (size_t j = 0; j < g->adjlist_[v].succ.size(); ++j) {
-      if (backtracking || (!backtracking && g->adjlist_[v].succ[j] != u)) {
-        lg->AddEdge(i, g->adjlist_[v].edge_id[j]);
+  for (size_t i = 0; i < mg->all_edges_src_.size(); ++i) {
+    const auto u = mg->all_edges_src_[i];
+    const auto v = mg->all_edges_dst_[i];
+    for (size_t j = 0; j < mg->adjlist_[v].succ.size(); ++j) {
+      if (backtracking || (!backtracking && mg->adjlist_[v].succ[j] != u)) {
+        lg->AddEdge(i, mg->adjlist_[v].edge_id[j]);
       }
     }
   }
-
   return lg;
 }
 
-GraphRef GraphOp::DisjointUnion(std::vector<GraphRef> graphs) {
-  GraphRef rst = GraphRef::Create();
-  uint64_t cumsum = 0;
-  for (GraphRef gr : graphs) {
-    rst->AddVertices(gr->NumVertices());
-    for (uint64_t i = 0; i < gr->NumEdges(); ++i) {
-      rst->AddEdge(gr->all_edges_src_[i] + cumsum, gr->all_edges_dst_[i] + cumsum);
+GraphPtr GraphOp::DisjointUnion(std::vector<GraphPtr> graphs) {
+  CHECK_GT(graphs.size(), 0) << "Input graph list is empty";
+  if (IsMutable(graphs[0])) {
+    // Disjointly union of a list of mutable graph inputs. The result is
+    // also a mutable graph.
+    MGraphPtr rst = Graph::Create();
+    uint64_t cumsum = 0;
+    for (GraphPtr gr : graphs) {
+      MGraphPtr mg = std::dynamic_pointer_cast<Graph>(gr);
+      CHECK(mg) << "All the input graphs should be mutable graphs.";
+      rst->AddVertices(gr->NumVertices());
+      for (uint64_t i = 0; i < gr->NumEdges(); ++i) {
+        // TODO(minjie): quite ugly to expose internal members
+        rst->AddEdge(mg->all_edges_src_[i] + cumsum, mg->all_edges_dst_[i] + cumsum);
+      }
+      cumsum += gr->NumVertices();
     }
-    cumsum += gr->NumVertices();
+    return rst;
+  } else {
+    // Disjointly union of a list of immutable graph inputs. The result is
+    // also an immutable graph.
+    int64_t num_nodes = 0;
+    int64_t num_edges = 0;
+    for (auto gr : graphs) {
+      num_nodes += gr->NumVertices();
+      num_edges += gr->NumEdges();
+    }
+    IdArray indptr_arr = aten::NewIdArray(num_nodes + 1);
+    IdArray indices_arr = aten::NewIdArray(num_edges);
+    IdArray edge_ids_arr = aten::NewIdArray(num_edges);
+    dgl_id_t* indptr = static_cast<dgl_id_t*>(indptr_arr->data);
+    dgl_id_t* indices = static_cast<dgl_id_t*>(indices_arr->data);
+    dgl_id_t* edge_ids = static_cast<dgl_id_t*>(edge_ids_arr->data);
+
+    indptr[0] = 0;
+    dgl_id_t cum_num_nodes = 0;
+    dgl_id_t cum_num_edges = 0;
+    for (auto g : graphs) {
+      ImGraphPtr gr = std::dynamic_pointer_cast<ImmutableGraph>(g);
+      CHECK(gr) << "All the input graphs should be immutable graphs.";
+      // TODO(minjie): why in csr?
+      const CSRPtr g_csrptr = gr->GetInCSR();
+      const int64_t g_num_nodes = g_csrptr->NumVertices();
+      const int64_t g_num_edges = g_csrptr->NumEdges();
+      dgl_id_t* g_indptr = static_cast<dgl_id_t*>(g_csrptr->indptr()->data);
+      dgl_id_t* g_indices = static_cast<dgl_id_t*>(g_csrptr->indices()->data);
+      dgl_id_t* g_edge_ids = static_cast<dgl_id_t*>(g_csrptr->edge_ids()->data);
+      for (dgl_id_t i = 1; i < g_num_nodes + 1; ++i) {
+        indptr[cum_num_nodes + i] = g_indptr[i] + cum_num_edges;
+      }
+      for (dgl_id_t i = 0; i < g_num_edges; ++i) {
+        indices[cum_num_edges + i] = g_indices[i] + cum_num_nodes;
+      }
+
+      for (dgl_id_t i = 0; i < g_num_edges; ++i) {
+        edge_ids[cum_num_edges + i] = g_edge_ids[i] + cum_num_edges;
+      }
+      cum_num_nodes += g_num_nodes;
+      cum_num_edges += g_num_edges;
+    }
+
+    return ImmutableGraph::CreateFromCSR(indptr_arr, indices_arr, edge_ids_arr, "in");
   }
-  return rst;
 }
 
-std::vector<GraphRef> GraphOp::DisjointPartitionByNum(GraphRef graph, int64_t num) {
+std::vector<GraphPtr> GraphOp::DisjointPartitionByNum(GraphPtr graph, int64_t num) {
   CHECK(num != 0 && graph->NumVertices() % num == 0)
     << "Number of partitions must evenly divide the number of nodes.";
   IdArray sizes = IdArray::Empty({num}, DLDataType{kDLInt, 64, 1}, DLContext{kDLCPU, 0});
@@ -82,7 +147,8 @@ std::vector<GraphRef> GraphOp::DisjointPartitionByNum(GraphRef graph, int64_t nu
   return DisjointPartitionBySizes(graph, sizes);
 }
 
-std::vector<GraphRef> GraphOp::DisjointPartitionBySizes(GraphRef graph, IdArray sizes) {
+std::vector<GraphPtr> GraphOp::DisjointPartitionBySizes(
+    GraphPtr batched_graph, IdArray sizes) {
   const int64_t len = sizes->shape[0];
   const int64_t* sizes_data = static_cast<int64_t*>(sizes->data);
   std::vector<int64_t> cumsum;
@@ -90,153 +156,94 @@ std::vector<GraphRef> GraphOp::DisjointPartitionBySizes(GraphRef graph, IdArray 
   for (int64_t i = 0; i < len; ++i) {
     cumsum.push_back(cumsum[i] + sizes_data[i]);
   }
-  CHECK_EQ(cumsum[len], graph->NumVertices())
-    << "Sum of the given sizes must equal to the number of nodes.";
-  dgl_id_t node_offset = 0, edge_offset = 0;
-  std::vector<GraphRef> rst(len);
-  for (int64_t i = 0; i < len; ++i) {
-    // copy adj
-    rst[i]->adjlist_.insert(rst[i]->adjlist_.end(),
-        graph->adjlist_.begin() + node_offset,
-        graph->adjlist_.begin() + node_offset + sizes_data[i]);
-    rst[i]->reverse_adjlist_.insert(rst[i]->reverse_adjlist_.end(),
-        graph->reverse_adjlist_.begin() + node_offset,
-        graph->reverse_adjlist_.begin() + node_offset + sizes_data[i]);
-    // relabel adjs
-    size_t num_edges = 0;
-    for (auto& elist : rst[i]->adjlist_) {
-      for (size_t j = 0; j < elist.succ.size(); ++j) {
-        elist.succ[j] -= node_offset;
-        elist.edge_id[j] -= edge_offset;
-      }
-      num_edges += elist.succ.size();
-    }
-    for (auto& elist : rst[i]->reverse_adjlist_) {
-      for (size_t j = 0; j < elist.succ.size(); ++j) {
-        elist.succ[j] -= node_offset;
-        elist.edge_id[j] -= edge_offset;
-      }
-    }
-    // copy edges
-    rst[i]->all_edges_src_.reserve(num_edges);
-    rst[i]->all_edges_dst_.reserve(num_edges);
-    rst[i]->num_edges_ = num_edges;
-    for (size_t j = edge_offset; j < edge_offset + num_edges; ++j) {
-      rst[i]->all_edges_src_.push_back(graph->all_edges_src_[j] - node_offset);
-      rst[i]->all_edges_dst_.push_back(graph->all_edges_dst_[j] - node_offset);
-    }
-    // update offset
-    CHECK_EQ(rst[i]->NumVertices(), sizes_data[i]);
-    CHECK_EQ(rst[i]->NumEdges(), num_edges);
-    node_offset += sizes_data[i];
-    edge_offset += num_edges;
-  }
-  return rst;
-}
-
-
-ImmutableGraphRef GraphOp::DisjointUnion(std::vector<ImmutableGraphRef> graphs) {
-  int64_t num_nodes = 0;
-  int64_t num_edges = 0;
-  for (ImmutableGraphRef gr : graphs) {
-    num_nodes += gr->NumVertices();
-    num_edges += gr->NumEdges();
-  }
-  IdArray indptr_arr = aten::NewIdArray(num_nodes + 1);
-  IdArray indices_arr = aten::NewIdArray(num_edges);
-  IdArray edge_ids_arr = aten::NewIdArray(num_edges);
-  dgl_id_t* indptr = static_cast<dgl_id_t*>(indptr_arr->data);
-  dgl_id_t* indices = static_cast<dgl_id_t*>(indices_arr->data);
-  dgl_id_t* edge_ids = static_cast<dgl_id_t*>(edge_ids_arr->data);
-
-  indptr[0] = 0;
-  dgl_id_t cum_num_nodes = 0;
-  dgl_id_t cum_num_edges = 0;
-  for (ImmutableGraphRef gr : graphs) {
-    // TODO(minjie): why in csr?
-    const CSRPtr g_csrptr = gr->GetInCSR();
-    const int64_t g_num_nodes = g_csrptr->NumVertices();
-    const int64_t g_num_edges = g_csrptr->NumEdges();
-    dgl_id_t* g_indptr = static_cast<dgl_id_t*>(g_csrptr->indptr()->data);
-    dgl_id_t* g_indices = static_cast<dgl_id_t*>(g_csrptr->indices()->data);
-    dgl_id_t* g_edge_ids = static_cast<dgl_id_t*>(g_csrptr->edge_ids()->data);
-    for (dgl_id_t i = 1; i < g_num_nodes + 1; ++i) {
-      indptr[cum_num_nodes + i] = g_indptr[i] + cum_num_edges;
-    }
-    for (dgl_id_t i = 0; i < g_num_edges; ++i) {
-      indices[cum_num_edges + i] = g_indices[i] + cum_num_nodes;
-    }
-
-    for (dgl_id_t i = 0; i < g_num_edges; ++i) {
-      edge_ids[cum_num_edges + i] = g_edge_ids[i] + cum_num_edges;
-    }
-    cum_num_nodes += g_num_nodes;
-    cum_num_edges += g_num_edges;
-  }
-
-  return ImmutableGraphRef::CreateFromCSR(indptr_arr, indices_arr, edge_ids_arr, "in");
-}
-
-std::vector<ImmutableGraphRef> GraphOp::DisjointPartitionByNum(
-    ImmutableGraphRef graph, int64_t num) {
-  CHECK(num != 0 && graph->NumVertices() % num == 0)
-    << "Number of partitions must evenly divide the number of nodes.";
-  IdArray sizes = IdArray::Empty({num}, DLDataType{kDLInt, 64, 1}, DLContext{kDLCPU, 0});
-  int64_t *sizes_data = static_cast<int64_t *>(sizes->data);
-  std::fill(sizes_data, sizes_data + num, graph->NumVertices() / num);
-  return DisjointPartitionBySizes(graph, sizes);
-}
-
-std::vector<ImmutableGraphRef> GraphOp::DisjointPartitionBySizes(
-    ImmutableGraphRef batched_graph, IdArray sizes) {
-  // TODO(minjie): use array views to speedup this operation
-  const int64_t len = sizes->shape[0];
-  const int64_t *sizes_data = static_cast<int64_t *>(sizes->data);
-  std::vector<int64_t> cumsum;
-  cumsum.reserve(len + 1);
-  cumsum.push_back(0);
-  for (int64_t i = 0; i < len; ++i) {
-    cumsum.push_back(cumsum[i] + sizes_data[i]);
-  }
   CHECK_EQ(cumsum[len], batched_graph->NumVertices())
     << "Sum of the given sizes must equal to the number of nodes.";
-  std::vector<ImmutableGraphRef> rst;
-  // TODO(minjie): why in csr?
-  CSRPtr in_csr_ptr = batched_graph->GetInCSR();
-  const dgl_id_t* indptr = static_cast<dgl_id_t*>(in_csr_ptr->indptr()->data);
-  const dgl_id_t* indices = static_cast<dgl_id_t*>(in_csr_ptr->indices()->data);
-  const dgl_id_t* edge_ids = static_cast<dgl_id_t*>(in_csr_ptr->edge_ids()->data);
-  dgl_id_t cum_sum_edges = 0;
-  for (int64_t i = 0; i < len; ++i) {
-    const int64_t start_pos = cumsum[i];
-    const int64_t end_pos = cumsum[i + 1];
-    const int64_t g_num_nodes = sizes_data[i];
-    const int64_t g_num_edges = indptr[end_pos] - indptr[start_pos];
-    IdArray indptr_arr = aten::NewIdArray(g_num_nodes + 1);
-    IdArray indices_arr = aten::NewIdArray(g_num_edges);
-    IdArray edge_ids_arr = aten::NewIdArray(g_num_edges);
-    dgl_id_t* g_indptr = static_cast<dgl_id_t*>(indptr_arr->data);
-    dgl_id_t* g_indices = static_cast<dgl_id_t*>(indices_arr->data);
-    dgl_id_t* g_edge_ids = static_cast<dgl_id_t*>(edge_ids_arr->data);
 
-    const dgl_id_t idoff = indptr[start_pos];
-    g_indptr[0] = 0;
-    for (int l = start_pos + 1; l < end_pos + 1; ++l) {
-      g_indptr[l - start_pos] = indptr[l] - indptr[start_pos];
+  std::vector<GraphPtr> rst;
+  if (IsMutable(batched_graph)) {
+    // Input is a mutable graph. Partition it into several multiple graphs.
+    MGraphPtr graph = std::dynamic_pointer_cast<Graph>(batched_graph);
+    dgl_id_t node_offset = 0, edge_offset = 0;
+    for (int64_t i = 0; i < len; ++i) {
+      MGraphPtr mg = Graph::Create();
+      // TODO(minjie): quite ugly to expose internal members
+      // copy adj
+      mg->adjlist_.insert(mg->adjlist_.end(),
+          graph->adjlist_.begin() + node_offset,
+          graph->adjlist_.begin() + node_offset + sizes_data[i]);
+      mg->reverse_adjlist_.insert(mg->reverse_adjlist_.end(),
+          graph->reverse_adjlist_.begin() + node_offset,
+          graph->reverse_adjlist_.begin() + node_offset + sizes_data[i]);
+      // relabel adjs
+      size_t num_edges = 0;
+      for (auto& elist : mg->adjlist_) {
+        for (size_t j = 0; j < elist.succ.size(); ++j) {
+          elist.succ[j] -= node_offset;
+          elist.edge_id[j] -= edge_offset;
+        }
+        num_edges += elist.succ.size();
+      }
+      for (auto& elist : mg->reverse_adjlist_) {
+        for (size_t j = 0; j < elist.succ.size(); ++j) {
+          elist.succ[j] -= node_offset;
+          elist.edge_id[j] -= edge_offset;
+        }
+      }
+      // copy edges
+      mg->all_edges_src_.reserve(num_edges);
+      mg->all_edges_dst_.reserve(num_edges);
+      mg->num_edges_ = num_edges;
+      for (size_t j = edge_offset; j < edge_offset + num_edges; ++j) {
+        mg->all_edges_src_.push_back(graph->all_edges_src_[j] - node_offset);
+        mg->all_edges_dst_.push_back(graph->all_edges_dst_[j] - node_offset);
+      }
+      // push to rst
+      rst.push_back(mg);
+      // update offset
+      CHECK_EQ(rst[i]->NumVertices(), sizes_data[i]);
+      CHECK_EQ(rst[i]->NumEdges(), num_edges);
+      node_offset += sizes_data[i];
+      edge_offset += num_edges;
     }
+  } else {
+    // Input is an mutable graph. Partition it into several multiple graphs.
+    ImGraphPtr graph = std::dynamic_pointer_cast<ImmutableGraph>(batched_graph);
+    // TODO(minjie): why in csr?
+    CSRPtr in_csr_ptr = graph->GetInCSR();
+    const dgl_id_t* indptr = static_cast<dgl_id_t*>(in_csr_ptr->indptr()->data);
+    const dgl_id_t* indices = static_cast<dgl_id_t*>(in_csr_ptr->indices()->data);
+    const dgl_id_t* edge_ids = static_cast<dgl_id_t*>(in_csr_ptr->edge_ids()->data);
+    dgl_id_t cum_sum_edges = 0;
+    for (int64_t i = 0; i < len; ++i) {
+      const int64_t start_pos = cumsum[i];
+      const int64_t end_pos = cumsum[i + 1];
+      const int64_t g_num_nodes = sizes_data[i];
+      const int64_t g_num_edges = indptr[end_pos] - indptr[start_pos];
+      IdArray indptr_arr = aten::NewIdArray(g_num_nodes + 1);
+      IdArray indices_arr = aten::NewIdArray(g_num_edges);
+      IdArray edge_ids_arr = aten::NewIdArray(g_num_edges);
+      dgl_id_t* g_indptr = static_cast<dgl_id_t*>(indptr_arr->data);
+      dgl_id_t* g_indices = static_cast<dgl_id_t*>(indices_arr->data);
+      dgl_id_t* g_edge_ids = static_cast<dgl_id_t*>(edge_ids_arr->data);
 
-    for (int j = indptr[start_pos]; j < indptr[end_pos]; ++j) {
-      g_indices[j - idoff] = indices[j] - cumsum[i];
+      const dgl_id_t idoff = indptr[start_pos];
+      g_indptr[0] = 0;
+      for (int l = start_pos + 1; l < end_pos + 1; ++l) {
+        g_indptr[l - start_pos] = indptr[l] - indptr[start_pos];
+      }
+
+      for (int j = indptr[start_pos]; j < indptr[end_pos]; ++j) {
+        g_indices[j - idoff] = indices[j] - cumsum[i];
+      }
+
+      for (int k = indptr[start_pos]; k < indptr[end_pos]; ++k) {
+        g_edge_ids[k - idoff] = edge_ids[k] - cum_sum_edges;
+      }
+
+      cum_sum_edges += g_num_edges;
+      rst.push_back(ImmutableGraph::CreateFromCSR(
+          indptr_arr, indices_arr, edge_ids_arr, "in"));
     }
-
-    for (int k = indptr[start_pos]; k < indptr[end_pos]; ++k) {
-      g_edge_ids[k - idoff] = edge_ids[k] - cum_sum_edges;
-    }
-
-    cum_sum_edges += g_num_edges;
-    ImmutableGraphRef r = ImmutableGraphRef::CreateFromCSR(
-        indptr_arr, indices_arr, edge_ids_arr, "in");
-    rst.push_back(r);
   }
   return rst;
 }
@@ -303,7 +310,7 @@ IdArray GraphOp::ExpandIds(IdArray ids, IdArray offset) {
   return rst;
 }
 
-ImmutableGraphRef GraphOp::ToSimpleGraph(BaseGraphRef graph) {
+GraphPtr GraphOp::ToSimpleGraph(GraphPtr graph) {
   std::vector<dgl_id_t> indptr(graph->NumVertices() + 1), indices;
   indptr[0] = 0;
   for (dgl_id_t src = 0; src < graph->NumVertices(); ++src) {
@@ -318,10 +325,10 @@ ImmutableGraphRef GraphOp::ToSimpleGraph(BaseGraphRef graph) {
   }
   CSRPtr csr(new CSR(graph->NumVertices(), indices.size(),
         indptr.begin(), indices.begin(), RangeIter(0), false));
-  return ImmutableGraphRef(std::make_shared<ImmutableGraph>(csr));
+  return std::make_shared<ImmutableGraph>(csr);
 }
 
-GraphRef GraphOp::ToBidirectedMutableGraph(BaseGraphRef g) {
+GraphPtr GraphOp::ToBidirectedMutableGraph(GraphPtr g) {
   std::unordered_map<int, std::unordered_map<int, int>> n_e;
   for (dgl_id_t u = 0; u < g->NumVertices(); ++u) {
     for (const dgl_id_t v : g->SuccVec(u)) {
@@ -329,7 +336,7 @@ GraphRef GraphOp::ToBidirectedMutableGraph(BaseGraphRef g) {
     }
   }
 
-  GraphRef bg;
+  GraphPtr bg = Graph::Create();
   bg->AddVertices(g->NumVertices());
   for (dgl_id_t u = 0; u < g->NumVertices(); ++u) {
     for (dgl_id_t v = u; v < g->NumVertices(); ++v) {
@@ -353,7 +360,7 @@ GraphRef GraphOp::ToBidirectedMutableGraph(BaseGraphRef g) {
   return bg;
 }
 
-ImmutableGraphRef GraphOp::ToBidirectedImmutableGraph(BaseGraphRef g) {
+GraphPtr GraphOp::ToBidirectedImmutableGraph(GraphPtr g) {
   std::unordered_map<int, std::unordered_map<int, int>> n_e;
   for (dgl_id_t u = 0; u < g->NumVertices(); ++u) {
     for (const dgl_id_t v : g->SuccVec(u)) {
@@ -388,101 +395,80 @@ ImmutableGraphRef GraphOp::ToBidirectedImmutableGraph(BaseGraphRef g) {
 
   IdArray srcs_array = aten::VecToIdArray(srcs);
   IdArray dsts_array = aten::VecToIdArray(dsts);
-  COOPtr coo(new COO(g->NumVertices(), srcs_array, dsts_array, g->IsMultigraph()));
-  return ImmutableGraphRef::CreateFromCOO(
+  return ImmutableGraph::CreateFromCOO(
       g->NumVertices(), srcs_array, dsts_array, g->IsMultigraph());
 }
 
 DGL_REGISTER_GLOBAL("graph_index._CAPI_DGLDisjointUnion")
 .set_body([] (DGLArgs args, DGLRetValue* rv) {
-    void* list = args[0];
-    GraphHandle* inhandles = static_cast<GraphHandle*>(list);
-    int list_size = args[1];
-    const GraphInterface *ptr = static_cast<const GraphInterface *>(inhandles[0]);
-    const ImmutableGraph *im_gr = dynamic_cast<const ImmutableGraph *>(ptr);
-    const Graph *gr = dynamic_cast<const Graph *>(ptr);
-    if (gr) {
-      DGLDisjointUnion<Graph>(inhandles, list_size, rv);
-    } else {
-      CHECK(im_gr) << "Args[0] is not a list of valid DGLGraph";
-      DGLDisjointUnion<ImmutableGraph>(inhandles, list_size, rv);
+    List<GraphRef> graphs = args[0];
+    std::vector<GraphPtr> ptrs(graphs.size());
+    for (size_t i = 0; i < graphs.size(); ++i) {
+      ptrs[i] = graphs[i].sptr();
     }
+    *rv = GraphOp::DisjointUnion(ptrs);
   });
 
 DGL_REGISTER_GLOBAL("graph_index._CAPI_DGLDisjointPartitionByNum")
 .set_body([] (DGLArgs args, DGLRetValue* rv) {
-    GraphHandle ghandle = args[0];
-    const GraphInterface *ptr = static_cast<const GraphInterface *>(ghandle);
-    const Graph* gptr = dynamic_cast<const Graph*>(ptr);
-    const ImmutableGraph* im_gptr = dynamic_cast<const ImmutableGraph*>(ptr);
-    if (gptr) {
-      DGLDisjointPartitionByNum(gptr, args, rv);
-    } else {
-      CHECK(im_gptr) << "Args[0] is not a valid DGLGraph";
-      DGLDisjointPartitionByNum(im_gptr, args, rv);
+    GraphRef g = args[0];
+    int64_t num = args[1];
+    const auto& ret = GraphOp::DisjointPartitionByNum(g.sptr(), num);
+    List<GraphRef> ret_list;
+    for (GraphPtr gp : ret) {
+      ret_list.push_back(GraphRef(gp));
     }
+    *rv = ret_list;
   });
 
 DGL_REGISTER_GLOBAL("graph_index._CAPI_DGLDisjointPartitionBySizes")
 .set_body([] (DGLArgs args, DGLRetValue* rv) {
-    GraphHandle ghandle = args[0];
+    GraphRef g = args[0];
     const IdArray sizes = args[1];
-    const GraphInterface *ptr = static_cast<const GraphInterface *>(ghandle);
-    const Graph* gptr = dynamic_cast<const Graph*>(ptr);
-    const ImmutableGraph* im_gptr = dynamic_cast<const ImmutableGraph*>(ptr);
-    if (gptr) {
-      DGLDisjointPartitionBySizes(gptr, sizes, rv);
-    } else {
-      CHECK(im_gptr) << "Args[0] is not a valid DGLGraph";
-      DGLDisjointPartitionBySizes(im_gptr, sizes, rv);
+    const auto& ret = GraphOp::DisjointPartitionBySizes(g.sptr(), sizes);
+    List<GraphRef> ret_list;
+    for (GraphPtr gp : ret) {
+      ret_list.push_back(GraphRef(gp));
     }
+    *rv = ret_list;
 });
 
 DGL_REGISTER_GLOBAL("graph_index._CAPI_DGLGraphLineGraph")
 .set_body([] (DGLArgs args, DGLRetValue* rv) {
-    GraphHandle ghandle = args[0];
+    GraphRef g = args[0];
     bool backtracking = args[1];
-    const GraphInterface *ptr = static_cast<const GraphInterface *>(ghandle);
-    const Graph* gptr = dynamic_cast<const Graph*>(ptr);
-    CHECK(gptr) << "_CAPI_DGLGraphLineGraph isn't implemented in immutable graph";
-    Graph* lgptr = new Graph();
-    *lgptr = GraphOp::LineGraph(gptr, backtracking);
-    GraphHandle lghandle = lgptr;
-    *rv = lghandle;
+    *rv = GraphOp::LineGraph(g.sptr(), backtracking);
   });
 
 DGL_REGISTER_GLOBAL("graph_index._CAPI_DGLToImmutable")
 .set_body([] (DGLArgs args, DGLRetValue* rv) {
-    GraphHandle ghandle = args[0];
-    const GraphInterface *ptr = static_cast<GraphInterface *>(ghandle);
-    GraphHandle newhandle = new ImmutableGraph(ImmutableGraph::ToImmutable(ptr));
-    *rv = newhandle;
+    GraphRef g = args[0];
+    *rv = ImmutableGraph::ToImmutable(g.sptr());
   });
 
 DGL_REGISTER_GLOBAL("transform._CAPI_DGLToSimpleGraph")
 .set_body([] (DGLArgs args, DGLRetValue* rv) {
-    GraphHandle ghandle = args[0];
-    const GraphInterface *ptr = static_cast<const GraphInterface *>(ghandle);
-    GraphHandle ret = GraphOp::ToSimpleGraph(ptr).Reset();
-    *rv = ret;
+    GraphRef g = args[0];
+    *rv = GraphOp::ToSimpleGraph(g.sptr());
   });
 
 DGL_REGISTER_GLOBAL("transform._CAPI_DGLToBidirectedMutableGraph")
 .set_body([] (DGLArgs args, DGLRetValue* rv) {
-    GraphHandle ghandle = args[0];
-    const GraphInterface *ptr = static_cast<const GraphInterface *>(ghandle);
-    Graph* bgptr = new Graph();
-    *bgptr = GraphOp::ToBidirectedMutableGraph(ptr);
-    GraphHandle bghandle = bgptr;
-    *rv = bghandle;
+    GraphRef g = args[0];
+    *rv = GraphOp::ToBidirectedMutableGraph(g.sptr());
   });
 
 DGL_REGISTER_GLOBAL("transform._CAPI_DGLToBidirectedImmutableGraph")
 .set_body([] (DGLArgs args, DGLRetValue* rv) {
-    GraphHandle ghandle = args[0];
-    const GraphInterface *ptr = static_cast<const GraphInterface *>(ghandle);
-    GraphHandle bghandle = GraphOp::ToBidirectedImmutableGraph(ptr).Reset();
-    *rv = bghandle;
+    GraphRef g = args[0];
+    *rv = GraphOp::ToBidirectedImmutableGraph(g.sptr());
+  });
+
+DGL_REGISTER_GLOBAL("graph_index._CAPI_DGLMapSubgraphNID")
+.set_body([] (DGLArgs args, DGLRetValue* rv) {
+    const IdArray parent_vids = args[0];
+    const IdArray query = args[1];
+    *rv = GraphOp::MapParentIdToSubgraphId(parent_vids, query);
   });
 
 }  // namespace dgl

--- a/src/graph/immutable_graph.cc
+++ b/src/graph/immutable_graph.cc
@@ -12,8 +12,16 @@
 
 #include "../c_api_common.h"
 
+using dgl::runtime::DGLArgs;
+using dgl::runtime::DGLArgValue;
+using dgl::runtime::DGLRetValue;
+
 namespace dgl {
 namespace {
+inline std::string GetSharedMemName(const std::string &name, const std::string &edge_dir) {
+  return name + "_" + edge_dir;
+}
+
 std::tuple<IdArray, IdArray, IdArray> MapFromSharedMemory(
   const std::string &shared_mem_name, int64_t num_verts, int64_t num_edges, bool is_create) {
 #ifndef _WIN32
@@ -124,22 +132,22 @@ bool CSR::IsMultigraph() const {
     });
 }
 
-CSR::EdgeArray CSR::OutEdges(dgl_id_t vid) const {
+EdgeArray CSR::OutEdges(dgl_id_t vid) const {
   CHECK(HasVertex(vid)) << "invalid vertex: " << vid;
   IdArray ret_dst = aten::CSRGetRowColumnIndices(adj_, vid);
   IdArray ret_eid = aten::CSRGetRowData(adj_, vid);
   IdArray ret_src = aten::Full(vid, ret_dst->shape[0], NumBits(), ret_dst->ctx);
-  return CSR::EdgeArray{ret_src, ret_dst, ret_eid};
+  return EdgeArray{ret_src, ret_dst, ret_eid};
 }
 
-CSR::EdgeArray CSR::OutEdges(IdArray vids) const {
+EdgeArray CSR::OutEdges(IdArray vids) const {
   CHECK(IsValidIdArray(vids)) << "Invalid vertex id array.";
   auto csrsubmat = aten::CSRSliceRows(adj_, vids);
   auto coosubmat = aten::CSRToCOO(csrsubmat, false);
   // Note that the row id in the csr submat is relabled, so
   // we need to recover it using an index select.
   auto row = aten::IndexSelect(vids, coosubmat.row);
-  return CSR::EdgeArray{row, coosubmat.col, coosubmat.data};
+  return EdgeArray{row, coosubmat.col, coosubmat.data};
 }
 
 DegreeArray CSR::OutDegrees(IdArray vids) const {
@@ -171,17 +179,17 @@ IdArray CSR::EdgeId(dgl_id_t src, dgl_id_t dst) const {
   return aten::CSRGetData(adj_, src, dst);
 }
 
-CSR::EdgeArray CSR::EdgeIds(IdArray src_ids, IdArray dst_ids) const {
+EdgeArray CSR::EdgeIds(IdArray src_ids, IdArray dst_ids) const {
   const auto& arrs = aten::CSRGetDataAndIndices(adj_, src_ids, dst_ids);
-  return CSR::EdgeArray{arrs[0], arrs[1], arrs[2]};
+  return EdgeArray{arrs[0], arrs[1], arrs[2]};
 }
 
-CSR::EdgeArray CSR::Edges(const std::string &order) const {
+EdgeArray CSR::Edges(const std::string &order) const {
   CHECK(order.empty() || order == std::string("srcdst"))
     << "CSR only support Edges of order \"srcdst\","
     << " but got \"" << order << "\".";
   const auto& coo = aten::CSRToCOO(adj_, false);
-  return CSR::EdgeArray{coo.row, coo.col, coo.data};
+  return EdgeArray{coo.row, coo.col, coo.data};
 }
 
 Subgraph CSR::VertexSubgraph(IdArray vids) const {
@@ -289,14 +297,14 @@ std::pair<dgl_id_t, dgl_id_t> COO::FindEdge(dgl_id_t eid) const {
   return std::pair<dgl_id_t, dgl_id_t>(src, dst);
 }
 
-COO::EdgeArray COO::FindEdges(IdArray eids) const {
+EdgeArray COO::FindEdges(IdArray eids) const {
   CHECK(IsValidIdArray(eids)) << "Invalid edge id array";
   return EdgeArray{aten::IndexSelect(adj_.row, eids),
                    aten::IndexSelect(adj_.col, eids),
                    eids};
 }
 
-COO::EdgeArray COO::Edges(const std::string &order) const {
+EdgeArray COO::Edges(const std::string &order) const {
   CHECK(order.empty() || order == std::string("eid"))
     << "COO only support Edges of order \"eid\", but got \""
     << order << "\".";
@@ -411,7 +419,7 @@ COOPtr ImmutableGraph::GetCOO() const {
   return coo_;
 }
 
-ImmutableGraph::EdgeArray ImmutableGraph::Edges(const std::string &order) const {
+EdgeArray ImmutableGraph::Edges(const std::string &order) const {
   if (order.empty()) {
     // arbitrary order
     if (in_csr_) {
@@ -515,5 +523,126 @@ ImmutableGraph ImmutableGraph::AsNumBits(uint8_t bits) const {
     return ImmutableGraph(new_incsr, new_outcsr);
   }
 }
+
+GraphPtr ImmutableGraph::Reverse() const {
+  if (coo_) {
+    return std::make_shared<ImmutableGraph>(
+          out_csr_, in_csr_, coo_->Transpose());
+  } else {
+    return std::make_shared<ImmutableGraph>(out_csr_, in_csr_);
+  }
+}
+
+ImmutableGraphRef ImmutableGraphRef::CreateFromCSR(
+    IdArray indptr, IdArray indices, IdArray edge_ids, const std::string &edge_dir) {
+    CSRPtr csr(new CSR(indptr, indices, edge_ids));
+  if (edge_dir == "in") {
+    return ImmutableGraphRef(std::make_shared<ImmutableGraph>(csr, nullptr));
+  } else if (edge_dir == "out") {
+    return ImmutableGraphRef(std::make_shared<ImmutableGraph>(nullptr, csr));
+  } else {
+    LOG(FATAL) << "Unknown edge direction: " << edge_dir;
+    return ImmutableGraphRef();
+  }
+}
+
+ImmutableGraphRef ImmutableGraphRef::CreateFromCSR(
+    IdArray indptr, IdArray indices, IdArray edge_ids,
+    bool multigraph, const std::string &edge_dir) {
+  CSRPtr csr(new CSR(indptr, indices, edge_ids, multigraph));
+  if (edge_dir == "in") {
+    return ImmutableGraphRef(std::make_shared<ImmutableGraph>(csr, nullptr));
+  } else if (edge_dir == "out") {
+    return ImmutableGraphRef(std::make_shared<ImmutableGraph>(nullptr, csr));
+  } else {
+    LOG(FATAL) << "Unknown edge direction: " << edge_dir;
+    return ImmutableGraphRef();
+  }
+}
+
+ImmutableGraphRef ImmutableGraphRef::CreateFromCSR(
+    IdArray indptr, IdArray indices, IdArray edge_ids,
+    const std::string &edge_dir,
+    const std::string &shared_mem_name) {
+  CSRPtr csr(new CSR(indptr, indices, edge_ids, GetSharedMemName(shared_mem_name, edge_dir)));
+  if (edge_dir == "in") {
+    return ImmutableGraphRef(std::make_shared<ImmutableGraph>(csr, nullptr, shared_mem_name));
+  } else if (edge_dir == "out") {
+    return ImmutableGraphRef(std::make_shared<ImmutableGraph>(nullptr, csr, shared_mem_name));
+  } else {
+    LOG(FATAL) << "Unknown edge direction: " << edge_dir;
+    return ImmutableGraphRef();
+  }
+}
+
+ImmutableGraphRef ImmutableGraphRef::CreateFromCSR(
+    IdArray indptr, IdArray indices, IdArray edge_ids,
+    bool multigraph, const std::string &edge_dir,
+    const std::string &shared_mem_name) {
+  CSRPtr csr(new CSR(indptr, indices, edge_ids, multigraph,
+                     GetSharedMemName(shared_mem_name, edge_dir)));
+  if (edge_dir == "in") {
+    return ImmutableGraphRef(std::make_shared<ImmutableGraph>(csr, nullptr, shared_mem_name));
+  } else if (edge_dir == "out") {
+    return ImmutableGraphRef(std::make_shared<ImmutableGraph>(nullptr, csr, shared_mem_name));
+  } else {
+    LOG(FATAL) << "Unknown edge direction: " << edge_dir;
+    return ImmutableGraphRef();
+  }
+}
+
+ImmutableGraphRef ImmutableGraphRef::CreateFromCSR(
+    const std::string &shared_mem_name, size_t num_vertices,
+    size_t num_edges, bool multigraph,
+    const std::string &edge_dir) {
+  CSRPtr csr(new CSR(GetSharedMemName(shared_mem_name, edge_dir), num_vertices, num_edges,
+                     multigraph));
+  if (edge_dir == "in") {
+    return ImmutableGraphRef(std::make_shared<ImmutableGraph>(csr, nullptr, shared_mem_name));
+  } else if (edge_dir == "out") {
+    return ImmutableGraphRef(std::make_shared<ImmutableGraph>(nullptr, csr, shared_mem_name));
+  } else {
+    LOG(FATAL) << "Unknown edge direction: " << edge_dir;
+    return ImmutableGraphRef();
+  }
+}
+
+ImmutableGraphRef ImmutableGraphRef::CreateFromCOO(
+    int64_t num_vertices, IdArray src, IdArray dst) {
+  COOPtr coo(new COO(num_vertices, src, dst));
+  return ImmutableGraphRef(std::make_shared<ImmutableGraph>(coo));
+}
+
+ImmutableGraphRef ImmutableGraphRef::CreateFromCOO(
+    int64_t num_vertices, IdArray src, IdArray dst, bool multigraph) {
+  COOPtr coo(new COO(num_vertices, src, dst, multigraph));
+  return ImmutableGraphRef(std::make_shared<ImmutableGraph>(coo));
+}
+
+DGL_REGISTER_GLOBAL("graph_index._CAPI_DGLImmutableGraphCopyTo")
+.set_body([] (DGLArgs args, DGLRetValue* rv) {
+    ImmutableGraphRef ig = args[0];
+    const int device_type = args[1];
+    const int device_id = args[2];
+    DLContext ctx;
+    ctx.device_type = static_cast<DLDeviceType>(device_type);
+    ctx.device_id = device_id;
+    *rv = ig->CopyTo(ctx);
+  });
+
+DGL_REGISTER_GLOBAL("graph_index._CAPI_DGLImmutableGraphCopyToSharedMem")
+.set_body([] (DGLArgs args, DGLRetValue* rv) {
+    ImmutableGraphRef ig = args[0];
+    std::string edge_dir = args[1];
+    std::string name = args[2];
+    *rv = ig->CopyToSharedMem(edge_dir, name);
+  });
+
+DGL_REGISTER_GLOBAL("graph_index._CAPI_DGLImmutableGraphAsNumBits")
+.set_body([] (DGLArgs args, DGLRetValue* rv) {
+    ImmutableGraphRef ig = args[0];
+    int bits = args[1];
+    *rv = ig->AsNumBits(bits);
+  });
 
 }  // namespace dgl

--- a/src/graph/immutable_graph.cc
+++ b/src/graph/immutable_graph.cc
@@ -474,94 +474,94 @@ std::vector<IdArray> ImmutableGraph::GetAdj(bool transpose, const std::string &f
   }
 }
 
-ImGraphPtr ImmutableGraph::CreateFromCSR(
+ImmutableGraphPtr ImmutableGraph::CreateFromCSR(
     IdArray indptr, IdArray indices, IdArray edge_ids, const std::string &edge_dir) {
     CSRPtr csr(new CSR(indptr, indices, edge_ids));
   if (edge_dir == "in") {
-    return ImGraphPtr(new ImmutableGraph(csr, nullptr));
+    return ImmutableGraphPtr(new ImmutableGraph(csr, nullptr));
   } else if (edge_dir == "out") {
-    return ImGraphPtr(new ImmutableGraph(nullptr, csr));
+    return ImmutableGraphPtr(new ImmutableGraph(nullptr, csr));
   } else {
     LOG(FATAL) << "Unknown edge direction: " << edge_dir;
-    return ImGraphPtr();
+    return ImmutableGraphPtr();
   }
 }
 
-ImGraphPtr ImmutableGraph::CreateFromCSR(
+ImmutableGraphPtr ImmutableGraph::CreateFromCSR(
     IdArray indptr, IdArray indices, IdArray edge_ids,
     bool multigraph, const std::string &edge_dir) {
   CSRPtr csr(new CSR(indptr, indices, edge_ids, multigraph));
   if (edge_dir == "in") {
-    return ImGraphPtr(new ImmutableGraph(csr, nullptr));
+    return ImmutableGraphPtr(new ImmutableGraph(csr, nullptr));
   } else if (edge_dir == "out") {
-    return ImGraphPtr(new ImmutableGraph(nullptr, csr));
+    return ImmutableGraphPtr(new ImmutableGraph(nullptr, csr));
   } else {
     LOG(FATAL) << "Unknown edge direction: " << edge_dir;
-    return ImGraphPtr();
+    return ImmutableGraphPtr();
   }
 }
 
-ImGraphPtr ImmutableGraph::CreateFromCSR(
+ImmutableGraphPtr ImmutableGraph::CreateFromCSR(
     IdArray indptr, IdArray indices, IdArray edge_ids,
     const std::string &edge_dir,
     const std::string &shared_mem_name) {
   CSRPtr csr(new CSR(indptr, indices, edge_ids, GetSharedMemName(shared_mem_name, edge_dir)));
   if (edge_dir == "in") {
-    return ImGraphPtr(new ImmutableGraph(csr, nullptr, shared_mem_name));
+    return ImmutableGraphPtr(new ImmutableGraph(csr, nullptr, shared_mem_name));
   } else if (edge_dir == "out") {
-    return ImGraphPtr(new ImmutableGraph(nullptr, csr, shared_mem_name));
+    return ImmutableGraphPtr(new ImmutableGraph(nullptr, csr, shared_mem_name));
   } else {
     LOG(FATAL) << "Unknown edge direction: " << edge_dir;
-    return ImGraphPtr();
+    return ImmutableGraphPtr();
   }
 }
 
-ImGraphPtr ImmutableGraph::CreateFromCSR(
+ImmutableGraphPtr ImmutableGraph::CreateFromCSR(
     IdArray indptr, IdArray indices, IdArray edge_ids,
     bool multigraph, const std::string &edge_dir,
     const std::string &shared_mem_name) {
   CSRPtr csr(new CSR(indptr, indices, edge_ids, multigraph,
                      GetSharedMemName(shared_mem_name, edge_dir)));
   if (edge_dir == "in") {
-    return ImGraphPtr(new ImmutableGraph(csr, nullptr, shared_mem_name));
+    return ImmutableGraphPtr(new ImmutableGraph(csr, nullptr, shared_mem_name));
   } else if (edge_dir == "out") {
-    return ImGraphPtr(new ImmutableGraph(nullptr, csr, shared_mem_name));
+    return ImmutableGraphPtr(new ImmutableGraph(nullptr, csr, shared_mem_name));
   } else {
     LOG(FATAL) << "Unknown edge direction: " << edge_dir;
-    return ImGraphPtr();
+    return ImmutableGraphPtr();
   }
 }
 
-ImGraphPtr ImmutableGraph::CreateFromCSR(
+ImmutableGraphPtr ImmutableGraph::CreateFromCSR(
     const std::string &shared_mem_name, size_t num_vertices,
     size_t num_edges, bool multigraph,
     const std::string &edge_dir) {
   CSRPtr csr(new CSR(GetSharedMemName(shared_mem_name, edge_dir), num_vertices, num_edges,
                      multigraph));
   if (edge_dir == "in") {
-    return ImGraphPtr(new ImmutableGraph(csr, nullptr, shared_mem_name));
+    return ImmutableGraphPtr(new ImmutableGraph(csr, nullptr, shared_mem_name));
   } else if (edge_dir == "out") {
-    return ImGraphPtr(new ImmutableGraph(nullptr, csr, shared_mem_name));
+    return ImmutableGraphPtr(new ImmutableGraph(nullptr, csr, shared_mem_name));
   } else {
     LOG(FATAL) << "Unknown edge direction: " << edge_dir;
-    return ImGraphPtr();
+    return ImmutableGraphPtr();
   }
 }
 
-ImGraphPtr ImmutableGraph::CreateFromCOO(
+ImmutableGraphPtr ImmutableGraph::CreateFromCOO(
     int64_t num_vertices, IdArray src, IdArray dst) {
   COOPtr coo(new COO(num_vertices, src, dst));
   return std::make_shared<ImmutableGraph>(coo);
 }
 
-ImGraphPtr ImmutableGraph::CreateFromCOO(
+ImmutableGraphPtr ImmutableGraph::CreateFromCOO(
     int64_t num_vertices, IdArray src, IdArray dst, bool multigraph) {
   COOPtr coo(new COO(num_vertices, src, dst, multigraph));
   return std::make_shared<ImmutableGraph>(coo);
 }
 
-ImGraphPtr ImmutableGraph::ToImmutable(GraphPtr graph) {
-  ImGraphPtr ig = std::dynamic_pointer_cast<ImmutableGraph>(graph);
+ImmutableGraphPtr ImmutableGraph::ToImmutable(GraphPtr graph) {
+  ImmutableGraphPtr ig = std::dynamic_pointer_cast<ImmutableGraph>(graph);
   if (ig) {
     return ig;
   } else {
@@ -571,7 +571,7 @@ ImGraphPtr ImmutableGraph::ToImmutable(GraphPtr graph) {
   }
 }
 
-ImGraphPtr ImmutableGraph::CopyTo(ImGraphPtr g, const DLContext& ctx) {
+ImmutableGraphPtr ImmutableGraph::CopyTo(ImmutableGraphPtr g, const DLContext& ctx) {
   if (ctx == g->Context()) {
     return g;
   }
@@ -581,10 +581,10 @@ ImGraphPtr ImmutableGraph::CopyTo(ImGraphPtr g, const DLContext& ctx) {
   //   be fixed later.
   CSRPtr new_incsr = CSRPtr(new CSR(g->GetInCSR()->CopyTo(ctx)));
   CSRPtr new_outcsr = CSRPtr(new CSR(g->GetOutCSR()->CopyTo(ctx)));
-  return ImGraphPtr(new ImmutableGraph(new_incsr, new_outcsr));
+  return ImmutableGraphPtr(new ImmutableGraph(new_incsr, new_outcsr));
 }
 
-ImGraphPtr ImmutableGraph::CopyToSharedMem(ImGraphPtr g,
+ImmutableGraphPtr ImmutableGraph::CopyToSharedMem(ImmutableGraphPtr g,
     const std::string &edge_dir, const std::string &name) {
   CSRPtr new_incsr, new_outcsr;
   std::string shared_mem_name = GetSharedMemName(name, edge_dir);
@@ -592,10 +592,10 @@ ImGraphPtr ImmutableGraph::CopyToSharedMem(ImGraphPtr g,
     new_incsr = CSRPtr(new CSR(g->GetInCSR()->CopyToSharedMem(shared_mem_name)));
   else if (edge_dir == std::string("out"))
     new_outcsr = CSRPtr(new CSR(g->GetOutCSR()->CopyToSharedMem(shared_mem_name)));
-  return ImGraphPtr(new ImmutableGraph(new_incsr, new_outcsr, name));
+  return ImmutableGraphPtr(new ImmutableGraph(new_incsr, new_outcsr, name));
 }
 
-ImGraphPtr ImmutableGraph::AsNumBits(ImGraphPtr g, uint8_t bits) {
+ImmutableGraphPtr ImmutableGraph::AsNumBits(ImmutableGraphPtr g, uint8_t bits) {
   if (g->NumBits() == bits) {
     return g;
   } else {
@@ -605,16 +605,16 @@ ImGraphPtr ImmutableGraph::AsNumBits(ImGraphPtr g, uint8_t bits) {
     //   be fixed later.
     CSRPtr new_incsr = CSRPtr(new CSR(g->GetInCSR()->AsNumBits(bits)));
     CSRPtr new_outcsr = CSRPtr(new CSR(g->GetOutCSR()->AsNumBits(bits)));
-    return ImGraphPtr(new ImmutableGraph(new_incsr, new_outcsr));
+    return ImmutableGraphPtr(new ImmutableGraph(new_incsr, new_outcsr));
   }
 }
 
-ImGraphPtr ImmutableGraph::Reverse() const {
+ImmutableGraphPtr ImmutableGraph::Reverse() const {
   if (coo_) {
-    return ImGraphPtr(new ImmutableGraph(
+    return ImmutableGraphPtr(new ImmutableGraph(
           out_csr_, in_csr_, coo_->Transpose()));
   } else {
-    return ImGraphPtr(new ImmutableGraph(out_csr_, in_csr_));
+    return ImmutableGraphPtr(new ImmutableGraph(out_csr_, in_csr_));
   }
 }
 
@@ -626,7 +626,7 @@ DGL_REGISTER_GLOBAL("graph_index._CAPI_DGLImmutableGraphCopyTo")
     DLContext ctx;
     ctx.device_type = static_cast<DLDeviceType>(device_type);
     ctx.device_id = device_id;
-    ImGraphPtr ig = CHECK_NOTNULL(std::dynamic_pointer_cast<ImmutableGraph>(g.sptr()));
+    ImmutableGraphPtr ig = CHECK_NOTNULL(std::dynamic_pointer_cast<ImmutableGraph>(g.sptr()));
     *rv = ImmutableGraph::CopyTo(ig, ctx);
   });
 
@@ -635,7 +635,7 @@ DGL_REGISTER_GLOBAL("graph_index._CAPI_DGLImmutableGraphCopyToSharedMem")
     GraphRef g = args[0];
     std::string edge_dir = args[1];
     std::string name = args[2];
-    ImGraphPtr ig = CHECK_NOTNULL(std::dynamic_pointer_cast<ImmutableGraph>(g.sptr()));
+    ImmutableGraphPtr ig = CHECK_NOTNULL(std::dynamic_pointer_cast<ImmutableGraph>(g.sptr()));
     *rv = ImmutableGraph::CopyToSharedMem(ig, edge_dir, name);
   });
 
@@ -643,7 +643,7 @@ DGL_REGISTER_GLOBAL("graph_index._CAPI_DGLImmutableGraphAsNumBits")
 .set_body([] (DGLArgs args, DGLRetValue* rv) {
     GraphRef g = args[0];
     int bits = args[1];
-    ImGraphPtr ig = CHECK_NOTNULL(std::dynamic_pointer_cast<ImmutableGraph>(g.sptr()));
+    ImmutableGraphPtr ig = CHECK_NOTNULL(std::dynamic_pointer_cast<ImmutableGraph>(g.sptr()));
     *rv = ImmutableGraph::AsNumBits(ig, bits);
   });
 

--- a/src/graph/network.cc
+++ b/src/graph/network.cc
@@ -4,6 +4,8 @@
  * \brief DGL networking related APIs
  */
 
+#include <dgl/runtime/container.h>
+#include <dgl/packed_func_ext.h>
 #include "./network.h"
 #include "./network/communicator.h"
 #include "./network/socket_communicator.h"
@@ -11,11 +13,7 @@
 
 #include "../c_api_common.h"
 
-using dgl::runtime::DGLArgs;
-using dgl::runtime::DGLArgValue;
-using dgl::runtime::DGLRetValue;
-using dgl::runtime::PackedFunc;
-using dgl::runtime::NDArray;
+using namespace dgl::runtime;
 
 namespace dgl {
 namespace network {
@@ -84,12 +82,13 @@ DGL_REGISTER_GLOBAL("network._CAPI_SenderSendSubgraph")
 .set_body([] (DGLArgs args, DGLRetValue* rv) {
     CommunicatorHandle chandle = args[0];
     int recv_id = args[1];
-    GraphHandle ghandle = args[2];
+    GraphRef g = args[2];
     const IdArray node_mapping = args[3];
     const IdArray edge_mapping = args[4];
     const IdArray layer_offsets = args[5];
     const IdArray flow_offsets = args[6];
-    ImmutableGraph *ptr = static_cast<ImmutableGraph*>(ghandle);
+    auto ptr = std::dynamic_pointer_cast<ImmutableGraph>(g.sptr());
+    CHECK(ptr) << "only immutable graph is allowed in send/recv";
     network::Sender* sender = static_cast<network::Sender*>(chandle);
     auto csr = ptr->GetInCSR();
     // Write control message
@@ -159,7 +158,7 @@ DGL_REGISTER_GLOBAL("network._CAPI_ReceiverRecvSubgraph")
     RecvData(receiver, buffer, kMaxBufferSize);
     int control = *buffer;
     if (control == CONTROL_NODEFLOW) {
-      NodeFlow* nf = new NodeFlow();
+      NodeFlow nf = NodeFlow::Create();
       CSRPtr csr;
       // Deserialize nodeflow from recv_data_buffer
       network::DeserializeSampledSubgraph(buffer+sizeof(CONTROL_NODEFLOW),
@@ -169,9 +168,9 @@ DGL_REGISTER_GLOBAL("network._CAPI_ReceiverRecvSubgraph")
                                           &(nf->layer_offsets),
                                           &(nf->flow_offsets));
       nf->graph = GraphPtr(new ImmutableGraph(csr, nullptr));
-      std::vector<NodeFlow*> subgs(1);
-      subgs[0] = nf;
-      *rv = WrapVectorReturn(subgs);
+      List<NodeFlow> subgs;
+      subgs.push_back(nf);
+      *rv = subgs;
     } else if (control == CONTROL_END_SIGNAL) {
       *rv = CONTROL_END_SIGNAL;
     } else {

--- a/src/graph/network.cc
+++ b/src/graph/network.cc
@@ -82,6 +82,7 @@ DGL_REGISTER_GLOBAL("network._CAPI_SenderSendSubgraph")
 .set_body([] (DGLArgs args, DGLRetValue* rv) {
     CommunicatorHandle chandle = args[0];
     int recv_id = args[1];
+    // TODO(minjie): could simply use NodeFlow nf = args[2];
     GraphRef g = args[2];
     const IdArray node_mapping = args[3];
     const IdArray edge_mapping = args[4];

--- a/src/graph/nodeflow.cc
+++ b/src/graph/nodeflow.cc
@@ -5,6 +5,7 @@
  */
 
 #include <dgl/immutable_graph.h>
+#include <dgl/packed_func_ext.h>
 #include <dgl/nodeflow.h>
 
 #include <string.h>
@@ -78,15 +79,14 @@ std::vector<IdArray> GetNodeFlowSlice(const ImmutableGraph &graph, const std::st
 
 DGL_REGISTER_GLOBAL("nodeflow._CAPI_NodeFlowGetBlockAdj")
 .set_body([] (DGLArgs args, DGLRetValue* rv) {
-    GraphHandle ghandle = args[0];
+    GraphRef g = args[0];
     std::string format = args[1];
     int64_t layer0_size = args[2];
     int64_t start = args[3];
     int64_t end = args[4];
     const bool remap = args[5];
-    const GraphInterface *ptr = static_cast<const GraphInterface *>(ghandle);
-    const ImmutableGraph* gptr = dynamic_cast<const ImmutableGraph*>(ptr);
-    auto res = GetNodeFlowSlice(*gptr, format, layer0_size, start, end, remap);
+    auto ig = CHECK_NOTNULL(std::dynamic_pointer_cast<ImmutableGraph>(g.sptr()));
+    auto res = GetNodeFlowSlice(*ig, format, layer0_size, start, end, remap);
     *rv = ConvertNDArrayVectorToPackedFunc(res);
   });
 

--- a/src/graph/nodeflow.cc
+++ b/src/graph/nodeflow.cc
@@ -8,7 +8,7 @@
 #include <dgl/packed_func_ext.h>
 #include <dgl/nodeflow.h>
 
-#include <string.h>
+#include <string>
 
 #include "../c_api_common.h"
 

--- a/src/graph/randomwalk.cc
+++ b/src/graph/randomwalk.cc
@@ -7,6 +7,7 @@
 #include <dgl/sampler.h>
 #include <dmlc/omp.h>
 #include <dgl/immutable_graph.h>
+#include <dgl/packed_func_ext.h>
 #include <algorithm>
 #include <cstdlib>
 #include <cmath>
@@ -14,11 +15,7 @@
 #include <functional>
 #include "../c_api_common.h"
 
-using dgl::runtime::DGLArgs;
-using dgl::runtime::DGLArgValue;
-using dgl::runtime::DGLRetValue;
-using dgl::runtime::PackedFunc;
-using dgl::runtime::NDArray;
+using namespace dgl::runtime;
 
 namespace dgl {
 
@@ -218,43 +215,40 @@ RandomWalkTraces BipartiteSingleSidedRandomWalkWithRestart(
 
 DGL_REGISTER_GLOBAL("randomwalk._CAPI_DGLRandomWalk")
 .set_body([] (DGLArgs args, DGLRetValue* rv) {
-    GraphHandle ghandle = args[0];
+    GraphRef g = args[0];
     const IdArray seeds = args[1];
     const int num_traces = args[2];
     const int num_hops = args[3];
-    const GraphInterface *ptr = static_cast<const GraphInterface *>(ghandle);
 
-    *rv = RandomWalk(ptr, seeds, num_traces, num_hops);
+    *rv = RandomWalk(g.sptr().get(), seeds, num_traces, num_hops);
   });
 
 DGL_REGISTER_GLOBAL("randomwalk._CAPI_DGLRandomWalkWithRestart")
 .set_body([] (DGLArgs args, DGLRetValue* rv) {
-    GraphHandle ghandle = args[0];
+    GraphRef g = args[0];
     const IdArray seeds = args[1];
     const double restart_prob = args[2];
     const uint64_t visit_threshold_per_seed = args[3];
     const uint64_t max_visit_counts = args[4];
     const uint64_t max_frequent_visited_nodes = args[5];
-    const GraphInterface *gptr = static_cast<const GraphInterface *>(ghandle);
 
     *rv = ConvertRandomWalkTracesToPackedFunc(
-        RandomWalkWithRestart(gptr, seeds, restart_prob, visit_threshold_per_seed,
+        RandomWalkWithRestart(g.sptr().get(), seeds, restart_prob, visit_threshold_per_seed,
           max_visit_counts, max_frequent_visited_nodes));
   });
 
 DGL_REGISTER_GLOBAL("randomwalk._CAPI_DGLBipartiteSingleSidedRandomWalkWithRestart")
 .set_body([] (DGLArgs args, DGLRetValue* rv) {
-    GraphHandle ghandle = args[0];
+    GraphRef g = args[0];
     const IdArray seeds = args[1];
     const double restart_prob = args[2];
     const uint64_t visit_threshold_per_seed = args[3];
     const uint64_t max_visit_counts = args[4];
     const uint64_t max_frequent_visited_nodes = args[5];
-    const GraphInterface *gptr = static_cast<const GraphInterface *>(ghandle);
 
     *rv = ConvertRandomWalkTracesToPackedFunc(
         BipartiteSingleSidedRandomWalkWithRestart(
-          gptr, seeds, restart_prob, visit_threshold_per_seed,
+          g.sptr().get(), seeds, restart_prob, visit_threshold_per_seed,
           max_visit_counts, max_frequent_visited_nodes));
   });
 

--- a/src/graph/sampler.cc
+++ b/src/graph/sampler.cc
@@ -6,6 +6,7 @@
 #include <dgl/sampler.h>
 #include <dgl/immutable_graph.h>
 #include <dgl/runtime/container.h>
+#include <dgl/packed_func_ext.h>
 #include <dmlc/omp.h>
 #include <algorithm>
 #include <cstdlib>

--- a/src/graph/sampler.cc
+++ b/src/graph/sampler.cc
@@ -3,10 +3,9 @@
  * \file graph/sampler.cc
  * \brief DGL sampler implementation
  */
-
 #include <dgl/sampler.h>
-#include <dmlc/omp.h>
 #include <dgl/immutable_graph.h>
+#include <dgl/runtime/container.h>
 #include <dmlc/omp.h>
 #include <algorithm>
 #include <cstdlib>
@@ -14,11 +13,7 @@
 #include <numeric>
 #include "../c_api_common.h"
 
-using dgl::runtime::DGLArgs;
-using dgl::runtime::DGLArgValue;
-using dgl::runtime::DGLRetValue;
-using dgl::runtime::PackedFunc;
-using dgl::runtime::NDArray;
+using namespace dgl::runtime;
 
 namespace dgl {
 
@@ -246,17 +241,17 @@ NodeFlow ConstructNodeFlow(std::vector<dgl_id_t> neighbor_list,
                            std::vector<neighbor_info> *neigh_pos,
                            const std::string &edge_type,
                            int64_t num_edges, int num_hops, bool is_multigraph) {
-  NodeFlow nf;
+  NodeFlow nf = NodeFlow::Create();
   uint64_t num_vertices = sub_vers->size();
-  nf.node_mapping = aten::NewIdArray(num_vertices);
-  nf.edge_mapping = aten::NewIdArray(num_edges);
-  nf.layer_offsets = aten::NewIdArray(num_hops + 1);
-  nf.flow_offsets = aten::NewIdArray(num_hops);
+  nf->node_mapping = aten::NewIdArray(num_vertices);
+  nf->edge_mapping = aten::NewIdArray(num_edges);
+  nf->layer_offsets = aten::NewIdArray(num_hops + 1);
+  nf->flow_offsets = aten::NewIdArray(num_hops);
 
-  dgl_id_t *node_map_data = static_cast<dgl_id_t *>(nf.node_mapping->data);
-  dgl_id_t *layer_off_data = static_cast<dgl_id_t *>(nf.layer_offsets->data);
-  dgl_id_t *flow_off_data = static_cast<dgl_id_t *>(nf.flow_offsets->data);
-  dgl_id_t *edge_map_data = static_cast<dgl_id_t *>(nf.edge_mapping->data);
+  dgl_id_t *node_map_data = static_cast<dgl_id_t *>(nf->node_mapping->data);
+  dgl_id_t *layer_off_data = static_cast<dgl_id_t *>(nf->layer_offsets->data);
+  dgl_id_t *flow_off_data = static_cast<dgl_id_t *>(nf->flow_offsets->data);
+  dgl_id_t *edge_map_data = static_cast<dgl_id_t *>(nf->edge_mapping->data);
 
   // Construct sub_csr_graph
   // TODO(minjie): is nodeflow a multigraph?
@@ -364,9 +359,9 @@ NodeFlow ConstructNodeFlow(std::vector<dgl_id_t> neighbor_list,
   std::iota(eid_out, eid_out + num_edges, 0);
 
   if (edge_type == std::string("in")) {
-    nf.graph = GraphPtr(new ImmutableGraph(subg_csr, nullptr));
+    nf->graph = GraphPtr(new ImmutableGraph(subg_csr, nullptr));
   } else {
-    nf.graph = GraphPtr(new ImmutableGraph(nullptr, subg_csr));
+    nf->graph = GraphPtr(new ImmutableGraph(nullptr, subg_csr));
   }
 
   return nf;
@@ -491,45 +486,32 @@ NodeFlow SampleSubgraph(const ImmutableGraph *graph,
 
 DGL_REGISTER_GLOBAL("nodeflow._CAPI_NodeFlowGetGraph")
 .set_body([] (DGLArgs args, DGLRetValue* rv) {
-    void* ptr = args[0];
-    const NodeFlow* nflow = static_cast<NodeFlow*>(ptr);
-    GraphInterface* gptr = nflow->graph->Reset();
-    *rv = gptr;
+    NodeFlow nflow = args[0];
+    *rv = nflow->graph;
   });
 
 DGL_REGISTER_GLOBAL("nodeflow._CAPI_NodeFlowGetNodeMapping")
 .set_body([] (DGLArgs args, DGLRetValue* rv) {
-    void* ptr = args[0];
-    const NodeFlow* nflow = static_cast<NodeFlow*>(ptr);
+    NodeFlow nflow = args[0];
     *rv = nflow->node_mapping;
   });
 
 DGL_REGISTER_GLOBAL("nodeflow._CAPI_NodeFlowGetEdgeMapping")
 .set_body([] (DGLArgs args, DGLRetValue* rv) {
-    void* ptr = args[0];
-    const NodeFlow* nflow = static_cast<NodeFlow*>(ptr);
+    NodeFlow nflow = args[0];
     *rv = nflow->edge_mapping;
   });
 
 DGL_REGISTER_GLOBAL("nodeflow._CAPI_NodeFlowGetLayerOffsets")
 .set_body([] (DGLArgs args, DGLRetValue* rv) {
-    void* ptr = args[0];
-    const NodeFlow* nflow = static_cast<NodeFlow*>(ptr);
+    NodeFlow nflow = args[0];
     *rv = nflow->layer_offsets;
   });
 
 DGL_REGISTER_GLOBAL("nodeflow._CAPI_NodeFlowGetBlockOffsets")
 .set_body([] (DGLArgs args, DGLRetValue* rv) {
-    void* ptr = args[0];
-    const NodeFlow* nflow = static_cast<NodeFlow*>(ptr);
+    NodeFlow nflow = args[0];
     *rv = nflow->flow_offsets;
-  });
-
-DGL_REGISTER_GLOBAL("nodeflow._CAPI_NodeFlowFree")
-.set_body([] (DGLArgs args, DGLRetValue* rv) {
-    void* ptr = args[0];
-    NodeFlow* nflow = static_cast<NodeFlow*>(ptr);
-    delete nflow;
   });
 
 NodeFlow SamplerOp::NeighborUniformSample(const ImmutableGraph *graph,
@@ -702,21 +684,21 @@ NodeFlow SamplerOp::LayerUniformSample(const ImmutableGraph *graph,
   CHECK_EQ(sub_indptr.back(), sub_indices.size());
   CHECK_EQ(sub_indices.size(), sub_edge_ids.size());
 
-  NodeFlow nf;
+  NodeFlow nf = NodeFlow::Create();
   auto sub_csr = CSRPtr(new CSR(aten::VecToIdArray(sub_indptr),
                                 aten::VecToIdArray(sub_indices),
                                 aten::VecToIdArray(sub_edge_ids)));
 
   if (neighbor_type == std::string("in")) {
-    nf.graph = GraphPtr(new ImmutableGraph(sub_csr, nullptr));
+    nf->graph = GraphPtr(new ImmutableGraph(sub_csr, nullptr));
   } else {
-    nf.graph = GraphPtr(new ImmutableGraph(nullptr, sub_csr));
+    nf->graph = GraphPtr(new ImmutableGraph(nullptr, sub_csr));
   }
 
-  nf.node_mapping = aten::VecToIdArray(node_mapping);
-  nf.edge_mapping = aten::VecToIdArray(edge_mapping);
-  nf.layer_offsets = aten::VecToIdArray(layer_offsets);
-  nf.flow_offsets = aten::VecToIdArray(flow_offsets);
+  nf->node_mapping = aten::VecToIdArray(node_mapping);
+  nf->edge_mapping = aten::VecToIdArray(edge_mapping);
+  nf->layer_offsets = aten::VecToIdArray(layer_offsets);
+  nf->flow_offsets = aten::VecToIdArray(flow_offsets);
 
   return nf;
 }
@@ -736,7 +718,7 @@ void BuildCsr(const ImmutableGraph &g, const std::string neigh_type) {
 DGL_REGISTER_GLOBAL("sampling._CAPI_UniformSampling")
 .set_body([] (DGLArgs args, DGLRetValue* rv) {
     // arguments
-    const GraphHandle ghdl = args[0];
+    GraphRef g = args[0];
     const IdArray seed_nodes = args[1];
     const int64_t batch_start_id = args[2];
     const int64_t batch_size = args[3];
@@ -746,8 +728,7 @@ DGL_REGISTER_GLOBAL("sampling._CAPI_UniformSampling")
     const std::string neigh_type = args[7];
     const bool add_self_loop = args[8];
     // process args
-    const GraphInterface *ptr = static_cast<const GraphInterface *>(ghdl);
-    const ImmutableGraph *gptr = dynamic_cast<const ImmutableGraph*>(ptr);
+    auto gptr = std::dynamic_pointer_cast<ImmutableGraph>(g.sptr());
     CHECK(gptr) << "sampling isn't implemented in mutable graph";
     CHECK(IsValidIdArray(seed_nodes));
     const dgl_id_t* seed_nodes_data = static_cast<dgl_id_t*>(seed_nodes->data);
@@ -757,7 +738,7 @@ DGL_REGISTER_GLOBAL("sampling._CAPI_UniformSampling")
     // We need to make sure we have the right CSR before we enter parallel sampling.
     BuildCsr(*gptr, neigh_type);
     // generate node flows
-    std::vector<NodeFlow*> nflows(num_workers);
+    std::vector<NodeFlow> nflows(num_workers);
 #pragma omp parallel for
     for (int i = 0; i < num_workers; i++) {
       // create per-worker seed nodes.
@@ -767,17 +748,16 @@ DGL_REGISTER_GLOBAL("sampling._CAPI_UniformSampling")
       std::vector<dgl_id_t> worker_seeds(end - start);
       std::copy(seed_nodes_data + start, seed_nodes_data + end,
                 worker_seeds.begin());
-      nflows[i] = new NodeFlow();
-      *nflows[i] = SamplerOp::NeighborUniformSample(
-          gptr, worker_seeds, neigh_type, num_hops, expand_factor, add_self_loop);
+      nflows[i] = SamplerOp::NeighborUniformSample(
+          gptr.get(), worker_seeds, neigh_type, num_hops, expand_factor, add_self_loop);
     }
-    *rv = WrapVectorReturn(nflows);
+    *rv = List<NodeFlow>(nflows);
   });
 
 DGL_REGISTER_GLOBAL("sampling._CAPI_LayerSampling")
 .set_body([] (DGLArgs args, DGLRetValue* rv) {
     // arguments
-    const GraphHandle ghdl = args[0];
+    GraphRef g = args[0];
     const IdArray seed_nodes = args[1];
     const int64_t batch_start_id = args[2];
     const int64_t batch_size = args[3];
@@ -785,8 +765,7 @@ DGL_REGISTER_GLOBAL("sampling._CAPI_LayerSampling")
     const IdArray layer_sizes = args[5];
     const std::string neigh_type = args[6];
     // process args
-    const GraphInterface *ptr = static_cast<const GraphInterface *>(ghdl);
-    const ImmutableGraph *gptr = dynamic_cast<const ImmutableGraph*>(ptr);
+    auto gptr = std::dynamic_pointer_cast<ImmutableGraph>(g.sptr());
     CHECK(gptr) << "sampling isn't implemented in mutable graph";
     CHECK(IsValidIdArray(seed_nodes));
     const dgl_id_t* seed_nodes_data = static_cast<dgl_id_t*>(seed_nodes->data);
@@ -796,7 +775,7 @@ DGL_REGISTER_GLOBAL("sampling._CAPI_LayerSampling")
     // We need to make sure we have the right CSR before we enter parallel sampling.
     BuildCsr(*gptr, neigh_type);
     // generate node flows
-    std::vector<NodeFlow*> nflows(num_workers);
+    std::vector<NodeFlow> nflows(num_workers);
 #pragma omp parallel for
     for (int i = 0; i < num_workers; i++) {
       // create per-worker seed nodes.
@@ -806,11 +785,10 @@ DGL_REGISTER_GLOBAL("sampling._CAPI_LayerSampling")
       std::vector<dgl_id_t> worker_seeds(end - start);
       std::copy(seed_nodes_data + start, seed_nodes_data + end,
                 worker_seeds.begin());
-      nflows[i] = new NodeFlow();
-      *nflows[i] = SamplerOp::LayerUniformSample(
-          gptr, worker_seeds, neigh_type, layer_sizes);
+      nflows[i] = SamplerOp::LayerUniformSample(
+          gptr.get(), worker_seeds, neigh_type, layer_sizes);
     }
-    *rv = WrapVectorReturn(nflows);
+    *rv = List<NodeFlow>(nflows);
   });
 
 }  // namespace dgl

--- a/src/graph/traversal.cc
+++ b/src/graph/traversal.cc
@@ -3,16 +3,13 @@
  * \file graph/traversal.cc
  * \brief Graph traversal implementation
  */
+#include <dgl/packed_func_ext.h>
 #include <algorithm>
 #include <queue>
 #include "./traversal.h"
 #include "../c_api_common.h"
 
-using dgl::runtime::DGLArgs;
-using dgl::runtime::DGLArgValue;
-using dgl::runtime::DGLRetValue;
-using dgl::runtime::PackedFunc;
-using dgl::runtime::NDArray;
+using namespace dgl::runtime;
 
 namespace dgl {
 namespace traverse {
@@ -115,7 +112,7 @@ struct Frontiers {
   std::vector<int64_t> sections;
 };
 
-Frontiers BFSNodesFrontiers(const Graph& graph, IdArray source, bool reversed) {
+Frontiers BFSNodesFrontiers(const GraphInterface& graph, IdArray source, bool reversed) {
   Frontiers front;
   VectorQueueWrapper<dgl_id_t> queue(&front.ids);
   auto visit = [&] (const dgl_id_t v) { };
@@ -131,17 +128,16 @@ Frontiers BFSNodesFrontiers(const Graph& graph, IdArray source, bool reversed) {
 
 DGL_REGISTER_GLOBAL("traversal._CAPI_DGLBFSNodes")
 .set_body([] (DGLArgs args, DGLRetValue* rv) {
-    GraphHandle ghandle = args[0];
-    const Graph* gptr = static_cast<Graph*>(ghandle);
+    GraphRef g = args[0];
     const IdArray src = args[1];
     bool reversed = args[2];
-    const auto& front = BFSNodesFrontiers(*gptr, src, reversed);
+    const auto& front = BFSNodesFrontiers(*(g.sptr()), src, reversed);
     IdArray node_ids = CopyVectorToNDArray(front.ids);
     IdArray sections = CopyVectorToNDArray(front.sections);
     *rv = ConvertNDArrayVectorToPackedFunc({node_ids, sections});
   });
 
-Frontiers BFSEdgesFrontiers(const Graph& graph, IdArray source, bool reversed) {
+Frontiers BFSEdgesFrontiers(const GraphInterface& graph, IdArray source, bool reversed) {
   Frontiers front;
   // NOTE: std::queue has no top() method.
   std::vector<dgl_id_t> nodes;
@@ -162,17 +158,16 @@ Frontiers BFSEdgesFrontiers(const Graph& graph, IdArray source, bool reversed) {
 
 DGL_REGISTER_GLOBAL("traversal._CAPI_DGLBFSEdges")
 .set_body([] (DGLArgs args, DGLRetValue* rv) {
-    GraphHandle ghandle = args[0];
-    const Graph* gptr = static_cast<Graph*>(ghandle);
+    GraphRef g = args[0];
     const IdArray src = args[1];
     bool reversed = args[2];
-    const auto& front = BFSEdgesFrontiers(*gptr, src, reversed);
+    const auto& front = BFSEdgesFrontiers(*(g.sptr()), src, reversed);
     IdArray edge_ids = CopyVectorToNDArray(front.ids);
     IdArray sections = CopyVectorToNDArray(front.sections);
     *rv = ConvertNDArrayVectorToPackedFunc({edge_ids, sections});
   });
 
-Frontiers TopologicalNodesFrontiers(const Graph& graph, bool reversed) {
+Frontiers TopologicalNodesFrontiers(const GraphInterface& graph, bool reversed) {
   Frontiers front;
   VectorQueueWrapper<dgl_id_t> queue(&front.ids);
   auto visit = [&] (const dgl_id_t v) { };
@@ -188,10 +183,9 @@ Frontiers TopologicalNodesFrontiers(const Graph& graph, bool reversed) {
 
 DGL_REGISTER_GLOBAL("traversal._CAPI_DGLTopologicalNodes")
 .set_body([] (DGLArgs args, DGLRetValue* rv) {
-    GraphHandle ghandle = args[0];
-    const Graph* gptr = static_cast<Graph*>(ghandle);
+    GraphRef g = args[0];
     bool reversed = args[1];
-    const auto& front = TopologicalNodesFrontiers(*gptr, reversed);
+    const auto& front = TopologicalNodesFrontiers(*g.sptr(), reversed);
     IdArray node_ids = CopyVectorToNDArray(front.ids);
     IdArray sections = CopyVectorToNDArray(front.sections);
     *rv = ConvertNDArrayVectorToPackedFunc({node_ids, sections});
@@ -200,8 +194,7 @@ DGL_REGISTER_GLOBAL("traversal._CAPI_DGLTopologicalNodes")
 
 DGL_REGISTER_GLOBAL("traversal._CAPI_DGLDFSEdges")
 .set_body([] (DGLArgs args, DGLRetValue* rv) {
-    GraphHandle ghandle = args[0];
-    const Graph* gptr = static_cast<Graph*>(ghandle);
+    GraphRef g = args[0];
     const IdArray source = args[1];
     const bool reversed = args[2];
     CHECK(IsValidIdArray(source)) << "Invalid source node id array.";
@@ -210,7 +203,7 @@ DGL_REGISTER_GLOBAL("traversal._CAPI_DGLDFSEdges")
     std::vector<std::vector<dgl_id_t>> edges(len);
     for (int64_t i = 0; i < len; ++i) {
       auto visit = [&] (dgl_id_t e, int tag) { edges[i].push_back(e); };
-      DFSLabeledEdges(*gptr, src_data[i], reversed, false, false, visit);
+      DFSLabeledEdges(*g.sptr(), src_data[i], reversed, false, false, visit);
     }
     IdArray ids = MergeMultipleTraversals(edges);
     IdArray sections = ComputeMergedSections(edges);
@@ -219,8 +212,7 @@ DGL_REGISTER_GLOBAL("traversal._CAPI_DGLDFSEdges")
 
 DGL_REGISTER_GLOBAL("traversal._CAPI_DGLDFSLabeledEdges")
 .set_body([] (DGLArgs args, DGLRetValue* rv) {
-    GraphHandle ghandle = args[0];
-    const Graph* gptr = static_cast<Graph*>(ghandle);
+    GraphRef g = args[0];
     const IdArray source = args[1];
     const bool reversed = args[2];
     const bool has_reverse_edge = args[3];
@@ -243,7 +235,7 @@ DGL_REGISTER_GLOBAL("traversal._CAPI_DGLDFSLabeledEdges")
           tags[i].push_back(tag);
         }
       };
-      DFSLabeledEdges(*gptr, src_data[i], reversed,
+      DFSLabeledEdges(*g.sptr(), src_data[i], reversed,
           has_reverse_edge, has_nontree_edge, visit);
     }
 

--- a/src/graph/traversal.h
+++ b/src/graph/traversal.h
@@ -11,7 +11,7 @@
 #ifndef DGL_GRAPH_TRAVERSAL_H_
 #define DGL_GRAPH_TRAVERSAL_H_
 
-#include <dgl/graph.h>
+#include <dgl/graph_interface.h>
 #include <stack>
 #include <tuple>
 #include <vector>
@@ -45,7 +45,7 @@ namespace traverse {
  * \param make_frontier The function to indicate that a new froniter can be made;
  */
 template<typename Queue, typename VisitFn, typename FrontierFn>
-void BFSNodes(const Graph& graph,
+void BFSNodes(const GraphInterface& graph,
               IdArray source,
               bool reversed,
               Queue* queue,
@@ -63,7 +63,7 @@ void BFSNodes(const Graph& graph,
   }
   make_frontier();
 
-  const auto neighbor_iter = reversed? &Graph::PredVec : &Graph::SuccVec;
+  const auto neighbor_iter = reversed? &GraphInterface::PredVec : &GraphInterface::SuccVec;
   while (!queue->empty()) {
     const size_t size = queue->size();
     for (size_t i = 0; i < size; ++i) {
@@ -109,7 +109,7 @@ void BFSNodes(const Graph& graph,
  * \param make_frontier The function to indicate that a new frontier can be made;
  */
 template<typename Queue, typename VisitFn, typename FrontierFn>
-void BFSEdges(const Graph& graph,
+void BFSEdges(const GraphInterface& graph,
               IdArray source,
               bool reversed,
               Queue* queue,
@@ -126,7 +126,7 @@ void BFSEdges(const Graph& graph,
   }
   make_frontier();
 
-  const auto neighbor_iter = reversed? &Graph::InEdgeVec : &Graph::OutEdgeVec;
+  const auto neighbor_iter = reversed? &GraphInterface::InEdgeVec : &GraphInterface::OutEdgeVec;
   while (!queue->empty()) {
     const size_t size = queue->size();
     for (size_t i = 0; i < size; ++i) {
@@ -171,13 +171,13 @@ void BFSEdges(const Graph& graph,
  * \param make_frontier The function to indicate that a new froniter can be made;
  */
 template<typename Queue, typename VisitFn, typename FrontierFn>
-void TopologicalNodes(const Graph& graph,
+void TopologicalNodes(const GraphInterface& graph,
                       bool reversed,
                       Queue* queue,
                       VisitFn visit,
                       FrontierFn make_frontier) {
-  const auto get_degree = reversed? &Graph::OutDegree : &Graph::InDegree;
-  const auto neighbor_iter = reversed? &Graph::PredVec : &Graph::SuccVec;
+  const auto get_degree = reversed? &GraphInterface::OutDegree : &GraphInterface::InDegree;
+  const auto neighbor_iter = reversed? &GraphInterface::PredVec : &GraphInterface::SuccVec;
   uint64_t num_visited_nodes = 0;
   std::vector<uint64_t> degrees(graph.NumVertices(), 0);
   for (dgl_id_t vid = 0; vid < graph.NumVertices(); ++vid) {
@@ -237,14 +237,14 @@ enum DFSEdgeTag {
  *              tag will be given as the arguments.
  */
 template<typename VisitFn>
-void DFSLabeledEdges(const Graph& graph,
+void DFSLabeledEdges(const GraphInterface& graph,
                      dgl_id_t source,
                      bool reversed,
                      bool has_reverse_edge,
                      bool has_nontree_edge,
                      VisitFn visit) {
-  const auto succ = reversed? &Graph::PredVec : &Graph::SuccVec;
-  const auto out_edge = reversed? &Graph::InEdgeVec : &Graph::OutEdgeVec;
+  const auto succ = reversed? &GraphInterface::PredVec : &GraphInterface::SuccVec;
+  const auto out_edge = reversed? &GraphInterface::InEdgeVec : &GraphInterface::OutEdgeVec;
 
   if ((graph.*succ)(source).size() == 0) {
     // no out-going edges from the source node

--- a/src/kernel/binary_reduce.cc
+++ b/src/kernel/binary_reduce.cc
@@ -3,17 +3,14 @@
  * \file kernel/binary_reduce.cc
  * \brief Binary reduce C APIs and definitions.
  */
+#include <dgl/packed_func_ext.h>
 #include "./binary_reduce.h"
 #include "./common.h"
 #include "./binary_reduce_impl_decl.h"
 #include "./utils.h"
 #include "../c_api_common.h"
 
-using dgl::runtime::DGLArgs;
-using dgl::runtime::DGLArgValue;
-using dgl::runtime::DGLRetValue;
-using dgl::runtime::PackedFunc;
-using dgl::runtime::NDArray;
+using namespace dgl::runtime;
 
 namespace dgl {
 namespace kernel {
@@ -273,7 +270,7 @@ DGL_REGISTER_GLOBAL("kernel._CAPI_DGLKernelBinaryOpReduce")
 .set_body([] (DGLArgs args, DGLRetValue* rv) {
     std::string reducer = args[0];
     std::string op = args[1];
-    GraphHandle ghdl = args[2];
+    GraphRef g = args[2];
     int lhs = args[3];
     int rhs = args[4];
     NDArray lhs_data = args[5];
@@ -283,10 +280,9 @@ DGL_REGISTER_GLOBAL("kernel._CAPI_DGLKernelBinaryOpReduce")
     NDArray rhs_mapping = args[9];
     NDArray out_mapping = args[10];
 
-    GraphInterface* gptr = static_cast<GraphInterface*>(ghdl);
-    const ImmutableGraph* igptr = dynamic_cast<ImmutableGraph*>(gptr);
+    auto igptr = std::dynamic_pointer_cast<ImmutableGraph>(g.sptr());
     CHECK(igptr) << "Invalid graph object argument. Must be an immutable graph.";
-    BinaryOpReduce(reducer, op, igptr,
+    BinaryOpReduce(reducer, op, igptr.get(),
         static_cast<binary_op::Target>(lhs), static_cast<binary_op::Target>(rhs),
         lhs_data, rhs_data, out_data,
         lhs_mapping, rhs_mapping, out_mapping);
@@ -346,7 +342,7 @@ DGL_REGISTER_GLOBAL("kernel._CAPI_DGLKernelBackwardLhsBinaryOpReduce")
 .set_body([] (DGLArgs args, DGLRetValue* rv) {
     std::string reducer = args[0];
     std::string op = args[1];
-    GraphHandle ghdl = args[2];
+    GraphRef g = args[2];
     int lhs = args[3];
     int rhs = args[4];
     NDArray lhs_mapping = args[5];
@@ -358,11 +354,10 @@ DGL_REGISTER_GLOBAL("kernel._CAPI_DGLKernelBackwardLhsBinaryOpReduce")
     NDArray grad_out_data = args[11];
     NDArray grad_lhs_data = args[12];
 
-    GraphInterface* gptr = static_cast<GraphInterface*>(ghdl);
-    const ImmutableGraph* igptr = dynamic_cast<ImmutableGraph*>(gptr);
+    auto igptr = std::dynamic_pointer_cast<ImmutableGraph>(g.sptr());
     CHECK(igptr) << "Invalid graph object argument. Must be an immutable graph.";
     BackwardLhsBinaryOpReduce(
-        reducer, op, igptr,
+        reducer, op, igptr.get(),
         static_cast<binary_op::Target>(lhs), static_cast<binary_op::Target>(rhs),
         lhs_mapping, rhs_mapping, out_mapping,
         lhs_data, rhs_data, out_data, grad_out_data,
@@ -422,7 +417,7 @@ DGL_REGISTER_GLOBAL("kernel._CAPI_DGLKernelBackwardRhsBinaryOpReduce")
 .set_body([] (DGLArgs args, DGLRetValue* rv) {
     std::string reducer = args[0];
     std::string op = args[1];
-    GraphHandle ghdl = args[2];
+    GraphRef g = args[2];
     int lhs = args[3];
     int rhs = args[4];
     NDArray lhs_mapping = args[5];
@@ -434,11 +429,10 @@ DGL_REGISTER_GLOBAL("kernel._CAPI_DGLKernelBackwardRhsBinaryOpReduce")
     NDArray grad_out_data = args[11];
     NDArray grad_rhs_data = args[12];
 
-    GraphInterface* gptr = static_cast<GraphInterface*>(ghdl);
-    const ImmutableGraph* igptr = dynamic_cast<ImmutableGraph*>(gptr);
+    auto igptr = std::dynamic_pointer_cast<ImmutableGraph>(g.sptr());
     CHECK(igptr) << "Invalid graph object argument. Must be an immutable graph.";
     BackwardRhsBinaryOpReduce(
-        reducer, op, igptr,
+        reducer, op, igptr.get(),
         static_cast<binary_op::Target>(lhs), static_cast<binary_op::Target>(rhs),
         lhs_mapping, rhs_mapping, out_mapping,
         lhs_data, rhs_data, out_data, grad_out_data,
@@ -469,17 +463,16 @@ void CopyReduce(
 DGL_REGISTER_GLOBAL("kernel._CAPI_DGLKernelCopyReduce")
 .set_body([] (DGLArgs args, DGLRetValue* rv) {
     std::string reducer = args[0];
-    GraphHandle ghdl = args[1];
+    GraphRef g = args[1];
     int target = args[2];
     NDArray in_data = args[3];
     NDArray out_data = args[4];
     NDArray in_mapping = args[5];
     NDArray out_mapping = args[6];
 
-    GraphInterface* gptr = static_cast<GraphInterface*>(ghdl);
-    const ImmutableGraph* igptr = dynamic_cast<ImmutableGraph*>(gptr);
+    auto igptr = std::dynamic_pointer_cast<ImmutableGraph>(g.sptr());
     CHECK(igptr) << "Invalid graph object argument. Must be an immutable graph.";
-    CopyReduce(reducer, igptr,
+    CopyReduce(reducer, igptr.get(),
         static_cast<binary_op::Target>(target),
         in_data, out_data,
         in_mapping, out_mapping);
@@ -518,7 +511,7 @@ void BackwardCopyReduce(
 DGL_REGISTER_GLOBAL("kernel._CAPI_DGLKernelBackwardCopyReduce")
 .set_body([] (DGLArgs args, DGLRetValue* rv) {
     std::string reducer = args[0];
-    GraphHandle ghdl = args[1];
+    GraphRef g = args[1];
     int target = args[2];
     NDArray in_data = args[3];
     NDArray out_data = args[4];
@@ -527,11 +520,10 @@ DGL_REGISTER_GLOBAL("kernel._CAPI_DGLKernelBackwardCopyReduce")
     NDArray in_mapping = args[7];
     NDArray out_mapping = args[8];
 
-    GraphInterface* gptr = static_cast<GraphInterface*>(ghdl);
-    const ImmutableGraph* igptr = dynamic_cast<ImmutableGraph*>(gptr);
+    auto igptr = std::dynamic_pointer_cast<ImmutableGraph>(g.sptr());
     CHECK(igptr) << "Invalid graph object argument. Must be an immutable graph.";
     BackwardCopyReduce(
-        reducer, igptr, static_cast<binary_op::Target>(target),
+        reducer, igptr.get(), static_cast<binary_op::Target>(target),
         in_mapping, out_mapping,
         in_data, out_data, grad_out_data,
         grad_in_data);


### PR DESCRIPTION
## Description
The PR refactors our CAPIs to use the new object FFI solution introduced in https://github.com/dmlc/dgl/pull/693 . The principle is following:

* Use shared pointer everywhere in C++. For example, `GraphPtr` is of type `shared_ptr<GraphInterface>`. All the graph operators should accept `GraphPtr` type arguments and return `GraphPtr` type results.
* When returning a graph to python. You could either directly return `GraphPtr` or use `GraphRef` to wrap it and return. They are the same.
* When returning a collection of graphs to python. use `dgl::runtime::List<GraphRef>`.
* On python side, the `dgl.graph_index.GraphIndex` object has been registered as the wrapper class for graph type values. Therefore, you could directly use `dgl.graph_index.GraphIndex` object as the CAPI argument and return type. No internal C handle is exposed.

The new FFI greatly simplifies the CAPI logics (**no more hack of vector type return**). Note that `Nodeflow` now also uses object FFI, and I suggest we change BatchedGraph and Subgraph as well in the future.

Other subtlety:
* Move `GraphInterface::EdgeArray` out of class scope so it can be used by other subclasses.
* Move `GraphInterface::Reverse` out of graph interface as a functional API in GraphOp.
* `LazyObject` -> `Lazy` to avoid naming confusion.
* Merge the two implementation of `GraphOp::DisjointUnion` for mutable and immutable graph into one. It now accepts `vector<GraphPtr>` and returns `GraphPtr`. I think this is cleaner. @yzh119
* Suggest @aksnzhy to take a look at this new practice. I think your `CommunicatorHandler` can also be refactored into `Object`. I didn't touch that part though.
* @VoVAllen Please aware of this change as you might be working on similar stuff.

## Checklist
Please feel free to remove inapplicable items for your PR.
- [x] The PR title starts with [$CATEGORY] (such as [Model], [Doc], [Feature]])
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage
- [x] Code is well-documented
- [x] To the my best knowledge, examples are either not affected by this change,
      or have been fixed to be compatible with this change
- [x] Related issue is referred in this PR