### PR TITLE
[BUGFIX] deal with neg_sample_size properly

### DIFF
--- a/src/graph/sampler.cc
+++ b/src/graph/sampler.cc
@@ -993,6 +993,8 @@ NegSubgraph NegEdgeSubgraph(GraphPtr gptr, IdArray relations, const Subgraph &po
                             int neg_sample_size, bool exclude_positive,
                             bool check_false_neg) {
   int64_t num_tot_nodes = gptr->NumVertices();
+  if (neg_sample_size > num_tot_nodes)
+    neg_sample_size = num_tot_nodes;
   bool is_multigraph = gptr->IsMultigraph();
   std::vector<IdArray> adj = pos_subg.graph->GetAdj(false, "coo");
   IdArray coo = adj[0];
@@ -1165,6 +1167,8 @@ NegSubgraph PBGNegEdgeSubgraph(GraphPtr gptr, IdArray relations, const Subgraph 
   std::vector<IdArray> adj = pos_subg.graph->GetAdj(false, "coo");
   IdArray coo = adj[0];
   int64_t num_pos_edges = coo->shape[0] / 2;
+  if (neg_sample_size > num_tot_nodes)
+    neg_sample_size = num_tot_nodes;
 
   int64_t chunk_size = neg_sample_size;
   // If num_pos_edges isn't divisible by chunk_size, the actual number of chunks


### PR DESCRIPTION
## Description
When `neg_sample_size` is larger than the number of nodes in a graph, we can negatively sample at most the number of nodes in the graph.

## Checklist
Please feel free to remove inapplicable items for your PR.
- [ ] The PR title starts with [$CATEGORY] (such as [NN], [Model], [Doc], [Feature]])
- [ ] Changes are complete (i.e. I finished coding on this PR)
- [ ] All changes have test coverage
- [ ] Code is well-documented
- [ ] To the my best knowledge, examples are either not affected by this change,
      or have been fixed to be compatible with this change
- [ ] Related issue is referred in this PR

## Changes
<!-- You could use following template
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)
-->
