### PR TITLE
[Feature] add degree padding schedule

### DIFF
--- a/include/dgl/scheduler.h
+++ b/include/dgl/scheduler.h
@@ -32,6 +32,11 @@ namespace sched {
 std::vector<IdArray> DegreeBucketing(const IdArray& msg_ids, const IdArray& vids,
         const IdArray& recv_ids);
 
+/*! TODO(zihao): finish the docstring
+ */
+std::vector<IdArray> DegreePadding(const IdArray& msg_ids, const IdArray& vids,
+        const IdArray& recv_ids, const IdArray& bkt_split);
+
 /*!
  * \brief Generate degree bucketing schedule for group_apply edge
  * \param uids One end vertex of edge by which edges are grouped

--- a/python/dgl/function/reducer.py
+++ b/python/dgl/function/reducer.py
@@ -3,11 +3,11 @@
 from __future__ import absolute_import
 
 import sys
+import functools
 
 from .base import BuiltinFunction, TargetCode
 from ..runtime import ir
 from ..runtime.ir import var
-from functools import wraps
 
 
 class ReduceFunction(BuiltinFunction):
@@ -91,10 +91,18 @@ class DegreePadding(object):
             self.bucket_split = bucket_split
         self.padding_val = padding_val
 
+    def __get__(self, obj):
+        return functools.partial(self, obj)
+
     def __call__(self, *args, **kwargs):
         return self.fn(*args, **kwargs)
 
-__all__ = ['DegreePadding']
+def degree_padding(bucket_split=None, padding_val=0):
+    return functools.partial(DegreePadding,
+                             bucket_split=bucket_split,
+                             padding_val=padding_val)
+
+__all__ = ['DegreePadding', 'degree_padding']
 
 
 def _register_builtin_reduce_func():

--- a/python/dgl/function/reducer.py
+++ b/python/dgl/function/reducer.py
@@ -83,12 +83,12 @@ def _gen_reduce_builtin(reducer):
     return func
 
 class DegreePadding(object):
-    def __init__(self, fn, bucket_sizes=None, padding_val=0):
+    def __init__(self, fn, bucket_split=None, padding_val=0):
         self.fn = fn
-        if bucket_sizes is None:
-            self.bucket_sizes = []
+        if bucket_split is None:
+            self.bucket_split = []
         else:
-            self.bucket_sizes = bucket_sizes
+            self.bucket_split = bucket_split
         self.padding_val = padding_val
 
     def __call__(self, *args, **kwargs):

--- a/python/dgl/function/reducer.py
+++ b/python/dgl/function/reducer.py
@@ -83,21 +83,29 @@ def _gen_reduce_builtin(reducer):
     return func
 
 class DegreePadding(object):
+    """TODO"""
     def __init__(self, fn, bucket_split=None, padding_val=0):
         self.fn = fn
+        self.bucket_split = []
+        self.padding_val = 0
         if bucket_split is None:
             self.bucket_split = []
         else:
             self.bucket_split = bucket_split
         self.padding_val = padding_val
+        self.instance = None
 
-    def __get__(self, obj):
-        return functools.partial(self, obj)
+    def __get__(self, instance, cls):
+        self.instance = instance
+        return self
 
     def __call__(self, *args, **kwargs):
+        if self.instance is not None:
+            return self.fn(self.instance, *args, **kwargs)
         return self.fn(*args, **kwargs)
 
 def degree_padding(bucket_split=None, padding_val=0):
+    """TODO"""
     return functools.partial(DegreePadding,
                              bucket_split=bucket_split,
                              padding_val=padding_val)

--- a/python/dgl/function/reducer.py
+++ b/python/dgl/function/reducer.py
@@ -7,6 +7,7 @@ import sys
 from .base import BuiltinFunction, TargetCode
 from ..runtime import ir
 from ..runtime.ir import var
+from functools import wraps
 
 
 class ReduceFunction(BuiltinFunction):
@@ -81,8 +82,19 @@ def _gen_reduce_builtin(reducer):
     func.__doc__ = docstring
     return func
 
+class DegreePadding(object):
+    def __init__(self, fn, bucket_sizes=None, padding_val=0):
+        self.fn = fn
+        if bucket_sizes is None:
+            self.bucket_sizes = []
+        else:
+            self.bucket_sizes = bucket_sizes
+        self.padding_val = padding_val
 
-__all__ = []
+    def __call__(self, *args, **kwargs):
+        return self.fn(*args, **kwargs)
+
+__all__ = ['DegreePadding']
 
 
 def _register_builtin_reduce_func():

--- a/python/dgl/nn/pytorch/conv/sageconv.py
+++ b/python/dgl/nn/pytorch/conv/sageconv.py
@@ -77,10 +77,6 @@ class SAGEConv(nn.Module):
 
     @degree_padding(bucket_split=[1,8])
     def _lstm_reducer(self, nodes, degs):
-        """LSTM reducer
-        NOTE(zihao): lstm reducer with default schedule (degree bucketing)
-        is slow, we could accelerate this with degree padding in the future.
-        """
         m = nodes.mailbox['m'] # (B, L, D)
         m_packed = pack_padded_sequence(m, degs, batch_first=True, enforce_sorted=False)
 

--- a/python/dgl/nn/pytorch/conv/sageconv.py
+++ b/python/dgl/nn/pytorch/conv/sageconv.py
@@ -75,7 +75,7 @@ class SAGEConv(nn.Module):
             nn.init.xavier_uniform_(self.fc_self.weight, gain=gain)
         nn.init.xavier_uniform_(self.fc_neigh.weight, gain=gain)
 
-    @degree_padding(bucket_split=[1,8])
+    @degree_padding(bucket_split=[1, 8])
     def _lstm_reducer(self, nodes, degs):
         m = nodes.mailbox['m'] # (B, L, D)
         m_packed = pack_padded_sequence(m, degs, batch_first=True, enforce_sorted=False)

--- a/python/dgl/runtime/degree_bucketing.py
+++ b/python/dgl/runtime/degree_bucketing.py
@@ -48,7 +48,7 @@ def gen_degree_bucketing_schedule(
     """
     if isinstance(reduce_udf, DegreePadding):
         buckets = _degree_padding_schedule(message_ids, dst_nodes, recv_nodes,
-                                           utils.Index(reduce_udf.bucket_sizes))
+                                           utils.Index(reduce_udf.bucket_split))
     else:
         buckets = _degree_bucketing_schedule(message_ids, dst_nodes, recv_nodes)
 
@@ -91,7 +91,7 @@ def gen_degree_bucketing_schedule(
     reduced_feat = ir.MERGE_ROW(var_order, fd_list)
     ir.WRITE_DICT_(var_out, reduced_feat)
 
-def _degree_padding_schedule(mids, dsts, v, bkt_sizes):
+def _degree_padding_schedule(mids, dsts, v, bkt_split):
     """Return the bucketing by padding scheduling for destination nodes of
      messages.
 
@@ -103,11 +103,11 @@ def _degree_padding_schedule(mids, dsts, v, bkt_sizes):
         destination node for each message
     v : utils.Index
         all receiving nodes (for checking zero degree nodes)
-    bkt_sizes : utils.Index
+    bkt_split : utils.Index
         Pre-defined bucket sizes (must be ordered).
     """
     buckets = _CAPI_DGLDegreePadding(mids.todgltensor(), dsts.todgltensor(),
-                                     v.todgltensor(), bkt_sizes.todgltensor())
+                                     v.todgltensor(), bkt_split.todgltensor())
     # TODO(zihao)
     pass
 

--- a/src/scheduler/scheduler.cc
+++ b/src/scheduler/scheduler.cc
@@ -94,16 +94,16 @@ std::vector<IdArray> DegreeBucketing(const IdArray& msg_ids, const IdArray& vids
 }
 
 std::vector<IdArray> DegreePadding(const IdArray& msg_ids, const IdArray& vids,
-        const IdArray& recv_ids, const IdArray& bkt_sizes) {
+        const IdArray& recv_ids, const IdArray& bkt_split) {
 
     auto n_msgs = msg_ids->shape[0];
-    auto n_bkts = bkt_sizes->shape[0];
+    auto n_bkts = bkt_split->shape[0];
     auto n_recv_nodes = recv_ids->shape[0];
 
     const int64_t* vid_data = static_cast<int64_t*>(vids->data)
     const int64_t* msg_id_data = static_cast<int64_t*>(msg_ids->data)
     const int64_t* recv_id_data = static_cast<int64_t*>(recv_ids->data);
-    const int64_t* bkt_data = static_cast<int64_t*>(bkt_sizes->data);
+    const int64_t* bkt_data = static_cast<int64_t*>(bkt_split->data);
 
     // in edge: dst->msgs
     std::unordered_map<int64_t, std::vector<int64_t>> in_edges;

--- a/src/scheduler/scheduler.cc
+++ b/src/scheduler/scheduler.cc
@@ -95,7 +95,6 @@ std::vector<IdArray> DegreeBucketing(const IdArray& msg_ids, const IdArray& vids
 
 std::vector<IdArray> DegreePadding(const IdArray& msg_ids, const IdArray& vids,
         const IdArray& recv_ids, const IdArray& bkt_split) {
-
     auto n_msgs = msg_ids->shape[0];
     auto n_bkts = bkt_split->shape[0];
     auto n_recv_nodes = recv_ids->shape[0];
@@ -114,7 +113,8 @@ std::vector<IdArray> DegreePadding(const IdArray& msg_ids, const IdArray& vids,
     // bkt: deg->dsts
     std::unordered_map<int64_t, std::vector<std::pair<int64_t, int64_t>>> bkt;
     for (const auto &it : in_edges) {
-        const int64_t idx = std::lower_bound(bkt_data, bkt_data + n_bkts, it.second.size()) - bkt_data;
+        const int64_t idx = std::lower_bound(
+            bkt_data, bkt_data + n_bkts, it.second.size()) - bkt_data;
         bkt[idx].push_back(std::make_pair(it.second.size(), it.first));
     }
 
@@ -148,15 +148,15 @@ std::vector<IdArray> DegreePadding(const IdArray& msg_ids, const IdArray& vids,
     int64_t* msec_ptr = static_cast<int64_t*>(mid_section->data);
 
     // fill in bucketing ordering
-    for (const auto& it : bkt) { // for each bucket
+    for (const auto& it : bkt) {    // for each bucket
         const int64_t bucket_size = it.second.size();
         *nsec_ptr++ = bucket_size;
         int64_t msg_cnt = 0;
-        for (const auto deg_dst : it.second) { // for each dst in this bucket
+        for (const auto deg_dst : it.second) {  // for each dst in this bucket
             auto deg = deg_dst.first, dst = deg_dst.second;
             *nid_ptr++ = dst;
             *deg_ptr++ = deg;
-            for (const auto mid : in_edges[dst]) { // for each in-edge of dst
+            for (const auto mid : in_edges[dst]) {  // for each in-edge of dst
                 *mid_ptr++ = mid;
                 msg_cnt++;
             }

--- a/src/scheduler/scheduler.cc
+++ b/src/scheduler/scheduler.cc
@@ -6,6 +6,7 @@
 #include <dgl/scheduler.h>
 #include <unordered_map>
 #include <vector>
+#include <algorithm>
 
 namespace dgl {
 namespace sched {
@@ -68,7 +69,7 @@ std::vector<IdArray> DegreeBucketing(const IdArray& msg_ids, const IdArray& vids
         *msec_ptr++ = deg * bucket_size;
         for (const auto dst : it.second) {  // for each dst in this bucket
             *nid_ptr++ = dst;
-            for (const auto mid : in_edges[dst]) {  // for each in edge of dst
+            for (const auto mid : in_edges[dst]) {  // for each in-edge of dst
                 *mid_ptr++ = mid;
             }
         }
@@ -78,6 +79,95 @@ std::vector<IdArray> DegreeBucketing(const IdArray& msg_ids, const IdArray& vids
         *deg_ptr = 0;
         *nsec_ptr = n_zero_deg;
         for (const auto dst : zero_deg_nodes) {
+            *nid_ptr++ = dst;
+        }
+    }
+
+    std::vector<IdArray> ret;
+    ret.push_back(std::move(degs));
+    ret.push_back(std::move(nids));
+    ret.push_back(std::move(nid_section));
+    ret.push_back(std::move(mids));
+    ret.push_back(std::move(mid_section));
+
+    return std::move(ret);
+}
+
+std::vector<IdArray> DegreePadding(const IdArray& msg_ids, const IdArray& vids,
+        const IdArray& recv_ids, const IdArray& bkt_sizes) {
+
+    auto n_msgs = msg_ids->shape[0];
+    auto n_bkts = bkt_sizes->shape[0];
+    auto n_recv_nodes = recv_ids->shape[0];
+
+    const int64_t* vid_data = static_cast<int64_t*>(vids->data)
+    const int64_t* msg_id_data = static_cast<int64_t*>(msg_ids->data)
+    const int64_t* recv_id_data = static_cast<int64_t*>(recv_ids->data);
+    const int64_t* bkt_data = static_cast<int64_t*>(bkt_sizes->data);
+
+    // in edge: dst->msgs
+    std::unordered_map<int64_t, std::vector<int64_t>> in_edges;
+    for (int64_t i = 0; i < n_msgs; ++i) {
+        in_edges[vid_data[i]].push_back(msg_id_data[i]);
+    }
+
+    // bkt: deg->dsts
+    std::unordered_map<int64_t, std::vector<std::pair<int64_t, int64_t>>> bkt;
+    for (const auto &it : in_edges) {
+        int64_t idx = std::lower_bound(bkt_data, bkt_data + n_bkts, it.second.size());
+        bkt[idx].push_back(std::make_pair(it.second.size(), it.first));
+    }
+
+    std::unordered_set<int64_t> zero_deg_nodes;
+    for (int64_t i = 0; i < n_recv_nodes; ++i) {
+        if (in_edges.find(recv_id_data[i]) == in_edges.end()) {
+            zero_deg_nodes.insert(recv_id_data[i]);
+        }
+    }
+    auto n_zero_deg = zero_deg_nodes.size();
+
+    // calc output size
+    int64_t n_deg = bkt.size();
+    int64_t n_dst = in_edges.size();
+    int64_t n_mid_sec = bkt.size();
+    if (n_zero_deg > 0) {
+        n_deg += 1;
+        n_dst += n_zero_deg;
+    }
+
+    // initialize output
+    IdArray degs = IdArray::Empty({n_dst}, vids->dtype, vids->ctx);
+    IdArray nids = IdArray::Empty({n_dst}, vids->dtype, vids->ctx);
+    IdArray nid_section = IdArray::Empty({n_deg}, vids->dtype, vids->ctx);
+    IdArray mids = IdArray::Empty({n_msgs}, vids->dtype, vids->ctx);
+    IdArray mid_section = IdArray::Empty({n_mid_sec}, vids->dtype, vids->ctx);
+    int64_t* deg_ptr = static_cast<int64_t*>(degs->data);
+    int64_t* nid_ptr = static_cast<int64_t*>(nids->data);
+    int64_t* nsec_ptr = static_cast<int64_t*>(nid_section->data);
+    int64_t* mid_ptr = static_cast<int64_t*>(mids->data);
+    int64_t* msec_ptr = static_cast<int64_t*>(mid_section->data);
+
+    // fill in bucketing ordering
+    for (const auto& it : bkt) { // for each bucket
+        const int64_t bucket_size = it.second.size();
+        *nsec_ptr++ = bucket_size;
+        int64_t msg_cnt = 0;
+        for (const auto deg_dst : it.second) { // for each dst in this bucket
+            auto deg = deg_dst.first, dst = deg_dst.second;
+            *nid_ptr++ = dst;
+            *deg_ptr++ = deg;
+            for (const auto mid : in_edges[dst]) { // for each in-edge of dst
+                *mid_ptr++ = mid;
+                msg_cnt++;
+            }
+        }
+        *msec_ptr++ = msg_cnt;
+    }
+
+    if (n_zero_deg > 0) {
+        *nsec_ptr = n_zero_deg;
+        for (const auto dst : zero_deg_nodes) {
+            *deg_ptr++ = 0;
             *nid_ptr++ = dst;
         }
     }

--- a/src/scheduler/scheduler.cc
+++ b/src/scheduler/scheduler.cc
@@ -100,8 +100,8 @@ std::vector<IdArray> DegreePadding(const IdArray& msg_ids, const IdArray& vids,
     auto n_bkts = bkt_split->shape[0];
     auto n_recv_nodes = recv_ids->shape[0];
 
-    const int64_t* vid_data = static_cast<int64_t*>(vids->data)
-    const int64_t* msg_id_data = static_cast<int64_t*>(msg_ids->data)
+    const int64_t* vid_data = static_cast<int64_t*>(vids->data);
+    const int64_t* msg_id_data = static_cast<int64_t*>(msg_ids->data);
     const int64_t* recv_id_data = static_cast<int64_t*>(recv_ids->data);
     const int64_t* bkt_data = static_cast<int64_t*>(bkt_split->data);
 
@@ -114,7 +114,7 @@ std::vector<IdArray> DegreePadding(const IdArray& msg_ids, const IdArray& vids,
     // bkt: deg->dsts
     std::unordered_map<int64_t, std::vector<std::pair<int64_t, int64_t>>> bkt;
     for (const auto &it : in_edges) {
-        int64_t idx = std::lower_bound(bkt_data, bkt_data + n_bkts, it.second.size());
+        const int64_t idx = std::lower_bound(bkt_data, bkt_data + n_bkts, it.second.size()) - bkt_data;
         bkt[idx].push_back(std::make_pair(it.second.size(), it.first));
     }
 

--- a/src/scheduler/scheduler_apis.cc
+++ b/src/scheduler/scheduler_apis.cc
@@ -21,6 +21,15 @@ DGL_REGISTER_GLOBAL("runtime.degree_bucketing._CAPI_DGLDegreeBucketing")
     *rv = ConvertNDArrayVectorToPackedFunc(sched::DegreeBucketing(msg_ids, vids, nids));
   });
 
+DGL_REGISTER_GLOBAL("runtime.degree_bucketing._CAPI_DGLDegreePadding")
+.set_body([] (DGLArgs args, DGLRetValue* rv) {
+    const IdArray msg_ids = args[0];
+    const IdArray vids = args[1];
+    const IdArray nids = args[2];
+    const IdArray bkt_sizes = args[3];
+    *rv = ConvertNDArrayVectorToPackedFunc(sched::DegreePadding(msg_ids, vids, nids, bkt_sizes));
+  });
+
 DGL_REGISTER_GLOBAL("runtime.degree_bucketing._CAPI_DGLGroupEdgeByNodeDegree")
 .set_body([] (DGLArgs args, DGLRetValue* rv) {
     const IdArray uids = args[0];

--- a/src/scheduler/scheduler_apis.cc
+++ b/src/scheduler/scheduler_apis.cc
@@ -26,8 +26,8 @@ DGL_REGISTER_GLOBAL("runtime.degree_bucketing._CAPI_DGLDegreePadding")
     const IdArray msg_ids = args[0];
     const IdArray vids = args[1];
     const IdArray nids = args[2];
-    const IdArray bkt_sizes = args[3];
-    *rv = ConvertNDArrayVectorToPackedFunc(sched::DegreePadding(msg_ids, vids, nids, bkt_sizes));
+    const IdArray bkt_split = args[3];
+    *rv = ConvertNDArrayVectorToPackedFunc(sched::DegreePadding(msg_ids, vids, nids, bkt_split));
   });
 
 DGL_REGISTER_GLOBAL("runtime.degree_bucketing._CAPI_DGLGroupEdgeByNodeDegree")


### PR DESCRIPTION
## Description
Our default degree bucketing strategy is slow for graphs whose degree variance is large (e.g. power-law graphs).

This PR implements degree padding strategy discussed in #777 , where a set of pre-defined buckets are given, messages of each node are padded to the length of least bucket size greater than its in degrees.

## Usage
We defined a decorator `degree_bucketing`  in `dgl.function.reducer` that specifies whether to use degree bucketing strategy and related parameters (bucket splits and padding values). The following is an example of lstm reducer used in graphsage:
```python
@degree_padding(bucket_split=[1,8])
def _lstm_reducer(nodes, degs):
    m = nodes.mailbox['m'] # (B, L, D)
    m_packed = pack_padded_sequence(m, degs, batch_first=True, enforce_sorted=False)

    batch_size = m.shape[0]
    h = (m.new_zeros((1, batch_size, self._in_feats)),
         m.new_zeros((1, batch_size, self._in_feats)))
    _, (rst, _) = self.lstm(m_packed, h)
    return {'neigh': rst.squeeze(0)}
```


## Checklist
Please feel free to remove inapplicable items for your PR.
- [x] The PR title starts with [$CATEGORY] (such as [NN], [Model], [Doc], [Feature]])
- [x] Changes are complete (i.e. I finished coding on this PR)
- [ ] All changes have test coverage
- [ ] Code is well-documented
- [ ] To the my best knowledge, examples are either not affected by this change,
      or have been fixed to be compatible with this change
- [x] Related issue is referred in this PR

## Changes
<!-- You could use following template
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)
-->
