### PR TITLE
[KG] Disable filter in evaluation

### DIFF
--- a/apps/kg/eval.py
+++ b/apps/kg/eval.py
@@ -44,6 +44,8 @@ class ArgParser(argparse.ArgumentParser):
                           help='margin value')
         self.add_argument('--eval_percent', type=float, default=1,
                           help='sample some percentage for evaluation.')
+        self.add_argument('--no_eval_filter', action='store_true',
+                          help='do not filter positive edges among negative edges for evaluation')
 
         self.add_argument('--gpu', type=int, default=-1,
                           help='use GPU')
@@ -99,17 +101,20 @@ def main(args):
     args.neg_sample_size_test = args.neg_sample_size
     if args.neg_sample_size < 0:
         args.neg_sample_size_test = args.neg_sample_size = eval_dataset.g.number_of_nodes()
+    args.eval_filter = not args.no_eval_filter
     if args.num_proc > 1:
         test_sampler_tails = []
         test_sampler_heads = []
         for i in range(args.num_proc):
             test_sampler_head = eval_dataset.create_sampler('test', args.batch_size,
                                                             args.neg_sample_size,
+                                                            args.eval_filter,
                                                             mode='PBG-head',
                                                             num_workers=args.num_worker,
                                                             rank=i, ranks=args.num_proc)
             test_sampler_tail = eval_dataset.create_sampler('test', args.batch_size,
                                                             args.neg_sample_size,
+                                                            args.eval_filter,
                                                             mode='PBG-tail',
                                                             num_workers=args.num_worker,
                                                             rank=i, ranks=args.num_proc)
@@ -118,11 +123,13 @@ def main(args):
     else:
         test_sampler_head = eval_dataset.create_sampler('test', args.batch_size,
                                                         args.neg_sample_size,
+                                                        args.eval_filter,
                                                         mode='PBG-head',
                                                         num_workers=args.num_worker,
                                                         rank=0, ranks=1)
         test_sampler_tail = eval_dataset.create_sampler('test', args.batch_size,
                                                         args.neg_sample_size,
+                                                        args.eval_filter,
                                                         mode='PBG-tail',
                                                         num_workers=args.num_worker,
                                                         rank=0, ranks=1)

