### PR TITLE
[Backend] Memory leak fix in PyTorch backend

### DIFF
--- a/python/dgl/backend/pytorch/tensor.py
+++ b/python/dgl/backend/pytorch/tensor.py
@@ -326,15 +326,17 @@ class BinaryReduce(th.autograd.Function):
         # save_for_backward can only save variables
         ctx.backward_cache = (reducer, binary_op, graph, lhs, rhs, lhs_map,
                               rhs_map, out_map, lhs_data_nd, rhs_data_nd,
-                              out_data_nd, feat_shape, degs)
+                              feat_shape, degs)
+        ctx.save_for_backward(out_data)
         return out_data
 
     @staticmethod
     def backward(ctx, grad_out):
         reducer, binary_op, graph, lhs, rhs, lhs_map, rhs_map, out_map, \
-            lhs_data_nd, rhs_data_nd, out_data_nd, feat_shape, degs \
+            lhs_data_nd, rhs_data_nd, feat_shape, degs \
             = ctx.backward_cache
-        ctx.backward_cache = None
+        out_data, = ctx.saved_variables
+        out_data_nd = zerocopy_to_dgl_ndarray(out_data)
         grad_lhs = None
         grad_rhs = None
         if reducer == 'mean':
@@ -387,14 +389,16 @@ class CopyReduce(th.autograd.Function):
             degs = None
         # save_for_backward can only save variables
         ctx.backward_cache = (reducer, graph, target, in_map, out_map,
-                              in_data_nd, out_data_nd, degs)
+                              in_data_nd, degs)
+        ctx.save_for_backward(out_data)
         return out_data
 
     @staticmethod
     def backward(ctx, grad_out):
-        reducer, graph, target, in_map, out_map, in_data_nd, out_data_nd, degs \
+        reducer, graph, target, in_map, out_map, in_data_nd, degs \
             = ctx.backward_cache
-        ctx.backward_cache = None
+        out_data, = ctx.saved_variables
+        out_data_nd = zerocopy_to_dgl_ndarray(out_data)
         grad_in = None
         if reducer == 'mean':
             grad_out = grad_out / degs


### PR DESCRIPTION
## Description

PyTorch documentation recommends saving the tensors required to compute gradients with `ctx.save_for_backward`.  However, DGL currently requires several non-tensor objects, which cannot be saved with `ctx.save_for_backward`, to compute gradients.  We previously worked around this issue by putting everything required in a Python attribute (`ctx.backward_cache`), but without explicitly clearing the cache (i.e. setting `ctx.backward_cache = None`), PyTorch autograd would have trouble deallocating the tensors created in forward() function, hence the memory leakage.  The workaround presumably raises another issue related to backward'ing with `retain_graph=True` according to #1046 .

### Minimal reproducible code for PyTorch autograd memory leakage with custom attributes

The following code is copied and modified from `scatter_mul` function in PyTorch-Scatter, which demonstrates the memory leakage issue.

```python
class ScatterMul(Function):
    @staticmethod
    def forward(ctx, out, src, index, dim):
        func = get_func('scatter_mul', src)
        func(src, index, out, dim)

        ctx.mark_dirty(out)
        # This is the original code in PyTorch-Scatter, does not leak
        #ctx.save_for_backward(out, src, index)
        # Does not leak
        ctx.save_for_backward(out)
        ctx.backward_cache = src, index
        # Leaks
        #ctx.save_for_backward(src, index)
        #ctx.backward_cache = out
        ctx.dim = dim

        return out

    @staticmethod
    def backward(ctx, grad_out):
        # This is the original code in PyTorch-Scatter, does not leak
        #out, src, index = ctx.saved_tensors
        # Does not leak
        src, index = ctx.backward_cache
        out, = ctx.saved_tensors
        # Leaks
        #src, index = ctx.saved_tensors
        #out = ctx.backward_cache

        grad_src = None
        if ctx.needs_input_grad[1]:
            grad_src = (grad_out * out).gather(ctx.dim, index) / src

        return None, grad_src, None, None
```

Presumably, if an output tensor is saved in a custom attribute instead of with `save_for_backward`, then PyTorch Autograd somehow never deallocates the output tensor.  I don't know the reason why this is happening, though.

### Notes

This also coincidentally (?) fixes the issue where DGL `update_all()` leaks memory when not specifying `torch.no_grad()`.

## Checklist
Please feel free to remove inapplicable items for your PR.
- [x] The PR title starts with [$CATEGORY] (such as [NN], [Model], [Doc], [Feature]])
- [ ] Changes are complete (i.e. I finished coding on this PR)
- [ ] All changes have test coverage
- [x] Code is well-documented
- [x] To the my best knowledge, examples are either not affected by this change,
      or have been fixed to be compatible with this change
- [x] Related issue is referred in this PR
