### PR TITLE
[Fix] Fix serialize NDArray when shape is 0

### DIFF
--- a/include/dgl/runtime/ndarray.h
+++ b/include/dgl/runtime/ndarray.h
@@ -441,6 +441,8 @@ inline bool NDArray::Load(dmlc::Stream* strm) {
   CHECK(data_byte_size == num_elems * elem_bytes)
       << "Invalid DLTensor file format";
   if (data_byte_size != 0)  {
+    // strm->Read will return the total number of elements successfully read.
+    // Therefore if data_byte_size is zero, the CHECK below would fail.
     CHECK(strm->Read(ret->data, data_byte_size))
         << "Invalid DLTensor file format";
   }

--- a/include/dgl/runtime/ndarray.h
+++ b/include/dgl/runtime/ndarray.h
@@ -440,8 +440,10 @@ inline bool NDArray::Load(dmlc::Stream* strm) {
       << "Invalid DLTensor file format";
   CHECK(data_byte_size == num_elems * elem_bytes)
       << "Invalid DLTensor file format";
-  CHECK(strm->Read(ret->data, data_byte_size))
-      << "Invalid DLTensor file format";
+  if (data_byte_size != 0)  {
+    CHECK(strm->Read(ret->data, data_byte_size))
+        << "Invalid DLTensor file format";
+  }
   if (!DMLC_IO_NO_ENDIAN_SWAP) {
     dmlc::ByteSwap(ret->data, elem_bytes, num_elems);
   }

--- a/python/dgl/data/graph_serialize.py
+++ b/python/dgl/data/graph_serialize.py
@@ -135,9 +135,9 @@ def load_graphs(filename, idx_list=None):
     >>> glist, label_dict = load_graphs("./data.bin", [0]) # glist will be [g1]
 
     """
-    assert isinstance(idx_list, list)
     if idx_list is None:
         idx_list = []
+    assert isinstance(idx_list, list)
     metadata = _CAPI_DGLLoadGraphs(filename, idx_list, False)
     label_dict = {}
     for k, v in metadata.labels.items():

--- a/src/graph/graph_serialize.cc
+++ b/src/graph/graph_serialize.cc
@@ -191,6 +191,7 @@ StorageMetaData LoadDGLGraphs(const std::string &filename,
                               std::vector<dgl_id_t> idx_list,
                               bool onlyMeta) {
   SeekStream *fs = SeekStream::CreateForRead(filename.c_str(), true);
+  CHECK(fs) << "Filename is invalid";
   StorageMetaData metadata = StorageMetaData::Create();
   // Read DGL MetaData
   uint64_t magicNum, graphType, version;


### PR DESCRIPTION
## Description
<!-- Brief description. Refer to the related issues if existed.
It'll be great if relevant reviewers can be assigned as well.-->
Cases:
The indices of a readonly graph without any edges will be a zero shape NDArray. And previously it's not properly handled in serialization.

Related issue:
https://github.com/dmlc/dgl/issues/883

Side notes:
For a zero-shape ndarray, should its ndim be 1 or 0?

## Checklist
Please feel free to remove inapplicable items for your PR.
- [ ] The PR title starts with [$CATEGORY] (such as [NN], [Model], [Doc], [Feature]])
- [ ] Changes are complete (i.e. I finished coding on this PR)
- [ ] All changes have test coverage
- [ ] Code is well-documented
- [ ] To the my best knowledge, examples are either not affected by this change,
      or have been fixed to be compatible with this change
- [ ] Related issue is referred in this PR

## Changes
<!-- You could use following template
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)
-->
