### PR TITLE
[Hetero] Heterograph C++ implementation; Bipartite and Python wrapper

### DIFF
--- a/include/dgl/base_heterograph.h
+++ b/include/dgl/base_heterograph.h
@@ -355,7 +355,7 @@ class BaseHeteroGraph : public runtime::Object {
    * \return a vector of IdArrays.
    */
   virtual std::vector<IdArray> GetAdj(
-      dgl_id_t etype, bool transpose, const std::string &fmt) const = 0;
+      dgl_type_t etype, bool transpose, const std::string &fmt) const = 0;
 
   /*!
    * \brief Extract the induced subgraph by the given vertices.

--- a/include/dgl/base_heterograph.h
+++ b/include/dgl/base_heterograph.h
@@ -436,6 +436,21 @@ struct HeteroSubgraph : public runtime::Object {
   DGL_DECLARE_OBJECT_TYPE_INFO(HeteroSubgraph, runtime::Object);
 };
 
+// creators
+
+/*! \brief Create a bipartite graph from COO arrays */
+HeteroGraphPtr CreateBipartiteFromCOO(
+    int64_t num_src, int64_t num_dst, IdArray row, IdArray col);
+
+/*! \brief Create a bipartite graph from (out) CSR arrays */
+HeteroGraphPtr CreateBipartiteFromCSR(
+    int64_t num_src, int64_t num_dst,
+    IdArray indptr, IdArray indices, IdArray edge_ids);
+
+/*! \brief Create a heterograph from meta graph and a list of bipartite graph */
+HeteroGraphPtr CreateHeteroGraph(
+    GraphPtr meta_graph, const std::vector<HeteroGraphPtr>& rel_graphs);
+
 };  // namespace dgl
 
 #endif  // DGL_HETEROGRAPH_INTERFACE_H_

