### PR TITLE
[Feature] Edge softmax on a subset of edges in the graph.

### DIFF
--- a/examples/mxnet/gat/utils.py
+++ b/examples/mxnet/gat/utils.py
@@ -1,5 +1,4 @@
 import numpy as np
-import torch
 
 class EarlyStopping:
     def __init__(self, patience=10):

--- a/python/dgl/nn/mxnet/softmax.py
+++ b/python/dgl/nn/mxnet/softmax.py
@@ -119,6 +119,7 @@ def edge_softmax(graph, logits, eids=ALL):
     -----
         * Input shape: :math:`(E, *, 1)` where * means any number of
           additional dimensions, :math:`E` equals the length of eids.
+          If eids is ALL, :math:`E` equals number of edges in the graph.
         * Return shape: :math:`(E, *, 1)`
 
     Examples

--- a/python/dgl/nn/mxnet/softmax.py
+++ b/python/dgl/nn/mxnet/softmax.py
@@ -29,8 +29,8 @@ class EdgeSoftmax(mx.autograd.Function):
         super(EdgeSoftmax, self).__init__()
         self.g = g
         if is_all(eids):
-            eids = mx.nd.arange(g.number_of_edges(), dtype='int64')
-        self.eids = eids
+            eids = mx.nd.arange(g.number_of_edges())
+        self.eids = eids.astype('int64')
 
     def forward(self, score):
         """Forward function.

--- a/python/dgl/nn/mxnet/softmax.py
+++ b/python/dgl/nn/mxnet/softmax.py
@@ -53,6 +53,7 @@ class EdgeSoftmax(mx.autograd.Function):
         g.update_all(fn.copy_e('out', 'm'), fn.sum('m', 'out_sum'))
         g.apply_edges(fn.e_div_v('out', 'out_sum', 'out'))
         out = g.edata['out']
+        self.save_for_backward(out)
         return out
 
     def backward(self, grad_out):

--- a/python/dgl/nn/pytorch/softmax.py
+++ b/python/dgl/nn/pytorch/softmax.py
@@ -46,6 +46,7 @@ class EdgeSoftmax(th.autograd.Function):
         g = g.local_var()
         if is_all(eids):
             eids = th.arange(g.number_of_edges())
+        eids = eids.long()
 
         g.edges[eids].data['s'] = score
         g.send_and_recv(eids, fn.copy_e('s', 'm'), fn.max('m', 'smax'))

--- a/python/dgl/nn/pytorch/softmax.py
+++ b/python/dgl/nn/pytorch/softmax.py
@@ -122,6 +122,7 @@ def edge_softmax(graph, logits, eids=ALL):
     -----
         * Input shape: :math:`(E, *, 1)` where * means any number of
           additional dimensions, :math:`E` equals the length of eids.
+          If eids is ALL, :math:`E` equals number of edges in the graph.
         * Return shape: :math:`(E, *, 1)`
 
     Examples

--- a/python/dgl/nn/pytorch/softmax.py
+++ b/python/dgl/nn/pytorch/softmax.py
@@ -3,6 +3,7 @@
 import torch as th
 
 from ... import function as fn
+from ...base import ALL, is_all
 
 __all__ = ['edge_softmax']
 
@@ -25,7 +26,7 @@ class EdgeSoftmax(th.autograd.Function):
     """
 
     @staticmethod
-    def forward(ctx, g, score):
+    def forward(ctx, g, score, eids):
         """Forward function.
 
         Pseudo-code:
@@ -43,14 +44,17 @@ class EdgeSoftmax(th.autograd.Function):
         # a local variable
         ctx.backward_cache = g
         g = g.local_var()
-        g.edata['s'] = score
-        g.update_all(fn.copy_e('s', 'm'), fn.max('m', 'smax'))
-        g.apply_edges(fn.e_sub_v('s', 'smax', 'out'))
-        g.edata['out'] = th.exp(g.edata['out'])
-        g.update_all(fn.copy_e('out', 'm'), fn.sum('m', 'out_sum'))
-        g.apply_edges(fn.e_div_v('out', 'out_sum', 'out'))
-        out = g.edata['out']
-        ctx.save_for_backward(out)
+        if is_all(eids):
+            eids = th.arange(g.number_of_edges())
+
+        g.edges[eids].data['s'] = score
+        g.send_and_recv(eids, fn.copy_e('s', 'm'), fn.max('m', 'smax'))
+        g.apply_edges(fn.e_sub_v('s', 'smax', 'out'), eids)
+        g.edges[eids].data['out'] = th.exp(g.edges[eids].data['out'])
+        g.send_and_recv(eids, fn.copy_e('out', 'm'), fn.sum('m', 'out_sum'))
+        g.apply_edges(fn.e_div_v('out', 'out_sum', 'out'), eids)
+        out = g.edges[eids].data['out']
+        ctx.save_for_backward(out, eids)
         return out
 
     @staticmethod
@@ -71,18 +75,18 @@ class EdgeSoftmax(th.autograd.Function):
         """
         g = ctx.backward_cache
         g = g.local_var()
