### PR TITLE
[Build] Setup for prerelease builds

### DIFF
--- a/python/setup.py
+++ b/python/setup.py
@@ -110,7 +110,7 @@ if include_libs:
     }
 
 setup(
-    name='dgl',
+    name='dgl' + os.getenv('DGL_PACKAGE_SUFFIX', ''),
     version=VERSION,
     description='Deep Graph Library',
     zip_safe=False,

--- a/python/update_version.py
+++ b/python/update_version.py
@@ -11,7 +11,8 @@ import re
 # current version
 # We use the version of the incoming release for code
 # that is under development
-__version__ = "0.3"
+__version__ = "0.3" + os.getenv('DGL_PRERELEASE', '')
+print(__version__)
 
 # Implementations
 def update(file_name, pattern, repl):


### PR DESCRIPTION
## Description
Some minor changes to setup scripts to optionally include prerelease version numbers & CUDA versions.

Nightly builds will be available on pip with the following commands (Hopefully available from August 16th for Linux; Windows and Mac builds would be available later than that):
```bash
pip install --pre dgl        # CPU
pip install --pre dgl-cu90   # CUDA 9.0
pip install --pre dgl-cu92   # CUDA 9.2
pip install --pre dgl-cu100  # CUDA 10.0
```