### PR TITLE
[Fix] Synchronize frame initializers for local_var and local_scope & Remove warning

### DIFF
--- a/python/dgl/contrib/graph_store.py
+++ b/python/dgl/contrib/graph_store.py
@@ -684,7 +684,7 @@ class SharedMemoryDGLGraph(BaseGraphStore):
             raise Exception("graph store only supports CPU context for node data")
         init = self._node_frame.get_initializer(ndata_name)
         if init is None:
-            self._node_frame._frame._warn_and_set_initializer()
+            self._node_frame._frame._set_zero_default_initializer()
         init = self._node_frame.get_initializer(ndata_name)
         init = self._init_manager.serialize(init)
         self.proxy.init_ndata(init, ndata_name, tuple(shape), dtype)
@@ -712,7 +712,7 @@ class SharedMemoryDGLGraph(BaseGraphStore):
             raise Exception("graph store only supports CPU context for edge data")
         init = self._edge_frame.get_initializer(edata_name)
         if init is None:
-            self._edge_frame._frame._warn_and_set_initializer()
+            self._edge_frame._frame._set_zero_default_initializer()
         init = self._edge_frame.get_initializer(edata_name)
         init = self._init_manager.serialize(init)
         self.proxy.init_edata(init, edata_name, tuple(shape), dtype)

--- a/python/dgl/graph.py
+++ b/python/dgl/graph.py
@@ -9,7 +9,7 @@ import dgl
 from .base import ALL, is_all, DGLError
 from . import backend as F
 from . import init
-from .frame import FrameRef, Frame, Scheme
+from .frame import FrameRef, Frame, Scheme, sync_frame_initializer
 from . import graph_index
 from .runtime import ir, scheduler, Runtime
 from . import utils
@@ -3353,6 +3353,9 @@ class DGLGraph(DGLBaseGraph):
         However, any out-place mutation to the feature data will not reflect to this graph,
         thus making it easier to use in a function scope.
 
+        If set, the local graph object will use same initializers for node features and
+        edge features.
+
         Examples
         --------
         The following example uses PyTorch backend.
@@ -3401,9 +3404,16 @@ class DGLGraph(DGLBaseGraph):
         DGLGraph
             The graph object that can be used as a local variable.
         """
+        local_node_frame = FrameRef(Frame(self._node_frame._frame))
+        local_edge_frame = FrameRef(Frame(self._edge_frame._frame))
+        # Use same per-column initializers and default initializer.
+        # If registered, a column (based on key) initializer will be used first,
+        # otherwise the default initializer will be used.
+        sync_frame_initializer(local_node_frame._frame, self._node_frame._frame)
+        sync_frame_initializer(local_edge_frame._frame, self._edge_frame._frame)
         return DGLGraph(self._graph,
-                        FrameRef(Frame(self._node_frame._frame)),
-                        FrameRef(Frame(self._edge_frame._frame)))
+                        local_node_frame,
+                        local_edge_frame)
 
     @contextmanager
     def local_scope(self):
@@ -3411,6 +3421,9 @@ class DGLGraph(DGLBaseGraph):
 
         By entering a local scope, any out-place mutation to the feature data will
         not reflect to the original graph, thus making it easier to use in a function scope.
+
+        If set, the local scope will use same initializers for node features and
+        edge features.
 
         Examples
         --------
@@ -3451,6 +3464,11 @@ class DGLGraph(DGLBaseGraph):
         old_eframe = self._edge_frame
         self._node_frame = FrameRef(Frame(self._node_frame._frame))
         self._edge_frame = FrameRef(Frame(self._edge_frame._frame))
+        # Use same per-column initializers and default initializer.
+        # If registered, a column (based on key) initializer will be used first,
+        # otherwise the default initializer will be used.
+        sync_frame_initializer(self._node_frame._frame, old_nframe._frame)
+        sync_frame_initializer(self._edge_frame._frame, old_eframe._frame)
         yield
         self._node_frame = old_nframe
         self._edge_frame = old_eframe

--- a/tests/compute/test_basics.py
+++ b/tests/compute/test_basics.py
@@ -691,6 +691,28 @@ def test_local_var():
     assert 'hh' not in g.ndata
     assert 'ww' not in g.edata
 
+    # test initializer1
+    g = DGLGraph()
+    g.add_nodes(2)
+    g.add_edges([0, 1], [1, 1])
+    g.set_n_initializer(dgl.init.zero_initializer)
+    def foo(g):
+        g = g.local_var()
+        g.nodes[0].data['h'] = F.ones((1, 1))
+        assert F.allclose(g.ndata['h'], F.tensor([[1.], [0.]]))
+    foo(g)
+    # test initializer2
+    def foo_e_initializer(shape, dtype, ctx, id_range):
+        return F.ones(shape)
+    g.set_e_initializer(foo_e_initializer, field='h')
+    def foo(g):
+        g = g.local_var()
+        g.edges[0, 1].data['h'] = F.ones((1, 1))
+        assert F.allclose(g.edata['h'], F.ones((2, 1)))
+        g.edges[0, 1].data['w'] = F.ones((1, 1))
+        assert F.allclose(g.edata['w'], F.tensor([[1.], [0.]]))
+    foo(g)
+
 def test_local_scope():
     g = DGLGraph(nx.path_graph(5))
     g.ndata['h'] = F.zeros((g.number_of_nodes(), 3))
@@ -741,6 +763,28 @@ def test_local_scope():
     foo(g)
     assert 'hh' not in g.ndata
     assert 'ww' not in g.edata
+
+    # test initializer1
+    g = DGLGraph()
+    g.add_nodes(2)
+    g.add_edges([0, 1], [1, 1])
+    g.set_n_initializer(dgl.init.zero_initializer)
+    def foo(g):
+        with g.local_scope():
+            g.nodes[0].data['h'] = F.ones((1, 1))
+            assert F.allclose(g.ndata['h'], F.tensor([[1.], [0.]]))
+    foo(g)
+    # test initializer2
+    def foo_e_initializer(shape, dtype, ctx, id_range):
+        return F.ones(shape)
+    g.set_e_initializer(foo_e_initializer, field='h')
+    def foo(g):
+        with g.local_scope():
+            g.edges[0, 1].data['h'] = F.ones((1, 1))
+            assert F.allclose(g.edata['h'], F.ones((2, 1)))
+            g.edges[0, 1].data['w'] = F.ones((1, 1))
+            assert F.allclose(g.edata['w'], F.tensor([[1.], [0.]]))
+    foo(g)
 
 if __name__ == '__main__':
     test_nx_conversion()


### PR DESCRIPTION
## Description
**This PR is same as #751 , which has already been approved. I accidentally deleted my original fork before merging the PR and resubmit it here.**

Currently `local_var` and `local_scope` do not use the frame initializers of the original `_node_frame` and `_edge_frame`. This causes warnings about initializers even when we have initializers set, which can be confusing for example when using `nn modules`.

Also as discussed before, warnings about frame initializers are removed.

## Checklist
Please feel free to remove inapplicable items for your PR.
- [x] The PR title starts with [$CATEGORY] (such as [Model], [Doc], [Feature]])
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage
- [x] Code is well-documented
- [x] To the my best knowledge, examples are either not affected by this change,
      or have been fixed to be compatible with this change
- [ ] Related issue is referred in this PR

## Changes
- Synchronize frame initializers after the copy of frames
- Test cases are added