-        out, = ctx.saved_tensors
+        out, eids = ctx.saved_tensors
         # clear backward cache explicitly
         ctx.backward_cache = None
-        g.edata['out'] = out
-        g.edata['grad_s'] = out * grad_out
-        g.update_all(fn.copy_e('grad_s', 'm'), fn.sum('m', 'accum'))
-        g.apply_edges(fn.e_mul_v('out', 'accum', 'out'))
-        grad_score = g.edata['grad_s'] - g.edata['out']
-        return None, grad_score
+        g.edges[eids].data['out'] = out
+        g.edges[eids].data['grad_s'] = out * grad_out
+        g.send_and_recv(eids, fn.copy_e('grad_s', 'm'), fn.sum('m', 'accum'))
+        g.apply_edges(fn.e_mul_v('out', 'accum', 'out'), eids)
+        grad_score = g.edges[eids].data['grad_s'] - g.edges[eids].data['out']
+        return None, grad_score, None
 
 
-def edge_softmax(graph, logits):
+def edge_softmax(graph, logits, eids=ALL):
     r"""Compute edge softmax.
 
     For a node :math:`i`, edge softmax is an operation of computing
@@ -104,6 +108,9 @@ def edge_softmax(graph, logits):
         The graph to perform edge softmax
     logits : torch.Tensor
         The input edge feature
+    eids : torch.Tensor or ALL, optional
+        Edges on which to apply edge softmax. If ALL, apply edge
+        softmax on all edges in the graph. Default: ALL.
 
     Returns
     -------
@@ -112,9 +119,9 @@ def edge_softmax(graph, logits):
 
     Notes
     -----
-        * Input shape: :math:`(N, *, 1)` where * means any number of
-          additional dimensions, :math:`N` is the number of edges.
-        * Return shape: :math:`(N, *, 1)`
+        * Input shape: :math:`(E, *, 1)` where * means any number of
+          additional dimensions, :math:`E` equals the length of eids.
+        * Return shape: :math:`(E, *, 1)`
 
     Examples
     --------
@@ -145,5 +152,12 @@ def edge_softmax(graph, logits):
         [0.5000],
         [0.3333],
         [0.3333]])
+
+    Apply edge softmax on first 4 edges of g:
+    >>> edge_softmax(g, edata[:4], th.Tensor([0,1,2,3]))
+    tensor([[1.0000],
+        [0.5000],
+        [1.0000],
+        [0.5000]])
     """
-    return EdgeSoftmax.apply(graph, logits)
+    return EdgeSoftmax.apply(graph, logits, eids)

--- a/tests/mxnet/test_nn.py
+++ b/tests/mxnet/test_nn.py
@@ -235,7 +235,7 @@ def test_partial_edge_softmax():
     score.attach_grad()
     grad = F.randn((300, 1))
     import numpy as np
-    eids = np.random.choice(900, 300, replace=False)
+    eids = np.random.choice(900, 300, replace=False, dtype='int64')
     eids = F.zerocopy_from_numpy(eids)
     # compute partial edge softmax
     with mx.autograd.record():

--- a/tests/mxnet/test_nn.py
+++ b/tests/mxnet/test_nn.py
@@ -235,7 +235,7 @@ def test_partial_edge_softmax():
     score.attach_grad()
     grad = F.randn((300, 1))
     import numpy as np
-    eids = np.random.choice(900, 300, replace=False, dtype='int64')
+    eids = np.random.choice(900, 300, replace=False).astype('int64')
     eids = F.zerocopy_from_numpy(eids)
     # compute partial edge softmax
     with mx.autograd.record():

--- a/tests/mxnet/test_nn.py
+++ b/tests/mxnet/test_nn.py
@@ -223,6 +223,36 @@ def test_edge_softmax():
     assert np.allclose(a.asnumpy(), uniform_attention(g, a.shape).asnumpy(),
             1e-4, 1e-4)
 
