### PR TITLE
[Doc] hotfix for docstring and some examples

### DIFF
--- a/examples/mxnet/monet/README.md
+++ b/examples/mxnet/monet/README.md
@@ -11,6 +11,11 @@ Dependencies
 Results
 =======
 
-Node classification on citation networks:
+## Citation networks
+Run with following (available dataset: "cora", "citeseer", "pubmed")
+```bash
+python3 citation.py --dataset cora --gpu 0
+```
+
 - Cora: ~0.814
 - Pubmed: ~0.748

--- a/examples/pytorch/appnp/train.py
+++ b/examples/pytorch/appnp/train.py
@@ -43,9 +43,9 @@ def main(args):
       #Val samples %d
       #Test samples %d""" %
           (n_edges, n_classes,
-           train_mask.sum().item(),
-           val_mask.sum().item(),
-           test_mask.sum().item()))
+           train_mask.int().sum().item(),
+           val_mask.int().sum().item(),
+           test_mask.int().sum().item()))
 
     if args.gpu < 0:
         cuda = False

--- a/examples/pytorch/cluster_gcn/cluster_gcn.py
+++ b/examples/pytorch/cluster_gcn/cluster_gcn.py
@@ -59,9 +59,9 @@ def main(args):
     n_classes = data.num_labels
     n_edges = data.graph.number_of_edges()
 
-    n_train_samples = train_mask.sum().item()
-    n_val_samples = val_mask.sum().item()
-    n_test_samples = test_mask.sum().item()
+    n_train_samples = train_mask.int().sum().item()
+    n_val_samples = val_mask.int().sum().item()
+    n_test_samples = test_mask.int().sum().item()
 
     print("""----Data statistics------'
     #Edges %d

--- a/examples/pytorch/gat/train.py
+++ b/examples/pytorch/gat/train.py
@@ -60,9 +60,9 @@ def main(args):
       #Val samples %d
       #Test samples %d""" %
           (n_edges, n_classes,
-           train_mask.sum().item(),
-           val_mask.sum().item(),
-           test_mask.sum().item()))
+           train_mask.int().sum().item(),
+           val_mask.int().sum().item(),
+           test_mask.int().sum().item()))
 
     if args.gpu < 0:
         cuda = False

--- a/examples/pytorch/gcn/gcn_mp.py
+++ b/examples/pytorch/gcn/gcn_mp.py
@@ -137,9 +137,9 @@ def main(args):
       #Val samples %d
       #Test samples %d""" %
           (n_edges, n_classes,
-              train_mask.sum().item(),
-              val_mask.sum().item(),
-              test_mask.sum().item()))
+              train_mask.int().sum().item(),
+              val_mask.int().sum().item(),
+              test_mask.int().sum().item()))
 
     if args.gpu < 0:
         cuda = False

--- a/examples/pytorch/gcn/train.py
+++ b/examples/pytorch/gcn/train.py
@@ -44,9 +44,9 @@ def main(args):
       #Val samples %d
       #Test samples %d""" %
           (n_edges, n_classes,
-              train_mask.sum().item(),
-              val_mask.sum().item(),
-              test_mask.sum().item()))
+              train_mask.int().sum().item(),
+              val_mask.int().sum().item(),
+              test_mask.int().sum().item()))
 
     if args.gpu < 0:
         cuda = False

--- a/examples/pytorch/graphsage/graphsage.py
+++ b/examples/pytorch/graphsage/graphsage.py
@@ -78,9 +78,9 @@ def main(args):
       #Val samples %d
       #Test samples %d""" %
           (n_edges, n_classes,
-           train_mask.sum().item(),
-           val_mask.sum().item(),
-           test_mask.sum().item()))
+           train_mask.int().sum().item(),
+           val_mask.int().sum().item(),
+           test_mask.int().sum().item()))
 
     if args.gpu < 0:
         cuda = False

--- a/examples/pytorch/model_zoo/citation_network/run.py
+++ b/examples/pytorch/model_zoo/citation_network/run.py
@@ -64,9 +64,9 @@ def main(args):
       #Val samples %d
       #Test samples %d""" %
           (n_edges, n_classes,
-              train_mask.sum().item(),
-              val_mask.sum().item(),
-              test_mask.sum().item()))
+              train_mask.int().sum().item(),
+              val_mask.int().sum().item(),
+              test_mask.int().sum().item()))
 
     if args.gpu < 0:
         cuda = False

--- a/examples/pytorch/monet/README.md
+++ b/examples/pytorch/monet/README.md
@@ -11,9 +11,14 @@ Dependencies
 Results
 =======
 
-Node classification on citation networks:
+## Citation networks
+Run with following (available dataset: "cora", "citeseer", "pubmed")
+```bash
+python3 citation.py --dataset cora --gpu 0
+```
+
 - Cora: ~0.816
 - Pubmed: ~0.763
 
-Image classification on MNIST:
+## Image classification:
 - please refer to [model_zoo/geometric](../model_zoo/geometric).

--- a/examples/pytorch/sampling/dis_sampling/gcn_cv_sc_train.py
+++ b/examples/pytorch/sampling/dis_sampling/gcn_cv_sc_train.py
@@ -36,9 +36,9 @@ def main(args):
     n_classes = data.num_labels
     n_edges = data.graph.number_of_edges()
 
