### PR TITLE
[bugfix]adapt networkx version to run the tutorial

### DIFF
--- a/docker/install/ubuntu_install_python_package.sh
+++ b/docker/install/ubuntu_install_python_package.sh
@@ -1,3 +1,3 @@
 # install libraries for python package on ubuntu
 #pip2 install nose numpy cython scipy networkx matplotlib nltk requests[security] tqdm
-pip3 install nose numpy cython scipy networkx matplotlib nltk requests[security] tqdm
+pip3 install nose numpy cython scipy networkx==2.1 matplotlib nltk requests[security] tqdm


### PR DESCRIPTION
## new networkx wouldn't support the syntax dgl used
Hi, DGLer

I'm a new dgl developer,  I build a Docker Image according the docker scripts. I found a error when I run the tutorial
![image](https://user-images.githubusercontent.com/3112825/67073925-b25a8a80-f1ba-11e9-9e9a-3d34d70dedfa.png)
It was caused by the versions of `networkx` as show in [https://networkx.github.io/documentation/stable/release/migration_guide_from_1.x_to_2.0.html](https://networkx.github.io/documentation/stable/release/migration_guide_from_1.x_to_2.0.html). Unfortunately  network-2.3 wouldn't support the syntax that the dgl used. So we may specify the version of `networkx` or change the all `networkx` api in the dgl code.