--- a/include/dgl/base_heterograph.h
+++ b/include/dgl/base_heterograph.h
@@ -39,6 +39,8 @@ struct HeteroSubgraph;
  */
 class BaseHeteroGraph : public runtime::Object {
  public:
+  BaseHeteroGraph(GraphPtr meta_graph): meta_graph_(meta_graph) {}
+
   virtual ~BaseHeteroGraph() = default;
 
   ////////////////////////// query/operations on meta graph ////////////////////////

--- a/include/dgl/base_heterograph.h
+++ b/include/dgl/base_heterograph.h
@@ -436,6 +436,29 @@ struct HeteroSubgraph : public runtime::Object {
   DGL_DECLARE_OBJECT_TYPE_INFO(HeteroSubgraph, runtime::Object);
 };
 
+/*! \brief Heter-subgraph reference class */
+class HeteroSubgraphRef : public runtime::ObjectRef {
+ public:
+  /*! \brief empty reference */
+  HeteroSubgraphRef() {}
+  explicit HeteroSubgraphRef(std::shared_ptr<runtime::Object> obj): runtime::ObjectRef(obj) {}
+
+  const HeteroSubgraph* operator->() const {
+    return static_cast<const HeteroSubgraph*>(obj_.get());
+  }
+
+  HeteroSubgraph* operator->() {
+    return static_cast<HeteroSubgraph*>(obj_.get());
+  }
+
+  /*! \brief get shared pointer */
+  std::shared_ptr<HeteroSubgraph> sptr() const {
+    return CHECK_NOTNULL(std::dynamic_pointer_cast<HeteroSubgraph>(obj_));
+  }
+
+  using ContainerType = HeteroSubgraph;
+};
+
 // creators
 
 /*! \brief Create a bipartite graph from COO arrays */

--- a/include/dgl/base_heterograph.h
+++ b/include/dgl/base_heterograph.h
@@ -4,8 +4,8 @@
  * \brief DGL heterogeneous graph index class.
  */
 
-#ifndef DGL_HETEROGRAPH_INTERFACE_H_
-#define DGL_HETEROGRAPH_INTERFACE_H_
+#ifndef DGL_BASE_HETEROGRAPH_H_
+#define DGL_BASE_HETEROGRAPH_H_
 
 #include <string>
 #include <vector>
@@ -39,7 +39,7 @@ struct HeteroSubgraph;
  */
 class BaseHeteroGraph : public runtime::Object {
  public:
-  BaseHeteroGraph(GraphPtr meta_graph): meta_graph_(meta_graph) {}
+  explicit BaseHeteroGraph(GraphPtr meta_graph): meta_graph_(meta_graph) {}
 
   virtual ~BaseHeteroGraph() = default;
 
@@ -401,4 +401,4 @@ HeteroGraphPtr CreateHeteroGraph(
 
 };  // namespace dgl
 
-#endif  // DGL_HETEROGRAPH_INTERFACE_H_
+#endif  // DGL_BASE_HETEROGRAPH_H_

--- a/include/dgl/bipartite.h
+++ b/include/dgl/bipartite.h
@@ -1,0 +1,159 @@
+/*!
+ *  Copyright (c) 2019 by Contributors
+ * \file dgl/bipartite.h
+ * \brief Bipartite graph
+ */
+
+#ifndef DGL_BIPARTITE_H_
+#define DGL_BIPARTITE_H_
+
+#include <memory>
+#include "graph_interface.h"
+#include "base_heterograph.h"
+
+namespace dgl {
+
+/*!
+ * \brief Bipartite graph
+ *
+ * Bipartite graph is a special type of heterograph which has two types
+ * of nodes: "Src" and "Dst". All the edges are from "Src" type nodes to
+ * "Dst" type nodes, so there is no edge among nodes of the same type.
+ */
+class Bipartite : public BaseHeteroGraph {
+ public:
+  /*! \brief source node group type */
+  static constexpr dgl_type_t kSrcVType = 0;
+  /*! \brief destination node group type */
+  static constexpr dgl_type_t kDstVType = 1;
+  /*! \brief edge group type */
+  static constexpr dgl_type_t kEType = 0;
+
+  uint64_t NumVertexTypes() const override {
+    return 2;
+  }
+
+  uint64_t NumEdgeTypes() const override {
+    return 1;
+  }
+
+  HeteroGraphPtr GetRelationGraph(dgl_type_t etype) const override {
+    LOG(FATAL) << "The method shouldn't be called for Bipartite graph. "
+      << "The relation graph is simply this graph itself.";
+    return {};
+  }
+
+  void AddVertices(dgl_type_t vtype, uint64_t num_vertices) override {
+    LOG(FATAL) << "Bipartite graph is not mutable.";
+  }
+
+  void AddEdge(dgl_type_t etype, dgl_id_t src, dgl_id_t dst) override {
+    LOG(FATAL) << "Bipartite graph is not mutable.";
+  }
+
+  void AddEdges(dgl_type_t etype, IdArray src_ids, IdArray dst_ids) override {
+    LOG(FATAL) << "Bipartite graph is not mutable.";
+  }
+
+  void Clear() override {
+    LOG(FATAL) << "Bipartite graph is not mutable.";
+  }
+
+  DLContext Context() const override;
+
+  uint8_t NumBits() const override;
+
+  bool IsMultigraph() const override;
+
+  bool IsReadonly() const override {
+    return true;
+  }
+
+  uint64_t NumVertices(dgl_type_t vtype) const override;
+
+  uint64_t NumEdges(dgl_type_t etype) const override;
+
+  bool HasVertex(dgl_type_t vtype, dgl_id_t vid) const override;
+
+  bool HasEdgeBetween(dgl_type_t etype, dgl_id_t src, dgl_id_t dst) const override;
+
+  IdArray Predecessors(dgl_type_t etype, dgl_id_t dst) const override;
+
+  IdArray Successors(dgl_type_t etype, dgl_id_t src) const override;
+
+  IdArray EdgeId(dgl_type_t etype, dgl_id_t src, dgl_id_t dst) const override;
+
+  EdgeArray EdgeIds(dgl_type_t etype, IdArray src, IdArray dst) const override;
+
+  std::pair<dgl_id_t, dgl_id_t> FindEdge(dgl_type_t etype, dgl_id_t eid) const override;
+
+  EdgeArray FindEdges(dgl_type_t etype, IdArray eids) const override;
+
+  EdgeArray InEdges(dgl_type_t etype, dgl_id_t vid) const override;
+
+  EdgeArray InEdges(dgl_type_t etype, IdArray vids) const override;
+
+  EdgeArray OutEdges(dgl_type_t etype, dgl_id_t vid) const override;
+
+  EdgeArray OutEdges(dgl_type_t etype, IdArray vids) const override;
+
+  EdgeArray Edges(dgl_type_t etype, const std::string &order = "") const override;
+
+  uint64_t InDegree(dgl_type_t etype, dgl_id_t vid) const override;
+
+  DegreeArray InDegrees(dgl_type_t etype, IdArray vids) const override;
+
+  uint64_t OutDegree(dgl_type_t etype, dgl_id_t vid) const override;
+
+  DegreeArray OutDegrees(dgl_type_t etype, IdArray vids) const override;
+
+  DGLIdIters SuccVec(dgl_type_t etype, dgl_id_t vid) const override;
+
+  DGLIdIters OutEdgeVec(dgl_type_t etype, dgl_id_t vid) const override;
+
+  DGLIdIters PredVec(dgl_type_t etype, dgl_id_t vid) const override;
+
+  DGLIdIters InEdgeVec(dgl_type_t etype, dgl_id_t vid) const override;
+
+  std::vector<IdArray> GetAdj(
+      dgl_id_t etype, bool transpose, const std::string &fmt) const override;
+
+  HeteroSubgraph VertexSubgraph(const std::vector<IdArray>& vids) const override;
+
+  HeteroSubgraph EdgeSubgraph(
+      const std::vector<IdArray>& eids, bool preserve_nodes = false) const override;
+
+ private:
+  // internal data structure
+  class COO;
+  class CSR;
+  typedef std::shared_ptr<COO> COOPtr;
+  typedef std::shared_ptr<CSR> CSRPtr;
+
+  Bipartite(CSRPtr in_csr, CSRPtr out_csr, COOPtr coo);
+
+  /*! \return Return the in-edge CSR format. Create from other format if not exist. */
+  CSRPtr GetInCSR() const;
+
+  /*! \return Return the out-edge CSR format. Create from other format if not exist. */
+  CSRPtr GetOutCSR() const;
+
+  /*! \return Return the COO format. Create from other format if not exist. */
+  COOPtr GetCOO() const;
+
+  /*! \return Return any existing format. */
+  HeteroGraphPtr GetAny() const;
+
+  // Graph stored in different format. We use an on-demand strategy: the format is
+  // only materialized if the operation that suitable for it is invoked.
+  /*! \brief CSR graph that stores reverse edges */
+  CSRPtr in_csr_;
+  /*! \brief CSR representation */
+  CSRPtr out_csr_;
+  /*! \brief COO representation */
+  COOPtr coo_;
+};
+
+};  // namespace dgl
+
+#endif  // DGL_BIPARTITE_H_

--- a/python/dgl/_ffi/_ctypes/types.py
+++ b/python/dgl/_ffi/_ctypes/types.py
@@ -63,7 +63,8 @@ RETURN_SWITCH = {
     TypeCode.HANDLE: _return_handle,
     TypeCode.NULL: lambda x: None,
     TypeCode.STR: lambda x: py_str(x.v_str),
-    TypeCode.BYTES: _return_bytes
+    TypeCode.BYTES: _return_bytes,
+    TypeCode.DGL_CONTEXT: lambda x: DGLContext(x.v_ctx.device_type, x.v_ctx.device_id),
 }
 
 C_TO_PY_ARG_SWITCH = {
@@ -72,5 +73,6 @@ C_TO_PY_ARG_SWITCH = {
     TypeCode.HANDLE: _return_handle,
     TypeCode.NULL: lambda x: None,
     TypeCode.STR: lambda x: py_str(x.v_str),
-    TypeCode.BYTES: _return_bytes
+    TypeCode.BYTES: _return_bytes,
+    TypeCode.DGL_CONTEXT: lambda x: DGLContext(x.v_ctx.device_type, x.v_ctx.device_id),
 }

--- a/python/dgl/container.py
+++ b/python/dgl/container.py
@@ -69,3 +69,11 @@ class StrMap(Map):
         """Get the items from the map"""
         akvs = _api_internal._MapItems(self)
         return [(akvs[i].value, akvs[i+1]) for i in range(0, len(akvs), 2)]
+
+@register_object
+class Value(ObjectBase):
+    """Object wrapper for various values."""
+    @property
+    def data(self):
+        """Return the value data."""
+        return _api_internal._ValueGet(self)

--- a/python/dgl/graph_index.py
+++ b/python/dgl/graph_index.py
@@ -1270,6 +1270,14 @@ class HeteroGraphIndex(ObjectBase):
         """
         return _CAPI_DGLHeteroGetMetaGraph(self)
 
+    def number_of_ntypes(self):
+        """Return number of node types."""
+        return meta_graph.number_of_nodes()
+
+    def number_of_etypes(self):
+        """Return number of edge types."""
+        return meta_graph.number_of_edges()
+
     def get_relation_graph(self, etype):
         """Get the bipartite graph of the given edge/relation type.
 
@@ -1359,5 +1367,533 @@ class HeteroGraphIndex(ObjectBase):
             True if it is a multigraph, False otherwise.
         """
         return bool(_CAPI_DGLHeteroIsMultigraph(self))
+
+    def is_readonly(self):
+        """Return whether the graph index is read-only.
+
+        Returns
+        -------
+        bool
+            True if it is a read-only graph, False otherwise.
+        """
+        return bool(_CAPI_DGLHeteroIsReadonly(self))
+
+    def number_of_nodes(self, ntype):
+        """Return the number of nodes.
+
+        Parameters
+        ----------
+        ntype : int
+            Node type
+
+        Returns
+        -------
+        int
+            The number of nodes
+        """
+        return _CAPI_DGLHeteroNumVertices(self, int(ntype))
+
+    def number_of_edges(self, etype):
+        """Return the number of edges.
+
+        Parameters
+        ----------
+        etype : int
+            Edge type
+
+        Returns
+        -------
+        int
+            The number of edges
+        """
+        return _CAPI_DGLHeteroNumEdges(self, int(etype))
+
+    def has_node(self, ntype, vid):
+        """Return true if the node exists.
+
+        Parameters
+        ----------
+        ntype : int
+            Node type
+        vid : int
+            The nodes
+
+        Returns
+        -------
+        bool
+            True if the node exists, False otherwise.
+        """
+        return bool(_CAPI_DGLHeteroHasVertex(self, int(ntype), int(vid)))
+
+    def has_nodes(self, ntype, vids):
+        """Return true if the nodes exist.
+
+        Parameters
+        ----------
+        ntype : int
+            Node type
+        vid : utils.Index
+            The nodes
+
+        Returns
+        -------
+        utils.Index
+            0-1 array indicating existence
+        """
+        vid_array = vids.todgltensor()
+        return utils.toindex(_CAPI_DGLHeteroHasVertices(self, int(ntype), vid_array))
+
+    def has_edge_between(self, etype, u, v):
+        """Return true if the edge exists.
+
+        Parameters
+        ----------
+        etype : int
+            Edge type
+        u : int
+            The src node.
+        v : int
+            The dst node.
+
+        Returns
+        -------
+        bool
+            True if the edge exists, False otherwise
+        """
+        return bool(_CAPI_DGLHeteroHasEdgeBetween(self, int(etype), int(u), int(v)))
+
+    def has_edges_between(self, etype, u, v):
+        """Return true if the edge exists.
+
+        Parameters
+        ----------
+        etype : int
+            Edge type
+        u : utils.Index
+            The src nodes.
+        v : utils.Index
+            The dst nodes.
+
+        Returns
+        -------
+        utils.Index
+            0-1 array indicating existence
+        """
+        u_array = u.todgltensor()
+        v_array = v.todgltensor()
+        return utils.toindex(_CAPI_DGLHeteroHasEdgesBetween(
+            self, int(etype), u_array, v_array))
+
+    def predecessors(self, etype, v):
+        """Return the predecessors of the node.
+
+        Parameters
+        ----------
+        etype : int
+            Edge type
+        v : int
+            The node.
+
+        Returns
+        -------
+        utils.Index
+            Array of predecessors
+        """
+        return utils.toindex(_CAPI_DGLHeteroPredecessors(
+            self, int(etype), int(v)))
+
+    def successors(self, etype, v):
+        """Return the successors of the node.
+
+        Parameters
+        ----------
+        etype : int
+            Edge type
+        v : int
+            The node.
+
+        Returns
+        -------
+        utils.Index
+            Array of successors
+        """
+        return utils.toindex(_CAPI_DGLHeteroSuccessors(
+            self, int(etype), int(v)))
+
+    def edge_id(self, etype, u, v):
+        """Return the id array of all edges between u and v.
+
+        Parameters
+        ----------
+        etype : int
+            Edge type
+        u : int
+            The src node.
+        v : int
+            The dst node.
+
+        Returns
+        -------
+        utils.Index
+            The edge id array.
+        """
+        return utils.toindex(_CAPI_DGLHeteroEdgeId(
+            self, int(etype), int(u), int(v)))
+
+    def edge_ids(self, etype, u, v):
+        """Return a triplet of arrays that contains the edge IDs.
+
+        Parameters
+        ----------
+        etype : int
+            Edge type
+        u : utils.Index
+            The src nodes.
+        v : utils.Index
+            The dst nodes.
+
+        Returns
+        -------
+        utils.Index
+            The src nodes.
+        utils.Index
+            The dst nodes.
+        utils.Index
+            The edge ids.
+        """
+        u_array = u.todgltensor()
+        v_array = v.todgltensor()
+        edge_array = _CAPI_DGLHeteroEdgeIds(self, int(etype), u_array, v_array)
+
+        src = utils.toindex(edge_array(0))
+        dst = utils.toindex(edge_array(1))
+        eid = utils.toindex(edge_array(2))
+
+        return src, dst, eid
+
+    def find_edges(self, etype, eid):
+        """Return a triplet of arrays that contains the edge IDs.
+
+        Parameters
+        ----------
+        etype : int
+            Edge type
+        eid : utils.Index
+            The edge ids.
+
+        Returns
+        -------
+        utils.Index
+            The src nodes.
+        utils.Index
+            The dst nodes.
+        utils.Index
+            The edge ids.
+        """
+        eid_array = eid.todgltensor()
+        edge_array = _CAPI_DGLHeteroFindEdges(self, int(etype), eid_array)
+
+        src = utils.toindex(edge_array(0))
+        dst = utils.toindex(edge_array(1))
+        eid = utils.toindex(edge_array(2))
+
+        return src, dst, eid
+
+    def in_edges(self, etype, v):
+        """Return the in edges of the node(s).
+
+        Parameters
+        ----------
+        etype : int
+            Edge type
+        v : utils.Index
+            The node(s).
+
+        Returns
+        -------
+        utils.Index
+            The src nodes.
+        utils.Index
+            The dst nodes.
+        utils.Index
+            The edge ids.
+        """
+        if len(v) == 1:
+            edge_array = _CAPI_DGLHeteroInEdges_1(self, int(etype), int(v[0]))
+        else:
+            v_array = v.todgltensor()
+            edge_array = _CAPI_DGLHeteroInEdges_2(self, int(etype), v_array)
+        src = utils.toindex(edge_array(0))
+        dst = utils.toindex(edge_array(1))
+        eid = utils.toindex(edge_array(2))
+        return src, dst, eid
+
+    def out_edges(self, etype, v):
+        """Return the out edges of the node(s).
+
+        Parameters
+        ----------
+        etype : int
+            Edge type
+        v : utils.Index
+            The node(s).
+
+        Returns
+        -------
+        utils.Index
+            The src nodes.
+        utils.Index
+            The dst nodes.
+        utils.Index
+            The edge ids.
+        """
+        if len(v) == 1:
+            edge_array = _CAPI_DGLHeteroOutEdges_1(self, int(etype), int(v[0]))
+        else:
+            v_array = v.todgltensor()
+            edge_array = _CAPI_DGLHeteroOutEdges_2(self, int(etype), v_array)
+        src = utils.toindex(edge_array(0))
+        dst = utils.toindex(edge_array(1))
+        eid = utils.toindex(edge_array(2))
+        return src, dst, eid
+
+    def edges(self, etype, order=None):
+        """Return all the edges
+
+        Parameters
+        ----------
+        etype : int
+            Edge type
+        order : string
+            The order of the returned edges. Currently support:
+
+            - 'srcdst' : sorted by their src and dst ids.
+            - 'eid'    : sorted by edge Ids.
+            - None     : the arbitrary order.
+
+        Returns
+        -------
+        utils.Index
+            The src nodes.
+        utils.Index
+            The dst nodes.
+        utils.Index
+            The edge ids.
+        """
+        if order is None:
+            order = ""
+        edge_array = _CAPI_DGLHeteroEdges(self, int(etype), order)
+        src = edge_array(0)
+        dst = edge_array(1)
+        eid = edge_array(2)
+        src = utils.toindex(src)
+        dst = utils.toindex(dst)
+        eid = utils.toindex(eid)
+        return src, dst, eid
+    
+    def in_degree(self, etype, v):
+        """Return the in degree of the node.
+
+        Parameters
+        ----------
+        etype : int
+            Edge type
+        v : int
+            The node.
+
+        Returns
+        -------
+        int
+            The in degree.
+        """
+        return _CAPI_DGLHeteroInDegree(self, int(etype), int(v))
+
+    def in_degrees(self, etype, v):
+        """Return the in degrees of the nodes.
+
+        Parameters
+        ----------
+        etype : int
+            Edge type
+        v : utils.Index
+            The nodes.
+
+        Returns
+        -------
+        int
+            The in degree array.
+        """
+        v_array = v.todgltensor()
+        return utils.toindex(_CAPI_DGLHeteroInDegrees(self, int(etype), v_array))
+
+    def out_degree(self, etype, v):
+        """Return the out degree of the node.
+
+        Parameters
+        ----------
+        etype : int
+            Edge type
+        v : int
+            The node.
+
+        Returns
+        -------
+        int
+            The out degree.
+        """
+        return _CAPI_DGLHeteroOutDegree(self, int(etype), int(v))
+
+    def out_degrees(self, etype, v):
+        """Return the out degrees of the nodes.
+
+        Parameters
+        ----------
+        etype : int
+            Edge type
+        v : utils.Index
+            The nodes.
+
+        Returns
+        -------
+        int
+            The out degree array.
+        """
+        v_array = v.todgltensor()
+        return utils.toindex(_CAPI_DGLHeteroOutDegrees(self, int(etype), v_array))
+
+    def adjacency_matrix(self, etype, transpose, ctx):
+        """Return the adjacency matrix representation of this graph.
+
+        By default, a row of returned adjacency matrix represents the destination
+        of an edge and the column represents the source.
+
+        When transpose is True, a row represents the source and a column represents
+        a destination.
+
+        Parameters
+        ----------
+        etype : int
+            Edge type
+        transpose : bool
+            A flag to transpose the returned adjacency matrix.
+        ctx : context
+            The context of the returned matrix.
+
+        Returns
+        -------
+        SparseTensor
+            The adjacency matrix.
+        utils.Index
+            A index for data shuffling due to sparse format change. Return None
+            if shuffle is not required.
+        """
+        if not isinstance(transpose, bool):
+            raise DGLError('Expect bool value for "transpose" arg,'
+                           ' but got %s.' % (type(transpose)))
+        fmt = F.get_preferred_sparse_format()
+        rst = _CAPI_DGLHeteroGetAdj(self, int(etype), transpose, fmt)
+        if fmt == "csr":
+            indptr = F.copy_to(utils.toindex(rst(0)).tousertensor(), ctx)
+            indices = F.copy_to(utils.toindex(rst(1)).tousertensor(), ctx)
+            shuffle = utils.toindex(rst(2))
+            dat = F.ones(indices.shape, dtype=F.float32, ctx=ctx)
+            spmat = F.sparse_matrix(dat, ('csr', indices, indptr),
+                                    (self.number_of_nodes(), self.number_of_nodes()))[0]
+            return spmat, shuffle
+        elif fmt == "coo":
+            ## FIXME(minjie): data type
+            idx = F.copy_to(utils.toindex(rst(0)).tousertensor(), ctx)
+            m = self.number_of_edges()
+            idx = F.reshape(idx, (2, m))
+            dat = F.ones((m,), dtype=F.float32, ctx=ctx)
+            n = self.number_of_nodes()
+            adj, shuffle_idx = F.sparse_matrix(dat, ('coo', idx), (n, n))
+            shuffle_idx = utils.toindex(shuffle_idx) if shuffle_idx is not None else None
+            return adj, shuffle_idx
+        else:
+            raise Exception("unknown format")
+
+    def node_subgraph(self, induced_nodes):
+        """Return the induced node subgraph.
+
+        Parameters
+        ----------
+        induced_nodes : list of utils.Index
+            Induced nodes. The length should be equal to the number of
+            node types in this heterograph.
+
+        Returns
+        -------
+        SubgraphIndex
+            The subgraph index.
+        """
+        vids = [nodes.todgltensor() for nodes in induced_nodes]
+        rst = _CAPI_DGLHeteroVertexSubgraph(self, vids)
+        induced_edges = utils.toindex(rst(2))
+        gidx = rst(0)
+        return SubgraphIndex(gidx, self, v, induced_edges)
+
+    def edge_subgraph(self, e, preserve_nodes):
+        """Return the induced edge subgraph.
+
+        Parameters
+        ----------
+        e : utils.Index
+            The edges.
+        preserve_nodes : bool
+            Indicates whether to preserve all nodes or not.
+            If true, keep the nodes which have no edge connected in the subgraph;
+            If false, all nodes without edge connected to it would be removed.
+
+        Returns
+        -------
+        SubgraphIndex
+            The subgraph index.
+        """
+        e_array = e.todgltensor()
+        rst = _CAPI_DGLHeteroEdgeSubgraph(self, e_array, preserve_nodes)
+        induced_nodes = utils.toindex(rst(1))
+        gidx = rst(0)
+        return SubgraphIndex(gidx, self, induced_nodes, e)
+
+@register_object('graph.HeteroSubgraph')
+class HeteroSubgraphIndex(ObjectBase):
+    """Hetero-subgraph data structure"""
+    @property
+    def graph(self):
+        """The subgraph structure
+
+        Returns
+        -------
+        HeteroGraphIndex
+            The subgraph
+        """
+        return _CAPI_DGLHeteroSubgraphGetGraph(self)
+
+    @property
+    def induced_nodes(self):
+        """Induced nodes for each node type. The return list
+        length should be equal to the number of node types.
+
+        Returns
+        -------
+        list of utils.Index
+            Induced nodes
+        """
+        ret = _CAPI_DGLHeteroSubgraphGetInducedVertices(self)
+        return [utils.toindex(v.data) for v in ret]
+
+    @property
+    def induced_edges(self):
+        """Induced edges for each edge type. The return list
+        length should be equal to the number of edge types.
+
+        Returns
+        -------
+        list of utils.Index
+            Induced edges
+        """
+        ret = _CAPI_DGLHeteroSubgraphGetInducedEdges(self)
+        return [utils.toindex(v.data) for v in ret]
 
 _init_api("dgl.graph_index")

--- a/python/dgl/graph_index.py
+++ b/python/dgl/graph_index.py
@@ -1272,11 +1272,11 @@ class HeteroGraphIndex(ObjectBase):
 
     def number_of_ntypes(self):
         """Return number of node types."""
-        return meta_graph.number_of_nodes()
+        return self.meta_graph.number_of_nodes()
 
     def number_of_etypes(self):
         """Return number of edge types."""
-        return meta_graph.number_of_edges()
+        return self.meta_graph.number_of_edges()
 
     def get_relation_graph(self, etype):
         """Get the bipartite graph of the given edge/relation type.

--- a/python/dgl/graph_index.py
+++ b/python/dgl/graph_index.py
@@ -1322,7 +1322,7 @@ class HeteroGraphIndex(ObjectBase):
             Number of nodes to be added.
         """
         _CAPI_DGLHetero(self, int(ntype), int(num))
-    
+
     def add_edge(self, etype, u, v):
         """Add one edge.
 
@@ -1349,8 +1349,7 @@ class HeteroGraphIndex(ObjectBase):
         v : utils.Index
             The dst nodes.
         """
-        _CAPI_DGLHeteroAddEdges(self, int(etype),
-            u.todgltensor(), v.todgltensor())
+        _CAPI_DGLHeteroAddEdges(self, int(etype), u.todgltensor(), v.todgltensor())
 
     def clear(self):
         """Clear the graph."""
@@ -1716,7 +1715,7 @@ class HeteroGraphIndex(ObjectBase):
         dst = utils.toindex(dst)
         eid = utils.toindex(eid)
         return src, dst, eid
-    
+
     def in_degree(self, etype, v):
         """Return the in degree of the node.
 
@@ -1945,7 +1944,7 @@ def create_bipartite_from_coo(num_src, num_dst, row, col):
     HeteroGraphIndex
     """
     return _CAPI_DGLHeteroCreateBipartiteFromCOO(
-            int(num_src), int(num_dst), row.todgltensor(), col.todgltensor())
+        int(num_src), int(num_dst), row.todgltensor(), col.todgltensor())
 
 def create_bipartite_from_csr(num_src, num_dst, indptr, indices, edge_ids):
     """Create a bipartite graph index from CSR format
@@ -1968,8 +1967,8 @@ def create_bipartite_from_csr(num_src, num_dst, indptr, indices, edge_ids):
     HeteroGraphIndex
     """
     return _CAPI_DGLHeteroCreateBipartiteFromCSR(
-            int(num_src), int(num_dst),
-            indptr.todgltensor(), indices.todgltensor(), edge_ids.todgltensor())
+        int(num_src), int(num_dst),
+        indptr.todgltensor(), indices.todgltensor(), edge_ids.todgltensor())
 
 def create_heterograph(meta_graph, rel_graphs):
     """Create a heterograph from metagraph and graphs of every relation.

--- a/python/dgl/graph_index.py
+++ b/python/dgl/graph_index.py
@@ -1896,4 +1896,65 @@ class HeteroSubgraphIndex(ObjectBase):
         ret = _CAPI_DGLHeteroSubgraphGetInducedEdges(self)
         return [utils.toindex(v.data) for v in ret]
 
+def create_bipartite_from_coo(num_src, num_dst, row, col):
+    """Create a bipartite graph index from COO format
+
+    Parameters
+    ----------
+    num_src : int
+        Number of nodes in the src type.
+    num_dst : int
+        Number of nodes in the dst type.
+    row : utils.Index
+        Row index.
+    col : utils.Index
+        Col index.
+
+    Returns
+    -------
+    HeteroGraphIndex
+    """
+    return _CAPI_DGLHeteroCreateBipartiteFromCOO(
+            int(num_src), int(num_dst), row.todgltensor(), col.todgltensor())
+
+def create_bipartite_from_csr(num_src, num_dst, indptr, indices, edge_ids):
+    """Create a bipartite graph index from CSR format
+
+    Parameters
+    ----------
+    num_src : int
+        Number of nodes in the src type.
+    num_dst : int
+        Number of nodes in the dst type.
+    indptr : utils.Index
+        CSR indptr.
+    indices : utils.Index
+        CSR indices.
+    edge_ids : utils.Index
+        Edge shuffle id.
+
+    Returns
+    -------
+    HeteroGraphIndex
+    """
+    return _CAPI_DGLHeteroCreateBipartiteFromCSR(
+            int(num_src), int(num_dst),
+            indptr.todgltensor(), indices.todgltensor(), edge_ids.todgltensor())
+
+def create_heterograph(meta_graph, rel_graphs):
+    """Create a heterograph from metagraph and graphs of every relation.
+
+    Parameters
+    ----------
+    meta_graph : GraphIndex
+        Meta-graph.
+    rel_graphs : list of HeteroGraphIndex
+        Bipartite graph of each relation.
+
+    Returns
+    -------
+    HeteroGraphIndex
+    """
+    return _CAPI_DGLHeteroCreateHeteroGraph(meta_graph, rel_graphs)
+
 _init_api("dgl.graph_index")

--- a/python/dgl/graph_index.py
+++ b/python/dgl/graph_index.py
@@ -89,7 +89,7 @@ class GraphIndex(ObjectBase):
         v : int
             The dst node.
         """
-        _CAPI_DGLGraphAddEdge(self, u, v)
+        _CAPI_DGLGraphAddEdge(self, int(u), int(v))
         self.clear_cache()
 
     def add_edges(self, u, v):
@@ -1234,5 +1234,130 @@ def create_graph_index(graph_data, multigraph, readonly):
             raise DGLError('Error while creating graph from input of type "%s".'
                            % type(graph_data))
         return gidx
+
+#############################################################
+# Hetero graph
+#############################################################
+
+@register_object('graph.HeteroGraph')
+class HeteroGraphIndex(ObjectBase):
+    """HeteroGraph index object.
+
+    Note
+    ----
+    Do not create GraphIndex directly.
+    """
+    def __new__(cls):
+        obj = ObjectBase.__new__(cls)
+        return obj
+
+    def __getstate__(self):
+        # TODO
+        return
+
+    def __setstate__(self, state):
+        # TODO
+        pass
+
+    @property
+    def meta_graph(self):
+        """Meta graph
+
+        Returns
+        -------
+        GraphIndex
+            The meta graph.
+        """
+        return _CAPI_DGLHeteroGetMetaGraph(self)
+
+    def get_relation_graph(self, etype):
+        """Get the bipartite graph of the given edge/relation type.
+
+        Parameters
+        ----------
+        etype : int
+            The edge/relation type.
+
+        Returns
+        -------
+        HeteroGraphIndex
+            The bipartite graph.
+        """
+        return _CAPI_DGLHeteroGetRelationGraph(self, int(etype))
+
+    def add_nodes(self, ntype, num):
+        """Add nodes.
+
+        Parameters
+        ----------
+        ntype : int
+            Node type
+        num : int
+            Number of nodes to be added.
+        """
+        _CAPI_DGLHetero(self, int(ntype), int(num))
+    
+    def add_edge(self, etype, u, v):
+        """Add one edge.
+
+        Parameters
+        ----------
+        etype : int
+            Edge type
+        u : int
+            The src node.
+        v : int
+            The dst node.
+        """
+        _CAPI_DGLHeteroAddEdge(self, int(etype), int(u), int(v))
+
+    def add_edges(self, etype, u, v):
+        """Add many edges.
+
+        Parameters
+        ----------
+        etype : int
+            Edge type
+        u : utils.Index
+            The src nodes.
+        v : utils.Index
+            The dst nodes.
+        """
+        _CAPI_DGLHeteroAddEdges(self, int(etype),
+            u.todgltensor(), v.todgltensor())
+
+    def clear(self):
+        """Clear the graph."""
+        _CAPI_DGLHeteroClear(self)
+
+    def ctx(self):
+        """Return the context of this graph index.
+
+        Returns
+        -------
+        DGLContext
+            The context of the graph.
+        """
+        return _CAPI_DGLHeteroContext(self)
+
+    def nbits(self):
+        """Return the number of integer bits used in the storage (32 or 64).
+
+        Returns
+        -------
+        int
+            The number of bits.
+        """
+        return _CAPI_DGLHeteroNumBits(self)
+
+    def is_multigraph(self):
+        """Return whether the graph is a multigraph
+
+        Returns
+        -------
+        bool
+            True if it is a multigraph, False otherwise.
+        """
+        return bool(_CAPI_DGLHeteroIsMultigraph(self))
 
 _init_api("dgl.graph_index")

--- a/src/c_api_common.cc
+++ b/src/c_api_common.cc
@@ -3,6 +3,7 @@
  * \file c_runtime_api.cc
  * \brief DGL C API common implementations
  */
+#include <dgl/graph_interface.h>
 #include "c_api_common.h"
 
 using dgl::runtime::DGLArgs;
@@ -23,6 +24,22 @@ PackedFunc ConvertNDArrayVectorToPackedFunc(const std::vector<NDArray>& vec) {
         }
     };
     return PackedFunc(body);
+}
+
+PackedFunc ConvertEdgeArrayToPackedFunc(const EdgeArray& ea) {
+  auto body = [ea] (DGLArgs args, DGLRetValue* rv) {
+      const int which = args[0];
+      if (which == 0) {
+        *rv = std::move(ea.src);
+      } else if (which == 1) {
+        *rv = std::move(ea.dst);
+      } else if (which == 2) {
+        *rv = std::move(ea.id);
+      } else {
+        LOG(FATAL) << "invalid choice";
+      }
+    };
+  return PackedFunc(body);
 }
 
 }  // namespace dgl

--- a/src/c_api_common.h
+++ b/src/c_api_common.h
@@ -10,6 +10,7 @@
 #include <dgl/runtime/packed_func.h>
 #include <dgl/runtime/registry.h>
 #include <dgl/array.h>
+#include <dgl/graph_interface.h>
 #include <algorithm>
 #include <vector>
 
@@ -34,9 +35,6 @@ inline std::ostream& operator << (std::ostream& os, const DLContext& ctx) {
 }
 
 namespace dgl {
-
-// forward declaration
-struct EdgeArray;
 
 // Communicator handler type
 typedef void* CommunicatorHandle;

--- a/src/c_api_common.h
+++ b/src/c_api_common.h
@@ -9,6 +9,7 @@
 #include <dgl/runtime/ndarray.h>
 #include <dgl/runtime/packed_func.h>
 #include <dgl/runtime/registry.h>
+#include <dgl/array.h>
 #include <algorithm>
 #include <vector>
 
@@ -33,6 +34,9 @@ inline std::ostream& operator << (std::ostream& os, const DLContext& ctx) {
 }
 
 namespace dgl {
+
+// forward declaration
+struct EdgeArray;
 
 // Communicator handler type
 typedef void* CommunicatorHandle;
@@ -69,6 +73,8 @@ dgl::runtime::NDArray CopyVectorToNDArray(
   std::copy(vec.begin(), vec.end(), static_cast<int64_t*>(a->data));
   return a;
 }
+
+runtime::PackedFunc ConvertEdgeArrayToPackedFunc(const EdgeArray& ea);
 
 }  // namespace dgl
 

--- a/src/graph/bipartite.cc
+++ b/src/graph/bipartite.cc
@@ -15,6 +15,7 @@ namespace {
 inline GraphPtr CreateBipartiteMetaGraph() {
   static IdArray row = aten::VecToIdArray(std::vector<int64_t>({Bipartite::kSrcVType}));
   static IdArray col = aten::VecToIdArray(std::vector<int64_t>({Bipartite::kDstVType}));
+  LOG(INFO) << "row size: " << row->shape[0] << " col size: " << col->shape[0];
   static GraphPtr g = ImmutableGraph::CreateFromCOO(2, row, col);
   return g;
 }

--- a/src/graph/bipartite.cc
+++ b/src/graph/bipartite.cc
@@ -13,12 +13,12 @@
 namespace dgl {
 namespace {
 inline GraphPtr CreateBipartiteMetaGraph() {
-  static IdArray row = aten::VecToIdArray(std::vector<int64_t>({Bipartite::kSrcVType}));
-  static IdArray col = aten::VecToIdArray(std::vector<int64_t>({Bipartite::kDstVType}));
-  LOG(INFO) << "row size: " << row->shape[0] << " col size: " << col->shape[0];
-  static GraphPtr g = ImmutableGraph::CreateFromCOO(2, row, col);
+  IdArray row = aten::VecToIdArray(std::vector<int64_t>({Bipartite::kSrcVType}));
+  IdArray col = aten::VecToIdArray(std::vector<int64_t>({Bipartite::kDstVType}));
+  GraphPtr g = ImmutableGraph::CreateFromCOO(2, row, col);
   return g;
 }
+static const GraphPtr kBipartiteMetaGraph = CreateBipartiteMetaGraph();
 }  // namespace
 
 //////////////////////////////////////////////////////////

--- a/src/graph/bipartite.cc
+++ b/src/graph/bipartite.cc
@@ -13,8 +13,10 @@
 namespace dgl {
 namespace {
 inline GraphPtr CreateBipartiteMetaGraph() {
-  IdArray row = aten::VecToIdArray(std::vector<int64_t>({Bipartite::kSrcVType}));
-  IdArray col = aten::VecToIdArray(std::vector<int64_t>({Bipartite::kDstVType}));
+  std::vector<int64_t> row_vec(1, Bipartite::kSrcVType);
+  std::vector<int64_t> col_vec(1, Bipartite::kDstVType);
+  IdArray row = aten::VecToIdArray(row_vec);
+  IdArray col = aten::VecToIdArray(col_vec);
   GraphPtr g = ImmutableGraph::CreateFromCOO(2, row, col);
   return g;
 }
@@ -32,17 +34,17 @@ class Bipartite::COO : public BaseHeteroGraph {
  public:
   COO(int64_t num_src, int64_t num_dst,
                IdArray src, IdArray dst)
-    : BaseHeteroGraph(CreateBipartiteMetaGraph()) {
+    : BaseHeteroGraph(kBipartiteMetaGraph) {
     adj_ = aten::COOMatrix{num_src, num_dst, src, dst};
   }
   COO(int64_t num_src, int64_t num_dst,
                IdArray src, IdArray dst, bool is_multigraph)
-    : BaseHeteroGraph(CreateBipartiteMetaGraph()),
+    : BaseHeteroGraph(kBipartiteMetaGraph),
       is_multigraph_(is_multigraph) {
     adj_ = aten::COOMatrix{num_src, num_dst, src, dst};
   }
   explicit COO(const aten::COOMatrix& coo)
-    : BaseHeteroGraph(CreateBipartiteMetaGraph()), adj_(coo) {}
+    : BaseHeteroGraph(kBipartiteMetaGraph), adj_(coo) {}
 
   uint64_t NumVertexTypes() const override {
     return 2;
@@ -292,19 +294,19 @@ class Bipartite::CSR : public BaseHeteroGraph {
  public:
   CSR(int64_t num_src, int64_t num_dst,
       IdArray indptr, IdArray indices, IdArray edge_ids)
-    : BaseHeteroGraph(CreateBipartiteMetaGraph()) {
+    : BaseHeteroGraph(kBipartiteMetaGraph) {
     adj_ = aten::CSRMatrix{num_src, num_dst, indptr, indices, edge_ids};
   }
 
   CSR(int64_t num_src, int64_t num_dst,
       IdArray indptr, IdArray indices, IdArray edge_ids, bool is_multigraph)
-    : BaseHeteroGraph(CreateBipartiteMetaGraph()),
+    : BaseHeteroGraph(kBipartiteMetaGraph),
       is_multigraph_(is_multigraph) {
     adj_ = aten::CSRMatrix{num_src, num_dst, indptr, indices, edge_ids};
   }
 
   explicit CSR(const aten::CSRMatrix& csr)
-    : BaseHeteroGraph(CreateBipartiteMetaGraph()), adj_(csr) {}
+    : BaseHeteroGraph(kBipartiteMetaGraph), adj_(csr) {}
 
   uint64_t NumVertexTypes() const override {
     return 2;
@@ -760,7 +762,7 @@ HeteroGraphPtr Bipartite::CreateFromCSR(
 }
 
 Bipartite::Bipartite(CSRPtr in_csr, CSRPtr out_csr, COOPtr coo)
-  : BaseHeteroGraph(CreateBipartiteMetaGraph()), in_csr_(in_csr), out_csr_(out_csr), coo_(coo) {
+  : BaseHeteroGraph(kBipartiteMetaGraph), in_csr_(in_csr), out_csr_(out_csr), coo_(coo) {
   CHECK(GetAny()) << "At least one graph structure should exist.";
 }
 

--- a/src/graph/bipartite.cc
+++ b/src/graph/bipartite.cc
@@ -13,8 +13,8 @@
 namespace dgl {
 namespace {
 inline GraphPtr CreateBipartiteMetaGraph() {
-  static IdArray row = aten::VecToIdArray(std::vector<int64_t>({0}));
-  static IdArray col = aten::VecToIdArray(std::vector<int64_t>({1}));
+  static IdArray row = aten::VecToIdArray(std::vector<int64_t>({Bipartite::kSrcVType}));
+  static IdArray col = aten::VecToIdArray(std::vector<int64_t>({Bipartite::kDstVType}));
   static GraphPtr g = ImmutableGraph::CreateFromCOO(2, row, col);
   return g;
 }

--- a/src/graph/bipartite.cc
+++ b/src/graph/bipartite.cc
@@ -1,0 +1,761 @@
+/*!
+ *  Copyright (c) 2019 by Contributors
+ * \file graph/bipartite.cc
+ * \brief Bipartite graph implementation
+ */
+#include <dgl/bipartite.h>
+#include <dgl/array.h>
+#include <dgl/lazy.h>
+#include <dgl/immutable_graph.h>
+
+#include "../c_api_common.h"
+
+namespace dgl {
+
+//////////////////////////////////////////////////////////
+//
+// COO graph implementation
+//
+//////////////////////////////////////////////////////////
+
+/*! \brief COO graph */
+class Bipartite::COO : public BaseHeteroGraph {
+ public:
+  COO(int64_t num_src, int64_t num_dst,
+               IdArray src, IdArray dst) {
+    adj_ = aten::COOMatrix{num_src, num_dst, src, dst};
+  }
+  COO(int64_t num_src, int64_t num_dst,
+               IdArray src, IdArray dst, bool is_multigraph)
+    : is_multigraph_(is_multigraph) {
+    adj_ = aten::COOMatrix{num_src, num_dst, src, dst};
+  }
+  COO(const aten::COOMatrix& coo): adj_(coo) {}
+
+  uint64_t NumVertexTypes() const override {
+    return 2;
+  }
+  uint64_t NumEdgeTypes() const override {
+    return 1;
+  }
+
+  HeteroGraphPtr GetRelationGraph(dgl_type_t etype) const override {
+    LOG(FATAL) << "The method shouldn't be called for Bipartite graph. "
+      << "The relation graph is simply this graph itself.";
+    return {};
+  }
+
+  void AddVertices(dgl_type_t vtype, uint64_t num_vertices) override {
+    LOG(FATAL) << "Bipartite graph is not mutable.";
+  }
+
+  void AddEdge(dgl_type_t etype, dgl_id_t src, dgl_id_t dst) override {
+    LOG(FATAL) << "Bipartite graph is not mutable.";
+  }
+
+  void AddEdges(dgl_type_t etype, IdArray src_ids, IdArray dst_ids) override {
+    LOG(FATAL) << "Bipartite graph is not mutable.";
+  }
+
+  void Clear() override {
+    LOG(FATAL) << "Bipartite graph is not mutable.";
+  }
+
+  DLContext Context() const override {
+    return adj_.row->ctx;
+  }
+
+  uint8_t NumBits() const override {
+    return adj_.row->dtype.bits;
+  }
+
+  bool IsMultigraph() const override {
+    return const_cast<COO*>(this)->is_multigraph_.Get([this] () {
+        return aten::COOHasDuplicate(adj_);
+      });
+  }
+
+  bool IsReadonly() const override {
+    return true;
+  }
+
+  uint64_t NumVertices(dgl_type_t vtype) const override {
+    if (vtype == Bipartite::kSrcVType) {
+      return adj_.num_rows;
+    } else if (vtype == Bipartite::kDstVType) {
+      return adj_.num_cols;
+    } else {
+      LOG(FATAL) << "Invalid vertex type: " << vtype;
+      return 0;
+    }
+  }
+
+  uint64_t NumEdges(dgl_type_t etype) const override {
+    return adj_.row->shape[0];
+  }
+
+  bool HasVertex(dgl_type_t vtype, dgl_id_t vid) const override {
+    return vid < NumVertices(vtype);
+  }
+
+  bool HasEdgeBetween(dgl_type_t etype, dgl_id_t src, dgl_id_t dst) const override {
+    LOG(INFO) << "Not enabled for COO graph.";
+    return {};
+  }
+
+  IdArray Predecessors(dgl_type_t etype, dgl_id_t dst) const override {
+    LOG(INFO) << "Not enabled for COO graph.";
+    return {};
+  }
+
+  IdArray Successors(dgl_type_t etype, dgl_id_t src) const override {
+    LOG(INFO) << "Not enabled for COO graph.";
+    return {};
+  }
+
+  IdArray EdgeId(dgl_type_t etype, dgl_id_t src, dgl_id_t dst) const override {
+    LOG(INFO) << "Not enabled for COO graph.";
+    return {};
+  }
+
+  EdgeArray EdgeIds(dgl_type_t etype, IdArray src, IdArray dst) const override {
+    LOG(INFO) << "Not enabled for COO graph.";
+    return {};
+  }
+
+  std::pair<dgl_id_t, dgl_id_t> FindEdge(dgl_type_t etype, dgl_id_t eid) const override {
+    CHECK(eid < NumEdges(etype)) << "Invalid edge id: " << eid;
+    const auto src = aten::IndexSelect(adj_.row, eid);
+    const auto dst = aten::IndexSelect(adj_.col, eid);
+    return std::pair<dgl_id_t, dgl_id_t>(src, dst);
+  }
+
+  EdgeArray FindEdges(dgl_type_t etype, IdArray eids) const override {
+    CHECK(IsValidIdArray(eids)) << "Invalid edge id array";
+    return EdgeArray{aten::IndexSelect(adj_.row, eids),
+                     aten::IndexSelect(adj_.col, eids),
+                     eids};
+  }
+
+  EdgeArray InEdges(dgl_type_t etype, dgl_id_t vid) const override {
+    LOG(INFO) << "Not enabled for COO graph.";
+    return {};
+  }
+
+  EdgeArray InEdges(dgl_type_t etype, IdArray vids) const override {
+    LOG(INFO) << "Not enabled for COO graph.";
+    return {};
+  }
+
+  EdgeArray OutEdges(dgl_type_t etype, dgl_id_t vid) const override {
+    LOG(INFO) << "Not enabled for COO graph.";
+    return {};
+  }
+
+  EdgeArray OutEdges(dgl_type_t etype, IdArray vids) const override {
+    LOG(INFO) << "Not enabled for COO graph.";
+    return {};
+  }
+
+  EdgeArray Edges(dgl_type_t etype, const std::string &order = "") const override {
+    CHECK(order.empty() || order == std::string("eid"))
+      << "COO only support Edges of order \"eid\", but got \""
+      << order << "\".";
+    IdArray rst_eid = aten::Range(0, NumEdges(etype), NumBits(), Context());
+    return EdgeArray{adj_.row, adj_.col, rst_eid};
+  }
+
+  uint64_t InDegree(dgl_type_t etype, dgl_id_t vid) const override {
+    LOG(INFO) << "Not enabled for COO graph.";
+    return {};
+  }
+
+  DegreeArray InDegrees(dgl_type_t etype, IdArray vids) const override {
+    LOG(INFO) << "Not enabled for COO graph.";
+    return {};
+  }
+
+  uint64_t OutDegree(dgl_type_t etype, dgl_id_t vid) const override {
+    LOG(INFO) << "Not enabled for COO graph.";
+    return {};
+  }
+
+  DegreeArray OutDegrees(dgl_type_t etype, IdArray vids) const override {
+    LOG(INFO) << "Not enabled for COO graph.";
+    return {};
+  }
+
+  DGLIdIters SuccVec(dgl_type_t etype, dgl_id_t vid) const override {
+    LOG(INFO) << "Not enabled for COO graph.";
+    return {};
+  }
+
+  DGLIdIters OutEdgeVec(dgl_type_t etype, dgl_id_t vid) const override {
+    LOG(INFO) << "Not enabled for COO graph.";
+    return {};
+  }
+
+  DGLIdIters PredVec(dgl_type_t etype, dgl_id_t vid) const override {
+    LOG(INFO) << "Not enabled for COO graph.";
+    return {};
+  }
+
+  DGLIdIters InEdgeVec(dgl_type_t etype, dgl_id_t vid) const override {
+    LOG(INFO) << "Not enabled for COO graph.";
+    return {};
+  }
+
+  std::vector<IdArray> GetAdj(
+      dgl_id_t etype, bool transpose, const std::string &fmt) const override {
+    CHECK(fmt == "coo") << "Not valid adj format request.";
+    if (transpose) {
+      return {aten::HStack(adj_.col, adj_.row)};
+    } else {
+      return {aten::HStack(adj_.row, adj_.col)};
+    }
+  }
+
+  HeteroSubgraph VertexSubgraph(const std::vector<IdArray>& vids) const override {
+    LOG(INFO) << "Not enabled for COO graph.";
+    return {};
+  }
+
+  HeteroSubgraph EdgeSubgraph(
+      const std::vector<IdArray>& eids, bool preserve_nodes = false) const override {
+    CHECK_EQ(eids.size(), 1) << "Edge type number mismatch.";
+    HeteroSubgraph subg;
+    if (!preserve_nodes) {
+      IdArray new_src = aten::IndexSelect(adj_.row, eids[0]);
+      IdArray new_dst = aten::IndexSelect(adj_.col, eids[0]);
+      subg.induced_vertices.emplace_back(aten::Relabel_({new_src}));
+      subg.induced_vertices.emplace_back(aten::Relabel_({new_dst}));
+      const auto new_nsrc = subg.induced_vertices[0]->shape[0];
+      const auto new_ndst = subg.induced_vertices[1]->shape[0];
+      subg.graph = std::make_shared<COO>(
+          new_nsrc, new_ndst, new_src, new_dst);
+      subg.induced_edges = eids;
+    } else {
+      IdArray new_src = aten::IndexSelect(adj_.row, eids[0]);
+      IdArray new_dst = aten::IndexSelect(adj_.col, eids[0]);
+      subg.induced_vertices.emplace_back(aten::Range(0, NumVertices(0), NumBits(), Context()));
+      subg.induced_vertices.emplace_back(aten::Range(0, NumVertices(1), NumBits(), Context()));
+      subg.graph = std::make_shared<COO>(
+          NumVertices(0), NumVertices(1), new_src, new_dst);
+      subg.induced_edges = eids;
+    }
+    return subg;
+  }
+
+  aten::COOMatrix adj() const {
+    return adj_;
+  }
+
+ private:
+  /*! \brief internal adjacency matrix. Data array is empty */
+  aten::COOMatrix adj_;
+
+  /*! \brief multi-graph flag */
+  Lazy<bool> is_multigraph_;
+};
+
+//////////////////////////////////////////////////////////
+//
+// CSR graph implementation
+//
+//////////////////////////////////////////////////////////
+
+
+/*! \brief CSR graph */
+class Bipartite::CSR : public BaseHeteroGraph {
+ public:
+  CSR(int64_t num_src, int64_t num_dst,
+               IdArray indptr, IdArray indices, IdArray edge_ids) {
+    adj_ = aten::CSRMatrix{num_src, num_dst, indptr, indices, edge_ids};
+  }
+
+  CSR(int64_t num_src, int64_t num_dst,
+               IdArray indptr, IdArray indices, IdArray edge_ids,
+               bool is_multigraph)
+    : is_multigraph_(is_multigraph) {
+    adj_ = aten::CSRMatrix{num_src, num_dst, indptr, indices, edge_ids};
+  }
+
+  CSR(const aten::CSRMatrix& csr): adj_(csr) {}
+
+  uint64_t NumVertexTypes() const override {
+    return 2;
+  }
+  uint64_t NumEdgeTypes() const override {
+    return 1;
+  }
+
+  HeteroGraphPtr GetRelationGraph(dgl_type_t etype) const override {
+    LOG(FATAL) << "The method shouldn't be called for Bipartite graph. "
+      << "The relation graph is simply this graph itself.";
+    return {};
+  }
+
+  void AddVertices(dgl_type_t vtype, uint64_t num_vertices) override {
+    LOG(FATAL) << "Bipartite graph is not mutable.";
+  }
+
+  void AddEdge(dgl_type_t etype, dgl_id_t src, dgl_id_t dst) override {
+    LOG(FATAL) << "Bipartite graph is not mutable.";
+  }
+
+  void AddEdges(dgl_type_t etype, IdArray src_ids, IdArray dst_ids) override {
+    LOG(FATAL) << "Bipartite graph is not mutable.";
+  }
+
+  void Clear() override {
+    LOG(FATAL) << "Bipartite graph is not mutable.";
+  }
+
+  DLContext Context() const override {
+    return adj_.indices->ctx;
+  }
+
+  uint8_t NumBits() const override {
+    return adj_.indices->dtype.bits;
+  }
+
+  bool IsMultigraph() const override {
+    return const_cast<CSR*>(this)->is_multigraph_.Get([this] () {
+        return aten::CSRHasDuplicate(adj_);
+      });
+  }
+
+  bool IsReadonly() const override {
+    return true;
+  }
+
+  uint64_t NumVertices(dgl_type_t vtype) const override {
+    if (vtype == Bipartite::kSrcVType) {
+      return adj_.num_rows;
+    } else if (vtype == Bipartite::kDstVType) {
+      return adj_.num_cols;
+    } else {
+      LOG(FATAL) << "Invalid vertex type: " << vtype;
+      return 0;
+    }
+  }
+
+  uint64_t NumEdges(dgl_type_t etype) const override {
+    return adj_.indices->shape[0];
+  }
+
+  bool HasVertex(dgl_type_t vtype, dgl_id_t vid) const override {
+    return vid < NumVertices(vtype);
+  }
+
+  bool HasEdgeBetween(dgl_type_t etype, dgl_id_t src, dgl_id_t dst) const override {
+    CHECK(HasVertex(0, src)) << "Invalid src vertex id: " << src;
+    CHECK(HasVertex(1, dst)) << "Invalid dst vertex id: " << dst;
+    return aten::CSRIsNonZero(adj_, src, dst);
+  }
+
+  IdArray Predecessors(dgl_type_t etype, dgl_id_t dst) const override {
+    LOG(INFO) << "Not enabled for CSR graph.";
+    return {};
+  }
+
+  IdArray Successors(dgl_type_t etype, dgl_id_t src) const override {
+    CHECK(HasVertex(0, src)) << "Invalid src vertex id: " << src;
+    return aten::CSRGetRowColumnIndices(adj_, src);
+  }
+
+  IdArray EdgeId(dgl_type_t etype, dgl_id_t src, dgl_id_t dst) const override {
+    CHECK(HasVertex(0, src)) << "Invalid src vertex id: " << src;
+    CHECK(HasVertex(1, dst)) << "Invalid dst vertex id: " << dst;
+    return aten::CSRGetData(adj_, src, dst);
+  }
+
+  EdgeArray EdgeIds(dgl_type_t etype, IdArray src, IdArray dst) const override {
+    CHECK(IsValidIdArray(src)) << "Invalid vertex id array.";
+    CHECK(IsValidIdArray(dst)) << "Invalid vertex id array.";
+    const auto& arrs = aten::CSRGetDataAndIndices(adj_, src, dst);
+    return EdgeArray{arrs[0], arrs[1], arrs[2]};
+  }
+
+  std::pair<dgl_id_t, dgl_id_t> FindEdge(dgl_type_t etype, dgl_id_t eid) const override {
+    LOG(INFO) << "Not enabled for CSR graph.";
+    return {};
+  }
+
+  EdgeArray FindEdges(dgl_type_t etype, IdArray eids) const override {
+    LOG(INFO) << "Not enabled for CSR graph.";
+    return {};
+  }
+
+  EdgeArray InEdges(dgl_type_t etype, dgl_id_t vid) const override {
+    LOG(INFO) << "Not enabled for CSR graph.";
+    return {};
+  }
+
+  EdgeArray InEdges(dgl_type_t etype, IdArray vids) const override {
+    LOG(INFO) << "Not enabled for CSR graph.";
+    return {};
+  }
+
+  EdgeArray OutEdges(dgl_type_t etype, dgl_id_t vid) const override {
+    CHECK(HasVertex(0, vid)) << "Invalid src vertex id: " << vid;
+    IdArray ret_dst = aten::CSRGetRowColumnIndices(adj_, vid);
+    IdArray ret_eid = aten::CSRGetRowData(adj_, vid);
+    IdArray ret_src = aten::Full(vid, ret_dst->shape[0], NumBits(), ret_dst->ctx);
+    return EdgeArray{ret_src, ret_dst, ret_eid};
+  }
+
+  EdgeArray OutEdges(dgl_type_t etype, IdArray vids) const override {
+    CHECK(IsValidIdArray(vids)) << "Invalid vertex id array.";
+    auto csrsubmat = aten::CSRSliceRows(adj_, vids);
+    auto coosubmat = aten::CSRToCOO(csrsubmat, false);
+    // Note that the row id in the csr submat is relabled, so
+    // we need to recover it using an index select.
+    auto row = aten::IndexSelect(vids, coosubmat.row);
+    return EdgeArray{row, coosubmat.col, coosubmat.data};
+  }
+
+  EdgeArray Edges(dgl_type_t etype, const std::string &order = "") const override {
+    CHECK(order.empty() || order == std::string("srcdst"))
+      << "CSR only support Edges of order \"srcdst\","
+      << " but got \"" << order << "\".";
+    const auto& coo = aten::CSRToCOO(adj_, false);
+    return EdgeArray{coo.row, coo.col, coo.data};
+  }
+
+  uint64_t InDegree(dgl_type_t etype, dgl_id_t vid) const override {
+    LOG(INFO) << "Not enabled for CSR graph.";
+    return {};
+  }
+
+  DegreeArray InDegrees(dgl_type_t etype, IdArray vids) const override {
+    LOG(INFO) << "Not enabled for CSR graph.";
+    return {};
+  }
+
+  uint64_t OutDegree(dgl_type_t etype, dgl_id_t vid) const override {
+    CHECK(HasVertex(0, vid)) << "Invalid src vertex id: " << vid;
+    return aten::CSRGetRowNNZ(adj_, vid);
+  }
+
+  DegreeArray OutDegrees(dgl_type_t etype, IdArray vids) const override {
+    CHECK(IsValidIdArray(vids)) << "Invalid vertex id array.";
+    return aten::CSRGetRowNNZ(adj_, vids);
+  }
+
+  DGLIdIters SuccVec(dgl_type_t etype, dgl_id_t vid) const override {
+    // TODO(minjie): This still assumes the data type and device context
+    //   of this graph. Should fix later.
+    const dgl_id_t* indptr_data = static_cast<dgl_id_t*>(adj_.indptr->data);
+    const dgl_id_t* indices_data = static_cast<dgl_id_t*>(adj_.indices->data);
+    const dgl_id_t start = indptr_data[vid];
+    const dgl_id_t end = indptr_data[vid + 1];
+    return DGLIdIters(indices_data + start, indices_data + end);
+  }
+
+  DGLIdIters OutEdgeVec(dgl_type_t etype, dgl_id_t vid) const override {
+    // TODO(minjie): This still assumes the data type and device context
+    //   of this graph. Should fix later.
+    const dgl_id_t* indptr_data = static_cast<dgl_id_t*>(adj_.indptr->data);
+    const dgl_id_t* eid_data = static_cast<dgl_id_t*>(adj_.data->data);
+    const dgl_id_t start = indptr_data[vid];
+    const dgl_id_t end = indptr_data[vid + 1];
+    return DGLIdIters(eid_data + start, eid_data + end);
+  }
+
+  DGLIdIters PredVec(dgl_type_t etype, dgl_id_t vid) const override {
+    LOG(INFO) << "Not enabled for CSR graph.";
+    return {};
+  }
+
+  DGLIdIters InEdgeVec(dgl_type_t etype, dgl_id_t vid) const override {
+    LOG(INFO) << "Not enabled for CSR graph.";
+    return {};
+  }
+
+  std::vector<IdArray> GetAdj(
+      dgl_id_t etype, bool transpose, const std::string &fmt) const override {
+    CHECK(!transpose && fmt == "csr") << "Not valid adj format request.";
+    return {adj_.indptr, adj_.indices, adj_.data};
+  }
+
+  HeteroSubgraph VertexSubgraph(const std::vector<IdArray>& vids) const override {
+    CHECK_EQ(vids.size(), 2) << "Number of vertex types mismatch";
+    CHECK(IsValidIdArray(vids[0])) << "Invalid vertex id array.";
+    CHECK(IsValidIdArray(vids[1])) << "Invalid vertex id array.";
+    HeteroSubgraph subg;
+    const auto& submat = aten::CSRSliceMatrix(adj_, vids[0], vids[1]);
+    IdArray sub_eids = aten::Range(0, submat.data->shape[0], NumBits(), Context());
+    subg.graph = std::make_shared<CSR>(submat.num_rows, submat.num_cols,
+        submat.indptr, submat.indices, sub_eids);
+    subg.induced_vertices = vids;
+    subg.induced_edges.emplace_back(submat.data);
+    return subg;
+  }
+
+  HeteroSubgraph EdgeSubgraph(
+      const std::vector<IdArray>& eids, bool preserve_nodes = false) const override {
+    LOG(INFO) << "Not enabled for CSR graph.";
+    return {};
+  }
+
+  aten::CSRMatrix adj() const {
+    return adj_;
+  }
+
+ private:
+  /*! \brief internal adjacency matrix. Data array stores edge ids */
+  aten::CSRMatrix adj_;
+
+  /*! \brief multi-graph flag */
+  Lazy<bool> is_multigraph_;
+};
+
+//////////////////////////////////////////////////////////
+//
+// bipartite graph implementation
+//
+//////////////////////////////////////////////////////////
+
+DLContext Bipartite::Context() const {
+  return GetAny()->Context();
+}
+
+uint8_t Bipartite::NumBits() const {
+  return GetAny()->NumBits();
+}
+
+bool Bipartite::IsMultigraph() const {
+  return GetAny()->IsMultigraph();
+}
+
+uint64_t Bipartite::NumVertices(dgl_type_t vtype) const {
+  return GetAny()->NumVertices(vtype);
+}
+
+uint64_t Bipartite::NumEdges(dgl_type_t etype) const {
+  return GetAny()->NumEdges(etype);
+}
+
+bool Bipartite::HasVertex(dgl_type_t vtype, dgl_id_t vid) const {
+  return GetAny()->HasVertex(vtype, vid);
+}
+
+bool Bipartite::HasEdgeBetween(dgl_type_t etype, dgl_id_t src, dgl_id_t dst) const {
+  if (in_csr_) {
+    return in_csr_->HasEdgeBetween(etype, dst, src);
+  } else {
+    return GetOutCSR()->HasEdgeBetween(etype, src, dst);
+  }
+}
+
+IdArray Bipartite::Predecessors(dgl_type_t etype, dgl_id_t dst) const {
+  return GetInCSR()->Successors(etype, dst);
+}
+
+IdArray Bipartite::Successors(dgl_type_t etype, dgl_id_t src) const {
+  return GetOutCSR()->Successors(etype, src);
+}
+
+IdArray Bipartite::EdgeId(dgl_type_t etype, dgl_id_t src, dgl_id_t dst) const {
+  if (in_csr_) {
+    return in_csr_->EdgeId(etype, dst, src);
+  } else {
+    return GetOutCSR()->EdgeId(etype, src, dst);
+  }
+}
+
+EdgeArray Bipartite::EdgeIds(dgl_type_t etype, IdArray src, IdArray dst) const {
+  if (in_csr_) {
+    EdgeArray edges = in_csr_->EdgeIds(etype, dst, src);
+    return EdgeArray{edges.dst, edges.src, edges.id};
+  } else {
+    return GetOutCSR()->EdgeIds(etype, src, dst);
+  }
+}
+
+std::pair<dgl_id_t, dgl_id_t> Bipartite::FindEdge(dgl_type_t etype, dgl_id_t eid) const {
+  return GetCOO()->FindEdge(etype, eid);
+}
+
+EdgeArray Bipartite::FindEdges(dgl_type_t etype, IdArray eids) const {
+  return GetCOO()->FindEdges(etype, eids);
+}
+
+EdgeArray Bipartite::InEdges(dgl_type_t etype, dgl_id_t vid) const {
+  const EdgeArray& ret = GetInCSR()->OutEdges(etype, vid);
+  return {ret.dst, ret.src, ret.id};
+}
+
+EdgeArray Bipartite::InEdges(dgl_type_t etype, IdArray vids) const {
+  const EdgeArray& ret = GetInCSR()->OutEdges(etype, vids);
+  return {ret.dst, ret.src, ret.id};
+}
+
+EdgeArray Bipartite::OutEdges(dgl_type_t etype, dgl_id_t vid) const {
+  return GetOutCSR()->OutEdges(etype, vid);
+}
+
+EdgeArray Bipartite::OutEdges(dgl_type_t etype, IdArray vids) const {
+  return GetOutCSR()->OutEdges(etype, vids);
+}
+
+EdgeArray Bipartite::Edges(dgl_type_t etype, const std::string &order) const {
+  if (order.empty()) {
+    // arbitrary order
+    if (in_csr_) {
+      // transpose
+      const auto& edges = in_csr_->Edges(etype, order);
+      return EdgeArray{edges.dst, edges.src, edges.id};
+    } else {
+      return GetAny()->Edges(etype, order);
+    }
+  } else if (order == std::string("srcdst")) {
+    // TODO(minjie): CSR only guarantees "src" to be sorted.
+    //   Maybe we should relax this requirement?
+    return GetOutCSR()->Edges(etype, order);
+  } else if (order == std::string("eid")) {
+    return GetCOO()->Edges(etype, order);
+  } else {
+    LOG(FATAL) << "Unsupported order request: " << order;
+  }
+  return {};
+}
+
+uint64_t Bipartite::InDegree(dgl_type_t etype, dgl_id_t vid) const {
+  return GetInCSR()->OutDegree(etype, vid);
+}
+
+DegreeArray Bipartite::InDegrees(dgl_type_t etype, IdArray vids) const {
+  return GetInCSR()->OutDegrees(etype, vids);
+}
+
+uint64_t Bipartite::OutDegree(dgl_type_t etype, dgl_id_t vid) const {
+  return GetOutCSR()->OutDegree(etype, vid);
+}
+
+DegreeArray Bipartite::OutDegrees(dgl_type_t etype, IdArray vids) const {
+  return GetOutCSR()->OutDegrees(etype, vids);
+}
+
+DGLIdIters Bipartite::SuccVec(dgl_type_t etype, dgl_id_t vid) const {
+  return GetOutCSR()->SuccVec(etype, vid);
+}
+
+DGLIdIters Bipartite::OutEdgeVec(dgl_type_t etype, dgl_id_t vid) const {
+  return GetOutCSR()->OutEdgeVec(etype, vid);
+}
+
+DGLIdIters Bipartite::PredVec(dgl_type_t etype, dgl_id_t vid) const {
+  return GetInCSR()->SuccVec(etype, vid);
+}
+
+DGLIdIters Bipartite::InEdgeVec(dgl_type_t etype, dgl_id_t vid) const {
+  return GetInCSR()->OutEdgeVec(etype, vid);
+}
+
+std::vector<IdArray> Bipartite::GetAdj(
+    dgl_id_t etype, bool transpose, const std::string &fmt) const {
+  // TODO(minjie): Our current semantics of adjacency matrix is row for dst nodes and col for
+  //   src nodes. Therefore, we need to flip the transpose flag. For example, transpose=False
+  //   is equal to in edge CSR.
+  //   We have this behavior because previously we use framework's SPMM and we don't cache
+  //   reverse adj. This is not intuitive and also not consistent with networkx's
+  //   to_scipy_sparse_matrix. With the upcoming custom kernel change, we should change the
+  //   behavior and make row for src and col for dst.
+  if (fmt == std::string("csr")) {
+    return transpose? GetOutCSR()->GetAdj(etype, false, "csr")
+      : GetInCSR()->GetAdj(etype, false, "csr");
+  } else if (fmt == std::string("coo")) {
+    return GetCOO()->GetAdj(etype, !transpose, fmt);
+  } else {
+    LOG(FATAL) << "unsupported adjacency matrix format: " << fmt;
+    return {};
+  }
+}
+
+HeteroSubgraph Bipartite::VertexSubgraph(const std::vector<IdArray>& vids) const {
+  // We prefer to generate a subgraph from out-csr.
+  auto sg = GetOutCSR()->VertexSubgraph(vids);
+  CSRPtr subcsr = std::dynamic_pointer_cast<CSR>(sg.graph);
+  HeteroSubgraph ret;
+  ret.graph = HeteroGraphPtr(new Bipartite(nullptr, subcsr, nullptr));
+  ret.induced_vertices = std::move(sg.induced_vertices);
+  ret.induced_edges = std::move(sg.induced_edges);
+  return ret;
+}
+
+HeteroSubgraph Bipartite::EdgeSubgraph(
+    const std::vector<IdArray>& eids, bool preserve_nodes) const {
+  auto sg = GetCOO()->EdgeSubgraph(eids, preserve_nodes);
+  COOPtr subcoo = std::dynamic_pointer_cast<COO>(sg.graph);
+  HeteroSubgraph ret;
+  ret.graph = HeteroGraphPtr(new Bipartite(nullptr, nullptr, subcoo));
+  ret.induced_vertices = std::move(sg.induced_vertices);
+  ret.induced_edges = std::move(sg.induced_edges);
+  return ret;
+}
+
+Bipartite::Bipartite(CSRPtr in_csr, CSRPtr out_csr, COOPtr coo)
+  : in_csr_(in_csr), out_csr_(out_csr), coo_(coo) {
+  CHECK(GetAny()) << "At least one graph structure should exist.";
+}
+
+Bipartite::CSRPtr Bipartite::GetInCSR() const {
+  if (!in_csr_) {
+    if (out_csr_) {
+      const auto& newadj = aten::CSRTranspose(out_csr_->adj());
+      const_cast<Bipartite*>(this)->in_csr_ = std::make_shared<CSR>(newadj);
+    } else {
+      CHECK(coo_) << "None of CSR, COO exist";
+      const auto& adj = coo_->adj();
+      const auto& newadj = aten::COOToCSR(
+          aten::COOMatrix{adj.num_cols, adj.num_rows, adj.col, adj.row});
+      const_cast<Bipartite*>(this)->in_csr_ = std::make_shared<CSR>(newadj);
+    }
+  }
+  return in_csr_;
+}
+
+/* !\brief Return out csr. If not exist, transpose the other one.*/
+Bipartite::CSRPtr Bipartite::GetOutCSR() const {
+  if (!out_csr_) {
+    if (in_csr_) {
+      const auto& newadj = aten::CSRTranspose(in_csr_->adj());
+      const_cast<Bipartite*>(this)->out_csr_ = std::make_shared<CSR>(newadj);
+    } else {
+      CHECK(coo_) << "None of CSR, COO exist";
+      const auto& newadj = aten::COOToCSR(coo_->adj());
+      const_cast<Bipartite*>(this)->out_csr_ = std::make_shared<CSR>(newadj);
+    }
+  }
+  return out_csr_;
+}
+
+/* !\brief Return coo. If not exist, create from csr.*/
+Bipartite::COOPtr Bipartite::GetCOO() const {
+  if (!coo_) {
+    if (in_csr_) {
+      const auto& newadj = aten::CSRToCOO(in_csr_->adj(), true);
+      const_cast<Bipartite*>(this)->coo_ = std::make_shared<COO>(
+          aten::COOMatrix{newadj.num_cols, newadj.num_rows, newadj.col, newadj.row});
+    } else {
+      CHECK(out_csr_) << "Both CSR are missing.";
+      const auto& newadj = aten::CSRToCOO(out_csr_->adj(), true);
+      const_cast<Bipartite*>(this)->coo_ = std::make_shared<COO>(newadj);
+    }
+  }
+  return coo_;
+}
+
+HeteroGraphPtr Bipartite::GetAny() const {
+  if (in_csr_) {
+    return in_csr_;
+  } else if (out_csr_) {
+    return out_csr_;
+  } else {
+    return coo_;
+  }
+}
+
+}  // namespace dgl

--- a/src/graph/bipartite.cc
+++ b/src/graph/bipartite.cc
@@ -217,7 +217,7 @@ class Bipartite::COO : public BaseHeteroGraph {
   }
 
   std::vector<IdArray> GetAdj(
-      dgl_id_t etype, bool transpose, const std::string &fmt) const override {
+      dgl_type_t etype, bool transpose, const std::string &fmt) const override {
     CHECK(fmt == "coo") << "Not valid adj format request.";
     if (transpose) {
       return {aten::HStack(adj_.col, adj_.row)};
@@ -487,7 +487,7 @@ class Bipartite::CSR : public BaseHeteroGraph {
   }
 
   std::vector<IdArray> GetAdj(
-      dgl_id_t etype, bool transpose, const std::string &fmt) const override {
+      dgl_type_t etype, bool transpose, const std::string &fmt) const override {
     CHECK(!transpose && fmt == "csr") << "Not valid adj format request.";
     return {adj_.indptr, adj_.indices, adj_.data};
   }
@@ -668,7 +668,7 @@ DGLIdIters Bipartite::InEdgeVec(dgl_type_t etype, dgl_id_t vid) const {
 }
 
 std::vector<IdArray> Bipartite::GetAdj(
-    dgl_id_t etype, bool transpose, const std::string &fmt) const {
+    dgl_type_t etype, bool transpose, const std::string &fmt) const {
   // TODO(minjie): Our current semantics of adjacency matrix is row for dst nodes and col for
   //   src nodes. Therefore, we need to flip the transpose flag. For example, transpose=False
   //   is equal to in edge CSR.

--- a/src/graph/bipartite.cc
+++ b/src/graph/bipartite.cc
@@ -40,7 +40,7 @@ class Bipartite::COO : public BaseHeteroGraph {
       is_multigraph_(is_multigraph) {
     adj_ = aten::COOMatrix{num_src, num_dst, src, dst};
   }
-  COO(const aten::COOMatrix& coo)
+  explicit COO(const aten::COOMatrix& coo)
     : BaseHeteroGraph(CreateBipartiteMetaGraph()), adj_(coo) {}
 
   uint64_t NumVertexTypes() const override {
@@ -302,7 +302,7 @@ class Bipartite::CSR : public BaseHeteroGraph {
     adj_ = aten::CSRMatrix{num_src, num_dst, indptr, indices, edge_ids};
   }
 
-  CSR(const aten::CSRMatrix& csr)
+  explicit CSR(const aten::CSRMatrix& csr)
     : BaseHeteroGraph(CreateBipartiteMetaGraph()), adj_(csr) {}
 
   uint64_t NumVertexTypes() const override {

--- a/src/graph/bipartite.cc
+++ b/src/graph/bipartite.cc
@@ -709,6 +709,20 @@ HeteroSubgraph Bipartite::EdgeSubgraph(
   return ret;
 }
 
+HeteroGraphPtr Bipartite::CreateFromCOO(
+    int64_t num_src, int64_t num_dst,
+    IdArray row, IdArray col) {
+  COOPtr coo(new COO(num_src, num_dst, row, col));
+  return HeteroGraphPtr(new Bipartite(nullptr, nullptr, coo));
+}
+
+HeteroGraphPtr Bipartite::CreateFromCSR(
+    int64_t num_src, int64_t num_dst,
+    IdArray indptr, IdArray indices, IdArray edge_ids) {
+  CSRPtr csr(new CSR(num_src, num_dst, indptr, indices, edge_ids));
+  return HeteroGraphPtr(new Bipartite(nullptr, csr, nullptr));
+}
+
 Bipartite::Bipartite(CSRPtr in_csr, CSRPtr out_csr, COOPtr coo)
   : BaseHeteroGraph(CreateBipartiteMetaGraph()), in_csr_(in_csr), out_csr_(out_csr), coo_(coo) {
   CHECK(GetAny()) << "At least one graph structure should exist.";

--- a/src/graph/bipartite.h
+++ b/src/graph/bipartite.h
@@ -9,6 +9,9 @@
 
 #include <dgl/graph_interface.h>
 #include <dgl/base_heterograph.h>
+#include <vector>
+#include <string>
+#include <utility>
 #include <memory>
 
 namespace dgl {

--- a/src/graph/bipartite.h
+++ b/src/graph/bipartite.h
@@ -75,7 +75,11 @@ class Bipartite : public BaseHeteroGraph {
 
   bool HasVertex(dgl_type_t vtype, dgl_id_t vid) const override;
 
+  BoolArray HasVertices(dgl_type_t vtype, IdArray vids) const override;
+
   bool HasEdgeBetween(dgl_type_t etype, dgl_id_t src, dgl_id_t dst) const override;
+
+  BoolArray HasEdgesBetween(dgl_type_t etype, IdArray src_ids, IdArray dst_ids) const override;
 
   IdArray Predecessors(dgl_type_t etype, dgl_id_t dst) const override;
 

--- a/src/graph/bipartite.h
+++ b/src/graph/bipartite.h
@@ -116,7 +116,7 @@ class Bipartite : public BaseHeteroGraph {
   DGLIdIters InEdgeVec(dgl_type_t etype, dgl_id_t vid) const override;
 
   std::vector<IdArray> GetAdj(
-      dgl_id_t etype, bool transpose, const std::string &fmt) const override;
+      dgl_type_t etype, bool transpose, const std::string &fmt) const override;
 
   HeteroSubgraph VertexSubgraph(const std::vector<IdArray>& vids) const override;
 

--- a/src/graph/bipartite.h
+++ b/src/graph/bipartite.h
@@ -123,6 +123,16 @@ class Bipartite : public BaseHeteroGraph {
   HeteroSubgraph EdgeSubgraph(
       const std::vector<IdArray>& eids, bool preserve_nodes = false) const override;
 
+  // creators
+  /*! \brief Create a bipartite graph from COO arrays */
+  static HeteroGraphPtr CreateFromCOO(int64_t num_src, int64_t num_dst,
+      IdArray row, IdArray col);
+
+  /*! \brief Create a bipartite graph from (out) CSR arrays */
+  static HeteroGraphPtr CreateFromCSR(
+      int64_t num_src, int64_t num_dst,
+      IdArray indptr, IdArray indices, IdArray edge_ids);
+
  private:
   // internal data structure
   class COO;

--- a/src/graph/bipartite.h
+++ b/src/graph/bipartite.h
@@ -1,15 +1,15 @@
 /*!
  *  Copyright (c) 2019 by Contributors
- * \file dgl/bipartite.h
+ * \file graph/bipartite.h
  * \brief Bipartite graph
  */
 
-#ifndef DGL_BIPARTITE_H_
-#define DGL_BIPARTITE_H_
+#ifndef DGL_GRAPH_BIPARTITE_H_
+#define DGL_GRAPH_BIPARTITE_H_
 
+#include <dgl/graph_interface.h>
+#include <dgl/base_heterograph.h>
 #include <memory>
-#include "graph_interface.h"
-#include "base_heterograph.h"
 
 namespace dgl {
 
@@ -156,4 +156,4 @@ class Bipartite : public BaseHeteroGraph {
 
 };  // namespace dgl
 
-#endif  // DGL_BIPARTITE_H_
+#endif  // DGL_GRAPH_BIPARTITE_H_

--- a/src/graph/graph_apis.cc
+++ b/src/graph/graph_apis.cc
@@ -226,6 +226,18 @@ DGL_REGISTER_GLOBAL("graph_index._CAPI_DGLGraphEdgeIds")
     *rv = ConvertEdgeArrayToPackedFunc(g->EdgeIds(src, dst));
   });
 
+DGL_REGISTER_GLOBAL("graph_index._CAPI_DGLGraphFindEdge")
+.set_body([] (DGLArgs args, DGLRetValue* rv) {
+    GraphRef g = args[0];
+    const dgl_id_t eid = args[1];
+    const auto& pair = g->FindEdge(eid);
+    *rv = PackedFunc([pair] (DGLArgs args, DGLRetValue* rv) {
+        const int choice = args[0];
+        const int64_t ret = (choice == 0? pair.first : pair.second);
+        *rv = ret;
+      });
+  });
+
 DGL_REGISTER_GLOBAL("graph_index._CAPI_DGLGraphFindEdges")
 .set_body([] (DGLArgs args, DGLRetValue* rv) {
     GraphRef g = args[0];

--- a/src/graph/graph_apis.cc
+++ b/src/graph/graph_apis.cc
@@ -20,36 +20,6 @@ using dgl::runtime::NDArray;
 namespace dgl {
 
 namespace {
-// Convert EdgeArray structure to PackedFunc.
-template<class EdgeArray>
-PackedFunc ConvertEdgeArrayToPackedFunc(const EdgeArray& ea) {
-  auto body = [ea] (DGLArgs args, DGLRetValue* rv) {
-      const int which = args[0];
-      if (which == 0) {
-        *rv = std::move(ea.src);
-      } else if (which == 1) {
-        *rv = std::move(ea.dst);
-      } else if (which == 2) {
-        *rv = std::move(ea.id);
-      } else {
-        LOG(FATAL) << "invalid choice";
-      }
-    };
-  return PackedFunc(body);
-}
-
-// Convert CSRArray structure to PackedFunc.
-PackedFunc ConvertAdjToPackedFunc(const std::vector<IdArray>& ea) {
-  auto body = [ea] (DGLArgs args, DGLRetValue* rv) {
-      const int which = args[0];
-      if ((size_t) which < ea.size()) {
-        *rv = std::move(ea[which]);
-      } else {
-        LOG(FATAL) << "invalid choice";
-      }
-    };
-  return PackedFunc(body);
-}
 
 // Convert Subgraph structure to PackedFunc.
 PackedFunc ConvertSubgraphToPackedFunc(const Subgraph& sg) {
@@ -347,7 +317,7 @@ DGL_REGISTER_GLOBAL("graph_index._CAPI_DGLGraphGetAdj")
     bool transpose = args[1];
     std::string format = args[2];
     auto res = g->GetAdj(transpose, format);
-    *rv = ConvertAdjToPackedFunc(res);
+    *rv = ConvertNDArrayVectorToPackedFunc(res);
   });
 
 DGL_REGISTER_GLOBAL("graph_index._CAPI_DGLGraphContext")

--- a/src/graph/heterograph.cc
+++ b/src/graph/heterograph.cc
@@ -1,0 +1,83 @@
+#include "./heterograph.h"
+#include "./bipartite.h"
+
+namespace dgl {
+
+HeteroGraph::HeteroGraph(GraphPtr meta_graph, const std::vector<HeteroGraphPtr>& rel_graphs)
+  : BaseHeteroGraph(meta_graph), relation_graphs_(rel_graphs) {
+  // Sanity check
+  CHECK_EQ(meta_graph->NumEdges(), rel_graphs.size());
+  // all relation graph must be bipartite graphs
+  for (const auto rg : rel_graphs) {
+    CHECK_EQ(rg->NumVertexTypes(), 2) << "Each relation graph must be a bipartite graph.";
+    CHECK_EQ(rg->NumEdgeTypes(), 1) << "Each relation graph must be a bipartite graph.";
+  }
+  // create num verts per type
+  num_verts_per_type_.resize(meta_graph_->NumVertices(), -1);
+  for (dgl_type_t vtype = 0; vtype < meta_graph_->NumVertices(); ++vtype) {
+    for (dgl_type_t etype : meta_graph->OutEdgeVec(vtype)) {
+      const auto nv = rel_graphs[etype]->NumVertices(Bipartite::kSrcVType);
+      if (num_verts_per_type_[vtype] < 0) {
+        num_verts_per_type_[vtype] = nv;
+      } else {
+        CHECK_EQ(num_verts_per_type_[vtype], nv)
+          << "Mismatch number of vertices for vertex type " << vtype;
+      }
+    }
+  }
+}
+
+bool HeteroGraph::IsMultigraph() const {
+  return const_cast<HeteroGraph*>(this)->is_multigraph_.Get([this] () {
+      for (const auto hg : relation_graphs_) {
+        if (hg->IsMultigraph()) {
+          return true;
+        }
+      }
+      return false;
+    });
+}
+
+HeteroSubgraph HeteroGraph::VertexSubgraph(const std::vector<IdArray>& vids) const {
+  CHECK_EQ(vids.size(), NumVertexTypes())
+    << "Invalid input: the input list size must be the same as the number of vertex types.";
+  HeteroSubgraph ret;
+  ret.induced_vertices = vids;
+  ret.induced_edges.resize(NumEdgeTypes());
+  std::vector<HeteroGraphPtr> subrels(NumEdgeTypes());
+  for (dgl_type_t etype = 0; etype < NumEdgeTypes(); ++etype) {
+    auto pair = meta_graph_->FindEdge(etype);
+    const dgl_type_t src_vtype = pair.first;
+    const dgl_type_t dst_vtype = pair.second;
+    const auto& rel_vsg = GetRelationGraph(etype)->VertexSubgraph(
+        {vids[src_vtype], vids[dst_vtype]});
+    subrels[etype] = rel_vsg.graph;
+    ret.induced_edges[etype] = rel_vsg.induced_edges[0];
+  }
+  ret.graph = HeteroGraphPtr(new HeteroGraph(meta_graph_, subrels));
+  return ret;
+}
+
+HeteroSubgraph HeteroGraph::EdgeSubgraph(
+    const std::vector<IdArray>& eids, bool preserve_nodes) const {
+  CHECK_EQ(eids.size(), NumEdgeTypes())
+    << "Invalid input: the input list size must be the same as the number of edge type.";
+  HeteroSubgraph ret;
+  ret.induced_vertices.resize(NumVertexTypes());
+  ret.induced_edges = eids;
+  std::vector<HeteroGraphPtr> subrels(NumEdgeTypes());
+  for (dgl_type_t etype = 0; etype < NumEdgeTypes(); ++etype) {
+    auto pair = meta_graph_->FindEdge(etype);
+    const dgl_type_t src_vtype = pair.first;
+    const dgl_type_t dst_vtype = pair.second;
+    const auto& rel_vsg = GetRelationGraph(etype)->EdgeSubgraph(
+        {eids[etype]}, preserve_nodes);
+    subrels[etype] = rel_vsg.graph;
+    ret.induced_vertices[src_vtype] = rel_vsg.induced_vertices[0];
+    ret.induced_vertices[dst_vtype] = rel_vsg.induced_vertices[1];
+  }
+  ret.graph = HeteroGraphPtr(new HeteroGraph(meta_graph_, subrels));
+  return ret;
+}
+
+}  // namespace dgl

--- a/src/graph/heterograph.cc
+++ b/src/graph/heterograph.cc
@@ -1,5 +1,9 @@
 #include "./heterograph.h"
+#include <dgl/packed_func_ext.h>
+#include "../c_api_common.h"
 #include "./bipartite.h"
+
+using namespace dgl::runtime;
 
 namespace dgl {
 
@@ -79,5 +83,257 @@ HeteroSubgraph HeteroGraph::EdgeSubgraph(
   ret.graph = HeteroGraphPtr(new HeteroGraph(meta_graph_, subrels));
   return ret;
 }
+
+// creator implementation
+HeteroGraphPtr CreateBipartiteFromCOO(
+    int64_t num_src, int64_t num_dst, IdArray row, IdArray col) {
+  return Bipartite::CreateFromCOO(num_src, num_dst, row, col);
+}
+
+HeteroGraphPtr CreateBipartiteFromCSR(
+    int64_t num_src, int64_t num_dst,
+    IdArray indptr, IdArray indices, IdArray edge_ids) {
+  return Bipartite::CreateFromCSR(num_src, num_dst, indptr, indices, edge_ids);
+}
+
+HeteroGraphPtr CreateHeteroGraph(
+    GraphPtr meta_graph, const std::vector<HeteroGraphPtr>& rel_graphs) {
+  return HeteroGraphPtr(new HeteroGraph(meta_graph, rel_graphs));
+}
+
+///////////////////////// C APIs /////////////////////////
+
+DGL_REGISTER_GLOBAL("graph_index._CAPI_DGLHeteroCreateBipartiteFromCOO")
+.set_body([] (DGLArgs args, DGLRetValue* rv) {
+    int64_t num_src = args[0];
+    int64_t num_dst = args[1];
+    IdArray row = args[2];
+    IdArray col = args[3];
+    auto hgptr = CreateBipartiteFromCOO(num_src, num_dst, row, col);
+    *rv = HeteroGraphRef(hgptr);
+  });
+
+DGL_REGISTER_GLOBAL("graph_index._CAPI_DGLHeteroCreateBipartiteFromCSR")
+.set_body([] (DGLArgs args, DGLRetValue* rv) {
+    int64_t num_src = args[0];
+    int64_t num_dst = args[1];
+    IdArray indptr = args[2];
+    IdArray indices = args[3];
+    IdArray edge_ids = args[4];
+    auto hgptr = CreateBipartiteFromCSR(num_src, num_dst, indptr, indices, edge_ids);
+    *rv = HeteroGraphRef(hgptr);
+  });
+
+DGL_REGISTER_GLOBAL("graph_index._CAPI_DGLHeteroCreateHeteroGraph")
+.set_body([] (DGLArgs args, DGLRetValue* rv) {
+    GraphRef meta_graph = args[0];
+    List<HeteroGraphRef> rel_graphs = args[1];
+    std::vector<HeteroGraphPtr> rel_ptrs;
+    rel_ptrs.reserve(rel_graphs.size());
+    for (const auto& ref : rel_graphs) {
+      rel_ptrs.push_back(ref.sptr());
+    }
+    auto hgptr = CreateHeteroGraph(meta_graph.sptr(), rel_ptrs);
+    *rv = HeteroGraphRef(hgptr);
+  });
+
+DGL_REGISTER_GLOBAL("graph_index._CAPI_DGLHeteroGetMetaGraph")
+.set_body([] (DGLArgs args, DGLRetValue* rv) {
+    HeteroGraphRef hg = args[0];
+    *rv = GraphRef(hg->meta_graph());
+  });
+
+DGL_REGISTER_GLOBAL("graph_index._CAPI_DGLHeteroGetRelationGraph")
+.set_body([] (DGLArgs args, DGLRetValue* rv) {
+    HeteroGraphRef hg = args[0];
+    dgl_type_t etype = args[1];
+    *rv = HeteroGraphRef(hg->GetRelationGraph(etype));
+  });
+
+DGL_REGISTER_GLOBAL("graph_index._CAPI_DGLHeteroAddVertices")
+.set_body([] (DGLArgs args, DGLRetValue* rv) {
+    HeteroGraphRef hg = args[0];
+
+  });
+
+DGL_REGISTER_GLOBAL("graph_index._CAPI_DGLHeteroAddEdge")
+.set_body([] (DGLArgs args, DGLRetValue* rv) {
+    HeteroGraphRef hg = args[0];
+
+  });
+
+DGL_REGISTER_GLOBAL("graph_index._CAPI_DGLHeteroAddEdges")
+.set_body([] (DGLArgs args, DGLRetValue* rv) {
+    HeteroGraphRef hg = args[0];
+
+  });
+
+DGL_REGISTER_GLOBAL("graph_index._CAPI_DGLHeteroClear")
+.set_body([] (DGLArgs args, DGLRetValue* rv) {
+    HeteroGraphRef hg = args[0];
+
+  });
+
+DGL_REGISTER_GLOBAL("graph_index._CAPI_DGLHeteroContext")
+.set_body([] (DGLArgs args, DGLRetValue* rv) {
+    HeteroGraphRef hg = args[0];
+
+  });
+
+DGL_REGISTER_GLOBAL("graph_index._CAPI_DGLHeteroNumBits")
+.set_body([] (DGLArgs args, DGLRetValue* rv) {
+    HeteroGraphRef hg = args[0];
+
+  });
+
+DGL_REGISTER_GLOBAL("graph_index._CAPI_DGLHeteroIsMultigraph")
+.set_body([] (DGLArgs args, DGLRetValue* rv) {
+    HeteroGraphRef hg = args[0];
+
+  });
+
+DGL_REGISTER_GLOBAL("graph_index._CAPI_DGLHeteroIsReadonly")
+.set_body([] (DGLArgs args, DGLRetValue* rv) {
+    HeteroGraphRef hg = args[0];
+
+  });
+
+DGL_REGISTER_GLOBAL("graph_index._CAPI_DGLHeteroNumVertices")
+.set_body([] (DGLArgs args, DGLRetValue* rv) {
+    HeteroGraphRef hg = args[0];
+
+  });
+
+DGL_REGISTER_GLOBAL("graph_index._CAPI_DGLHeteroNumEdges")
+.set_body([] (DGLArgs args, DGLRetValue* rv) {
+    HeteroGraphRef hg = args[0];
+
+  });
+
+DGL_REGISTER_GLOBAL("graph_index._CAPI_DGLHeteroHasVertex")
+.set_body([] (DGLArgs args, DGLRetValue* rv) {
+    HeteroGraphRef hg = args[0];
+
+  });
+
+DGL_REGISTER_GLOBAL("graph_index._CAPI_DGLHeteroHasVertices")
+.set_body([] (DGLArgs args, DGLRetValue* rv) {
+    HeteroGraphRef hg = args[0];
+
+  });
+
+DGL_REGISTER_GLOBAL("graph_index._CAPI_DGLHeteroHasEdgeBetween")
+.set_body([] (DGLArgs args, DGLRetValue* rv) {
+    HeteroGraphRef hg = args[0];
+
+  });
+
+DGL_REGISTER_GLOBAL("graph_index._CAPI_DGLHeteroHasEdgesBetween")
+.set_body([] (DGLArgs args, DGLRetValue* rv) {
+    HeteroGraphRef hg = args[0];
+
+  });
+
+DGL_REGISTER_GLOBAL("graph_index._CAPI_DGLHeteroSuccessors")
+.set_body([] (DGLArgs args, DGLRetValue* rv) {
+    HeteroGraphRef hg = args[0];
+
+  });
+
+DGL_REGISTER_GLOBAL("graph_index._CAPI_DGLHeteroEdgeId")
+.set_body([] (DGLArgs args, DGLRetValue* rv) {
+    HeteroGraphRef hg = args[0];
+
+  });
+
+DGL_REGISTER_GLOBAL("graph_index._CAPI_DGLHeteroEdgeIds")
+.set_body([] (DGLArgs args, DGLRetValue* rv) {
+    HeteroGraphRef hg = args[0];
+
+  });
+
+DGL_REGISTER_GLOBAL("graph_index._CAPI_DGLHeteroFindEdge")
+.set_body([] (DGLArgs args, DGLRetValue* rv) {
+    HeteroGraphRef hg = args[0];
+
+  });
+
+DGL_REGISTER_GLOBAL("graph_index._CAPI_DGLHeteroFindEdges")
+.set_body([] (DGLArgs args, DGLRetValue* rv) {
+    HeteroGraphRef hg = args[0];
+
+  });
+
+DGL_REGISTER_GLOBAL("graph_index._CAPI_DGLHeteroInEdges_1")
+.set_body([] (DGLArgs args, DGLRetValue* rv) {
+    HeteroGraphRef hg = args[0];
+
+  });
+
+DGL_REGISTER_GLOBAL("graph_index._CAPI_DGLHeteroInEdges_2")
+.set_body([] (DGLArgs args, DGLRetValue* rv) {
+    HeteroGraphRef hg = args[0];
+
+  });
+
+DGL_REGISTER_GLOBAL("graph_index._CAPI_DGLHeteroOutEdges_1")
+.set_body([] (DGLArgs args, DGLRetValue* rv) {
+    HeteroGraphRef hg = args[0];
+
+  });
+
+DGL_REGISTER_GLOBAL("graph_index._CAPI_DGLHeteroOutEdges_2")
+.set_body([] (DGLArgs args, DGLRetValue* rv) {
+    HeteroGraphRef hg = args[0];
+
+  });
+
+DGL_REGISTER_GLOBAL("graph_index._CAPI_DGLHeteroEdges")
+.set_body([] (DGLArgs args, DGLRetValue* rv) {
+    HeteroGraphRef hg = args[0];
+
+  });
+
+DGL_REGISTER_GLOBAL("graph_index._CAPI_DGLHeteroInDegree")
+.set_body([] (DGLArgs args, DGLRetValue* rv) {
+    HeteroGraphRef hg = args[0];
+
+  });
+
+DGL_REGISTER_GLOBAL("graph_index._CAPI_DGLHeteroInDegrees")
+.set_body([] (DGLArgs args, DGLRetValue* rv) {
+    HeteroGraphRef hg = args[0];
+
+  });
+
+DGL_REGISTER_GLOBAL("graph_index._CAPI_DGLHeteroOutDegree")
+.set_body([] (DGLArgs args, DGLRetValue* rv) {
+    HeteroGraphRef hg = args[0];
+
+  });
+
+DGL_REGISTER_GLOBAL("graph_index._CAPI_DGLHeteroOutDegrees")
+.set_body([] (DGLArgs args, DGLRetValue* rv) {
+    HeteroGraphRef hg = args[0];
+
+  });
+
+DGL_REGISTER_GLOBAL("graph_index._CAPI_DGLHeteroGetAdj")
+.set_body([] (DGLArgs args, DGLRetValue* rv) {
+    HeteroGraphRef hg = args[0];
+
+  });
+
+DGL_REGISTER_GLOBAL("graph_index._CAPI_DGLHeteroVertexSubgraph")
+.set_body([] (DGLArgs args, DGLRetValue* rv) {
+    HeteroGraphRef hg = args[0];
+
+  });
+
+DGL_REGISTER_GLOBAL("graph_index._CAPI_DGLHeteroEdgeSubgraph")
+.set_body([] (DGLArgs args, DGLRetValue* rv) {
+    HeteroGraphRef hg = args[0];
+
+  });
 
 }  // namespace dgl

--- a/src/graph/heterograph.cc
+++ b/src/graph/heterograph.cc
@@ -1,5 +1,6 @@
 #include "./heterograph.h"
 #include <dgl/packed_func_ext.h>
+#include <dgl/runtime/container.h>
 #include "../c_api_common.h"
 #include "./bipartite.h"
 
@@ -153,187 +154,293 @@ DGL_REGISTER_GLOBAL("graph_index._CAPI_DGLHeteroGetRelationGraph")
 DGL_REGISTER_GLOBAL("graph_index._CAPI_DGLHeteroAddVertices")
 .set_body([] (DGLArgs args, DGLRetValue* rv) {
     HeteroGraphRef hg = args[0];
-
+    dgl_type_t vtype = args[1];
+    int64_t num = args[2];
+    hg->AddVertices(vtype, num);
   });
 
 DGL_REGISTER_GLOBAL("graph_index._CAPI_DGLHeteroAddEdge")
 .set_body([] (DGLArgs args, DGLRetValue* rv) {
     HeteroGraphRef hg = args[0];
-
+    dgl_type_t etype = args[1];
+    dgl_id_t src = args[2];
+    dgl_id_t dst = args[3];
+    hg->AddEdge(etype, src, dst);
   });
 
 DGL_REGISTER_GLOBAL("graph_index._CAPI_DGLHeteroAddEdges")
 .set_body([] (DGLArgs args, DGLRetValue* rv) {
     HeteroGraphRef hg = args[0];
-
+    dgl_type_t etype = args[1];
+    IdArray src = args[2];
+    IdArray dst = args[3];
+    hg->AddEdges(etype, src, dst);
   });
 
 DGL_REGISTER_GLOBAL("graph_index._CAPI_DGLHeteroClear")
 .set_body([] (DGLArgs args, DGLRetValue* rv) {
     HeteroGraphRef hg = args[0];
-
+    hg->Clear();
   });
 
 DGL_REGISTER_GLOBAL("graph_index._CAPI_DGLHeteroContext")
 .set_body([] (DGLArgs args, DGLRetValue* rv) {
     HeteroGraphRef hg = args[0];
-
+    *rv = hg->Context();
   });
 
 DGL_REGISTER_GLOBAL("graph_index._CAPI_DGLHeteroNumBits")
 .set_body([] (DGLArgs args, DGLRetValue* rv) {
     HeteroGraphRef hg = args[0];
-
+    *rv = hg->NumBits();
   });
 
 DGL_REGISTER_GLOBAL("graph_index._CAPI_DGLHeteroIsMultigraph")
 .set_body([] (DGLArgs args, DGLRetValue* rv) {
     HeteroGraphRef hg = args[0];
-
+    *rv = hg->IsMultigraph();
   });
 
 DGL_REGISTER_GLOBAL("graph_index._CAPI_DGLHeteroIsReadonly")
 .set_body([] (DGLArgs args, DGLRetValue* rv) {
     HeteroGraphRef hg = args[0];
-
+    *rv = hg->IsReadonly();
   });
 
 DGL_REGISTER_GLOBAL("graph_index._CAPI_DGLHeteroNumVertices")
 .set_body([] (DGLArgs args, DGLRetValue* rv) {
     HeteroGraphRef hg = args[0];
-
+    dgl_type_t vtype = args[1];
+    *rv = static_cast<int64_t>(hg->NumVertices(vtype));
   });
 
 DGL_REGISTER_GLOBAL("graph_index._CAPI_DGLHeteroNumEdges")
 .set_body([] (DGLArgs args, DGLRetValue* rv) {
     HeteroGraphRef hg = args[0];
-
+    dgl_type_t etype = args[1];
+    *rv = static_cast<int64_t>(hg->NumEdges(etype));
   });
 
 DGL_REGISTER_GLOBAL("graph_index._CAPI_DGLHeteroHasVertex")
 .set_body([] (DGLArgs args, DGLRetValue* rv) {
     HeteroGraphRef hg = args[0];
-
+    dgl_type_t vtype = args[1];
+    dgl_id_t vid = args[2];
+    *rv = hg->HasVertex(vtype, vid);
   });
 
 DGL_REGISTER_GLOBAL("graph_index._CAPI_DGLHeteroHasVertices")
 .set_body([] (DGLArgs args, DGLRetValue* rv) {
     HeteroGraphRef hg = args[0];
-
+    dgl_type_t vtype = args[1];
+    IdArray vids = args[2];
+    *rv = hg->HasVertices(vtype, vids);
   });
 
 DGL_REGISTER_GLOBAL("graph_index._CAPI_DGLHeteroHasEdgeBetween")
 .set_body([] (DGLArgs args, DGLRetValue* rv) {
     HeteroGraphRef hg = args[0];
-
+    dgl_type_t etype = args[1];
+    dgl_id_t src = args[2];
+    dgl_id_t dst = args[2];
+    *rv = hg->HasEdgeBetween(etype, src, dst);
   });
 
 DGL_REGISTER_GLOBAL("graph_index._CAPI_DGLHeteroHasEdgesBetween")
 .set_body([] (DGLArgs args, DGLRetValue* rv) {
     HeteroGraphRef hg = args[0];
+    dgl_type_t etype = args[1];
+    IdArray src = args[2];
+    IdArray dst = args[3];
+    *rv = hg->HasEdgesBetween(etype, src, dst);
+  });
 
+DGL_REGISTER_GLOBAL("graph_index._CAPI_DGLHeteroPredecessors")
+.set_body([] (DGLArgs args, DGLRetValue* rv) {
+    HeteroGraphRef hg = args[0];
+    dgl_type_t etype = args[1];
+    dgl_id_t dst = args[2];
+    *rv = hg->Predecessors(etype, dst);
   });
 
 DGL_REGISTER_GLOBAL("graph_index._CAPI_DGLHeteroSuccessors")
 .set_body([] (DGLArgs args, DGLRetValue* rv) {
     HeteroGraphRef hg = args[0];
-
+    dgl_type_t etype = args[1];
+    dgl_id_t src = args[2];
+    *rv = hg->Successors(etype, src);
   });
 
 DGL_REGISTER_GLOBAL("graph_index._CAPI_DGLHeteroEdgeId")
 .set_body([] (DGLArgs args, DGLRetValue* rv) {
     HeteroGraphRef hg = args[0];
-
+    dgl_type_t etype = args[1];
+    dgl_id_t src = args[2];
+    dgl_id_t dst = args[3];
+    *rv = hg->EdgeId(etype, src, dst);
   });
 
 DGL_REGISTER_GLOBAL("graph_index._CAPI_DGLHeteroEdgeIds")
 .set_body([] (DGLArgs args, DGLRetValue* rv) {
     HeteroGraphRef hg = args[0];
-
-  });
-
-DGL_REGISTER_GLOBAL("graph_index._CAPI_DGLHeteroFindEdge")
-.set_body([] (DGLArgs args, DGLRetValue* rv) {
-    HeteroGraphRef hg = args[0];
-
+    dgl_type_t etype = args[1];
+    IdArray src = args[2];
+    IdArray dst = args[3];
+    const auto& ret = hg->EdgeIds(etype, src, dst);
+    *rv = ConvertEdgeArrayToPackedFunc(ret);
   });
 
 DGL_REGISTER_GLOBAL("graph_index._CAPI_DGLHeteroFindEdges")
 .set_body([] (DGLArgs args, DGLRetValue* rv) {
     HeteroGraphRef hg = args[0];
-
+    dgl_type_t etype = args[1];
+    IdArray eids = args[2];
+    const auto& ret = hg->FindEdges(etype, eids);
+    *rv = ConvertEdgeArrayToPackedFunc(ret);
   });
 
 DGL_REGISTER_GLOBAL("graph_index._CAPI_DGLHeteroInEdges_1")
 .set_body([] (DGLArgs args, DGLRetValue* rv) {
     HeteroGraphRef hg = args[0];
-
+    dgl_type_t etype = args[1];
+    dgl_id_t vid = args[2];
+    const auto& ret = hg->InEdges(etype, vid);
+    *rv = ConvertEdgeArrayToPackedFunc(ret);
   });
 
 DGL_REGISTER_GLOBAL("graph_index._CAPI_DGLHeteroInEdges_2")
 .set_body([] (DGLArgs args, DGLRetValue* rv) {
     HeteroGraphRef hg = args[0];
-
+    dgl_type_t etype = args[1];
+    IdArray vids = args[2];
+    const auto& ret = hg->InEdges(etype, vids);
+    *rv = ConvertEdgeArrayToPackedFunc(ret);
   });
 
 DGL_REGISTER_GLOBAL("graph_index._CAPI_DGLHeteroOutEdges_1")
 .set_body([] (DGLArgs args, DGLRetValue* rv) {
     HeteroGraphRef hg = args[0];
-
+    dgl_type_t etype = args[1];
+    dgl_id_t vid = args[2];
+    const auto& ret = hg->OutEdges(etype, vid);
+    *rv = ConvertEdgeArrayToPackedFunc(ret);
   });
 
 DGL_REGISTER_GLOBAL("graph_index._CAPI_DGLHeteroOutEdges_2")
 .set_body([] (DGLArgs args, DGLRetValue* rv) {
     HeteroGraphRef hg = args[0];
-
+    dgl_type_t etype = args[1];
+    IdArray vids = args[2];
+    const auto& ret = hg->OutEdges(etype, vids);
+    *rv = ConvertEdgeArrayToPackedFunc(ret);
   });
 
 DGL_REGISTER_GLOBAL("graph_index._CAPI_DGLHeteroEdges")
 .set_body([] (DGLArgs args, DGLRetValue* rv) {
     HeteroGraphRef hg = args[0];
-
+    dgl_type_t etype = args[1];
+    std::string order = args[2];
+    const auto& ret = hg->Edges(etype, order);
+    *rv = ConvertEdgeArrayToPackedFunc(ret);
   });
 
 DGL_REGISTER_GLOBAL("graph_index._CAPI_DGLHeteroInDegree")
 .set_body([] (DGLArgs args, DGLRetValue* rv) {
     HeteroGraphRef hg = args[0];
-
+    dgl_type_t etype = args[1];
+    dgl_id_t vid = args[2];
+    *rv = static_cast<int64_t>(hg->InDegree(etype, vid));
   });
 
 DGL_REGISTER_GLOBAL("graph_index._CAPI_DGLHeteroInDegrees")
 .set_body([] (DGLArgs args, DGLRetValue* rv) {
     HeteroGraphRef hg = args[0];
-
+    dgl_type_t etype = args[1];
+    IdArray vids = args[2];
+    *rv = hg->InDegrees(etype, vids);
   });
 
 DGL_REGISTER_GLOBAL("graph_index._CAPI_DGLHeteroOutDegree")
 .set_body([] (DGLArgs args, DGLRetValue* rv) {
     HeteroGraphRef hg = args[0];
-
+    dgl_type_t etype = args[1];
+    dgl_id_t vid = args[2];
+    *rv = static_cast<int64_t>(hg->OutDegree(etype, vid));
   });
 
 DGL_REGISTER_GLOBAL("graph_index._CAPI_DGLHeteroOutDegrees")
 .set_body([] (DGLArgs args, DGLRetValue* rv) {
     HeteroGraphRef hg = args[0];
-
+    dgl_type_t etype = args[1];
+    IdArray vids = args[2];
+    *rv = hg->OutDegrees(etype, vids);
   });
 
 DGL_REGISTER_GLOBAL("graph_index._CAPI_DGLHeteroGetAdj")
 .set_body([] (DGLArgs args, DGLRetValue* rv) {
     HeteroGraphRef hg = args[0];
-
+    dgl_type_t etype = args[1];
+    bool transpose = args[2];
+    std::string fmt = args[3];
+    *rv = ConvertNDArrayVectorToPackedFunc(
+        hg->GetAdj(etype, transpose, fmt));
   });
 
 DGL_REGISTER_GLOBAL("graph_index._CAPI_DGLHeteroVertexSubgraph")
 .set_body([] (DGLArgs args, DGLRetValue* rv) {
     HeteroGraphRef hg = args[0];
-
+    List<Value> vids = args[1];
+    std::vector<IdArray> vid_vec;
+    vid_vec.reserve(vids.size());
+    for (Value val : vids) {
+      vid_vec.push_back(val->data);
+    }
+    std::shared_ptr<HeteroSubgraph> subg(
+        new HeteroSubgraph(hg->VertexSubgraph(vid_vec)));
+    *rv = subg;
   });
 
 DGL_REGISTER_GLOBAL("graph_index._CAPI_DGLHeteroEdgeSubgraph")
 .set_body([] (DGLArgs args, DGLRetValue* rv) {
     HeteroGraphRef hg = args[0];
+    List<Value> eids = args[1];
+    bool preserve_nodes = args[2];
+    std::vector<IdArray> eid_vec;
+    eid_vec.reserve(eids.size());
+    for (Value val : eids) {
+      eid_vec.push_back(val->data);
+    }
+    std::shared_ptr<HeteroSubgraph> subg(
+        new HeteroSubgraph(hg->EdgeSubgraph(eid_vec, preserve_nodes)));
+    *rv = subg;
+  });
 
+// HeteroSubgraph C APIs
+
+DGL_REGISTER_GLOBAL("graph_index._CAPI_DGLHeteroSubgraphGetGraph")
+.set_body([] (DGLArgs args, DGLRetValue* rv) {
+    std::shared_ptr<HeteroSubgraph> subg = args[0];
+    *rv = HeteroGraphRef(subg->graph);
+  });
+
+DGL_REGISTER_GLOBAL("graph_index._CAPI_DGLHeteroSubgraphGetInducedVertices")
+.set_body([] (DGLArgs args, DGLRetValue* rv) {
+    std::shared_ptr<HeteroSubgraph> subg = args[0];
+    List<Value> induced_verts;
+    for (IdArray arr : subg->induced_vertices) {
+      induced_verts.push_back(Value(MakeValue(arr)));
+    }
+    *rv = induced_verts;
+  });
+
+DGL_REGISTER_GLOBAL("graph_index._CAPI_DGLHeteroSubgraphGetInducedEdges")
+.set_body([] (DGLArgs args, DGLRetValue* rv) {
+    std::shared_ptr<HeteroSubgraph> subg = args[0];
+    List<Value> induced_edges;
+    for (IdArray arr : subg->induced_edges) {
+      induced_edges.push_back(Value(MakeValue(arr)));
+    }
+    *rv = induced_edges;
   });
 
 }  // namespace dgl

--- a/src/graph/heterograph.cc
+++ b/src/graph/heterograph.cc
@@ -242,7 +242,7 @@ DGL_REGISTER_GLOBAL("graph_index._CAPI_DGLHeteroHasEdgeBetween")
     HeteroGraphRef hg = args[0];
     dgl_type_t etype = args[1];
     dgl_id_t src = args[2];
-    dgl_id_t dst = args[2];
+    dgl_id_t dst = args[3];
     *rv = hg->HasEdgeBetween(etype, src, dst);
   });
 

--- a/src/graph/heterograph.cc
+++ b/src/graph/heterograph.cc
@@ -65,6 +65,7 @@ HeteroSubgraph HeteroGraph::VertexSubgraph(const std::vector<IdArray>& vids) con
 
 HeteroSubgraph HeteroGraph::EdgeSubgraph(
     const std::vector<IdArray>& eids, bool preserve_nodes) const {
+  // TODO(minjie): this is not correct
   CHECK_EQ(eids.size(), NumEdgeTypes())
     << "Invalid input: the input list size must be the same as the number of edge type.";
   HeteroSubgraph ret;

--- a/src/graph/heterograph.cc
+++ b/src/graph/heterograph.cc
@@ -1,3 +1,8 @@
+/*!
+ *  Copyright (c) 2019 by Contributors
+ * \file graph/heterograph.cc
+ * \brief Heterograph implementation
+ */
 #include "./heterograph.h"
 #include <dgl/packed_func_ext.h>
 #include <dgl/runtime/container.h>

--- a/src/graph/heterograph.cc
+++ b/src/graph/heterograph.cc
@@ -397,7 +397,7 @@ DGL_REGISTER_GLOBAL("graph_index._CAPI_DGLHeteroVertexSubgraph")
     }
     std::shared_ptr<HeteroSubgraph> subg(
         new HeteroSubgraph(hg->VertexSubgraph(vid_vec)));
-    *rv = subg;
+    *rv = HeteroSubgraphRef(subg);
   });
 
 DGL_REGISTER_GLOBAL("graph_index._CAPI_DGLHeteroEdgeSubgraph")
@@ -412,20 +412,20 @@ DGL_REGISTER_GLOBAL("graph_index._CAPI_DGLHeteroEdgeSubgraph")
     }
     std::shared_ptr<HeteroSubgraph> subg(
         new HeteroSubgraph(hg->EdgeSubgraph(eid_vec, preserve_nodes)));
-    *rv = subg;
+    *rv = HeteroSubgraphRef(subg);
   });
 
 // HeteroSubgraph C APIs
 
 DGL_REGISTER_GLOBAL("graph_index._CAPI_DGLHeteroSubgraphGetGraph")
 .set_body([] (DGLArgs args, DGLRetValue* rv) {
-    std::shared_ptr<HeteroSubgraph> subg = args[0];
+    HeteroSubgraphRef subg = args[0];
     *rv = HeteroGraphRef(subg->graph);
   });
 
 DGL_REGISTER_GLOBAL("graph_index._CAPI_DGLHeteroSubgraphGetInducedVertices")
 .set_body([] (DGLArgs args, DGLRetValue* rv) {
-    std::shared_ptr<HeteroSubgraph> subg = args[0];
+    HeteroSubgraphRef subg = args[0];
     List<Value> induced_verts;
     for (IdArray arr : subg->induced_vertices) {
       induced_verts.push_back(Value(MakeValue(arr)));
@@ -435,7 +435,7 @@ DGL_REGISTER_GLOBAL("graph_index._CAPI_DGLHeteroSubgraphGetInducedVertices")
 
 DGL_REGISTER_GLOBAL("graph_index._CAPI_DGLHeteroSubgraphGetInducedEdges")
 .set_body([] (DGLArgs args, DGLRetValue* rv) {
-    std::shared_ptr<HeteroSubgraph> subg = args[0];
+    HeteroSubgraphRef subg = args[0];
     List<Value> induced_edges;
     for (IdArray arr : subg->induced_edges) {
       induced_edges.push_back(Value(MakeValue(arr)));

--- a/src/graph/heterograph.h
+++ b/src/graph/heterograph.h
@@ -9,6 +9,9 @@
 
 #include <dgl/base_heterograph.h>
 #include <dgl/lazy.h>
+#include <utility>
+#include <string>
+#include <vector>
 
 namespace dgl {
 

--- a/src/graph/heterograph.h
+++ b/src/graph/heterograph.h
@@ -1,0 +1,179 @@
+/*!
+ *  Copyright (c) 2019 by Contributors
+ * \file graph/heterograph.h
+ * \brief Heterograph
+ */
+
+#ifndef DGL_GRAPH_HETEROGRAPH_H_
+#define DGL_GRAPH_HETEROGRAPH_H_
+
+#include <dgl/base_heterograph.h>
+#include <dgl/lazy.h>
+
+namespace dgl {
+
+/*! \brief Heterograph */
+class HeteroGraph : public BaseHeteroGraph {
+ public:
+  HeteroGraph(GraphPtr meta_graph, const std::vector<HeteroGraphPtr>& rel_graphs);
+
+  uint64_t NumVertexTypes() const override {
+    return meta_graph_->NumVertices();
+  }
+
+  uint64_t NumEdgeTypes() const override {
+    return meta_graph_->NumEdges();
+  }
+
+  HeteroGraphPtr GetRelationGraph(dgl_type_t etype) const override {
+    CHECK_LT(etype, meta_graph_->NumEdges()) << "Invalid edge type: " << etype;
+    return relation_graphs_[etype];
+  }
+
+  void AddVertices(dgl_type_t vtype, uint64_t num_vertices) override {
+    LOG(FATAL) << "Bipartite graph is not mutable.";
+  }
+
+  void AddEdge(dgl_type_t etype, dgl_id_t src, dgl_id_t dst) override {
+    LOG(FATAL) << "Bipartite graph is not mutable.";
+  }
+
+  void AddEdges(dgl_type_t etype, IdArray src_ids, IdArray dst_ids) override {
+    LOG(FATAL) << "Bipartite graph is not mutable.";
+  }
+
+  void Clear() override {
+    LOG(FATAL) << "Bipartite graph is not mutable.";
+  }
+
+  DLContext Context() const override {
+    return relation_graphs_[0]->Context();
+  }
+
+  uint8_t NumBits() const override {
+    return relation_graphs_[0]->NumBits();
+  }
+
+  bool IsMultigraph() const override;
+
+  bool IsReadonly() const override {
+    return true;
+  }
+
+  uint64_t NumVertices(dgl_type_t vtype) const override {
+    CHECK(meta_graph_->HasVertex(vtype)) << "Invalid vertex type: " << vtype;
+    return num_verts_per_type_[vtype];
+  }
+
+  uint64_t NumEdges(dgl_type_t etype) const override {
+    return GetRelationGraph(etype)->NumEdges(0);
+  }
+
+  bool HasVertex(dgl_type_t vtype, dgl_id_t vid) const override {
+    return vid < NumVertices(vtype);
+  }
+
+  bool HasEdgeBetween(dgl_type_t etype, dgl_id_t src, dgl_id_t dst) const override {
+    return GetRelationGraph(etype)->HasEdgeBetween(0, src, dst);
+  }
+
+  IdArray Predecessors(dgl_type_t etype, dgl_id_t dst) const override {
+    return GetRelationGraph(etype)->Predecessors(0, dst);
+  }
+
+  IdArray Successors(dgl_type_t etype, dgl_id_t src) const override {
+    return GetRelationGraph(etype)->Successors(0, src);
+  }
+
+  IdArray EdgeId(dgl_type_t etype, dgl_id_t src, dgl_id_t dst) const override {
+    return GetRelationGraph(etype)->EdgeId(0, src, dst);
+  }
+
+  EdgeArray EdgeIds(dgl_type_t etype, IdArray src, IdArray dst) const override {
+    return GetRelationGraph(etype)->EdgeIds(0, src, dst);
+  }
+
+  std::pair<dgl_id_t, dgl_id_t> FindEdge(dgl_type_t etype, dgl_id_t eid) const override {
+    return GetRelationGraph(etype)->FindEdge(0, eid);
+  }
+
+  EdgeArray FindEdges(dgl_type_t etype, IdArray eids) const override {
+    return GetRelationGraph(etype)->FindEdges(0, eids);
+  }
+
+  EdgeArray InEdges(dgl_type_t etype, dgl_id_t vid) const override {
+    return GetRelationGraph(etype)->InEdges(0, vid);
+  }
+
+  EdgeArray InEdges(dgl_type_t etype, IdArray vids) const override {
+    return GetRelationGraph(etype)->InEdges(0, vids);
+  }
+
+  EdgeArray OutEdges(dgl_type_t etype, dgl_id_t vid) const override {
+    return GetRelationGraph(etype)->OutEdges(0, vid);
+  }
+
+  EdgeArray OutEdges(dgl_type_t etype, IdArray vids) const override {
+    return GetRelationGraph(etype)->OutEdges(0, vids);
+  }
+
+  EdgeArray Edges(dgl_type_t etype, const std::string &order = "") const override {
+    return GetRelationGraph(etype)->Edges(0, order);
+  }
+
+  uint64_t InDegree(dgl_type_t etype, dgl_id_t vid) const override {
+    return GetRelationGraph(etype)->InDegree(0, vid);
+  }
+
+  DegreeArray InDegrees(dgl_type_t etype, IdArray vids) const override {
+    return GetRelationGraph(etype)->InDegrees(0, vids);
+  }
+
+  uint64_t OutDegree(dgl_type_t etype, dgl_id_t vid) const override {
+    return GetRelationGraph(etype)->OutDegree(0, vid);
+  }
+
+  DegreeArray OutDegrees(dgl_type_t etype, IdArray vids) const override {
+    return GetRelationGraph(etype)->OutDegrees(0, vids);
+  }
+
+  DGLIdIters SuccVec(dgl_type_t etype, dgl_id_t vid) const override {
+    return GetRelationGraph(etype)->SuccVec(0, vid);
+  }
+
+  DGLIdIters OutEdgeVec(dgl_type_t etype, dgl_id_t vid) const override {
+    return GetRelationGraph(etype)->OutEdgeVec(0, vid);
+  }
+
+  DGLIdIters PredVec(dgl_type_t etype, dgl_id_t vid) const override {
+    return GetRelationGraph(etype)->PredVec(0, vid);
+  }
+
+  DGLIdIters InEdgeVec(dgl_type_t etype, dgl_id_t vid) const override {
+    return GetRelationGraph(etype)->InEdgeVec(0, vid);
+  }
+
+  std::vector<IdArray> GetAdj(
+      dgl_id_t etype, bool transpose, const std::string &fmt) const override {
+    return GetRelationGraph(etype)->GetAdj(0, transpose, fmt);
+  }
+
+  HeteroSubgraph VertexSubgraph(const std::vector<IdArray>& vids) const override;
+
+  HeteroSubgraph EdgeSubgraph(
+      const std::vector<IdArray>& eids, bool preserve_nodes = false) const override;
+
+ private:
+  /*! \brief A map from edge type to bipartite graph */
+  std::vector<HeteroGraphPtr> relation_graphs_;
+
+  /*! \brief A map from vert type to the number of verts in the type */
+  std::vector<int64_t> num_verts_per_type_;
+
+  /*! \brief True if the graph is a multigraph */
+  Lazy<bool> is_multigraph_;
+};
+
+}  // namespace dgl
+
+#endif  // DGL_GRAPH_HETEROGRAPH_H_

--- a/src/graph/heterograph.h
+++ b/src/graph/heterograph.h
@@ -73,8 +73,14 @@ class HeteroGraph : public BaseHeteroGraph {
     return vid < NumVertices(vtype);
   }
 
+  BoolArray HasVertices(dgl_type_t vtype, IdArray vids) const override;
+
   bool HasEdgeBetween(dgl_type_t etype, dgl_id_t src, dgl_id_t dst) const override {
     return GetRelationGraph(etype)->HasEdgeBetween(0, src, dst);
+  }
+
+  BoolArray HasEdgesBetween(dgl_type_t etype, IdArray src_ids, IdArray dst_ids) const override {
+    return GetRelationGraph(etype)->HasEdgesBetween(0, src_ids, dst_ids);
   }
 
   IdArray Predecessors(dgl_type_t etype, dgl_id_t dst) const override {

--- a/src/graph/heterograph.h
+++ b/src/graph/heterograph.h
@@ -154,7 +154,7 @@ class HeteroGraph : public BaseHeteroGraph {
   }
 
   std::vector<IdArray> GetAdj(
-      dgl_id_t etype, bool transpose, const std::string &fmt) const override {
+      dgl_type_t etype, bool transpose, const std::string &fmt) const override {
     return GetRelationGraph(etype)->GetAdj(0, transpose, fmt);
   }
 

--- a/src/graph/immutable_graph.cc
+++ b/src/graph/immutable_graph.cc
@@ -449,7 +449,6 @@ Subgraph ImmutableGraph::VertexSubgraph(IdArray vids) const {
 }
 
 Subgraph ImmutableGraph::EdgeSubgraph(IdArray eids, bool preserve_nodes) const {
-  // We prefer to generate a subgraph from out-csr.
   auto sg = GetCOO()->EdgeSubgraph(eids, preserve_nodes);
   COOPtr subcoo = std::dynamic_pointer_cast<COO>(sg.graph);
   return Subgraph{GraphPtr(new ImmutableGraph(subcoo)),

--- a/tests/graph_index/test_hetero.py
+++ b/tests/graph_index/test_hetero.py
@@ -1,3 +1,4 @@
+import numpy as np
 import dgl
 import dgl.ndarray as nd
 import dgl.graph_index as dgl_gidx
@@ -20,6 +21,9 @@ rel graph:
 1->2 : [0 -> 0, 1 -> 1, 1 -> 2]
 2->1 : [0 -> 1, 1 -> 1, 2 -> 1]
 """
+
+def _array_equal(dglidx, l):
+    return dglidx.tonumpy().tolist() == l
 
 def rel1_from_coo():
     row = toindex([0, 1, 2, 3])
@@ -69,6 +73,20 @@ def test_query():
         assert g.meta_graph.number_of_nodes() == 3
         assert g.meta_graph.number_of_edges() == 3
         assert g.ctx() == nd.cpu(0)
+        assert g.nbits() == 64
+        assert not g.is_multigraph()
+        assert g.is_readonly()
+        # relation graph 1
+        assert g.number_of_nodes(0) == 5
+        assert g.number_of_edges(0) == 4
+        assert g.has_node(0, 0)
+        assert not g.has_node(0, 10)
+        assert _array_equal(g.has_nodes(0, toindex([0, 10])), [1, 0])
+        assert g.has_edge_between(0, 3, 0)
+        assert not g.has_edge_between(0, 4, 0)
+        assert _array_equal(g.has_edges_between(0, toindex([3, 4]), toindex([0, 0])), [1, 0])
+
+        assert g.number_of_nodes(1) == 2
 
     g = gen_from_coo()
     _test_g(g)

--- a/tests/graph_index/test_hetero.py
+++ b/tests/graph_index/test_hetero.py
@@ -1,0 +1,61 @@
+import dgl
+import dgl.graph_index as dgl_gidx
+
+"""
+Test with a heterograph of three ntypes and three etypes
+meta graph:
+0 -> 1
+1 -> 2
+2 -> 1
+
+Num nodes per ntype:
+0 : 5
+1 : 2
+2 : 3
+
+rel graph:
+0->1 : [0 -> 0, 1 -> 0, 2 -> 0, 3 -> 0]
+1->2 : [0 -> 0, 1 -> 1, 1 -> 2]
+2->1 : [0 -> 1, 1 -> 1, 2 -> 1]
+"""
+
+def rel1_from_coo():
+    row = dgl.toindex([0, 1, 2, 3])
+    col = dgl.toindex([0, 0, 0, 0])
+    return dgl_gidx.create_bipartite_from_coo(5, 2, row, col)
+
+def rel2_from_coo():
+    row = dgl.toindex([0, 1, 1])
+    col = dgl.toindex([0, 1, 2])
+    return dgl_gidx.create_bipartite_from_coo(2, 3, row, col)
+
+def rel3_from_coo():
+    row = dgl.toindex([0, 1, 2])
+    col = dgl.toindex([1, 1, 1])
+    return dgl_gidx.create_bipartite_from_coo(3, 2, row, col)
+
+def rel1_from_csr():
+    indptr = dgl.toindex([0, 1, 2, 3, 4, 4])
+    indices = dgl.toindex([0, 0, 0, 0])
+    edge_ids = dgl.toindex([0, 1, 2, 3])
+    return dgl_gidx.create_bipartite_from_csr(5, 2, indptr, indices, edge_ids)
+
+def rel2_from_csr():
+    row = dgl.toindex([0, 1, 3])
+    col = dgl.toindex([0, 1, 2])
+    edge_ids = dgl.toindex([0, 1, 2])
+    return dgl_gidx.create_bipartite_from_csr(2, 3, indptr, indices, edge_ids)
+
+def rel3_from_csr():
+    row = dgl.toindex([0, 1, 2, 3])
+    col = dgl.toindex([1, 1, 1])
+    edge_ids = dgl.toindex([0, 1, 2])
+    return dgl_gidx.create_bipartite_from_csr(3, 2, indptr, indices, edge_ids)
+
+def gen_from_coo():
+    mg = dgl_gidx.from_edge_list([(0, 1), (1, 2), (2, 1)], readonly=True)
+    return dgl_gidx.create_heterograph(mg, [rel1_from_coo(), rel2_from_coo(), rel3_from_coo()])
+
+def gen_from_csr():
+    mg = dgl_gidx.from_edge_list([(0, 1), (1, 2), (2, 1)], readonly=True)
+    return dgl_gidx.create_heterograph(mg, [rel1_from_csr(), rel2_from_csr(), rel3_from_csr()])

--- a/tests/graph_index/test_hetero.py
+++ b/tests/graph_index/test_hetero.py
@@ -205,6 +205,148 @@ def test_subgraph():
         assert np.allclose(F.sparse_to_numpy(adj),
                 np.array([]))
 
+        # edge subgraph (preserve_nodes=False)
+        induced_edges = [toindex([0, 2]), toindex([0]), toindex([0, 1, 2])]
+        sub = g.edge_subgraph(induced_edges, False)
+        subg = sub.graph
+        assert subg.number_of_ntypes() == 3
+        assert subg.number_of_etypes() == 3
+        assert subg.number_of_nodes(0) == 2
+        assert subg.number_of_nodes(1) == 2
+        assert subg.number_of_nodes(2) == 3
+        assert subg.number_of_edges(R1) == 2
+        assert subg.number_of_edges(R2) == 1
+        assert subg.number_of_edges(R3) == 3
+        adj = subg.adjacency_matrix(R1, True, F.cpu())[0]
+        assert np.allclose(F.sparse_to_numpy(adj),
+                np.array([[1., 0.],
+                          [1., 0.]]))
+        adj = subg.adjacency_matrix(R2, True, F.cpu())[0]
+        assert np.allclose(F.sparse_to_numpy(adj),
+                np.array([[1., 0., 0.],
+                          [0., 0., 0.]]))
+        adj = subg.adjacency_matrix(R3, True, F.cpu())[0]
+        assert np.allclose(F.sparse_to_numpy(adj),
+                np.array([[0., 1.],
+                          [0., 1.],
+                          [0., 1.]]))
+        assert len(sub.induced_nodes) == 3
+        assert _array_equal(sub.induced_nodes[0], [0, 2])
+        assert _array_equal(sub.induced_nodes[1], [0, 1])
+        assert _array_equal(sub.induced_nodes[2], [0, 1, 2])
+        assert len(sub.induced_edges) == 3
+        assert _array_equal(sub.induced_edges[0], induced_edges[0])
+        assert _array_equal(sub.induced_edges[1], induced_edges[1])
+        assert _array_equal(sub.induced_edges[2], induced_edges[2])
+
+        # edge subgraph (preserve_nodes=True)
+        induced_edges = [toindex([0, 2]), toindex([0]), toindex([0, 1, 2])]
+        sub = g.edge_subgraph(induced_edges, True)
+        subg = sub.graph
+        assert subg.number_of_ntypes() == 3
+        assert subg.number_of_etypes() == 3
+        assert subg.number_of_nodes(0) == 5
+        assert subg.number_of_nodes(1) == 2
+        assert subg.number_of_nodes(2) == 3
+        assert subg.number_of_edges(R1) == 2
+        assert subg.number_of_edges(R2) == 1
+        assert subg.number_of_edges(R3) == 3
+        adj = subg.adjacency_matrix(R1, True, F.cpu())[0]
+        assert np.allclose(F.sparse_to_numpy(adj),
+                np.array([[1., 0.],
+                          [0., 0.],
+                          [1., 0.],
+                          [0., 0.],
+                          [0., 0.]]))
+        adj = subg.adjacency_matrix(R2, True, F.cpu())[0]
+        assert np.allclose(F.sparse_to_numpy(adj),
+                np.array([[1., 0., 0.],
+                          [0., 0., 0.]]))
+        adj = subg.adjacency_matrix(R3, True, F.cpu())[0]
+        assert np.allclose(F.sparse_to_numpy(adj),
+                np.array([[0., 1.],
+                          [0., 1.],
+                          [0., 1.]]))
+        assert len(sub.induced_nodes) == 3
+        assert _array_equal(sub.induced_nodes[0], [0, 1, 2, 3, 4])
+        assert _array_equal(sub.induced_nodes[1], [0, 1])
+        assert _array_equal(sub.induced_nodes[2], [0, 1, 2])
+        assert len(sub.induced_edges) == 3
+        assert _array_equal(sub.induced_edges[0], induced_edges[0])
+        assert _array_equal(sub.induced_edges[1], induced_edges[1])
+        assert _array_equal(sub.induced_edges[2], induced_edges[2])
+
+        # edge subgraph with empty induced edges (preserve_nodes=False)
+        induced_edges = [toindex([0, 2]), toindex([]), toindex([0, 1, 2])]
+        sub = g.edge_subgraph(induced_edges, False)
+        subg = sub.graph
+        assert subg.number_of_ntypes() == 3
+        assert subg.number_of_etypes() == 3
+        assert subg.number_of_nodes(0) == 2
+        assert subg.number_of_nodes(1) == 2
+        assert subg.number_of_nodes(2) == 3
+        assert subg.number_of_edges(R1) == 2
+        assert subg.number_of_edges(R2) == 0
+        assert subg.number_of_edges(R3) == 3
+        adj = subg.adjacency_matrix(R1, True, F.cpu())[0]
+        assert np.allclose(F.sparse_to_numpy(adj),
+                np.array([[1., 0.],
+                          [1., 0.]]))
+        adj = subg.adjacency_matrix(R2, True, F.cpu())[0]
+        assert np.allclose(F.sparse_to_numpy(adj),
+                np.array([[0., 0., 0.],
+                          [0., 0., 0.]]))
+        adj = subg.adjacency_matrix(R3, True, F.cpu())[0]
+        assert np.allclose(F.sparse_to_numpy(adj),
+                np.array([[0., 1.],
+                          [0., 1.],
+                          [0., 1.]]))
+        assert len(sub.induced_nodes) == 3
+        assert _array_equal(sub.induced_nodes[0], [0, 2])
+        assert _array_equal(sub.induced_nodes[1], [0, 1])
+        assert _array_equal(sub.induced_nodes[2], [0, 1, 2])
+        assert len(sub.induced_edges) == 3
+        assert _array_equal(sub.induced_edges[0], induced_edges[0])
+        assert _array_equal(sub.induced_edges[1], induced_edges[1])
+        assert _array_equal(sub.induced_edges[2], induced_edges[2])
+
+        # edge subgraph with empty induced edges (preserve_nodes=True)
+        induced_edges = [toindex([0, 2]), toindex([]), toindex([0, 1, 2])]
+        sub = g.edge_subgraph(induced_edges, True)
+        subg = sub.graph
+        assert subg.number_of_ntypes() == 3
+        assert subg.number_of_etypes() == 3
+        assert subg.number_of_nodes(0) == 5
+        assert subg.number_of_nodes(1) == 2
+        assert subg.number_of_nodes(2) == 3
+        assert subg.number_of_edges(R1) == 2
+        assert subg.number_of_edges(R2) == 0
+        assert subg.number_of_edges(R3) == 3
+        adj = subg.adjacency_matrix(R1, True, F.cpu())[0]
+        assert np.allclose(F.sparse_to_numpy(adj),
+                np.array([[1., 0.],
+                          [0., 0.],
+                          [1., 0.],
+                          [0., 0.],
+                          [0., 0.]]))
+        adj = subg.adjacency_matrix(R2, True, F.cpu())[0]
+        assert np.allclose(F.sparse_to_numpy(adj),
+                np.array([[0., 0., 0.],
+                          [0., 0., 0.]]))
+        adj = subg.adjacency_matrix(R3, True, F.cpu())[0]
+        assert np.allclose(F.sparse_to_numpy(adj),
+                np.array([[0., 1.],
+                          [0., 1.],
+                          [0., 1.]]))
+        assert len(sub.induced_nodes) == 3
+        assert _array_equal(sub.induced_nodes[0], [0, 1, 2, 3, 4])
+        assert _array_equal(sub.induced_nodes[1], [0, 1])
+        assert _array_equal(sub.induced_nodes[2], [0, 1, 2])
+        assert len(sub.induced_edges) == 3
+        assert _array_equal(sub.induced_edges[0], induced_edges[0])
+        assert _array_equal(sub.induced_edges[1], induced_edges[1])
+        assert _array_equal(sub.induced_edges[2], induced_edges[2])
+
     g = gen_from_coo()
     _test_g(g)
     g = gen_from_csr()

--- a/tests/graph_index/test_hetero.py
+++ b/tests/graph_index/test_hetero.py
@@ -3,6 +3,7 @@ import dgl
 import dgl.ndarray as nd
 import dgl.graph_index as dgl_gidx
 from dgl.utils import toindex
+import backend as F
 
 """
 Test with a heterograph of three ntypes and three etypes
@@ -23,7 +24,7 @@ rel graph:
 """
 
 def _array_equal(dglidx, l):
-    return dglidx.tonumpy().tolist() == l
+    return list(dglidx) == list(l)
 
 def rel1_from_coo():
     row = toindex([0, 1, 2, 3])
@@ -47,14 +48,14 @@ def rel1_from_csr():
     return dgl_gidx.create_bipartite_from_csr(5, 2, indptr, indices, edge_ids)
 
 def rel2_from_csr():
-    row = toindex([0, 1, 3])
-    col = toindex([0, 1, 2])
+    indptr = toindex([0, 1, 3])
+    indices = toindex([0, 1, 2])
     edge_ids = toindex([0, 1, 2])
     return dgl_gidx.create_bipartite_from_csr(2, 3, indptr, indices, edge_ids)
 
 def rel3_from_csr():
-    row = toindex([0, 1, 2, 3])
-    col = toindex([1, 1, 1])
+    indptr = toindex([0, 1, 2, 3])
+    indices = toindex([1, 1, 1])
     edge_ids = toindex([0, 1, 2])
     return dgl_gidx.create_bipartite_from_csr(3, 2, indptr, indices, edge_ids)
 
@@ -67,6 +68,9 @@ def gen_from_csr():
     return dgl_gidx.create_heterograph(mg, [rel1_from_csr(), rel2_from_csr(), rel3_from_csr()])
 
 def test_query():
+    R1 = 0
+    R2 = 1
+    R3 = 2
     def _test_g(g):
         assert g.number_of_ntypes() == 3
         assert g.number_of_etypes() == 3
@@ -77,19 +81,135 @@ def test_query():
         assert not g.is_multigraph()
         assert g.is_readonly()
         # relation graph 1
-        assert g.number_of_nodes(0) == 5
-        assert g.number_of_edges(0) == 4
+        assert g.number_of_nodes(R1) == 5
+        assert g.number_of_edges(R1) == 4
         assert g.has_node(0, 0)
         assert not g.has_node(0, 10)
         assert _array_equal(g.has_nodes(0, toindex([0, 10])), [1, 0])
-        assert g.has_edge_between(0, 3, 0)
-        assert not g.has_edge_between(0, 4, 0)
-        assert _array_equal(g.has_edges_between(0, toindex([3, 4]), toindex([0, 0])), [1, 0])
-
-        assert g.number_of_nodes(1) == 2
+        assert g.has_edge_between(R1, 3, 0)
+        assert not g.has_edge_between(R1, 4, 0)
+        assert _array_equal(g.has_edges_between(R1, toindex([3, 4]), toindex([0, 0])), [1, 0])
+        assert _array_equal(g.predecessors(R1, 0), [0, 1, 2, 3])
+        assert _array_equal(g.predecessors(R1, 1), [])
+        assert _array_equal(g.successors(R1, 3), [0])
+        assert _array_equal(g.successors(R1, 4), [])
+        assert _array_equal(g.edge_id(R1, 0, 0), [0])
+        src, dst, eid = g.edge_ids(R1, toindex([0, 2, 1, 3]), toindex([0, 0, 0, 0]))
+        assert _array_equal(src, [0, 2, 1, 3])
+        assert _array_equal(dst, [0, 0, 0, 0])
+        assert _array_equal(eid, [0, 2, 1, 3])
+        src, dst, eid = g.find_edges(R1, toindex([3, 0]))
+        assert _array_equal(src, [3, 0])
+        assert _array_equal(dst, [0, 0])
+        assert _array_equal(eid, [3, 0])
+        src, dst, eid = g.in_edges(R1, toindex([0, 1]))
+        assert _array_equal(src, [0, 1, 2, 3])
+        assert _array_equal(dst, [0, 0, 0, 0])
+        assert _array_equal(eid, [0, 1, 2, 3])
+        src, dst, eid = g.out_edges(R1, toindex([1, 0, 4]))
+        assert _array_equal(src, [1, 0])
+        assert _array_equal(dst, [0, 0])
+        assert _array_equal(eid, [1, 0])
+        src, dst, eid = g.edges(R1, 'eid')
+        assert _array_equal(src, [0, 1, 2, 3])
+        assert _array_equal(dst, [0, 0, 0, 0])
+        assert _array_equal(eid, [0, 1, 2, 3])
+        assert g.in_degree(R1, 0) == 4
+        assert g.in_degree(R1, 1) == 0
+        assert _array_equal(g.in_degrees(R1, toindex([0, 1])), [4, 0])
+        assert g.out_degree(R1, 2) == 1
+        assert g.out_degree(R1, 4) == 0
+        assert _array_equal(g.out_degrees(R1, toindex([4, 2])), [0, 1])
+        # adjmat
+        adj = g.adjacency_matrix(R1, True, F.cpu())[0]
+        assert np.allclose(F.sparse_to_numpy(adj),
+                np.array([[1., 0.],
+                          [1., 0.],
+                          [1., 0.],
+                          [1., 0.],
+                          [0., 0.]]))
+        adj = g.adjacency_matrix(R2, True, F.cpu())[0]
+        assert np.allclose(F.sparse_to_numpy(adj),
+                np.array([[1., 0., 0.],
+                          [0., 1., 1.]]))
+        adj = g.adjacency_matrix(R3, True, F.cpu())[0]
+        assert np.allclose(F.sparse_to_numpy(adj),
+                np.array([[0., 1.],
+                          [0., 1.],
+                          [0., 1.]]))
 
     g = gen_from_coo()
+    _test_g(g)
+    g = gen_from_csr()
+    _test_g(g)
+
+def test_subgraph():
+    R1 = 0
+    R2 = 1
+    R3 = 2
+    def _test_g(g):
+        # node subgraph
+        induced_nodes = [toindex([0, 1, 4]), toindex([0]), toindex([0, 2])]
+        sub = g.node_subgraph(induced_nodes)
+        subg = sub.graph
+        assert subg.number_of_ntypes() == 3
+        assert subg.number_of_etypes() == 3
+        assert subg.number_of_nodes(0) == 3
+        assert subg.number_of_nodes(1) == 1
+        assert subg.number_of_nodes(2) == 2
+        assert subg.number_of_edges(R1) == 2
+        assert subg.number_of_edges(R2) == 1
+        assert subg.number_of_edges(R3) == 0
+        adj = subg.adjacency_matrix(R1, True, F.cpu())[0]
+        assert np.allclose(F.sparse_to_numpy(adj),
+                np.array([[1.],
+                          [1.],
+                          [0.]]))
+        adj = subg.adjacency_matrix(R2, True, F.cpu())[0]
+        assert np.allclose(F.sparse_to_numpy(adj),
+                np.array([[1., 0.]]))
+        adj = subg.adjacency_matrix(R3, True, F.cpu())[0]
+        assert np.allclose(F.sparse_to_numpy(adj),
+                np.array([[0.],
+                          [0.]]))
+        assert len(sub.induced_nodes) == 3
+        assert _array_equal(sub.induced_nodes[0], induced_nodes[0])
+        assert _array_equal(sub.induced_nodes[1], induced_nodes[1])
+        assert _array_equal(sub.induced_nodes[2], induced_nodes[2])
+        assert len(sub.induced_edges) == 3
+        assert _array_equal(sub.induced_edges[0], [0, 1])
+        assert _array_equal(sub.induced_edges[1], [0])
+        assert _array_equal(sub.induced_edges[2], [])
+
+        # node subgraph with empty type graph
+        induced_nodes = [toindex([0, 1, 4]), toindex([0]), toindex([])]
+        sub = g.node_subgraph(induced_nodes)
+        subg = sub.graph
+        assert subg.number_of_ntypes() == 3
+        assert subg.number_of_etypes() == 3
+        assert subg.number_of_nodes(0) == 3
+        assert subg.number_of_nodes(1) == 1
+        assert subg.number_of_nodes(2) == 0
+        assert subg.number_of_edges(R1) == 2
+        assert subg.number_of_edges(R2) == 0
+        assert subg.number_of_edges(R3) == 0
+        adj = subg.adjacency_matrix(R1, True, F.cpu())[0]
+        assert np.allclose(F.sparse_to_numpy(adj),
+                np.array([[1.],
+                          [1.],
+                          [0.]]))
+        adj = subg.adjacency_matrix(R2, True, F.cpu())[0]
+        assert np.allclose(F.sparse_to_numpy(adj),
+                np.array([]))
+        adj = subg.adjacency_matrix(R3, True, F.cpu())[0]
+        assert np.allclose(F.sparse_to_numpy(adj),
+                np.array([]))
+
+    g = gen_from_coo()
+    _test_g(g)
+    g = gen_from_csr()
     _test_g(g)
 
 if __name__ == '__main__':
     test_query()
+    test_subgraph()

--- a/tests/graph_index/test_hetero.py
+++ b/tests/graph_index/test_hetero.py
@@ -1,5 +1,7 @@
 import dgl
+import dgl.ndarray as nd
 import dgl.graph_index as dgl_gidx
+from dgl.utils import toindex
 
 """
 Test with a heterograph of three ntypes and three etypes
@@ -20,42 +22,56 @@ rel graph:
 """
 
 def rel1_from_coo():
-    row = dgl.toindex([0, 1, 2, 3])
-    col = dgl.toindex([0, 0, 0, 0])
+    row = toindex([0, 1, 2, 3])
+    col = toindex([0, 0, 0, 0])
     return dgl_gidx.create_bipartite_from_coo(5, 2, row, col)
 
 def rel2_from_coo():
-    row = dgl.toindex([0, 1, 1])
-    col = dgl.toindex([0, 1, 2])
+    row = toindex([0, 1, 1])
+    col = toindex([0, 1, 2])
     return dgl_gidx.create_bipartite_from_coo(2, 3, row, col)
 
 def rel3_from_coo():
-    row = dgl.toindex([0, 1, 2])
-    col = dgl.toindex([1, 1, 1])
+    row = toindex([0, 1, 2])
+    col = toindex([1, 1, 1])
     return dgl_gidx.create_bipartite_from_coo(3, 2, row, col)
 
 def rel1_from_csr():
-    indptr = dgl.toindex([0, 1, 2, 3, 4, 4])
-    indices = dgl.toindex([0, 0, 0, 0])
-    edge_ids = dgl.toindex([0, 1, 2, 3])
+    indptr = toindex([0, 1, 2, 3, 4, 4])
+    indices = toindex([0, 0, 0, 0])
+    edge_ids = toindex([0, 1, 2, 3])
     return dgl_gidx.create_bipartite_from_csr(5, 2, indptr, indices, edge_ids)
 
 def rel2_from_csr():
-    row = dgl.toindex([0, 1, 3])
-    col = dgl.toindex([0, 1, 2])
-    edge_ids = dgl.toindex([0, 1, 2])
+    row = toindex([0, 1, 3])
+    col = toindex([0, 1, 2])
+    edge_ids = toindex([0, 1, 2])
     return dgl_gidx.create_bipartite_from_csr(2, 3, indptr, indices, edge_ids)
 
 def rel3_from_csr():
-    row = dgl.toindex([0, 1, 2, 3])
-    col = dgl.toindex([1, 1, 1])
-    edge_ids = dgl.toindex([0, 1, 2])
+    row = toindex([0, 1, 2, 3])
+    col = toindex([1, 1, 1])
+    edge_ids = toindex([0, 1, 2])
     return dgl_gidx.create_bipartite_from_csr(3, 2, indptr, indices, edge_ids)
 
 def gen_from_coo():
-    mg = dgl_gidx.from_edge_list([(0, 1), (1, 2), (2, 1)], readonly=True)
+    mg = dgl_gidx.from_edge_list([(0, 1), (1, 2), (2, 1)], is_multigraph=False, readonly=True)
     return dgl_gidx.create_heterograph(mg, [rel1_from_coo(), rel2_from_coo(), rel3_from_coo()])
 
 def gen_from_csr():
-    mg = dgl_gidx.from_edge_list([(0, 1), (1, 2), (2, 1)], readonly=True)
+    mg = dgl_gidx.from_edge_list([(0, 1), (1, 2), (2, 1)], is_multigraph=False, readonly=True)
     return dgl_gidx.create_heterograph(mg, [rel1_from_csr(), rel2_from_csr(), rel3_from_csr()])
+
+def test_query():
+    def _test_g(g):
+        assert g.number_of_ntypes() == 3
+        assert g.number_of_etypes() == 3
+        assert g.meta_graph.number_of_nodes() == 3
+        assert g.meta_graph.number_of_edges() == 3
+        assert g.ctx() == nd.cpu(0)
+
+    g = gen_from_coo()
+    _test_g(g)
+
+if __name__ == '__main__':
+    test_query()


### PR DESCRIPTION
## Description
The PR implements bipartite graph and heterograph C++ data structure. As per our discussion, the bipartite graph is implemented similarly to immutable graph which contains on-demand-materialized CSR/COO structure. Heterograph is implemented as a list of bipartite graphs, each for one edge type. On python side, currently only minimal wrapper class is implemented.

Side note:
I feel we should hide the COO/CSR implementation from header file as what is done in [bipartite.h](https://github.com/dmlc/dgl/blob/682a3a9510667a29fbbd3ec35aeca582e8685a5a/src/graph/bipartite.h). It makes the header file much cleaner.

## Checklist
Please feel free to remove inapplicable items for your PR.
- [x] The PR title starts with [$CATEGORY] (such as [Model], [Doc], [Feature]])
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage
- [x] Code is well-documented
- [x] To the my best knowledge, examples are either not affected by this change,
      or have been fixed to be compatible with this change
- [x] Related issue is referred in this PR
