### PR TITLE
[Chem Model Zoo] Hot fix for README

### DIFF
--- a/examples/pytorch/model_zoo/chem/README.md
+++ b/examples/pytorch/model_zoo/chem/README.md
@@ -66,13 +66,13 @@ as front end and Set2Set for output prediction.
 from dgl.data.chem import Tox21, smiles_to_bigraph, CanonicalAtomFeaturizer
 from dgl import model_zoo
 
-dataset = Tox21()
+dataset = Tox21(smiles_to_bigraph, CanonicalAtomFeaturizer())
 model = model_zoo.chem.load_pretrained('GCN_Tox21') # Pretrained model loaded
 model.eval()
 
 smiles, g, label, mask = dataset[0]
 feats = g.ndata.pop('h')
-label_pred = model(feats, g)
+label_pred = model(g, feats)
 print(smiles)                   # CCOc1ccc2nc(S(N)(=O)=O)sc2c1
 print(label_pred[:, mask != 0]) # Mask non-existing labels
 # tensor([[-0.7956,  0.4054,  0.4288, -0.5565, -0.0911,  

--- a/examples/pytorch/model_zoo/chem/README.md
+++ b/examples/pytorch/model_zoo/chem/README.md
@@ -63,7 +63,7 @@ as front end and Set2Set for output prediction.
 ### Example Usage of Pre-trained Models
 
 ```python
-from dgl.data.chem import Tox21
+from dgl.data.chem import Tox21, smiles_to_bigraph, CanonicalAtomFeaturizer
 from dgl import model_zoo
 
 dataset = Tox21()


### PR DESCRIPTION
## Description
Fix the outdated README.md about loading a pre-trained model for property prediction.

## Checklist
Please feel free to remove inapplicable items for your PR.
- [x] The PR title starts with [$CATEGORY] (such as [NN], [Model], [Doc], [Feature]])
- [x] Changes are complete (i.e. I finished coding on this PR)
- [ ] All changes have test coverage
- [ ] Code is well-documented
- [x] To the my best knowledge, examples are either not affected by this change,
      or have been fixed to be compatible with this change
- [x] Related issue is referred in this PR

## Changes
- [x] `Tox21` no longer has a default node feature initializer so we need to explicitly set it.
- [x] We've interchanged the order of `DGLGraph` and `node features` when passing to the model.