### PR TITLE
[Feature] Convert np.ndarray to backend tensor at set_n_repr and set_e_repr

### DIFF
--- a/python/dgl/backend/pytorch/tensor.py
+++ b/python/dgl/backend/pytorch/tensor.py
@@ -270,7 +270,7 @@ def zerocopy_to_numpy(input):
     return asnumpy(input)
 
 def zerocopy_from_numpy(np_array):
-    return th.from_numpy(np_array)
+    return th.as_tensor(np_array)
 
 def zerocopy_to_dgl_ndarray(input):
     return nd.from_dlpack(dlpack.to_dlpack(input.contiguous()))

--- a/python/dgl/view.py
+++ b/python/dgl/view.py
@@ -4,6 +4,8 @@ from __future__ import absolute_import
 from collections import namedtuple
 from collections.abc import MutableMapping
 
+import numpy as np
+
 from .base import ALL, is_all, DGLError
 from . import backend as F
 
@@ -57,6 +59,8 @@ class NodeDataView(MutableMapping):
         return self._graph.get_n_repr(self._nodes)[key]
 
     def __setitem__(self, key, val):
+        if isinstance(val, np.ndarray):
+            val = F.zerocopy_from_numpy(val)
         self._graph.set_n_repr({key : val}, self._nodes)
 
     def __delitem__(self, key):
@@ -125,6 +129,8 @@ class EdgeDataView(MutableMapping):
         return self._graph.get_e_repr(self._edges)[key]
 
     def __setitem__(self, key, val):
+        if isinstance(val, np.ndarray):
+            val = F.zerocopy_from_numpy(val)
         self._graph.set_e_repr({key : val}, self._edges)
 
     def __delitem__(self, key):


### PR DESCRIPTION
## Description

- `torch.as_tensor` is recommended in new API, started from 1.0.0. It avoids copy as much as possible.
- This pr will convert np.ndarray to backend tensor when calling `g.ndata['feat'] = np.array(...)`. This simplifies the work in dataset part that don't need to manually convert numpy array to backend tensor. (example https://github.com/dmlc/dgl/blob/189c2c0907cdff54f733299a93360ddfcff4ccb7/python/dgl/data/chem/csv_dataset.py#L99)


## Checklist
Please feel free to remove inapplicable items for your PR.
- [ ] The PR title starts with [$CATEGORY] (such as [NN], [Model], [Doc], [Feature]])
- [ ] Changes are complete (i.e. I finished coding on this PR)
- [ ] All changes have test coverage
- [ ] Code is well-documented
- [ ] To the my best knowledge, examples are either not affected by this change,
      or have been fixed to be compatible with this change
- [ ] Related issue is referred in this PR

## Changes
<!-- You could use following template
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)
-->
