### PR TITLE
[Doc] Update README.md for pytorch PinSage example.

### DIFF
--- a/examples/pytorch/recommendation/README.md
+++ b/examples/pytorch/recommendation/README.md
@@ -1,6 +1,8 @@
 # PinSage model
 
 NOTE: this version is not using NodeFlow yet.
+      
+This example only work with Python 3.6+
 
 First, download and extract from https://dgl.ai.s3.us-east-2.amazonaws.com/dataset/ml-1m.tar.gz
 

--- a/examples/pytorch/recommendation/main.py
+++ b/examples/pytorch/recommendation/main.py
@@ -7,7 +7,6 @@ import tqdm
 from rec.model.pinsage import PinSage
 from rec.datasets.movielens import MovieLens
 from rec.utils import cuda
-from rec.adabound import AdaBound
 from dgl import DGLGraph
 
 import argparse


### PR DESCRIPTION
Add noting that the PinSage model example under
example/pytorch/recommendation only work with Python 3.6+
as its dataset loader depends on stanfordnlp package
which work only with Python 3.6+.

## Description
This fix for #769 

## Checklist
Please feel free to remove inapplicable items for your PR.
- [ ] The PR title starts with [$CATEGORY] (such as [Model], [Doc], [Feature]])
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage
- [x] Code is well-documented
- [x] To the my best knowledge, examples are either not affected by this change,
      or have been fixed to be compatible with this change
- [x] Related issue is referred in this PR

## Changes
<!-- You could use following template
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)
-->