+def test_partial_edge_softmax():
+    g = dgl.DGLGraph()
+    g.add_nodes(30)
+    # build a complete graph
+    for i in range(30):
+        for j in range(30):
+            g.add_edge(i, j)
+
+    score = F.randn((300, 1))
+    score.attach_grad()
+    grad = F.randn((300, 1))
+    import numpy as np
+    eids = np.random.choice(900, 300, replace=False)
+    eids = F.zerocopy_from_numpy(eids)
+    # compute partial edge softmax
+    with mx.autograd.record():
+        y_1 = nn.edge_softmax(g, score, eids)
+        y_1.backward(grad)
+        grad_1 = score.grad
+
+    # compute edge softmax on edge subgraph
+    subg = g.edge_subgraph(eids)
+    with mx.autograd.record():
+        y_2 = nn.edge_softmax(subg, score)
+        y_2.backward(grad)
+        grad_2 = score.grad
+
+    assert F.allclose(y_1, y_2)
+    assert F.allclose(grad_1, grad_2)
+
 def test_rgcn():
     ctx = F.ctx()
     etype = []
@@ -277,6 +307,7 @@ def test_rgcn():
 if __name__ == '__main__':
     test_graph_conv()
     test_edge_softmax()
+    test_partial_edge_softmax()
     test_set2set()
     test_glob_att_pool()
     test_simple_pool()

--- a/tests/pytorch/test_nn.py
+++ b/tests/pytorch/test_nn.py
@@ -332,7 +332,7 @@ def test_partial_edge_softmax():
     score.requires_grad_()
     grad = F.randn((300, 1))
     import numpy as np
-    eids = np.random.choice(900, 300, replace=False, dtype='int64')
+    eids = np.random.choice(900, 300, replace=False).astype('int64')
     eids = F.zerocopy_from_numpy(eids)
     # compute partial edge softmax
     y_1 = nn.edge_softmax(g, score, eids)

--- a/tests/pytorch/test_nn.py
+++ b/tests/pytorch/test_nn.py
@@ -332,7 +332,7 @@ def test_partial_edge_softmax():
     score.requires_grad_()
     grad = F.randn((300, 1))
     import numpy as np
-    eids = np.random.choice(900, 300, replace=False)
+    eids = np.random.choice(900, 300, replace=False, dtype='int64')
     eids = F.zerocopy_from_numpy(eids)
     # compute partial edge softmax
     y_1 = nn.edge_softmax(g, score, eids)

--- a/tests/pytorch/test_nn.py
+++ b/tests/pytorch/test_nn.py
@@ -319,7 +319,36 @@ def test_edge_softmax():
     assert len(g.ndata) == 0
     assert len(g.edata) == 2
     assert F.allclose(a1.grad, a2.grad, rtol=1e-4, atol=1e-4) # Follow tolerance in unittest backend
-    
+
+def test_partial_edge_softmax():
+    g = dgl.DGLGraph()
+    g.add_nodes(30)
+    # build a complete graph
+    for i in range(30):
+        for j in range(30):
+            g.add_edge(i, j)
+
+    score = F.randn((300, 1))
+    score.requires_grad_()
+    grad = F.randn((300, 1))
+    import numpy as np
+    eids = np.random.choice(900, 300, replace=False)
+    eids = F.zerocopy_from_numpy(eids)
+    # compute partial edge softmax
+    y_1 = nn.edge_softmax(g, score, eids)
+    y_1.backward(grad)
+    grad_1 = score.grad
+    score.grad.zero_()
+    # compute edge softmax on edge subgraph
+    subg = g.edge_subgraph(eids)
+    y_2 = nn.edge_softmax(subg, score)
+    y_2.backward(grad)
+    grad_2 = score.grad
+    score.grad.zero_()
+
+    assert F.allclose(y_1, y_2)
+    assert F.allclose(grad_1, grad_2)
+
 def test_rgcn():
     ctx = F.ctx()
     etype = []
@@ -570,6 +599,7 @@ def test_dense_cheb_conv():
 if __name__ == '__main__':
     test_graph_conv()
     test_edge_softmax()
+    test_partial_edge_softmax()
     test_set2set()
     test_glob_att_pool()
     test_simple_pool()


### PR DESCRIPTION
## Description
Our original design of `edge_softmax` applies softmax on all edges of the graph. However, for some scenarios (e.g. beam search) users need to apply edge softmax on a subset of edges in the graph.

This PR changes the api from
```python
def edge_softmax(graph, logits)
```
to
```python
def edge_softmax(graph, logits, eids=ALL)
```

This change is compatible with previous API and allow users to specify the indices of edges to apply edge softmax on.

## Checklist
Please feel free to remove inapplicable items for your PR.
- [x] The PR title starts with [$CATEGORY] (such as [NN], [Model], [Doc], [Feature]])
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage
- [x] Code is well-documented
- [x] To the my best knowledge, examples are either not affected by this change,
      or have been fixed to be compatible with this change
- [ ] Related issue is referred in this PR

## Changes
- dgl.nn.pytorch.softmax
- dgl.nn.mxnet.softmax
