### PR TITLE
[Model Zoo] Fix Early Stop

### DIFF
--- a/examples/pytorch/model_zoo/chem/property_prediction/utils.py
+++ b/examples/pytorch/model_zoo/chem/property_prediction/utils.py
@@ -1,3 +1,4 @@
+import datetime
 import dgl
 import numpy as np
 import os
@@ -42,9 +43,12 @@ class Meter(object):
         return total_score / n_tasks
 
 class EarlyStopping(object):
-    def __init__(self, patience=10, filename="es_checkpoint.pth"):
-        assert not os.path.exists(filename), \
-            'Filename {} is occupied. Either rename it or delete it.'.format(filename)
+    def __init__(self, patience=10, filename=None):
+        if filename is None:
+            dt = datetime.datetime.now()
+            filename = 'early_stop_{}_{:02d}-{:02d}-{:02d}.pth'.format(
+                dt.date(), dt.hour, dt.minute, dt.second)
+
         self.patience = patience
         self.counter = 0
         self.filename = filename


### PR DESCRIPTION
## Description
Previously we raise an assertion error if an early stop file already exists. This seems to be confusing for some users so we now add a postfix of time to avoid confusion.

## Checklist
Please feel free to remove inapplicable items for your PR.
- [x] The PR title starts with [$CATEGORY] (such as [Model], [Doc], [Feature]])
- [x] Changes are complete (i.e. I finished coding on this PR)
- [ ] All changes have test coverage
- [ ] Code is well-documented
- [x] To the my best knowledge, examples are either not affected by this change,
      or have been fixed to be compatible with this change
- [x] Related issue is referred in this PR

## Changes
Remove assertion error for repeated early stop model and add time dependent postfix.