--- a/apps/kg/eval.py
+++ b/apps/kg/eval.py
@@ -22,7 +22,7 @@ class ArgParser(argparse.ArgumentParser):
         super(ArgParser, self).__init__()
 
         self.add_argument('--model_name', default='TransE',
-                          choices=['TransE', 'TransH', 'TransR', 'TransD',
+                          choices=['TransE', 'TransE_l1', 'TransE_l2', 'TransH', 'TransR', 'TransD',
                                    'RESCAL', 'DistMult', 'ComplEx', 'RotatE', 'pRotatE'],
                           help='model to use')
         self.add_argument('--data_path', type=str, default='data',

--- a/apps/kg/models/general_models.py
+++ b/apps/kg/models/general_models.py
@@ -140,10 +140,11 @@ class KEModel(object):
         neg_scores = reshape(logsigmoid(neg_scores), batch_size, -1)
 
         # We need to filter the positive edges in the negative graph.
-        filter_bias = reshape(neg_g.edata['bias'], batch_size, -1)
-        if self.args.gpu >= 0:
-            filter_bias = cuda(filter_bias, self.args.gpu)
-        neg_scores += filter_bias
+        if self.args.eval_filter:
+            filter_bias = reshape(neg_g.edata['bias'], batch_size, -1)
+            if self.args.gpu >= 0:
+                filter_bias = cuda(filter_bias, self.args.gpu)
+            neg_scores += filter_bias
         # To compute the rank of a positive edge among all negative edges,
         # we need to know how many negative edges have higher scores than
         # the positive edge.

--- a/apps/kg/train.py
+++ b/apps/kg/train.py
@@ -59,6 +59,8 @@ class ArgParser(argparse.ArgumentParser):
                           help='margin value')
         self.add_argument('--eval_percent', type=float, default=1,
                           help='sample some percentage for evaluation.')
+        self.add_argument('--no_eval_filter', action='store_true',
+                          help='do not filter positive edges among negative edges for evaluation')
 
         self.add_argument('--gpu', type=int, default=-1,
                           help='use GPU')
@@ -135,6 +137,7 @@ def run(args, logger):
     n_relations = dataset.n_relations
     if args.neg_sample_size_test < 0:
         args.neg_sample_size_test = n_entities
+    args.eval_filter = not args.no_eval_filter
 
     train_data = TrainDataset(dataset, args, ranks=args.num_proc)
     if args.num_proc > 1:
@@ -179,11 +182,13 @@ def run(args, logger):
             for i in range(args.num_proc):
                 valid_sampler_head = eval_dataset.create_sampler('valid', args.batch_size_eval,
                                                                  args.neg_sample_size_valid,
+                                                                 args.eval_filter,
                                                                  mode='PBG-head',
                                                                  num_workers=args.num_worker,
                                                                  rank=i, ranks=args.num_proc)
                 valid_sampler_tail = eval_dataset.create_sampler('valid', args.batch_size_eval,
                                                                  args.neg_sample_size_valid,
+                                                                 args.eval_filter,
                                                                  mode='PBG-tail',
                                                                  num_workers=args.num_worker,
                                                                  rank=i, ranks=args.num_proc)
@@ -192,11 +197,13 @@ def run(args, logger):
         else:
             valid_sampler_head = eval_dataset.create_sampler('valid', args.batch_size_eval,
                                                              args.neg_sample_size_valid,
+                                                             args.eval_filter,
                                                              mode='PBG-head',
                                                              num_workers=args.num_worker,
                                                              rank=0, ranks=1)
             valid_sampler_tail = eval_dataset.create_sampler('valid', args.batch_size_eval,
                                                              args.neg_sample_size_valid,
+                                                             args.eval_filter,
                                                              mode='PBG-tail',
                                                              num_workers=args.num_worker,
                                                              rank=0, ranks=1)
@@ -209,11 +216,13 @@ def run(args, logger):
             for i in range(args.num_proc):
                 test_sampler_head = eval_dataset.create_sampler('test', args.batch_size_eval,
                                                                 args.neg_sample_size_test,
+                                                                args.eval_filter,
                                                                 mode='PBG-head',
                                                                 num_workers=args.num_worker,
                                                                 rank=i, ranks=args.num_proc)
                 test_sampler_tail = eval_dataset.create_sampler('test', args.batch_size_eval,
                                                                 args.neg_sample_size_test,
+                                                                args.eval_filter,
                                                                 mode='PBG-tail',
                                                                 num_workers=args.num_worker,
                                                                 rank=i, ranks=args.num_proc)
@@ -222,11 +231,13 @@ def run(args, logger):
         else:
             test_sampler_head = eval_dataset.create_sampler('test', args.batch_size_eval,
                                                             args.neg_sample_size_test,
+                                                            args.eval_filter,
                                                             mode='PBG-head',
                                                             num_workers=args.num_worker,
                                                             rank=0, ranks=1)
             test_sampler_tail = eval_dataset.create_sampler('test', args.batch_size_eval,
                                                             args.neg_sample_size_test,
+                                                            args.eval_filter,
                                                             mode='PBG-tail',
                                                             num_workers=args.num_worker,
                                                             rank=0, ranks=1)


### PR DESCRIPTION
## Description
By default, we remove the positive edges from sampled negative edges in evaluation. We should allow disabling the filtering for fair comparison with other frameworks.

## Checklist
Please feel free to remove inapplicable items for your PR.
- [ ] The PR title starts with [$CATEGORY] (such as [NN], [Model], [Doc], [Feature]])
- [ ] Changes are complete (i.e. I finished coding on this PR)
- [ ] All changes have test coverage
- [ ] Code is well-documented
- [ ] To the my best knowledge, examples are either not affected by this change,
      or have been fixed to be compatible with this change
- [ ] Related issue is referred in this PR

## Changes
<!-- You could use following template
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)
-->
