### PR TITLE
[BUG] Fix #717

### DIFF
--- a/python/dgl/subgraph.py
+++ b/python/dgl/subgraph.py
@@ -46,6 +46,7 @@ class DGLSubGraph(DGLGraph):
         self._parent = parent
         self._parent_nid = sgi.induced_nodes
         self._parent_eid = sgi.induced_edges
+        self._subgraph_index = sgi
 
     # override APIs
     def add_nodes(self, num, data=None):
@@ -136,4 +137,5 @@ class DGLSubGraph(DGLGraph):
         tensor
             The node ID array in the subgraph.
         """
-        return map_to_subgraph_nid(self._graph, utils.toindex(parent_vids)).tousertensor()
+        v = map_to_subgraph_nid(self._subgraph_index, utils.toindex(parent_vids))
+        return v.tousertensor()

--- a/tests/compute/test_subgraph.py
+++ b/tests/compute/test_subgraph.py
@@ -82,7 +82,7 @@ def test_map_to_subgraph():
     g.add_edges(F.arange(0, 9), F.arange(1, 10))
     h = g.subgraph([0, 1, 2, 5, 8])
     v = h.map_to_subgraph_nid([0, 8, 2])
-    assert F.array_equal(v, F.tensor([0, 4, 2]))
+    assert np.array_equal(F.asnumpy(v), np.array([0, 4, 2]))
 
 def test_merge():
     # FIXME: current impl cannot handle this case!!!

--- a/tests/compute/test_subgraph.py
+++ b/tests/compute/test_subgraph.py
@@ -76,6 +76,14 @@ def test_basics():
     sg.ndata['h'] = F.zeros((6, D))
     assert F.allclose(h, g.ndata['h'])
 
+def test_map_to_subgraph():
+    g = DGLGraph()
+    g.add_nodes(10)
+    g.add_edges(F.arange(0, 9), F.arange(1, 10))
+    h = g.subgraph([0, 1, 2, 5, 8])
+    v = h.map_to_subgraph_nid([0, 8, 2])
+    assert F.array_equal(v, F.tensor([0, 4, 2]))
+
 def test_merge():
     # FIXME: current impl cannot handle this case!!!
     #        comment out for now to test CI


### PR DESCRIPTION
## Description
Fixes #717 .

We were only testing on `SubGraphIndex` but not testing on the induced `DGLGraph`, which is why the bug gets away.