### PR TITLE
[Fix] use np.unique instead of loop

### DIFF
--- a/python/dgl/contrib/dis_kvstore.py
+++ b/python/dgl/contrib/dis_kvstore.py
@@ -367,8 +367,9 @@ class KVClient(object):
         numpy_id = F.asnumpy(ID)
         count = math.ceil(self._data_size[name] / self._server_count)
         server_id = numpy_id / count
-        for id in server_id:
-            group_size[int(id)] += 1
+        id_list, id_count = np.unique(server_id, return_counts=True)
+        for idx in range(len(id_list)):
+            group_size[int(id_list[idx])] += id_count[idx]
         min_idx = 0
         max_idx = 0
         for idx in range(self._server_count):
@@ -426,8 +427,9 @@ class KVClient(object):
         numpy_id = F.asnumpy(ID)
         count = math.ceil(self._data_size[name] / self._server_count)
         server_id = numpy_id / count
-        for id in server_id:
-            group_size[int(id)] += 1
+        id_list, id_count = np.unique(server_id, return_counts=True)
+        for idx in range(len(id_list)):
+            group_size[int(id_list[idx])] += id_count[idx]
         min_idx = 0
         max_idx = 0
         server_count = 0


### PR DESCRIPTION
## Description
This pr improve the kvstore performance by using np.unique() operator, instead of bumpy loop.

## Checklist
Please feel free to remove inapplicable items for your PR.
- [x] The PR title starts with [$CATEGORY] (such as [NN], [Model], [Doc], [Feature]])
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage
- [x] Code is well-documented
- [x] To the my best knowledge, examples are either not affected by this change,
      or have been fixed to be compatible with this change
- [ ] Related issue is referred in this PR

## Changes
<!-- You could use following template
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)
-->