### PR TITLE
[Bug] Fix local_var for BatchedDGLGraph

### DIFF
--- a/python/dgl/batched_graph.py
+++ b/python/dgl/batched_graph.py
@@ -349,14 +349,14 @@ class BatchedDGLGraph(DGLGraph):
         sync_frame_initializer(local_node_frame._frame, self._node_frame._frame)
         sync_frame_initializer(local_edge_frame._frame, self._edge_frame._frame)
 
-        bg = BatchedDGLGraph([DGLGraph()], ALL, ALL)
-        bg._graph = self._graph
-        bg._node_frame = local_node_frame
-        bg._edge_frame = local_edge_frame
-        bg._batch_size = self._batch_size
-        bg._batch_num_nodes = self._batch_num_nodes
-        bg._batch_num_edges = self._batch_num_edges
-        return bg
+        batched_graph = BatchedDGLGraph([DGLGraph()], ALL, ALL)
+        batched_graph._graph = self._graph
+        batched_graph._node_frame = local_node_frame
+        batched_graph._edge_frame = local_edge_frame
+        batched_graph._batch_size = self._batch_size
+        batched_graph._batch_num_nodes = self._batch_num_nodes
+        batched_graph._batch_num_edges = self._batch_num_edges
+        return batched_graph
 
 def split(graph_batch, num_or_size_splits):  # pylint: disable=unused-argument
     """Split the batch."""

--- a/tests/compute/test_batched_graph.py
+++ b/tests/compute/test_batched_graph.py
@@ -220,7 +220,7 @@ def test_local_var():
         g.edata['w'] = F.ones((g.number_of_edges(), 4))
         assert g.batch_size == 2
         assert g.batch_num_nodes == [2, 3]
-        assert g.batch_num_edges == [4, 6]
+        assert g.batch_num_edges == [2, 4]
     foo1(bg)
     assert F.allclose(bg.ndata['h'], F.zeros((bg.number_of_nodes(), 3)))
     assert F.allclose(bg.edata['w'], F.zeros((bg.number_of_edges(), 4)))


### PR DESCRIPTION
## Description

Previously we did not implement `local_var(self)` for `BatchedDGLGraph`. As a result of inheritance, we got a `DGLGraph` after calling `BatchedDGLGraph.local_var()` and the information about the batch gets lost. This is not desired and this PR aims to fix it.

## Related Issues & Discussions
- [Discussion #639](https://discuss.dgl.ai/t/batcheddglgraph-local-var-does-not-return-a-batcheddglgraph-object/639)
- #739 
- #792 

## Checklist
Please feel free to remove inapplicable items for your PR.
- [x] The PR title starts with [$CATEGORY] (such as [NN], [Model], [Doc], [Feature]])
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage
- [x] Code is well-documented
- [x] To the my best knowledge, examples are either not affected by this change,
      or have been fixed to be compatible with this change
- [x] Related issue is referred in this PR