### PR TITLE
[Bug] Fix dgl.to_homo

### DIFF
--- a/python/dgl/convert.py
+++ b/python/dgl/convert.py
@@ -590,8 +590,8 @@ def to_homo(G):
         srctype, _, dsttype = etype
         src, dst = G.all_edges(etype=etype, order='eid')
         num_edges = len(src)
-        srcs.append(src + offset_per_ntype[G.get_ntype_id(srctype)])
-        dsts.append(dst + offset_per_ntype[G.get_ntype_id(dsttype)])
+        srcs.append(src + int(offset_per_ntype[G.get_ntype_id(srctype)]))
+        dsts.append(dst + int(offset_per_ntype[G.get_ntype_id(dsttype)]))
         etype_ids.append(F.full_1d(num_edges, etype_id, F.int64, F.cpu()))
         eids.append(F.arange(0, num_edges))
 


### PR DESCRIPTION
## Description

Fix #1018 . It seems that as of PyTorch 1.3.1, adding a `np.int64` object to a `torch.int64` tensor will give a `torch.float32` tensor. Explicitly converting the `np.int64` object to an `int` object fixes this problem.

## Checklist
Please feel free to remove inapplicable items for your PR.
- [x] The PR title starts with [$CATEGORY] (such as [NN], [Model], [Doc], [Feature]])
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage
- [ ] Code is well-documented
- [x] To the my best knowledge, examples are either not affected by this change,
      or have been fixed to be compatible with this change
- [x] Related issue is referred in this PR