### PR TITLE
[Graph]To(device) should return updated object

### DIFF
--- a/python/dgl/graph.py
+++ b/python/dgl/graph.py
@@ -3339,6 +3339,11 @@ class DGLGraph(DGLBaseGraph):
         ctx : framework-specific context object
             The context to move data to.
 
+        Returns
+        -------
+        g : DGLGraph
+          Moved DGLGraph of the targeted mode.
+
         Examples
         --------
         The following example uses PyTorch backend.

--- a/python/dgl/graph.py
+++ b/python/dgl/graph.py
@@ -3354,6 +3354,7 @@ class DGLGraph(DGLBaseGraph):
             self.ndata[k] = F.copy_to(self.ndata[k], ctx)
         for k in self.edata.keys():
             self.edata[k] = F.copy_to(self.edata[k], ctx)
+        return self
     # pylint: enable=invalid-name
 
     def local_var(self):

--- a/python/dgl/graph.py
+++ b/python/dgl/graph.py
@@ -3348,7 +3348,7 @@ class DGLGraph(DGLBaseGraph):
         >>> G.add_nodes(5, {'h': torch.ones((5, 2))})
         >>> G.add_edges([0, 1], [1, 2], {'m' : torch.ones((2, 2))})
         >>> G.add_edges([0, 1], [1, 2], {'m' : torch.ones((2, 2))})
-        >>> G.to(torch.device('cuda:0'))
+        >>> G = G.to(torch.device('cuda:0'))
         """
         for k in self.ndata.keys():
             self.ndata[k] = F.copy_to(self.ndata[k], ctx)

--- a/python/dgl/heterograph.py
+++ b/python/dgl/heterograph.py
@@ -3575,6 +3575,11 @@ class DGLHeteroGraph(object):
         ctx : framework-specific context object
             The context to move data to.
 
+        Returns
+        -------
+        g : DGLHeteroGraph
+          Moved DGLHeteroGraph of the targeted mode.
+
         Examples
         --------
         The following example uses PyTorch backend.

--- a/python/dgl/heterograph.py
+++ b/python/dgl/heterograph.py
@@ -3583,7 +3583,7 @@ class DGLHeteroGraph(object):
         >>> g = dgl.bipartite([(0, 0), (1, 0), (1, 2), (2, 1)], 'user', 'plays', 'game')
         >>> g.nodes['user'].data['h'] = torch.tensor([[0.], [1.], [2.]])
         >>> g.edges['plays'].data['h'] = torch.tensor([[0.], [1.], [2.], [3.]])
-        >>> g.to(torch.device('cuda:0'))
+        >>> g = g.to(torch.device('cuda:0'))
         """
         for i in range(len(self._node_frames)):
             for k in self._node_frames[i].keys():
@@ -3591,6 +3591,7 @@ class DGLHeteroGraph(object):
         for i in range(len(self._edge_frames)):
             for k in self._edge_frames[i].keys():
                 self._edge_frames[i][k] = F.copy_to(self._edge_frames[i][k], ctx)
+        return self
 
     def local_var(self):
         """Return a heterograph object that can be used in a local function scope.

--- a/tests/compute/test_heterograph.py
+++ b/tests/compute/test_heterograph.py
@@ -592,6 +592,12 @@ def test_flatten():
     assert fg.etypes == ['follows+knows']
     check_mapping(g, fg)
 
+def test_to_device():
+    hg = create_test_heterograph()
+    if F.is_cuda_available():
+        hg = hg.to(F.cuda())
+        assert hg is not None
+
 def test_convert():
     hg = create_test_heterograph()
     hs = []

--- a/tests/compute/test_heterograph.py
+++ b/tests/compute/test_heterograph.py
@@ -1206,6 +1206,7 @@ if __name__ == '__main__':
     test_view1()
     test_flatten()
     test_convert()
+    test_to_device()
     test_transform()
     test_subgraph()
     test_apply()

--- a/tests/compute/test_to_device.py
+++ b/tests/compute/test_to_device.py
@@ -6,7 +6,8 @@ def test_to_device():
     g.add_nodes(5, {'h' : F.ones((5, 2))})
     g.add_edges([0, 1], [1, 2], {'m' : F.ones((2, 2))})
     if F.is_cuda_available():
-        g.to(F.cuda())
+        g = g.to(F.cuda())
+        assert g is not None
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
## Description
When using pytorch, users are used to assigning the return value of to () to a new variable:
```
# torch/nn/modules/module.py
def to(...):
    ...
    return self._apply(convert)
# we usually do this:
# new_tensor = tensor.to(device)
```
DGL's `to` behavior is different from pytorch, i.e. return None, which will cause bugs.

## Related Issues/Forum Threads
- [Convert BatchedDGL graph to cuda tensor](https://discuss.dgl.ai/t/convert-batcheddgl-graph-to-cuda-tensor/487/2)

## Checklist
Please feel free to remove inapplicable items for your PR.
- [x] The PR title starts with [$CATEGORY] (such as [NN], [Model], [Doc], [Feature]])
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage
- [x] Code is well-documented
- [x] To the my best knowledge, examples are either not affected by this change,
      or have been fixed to be compatible with this change
- [ ] Related issue is referred in this PR

## Changes
- [x] Modified the `to` function so that it returns itself
