### PR TITLE
[Bug] This PR can make model to run on FB15k-237 successfully.

### DIFF
--- a/python/dgl/contrib/data/knowledge_graph.py
+++ b/python/dgl/contrib/data/knowledge_graph.py
@@ -171,7 +171,7 @@ class RGCNLinkDataset(object):
     def __init__(self, name):
         self.name = name
         self.dir = get_download_dir()
-        tgz_path = os.path.join(self.dir, '{}.tar.gz'.format(self.name))
+        tgz_path = os.path.join(self.dir, '{}.tgz'.format(self.name))
         download(_downlaod_prefix + '{}.tgz'.format(self.name), tgz_path)
         self.dir = os.path.join(self.dir, self.name)
         extract_archive(tgz_path, self.dir)


### PR DESCRIPTION
## Description

I run the link prediction example and encounter this bug.

## Checklist

- [x] The PR title starts with [$CATEGORY] (such as [NN], [Model], [Doc], [Feature]])
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage
- [x] Code is well-documented
- [x] To the my best knowledge, examples are either not affected by this change,
      or have been fixed to be compatible with this change


## Changes

I changed the data path