-    n_train_samples = train_mask.sum().item()
-    n_val_samples = val_mask.sum().item()
-    n_test_samples = test_mask.sum().item()
+    n_train_samples = train_mask.int().sum().item()
+    n_val_samples = val_mask.int().sum().item()
+    n_test_samples = test_mask.int().sum().item()
 
     print("""----Data statistics------'
       #Edges %d

--- a/examples/pytorch/sampling/dis_sampling/gcn_ns_sc_train.py
+++ b/examples/pytorch/sampling/dis_sampling/gcn_ns_sc_train.py
@@ -37,9 +37,9 @@ def main(args):
     n_classes = data.num_labels
     n_edges = data.graph.number_of_edges()
 
-    n_train_samples = train_mask.sum().item()
-    n_val_samples = val_mask.sum().item()
-    n_test_samples = test_mask.sum().item()
+    n_train_samples = train_mask.int().sum().item()
+    n_val_samples = val_mask.int().sum().item()
+    n_test_samples = test_mask.int().sum().item()
 
     print("""----Data statistics------'
       #Edges %d

--- a/examples/pytorch/sampling/gcn_cv_sc.py
+++ b/examples/pytorch/sampling/gcn_cv_sc.py
@@ -161,9 +161,9 @@ def main(args):
     n_classes = data.num_labels
     n_edges = data.graph.number_of_edges()
 
-    n_train_samples = train_mask.sum().item()
-    n_val_samples = val_mask.sum().item()
-    n_test_samples = test_mask.sum().item()
+    n_train_samples = train_mask.int().sum().item()
+    n_val_samples = val_mask.int().sum().item()
+    n_test_samples = test_mask.int().sum().item()
 
     print("""----Data statistics------'
       #Edges %d

--- a/examples/pytorch/sampling/gcn_ns_sc.py
+++ b/examples/pytorch/sampling/gcn_ns_sc.py
@@ -132,9 +132,9 @@ def main(args):
     n_classes = data.num_labels
     n_edges = data.graph.number_of_edges()
 
-    n_train_samples = train_mask.sum().item()
-    n_val_samples = val_mask.sum().item()
-    n_test_samples = test_mask.sum().item()
+    n_train_samples = train_mask.int().sum().item()
+    n_val_samples = val_mask.int().sum().item()
+    n_test_samples = test_mask.int().sum().item()
 
     print("""----Data statistics------'
       #Edges %d

--- a/examples/pytorch/sgc/sgc.py
+++ b/examples/pytorch/sgc/sgc.py
@@ -48,9 +48,9 @@ def main(args):
       #Val samples %d
       #Test samples %d""" %
           (n_edges, n_classes,
-              train_mask.sum().item(),
-              val_mask.sum().item(),
-              test_mask.sum().item()))
+              train_mask.int().sum().item(),
+              val_mask.int().sum().item(),
+              test_mask.int().sum().item()))
 
     if args.gpu < 0:
         cuda = False

--- a/examples/pytorch/sgc/sgc_reddit.py
+++ b/examples/pytorch/sgc/sgc_reddit.py
@@ -51,9 +51,9 @@ def main(args):
       #Val samples %d
       #Test samples %d""" %
           (n_edges, n_classes,
-           train_mask.sum().item(),
-           val_mask.sum().item(),
-           test_mask.sum().item()))
+           train_mask.int().sum().item(),
+           val_mask.int().sum().item(),
+           test_mask.int().sum().item()))
 
     if args.gpu < 0:
         cuda = False

--- a/examples/pytorch/tagcn/train.py
+++ b/examples/pytorch/tagcn/train.py
@@ -42,9 +42,9 @@ def main(args):
       #Val samples %d
       #Test samples %d""" %
           (n_edges, n_classes,
-              train_mask.sum().item(),
-              val_mask.sum().item(),
-              test_mask.sum().item()))
+              train_mask.int().sum().item(),
+              val_mask.int().sum().item(),
+              test_mask.int().sum().item()))
 
     if args.gpu < 0:
         cuda = False

--- a/python/dgl/nn/mxnet/softmax.py
+++ b/python/dgl/nn/mxnet/softmax.py
@@ -152,6 +152,7 @@ def edge_softmax(graph, logits, eids=ALL):
     <NDArray 6x1 @cpu(0)>
 
     Apply edge softmax on first 4 edges of g:
+
     >>> edge_softmax(g, edata, nd.array([0,1,2,3], dtype='int64'))
     [[1. ]
      [0.5]

--- a/python/dgl/nn/pytorch/softmax.py
+++ b/python/dgl/nn/pytorch/softmax.py
@@ -154,6 +154,7 @@ def edge_softmax(graph, logits, eids=ALL):
         [0.3333]])
 
     Apply edge softmax on first 4 edges of g:
+
     >>> edge_softmax(g, edata[:4], th.Tensor([0,1,2,3]))
     tensor([[1.0000],
         [0.5000],


### PR DESCRIPTION
## Description
Docstring of edge softmax has some style problems.
Some pytorch examples are broken because BoolTensor do not support summation on CPU(BoolTensor was brought by #954).

## Checklist
Please feel free to remove inapplicable items for your PR.
- [x] The PR title starts with [$CATEGORY] (such as [NN], [Model], [Doc], [Feature]])
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage
- [x] Code is well-documented
- [x] To the my best knowledge, examples are either not affected by this change,
      or have been fixed to be compatible with this change
- [x] Related issue is referred in this PR

