### PR TITLE
[BUG] Fix empty heterograph creation with list & tuple

### DIFF
--- a/python/dgl/convert.py
+++ b/python/dgl/convert.py
@@ -734,18 +734,17 @@ def create_from_edges(u, v, utype, etype, vtype, urange=None, vrange=None, valid
     u = utils.toindex(u)
     v = utils.toindex(v)
 
-    if len(u) == 0 and len(v) == 0:
-        urange = vrange = 0
-    else:
-        if validate:
-            if urange is not None and urange <= int(F.asnumpy(F.max(u.tousertensor(), dim=0))):
-                raise DGLError('Invalid node id {} (should be less than cardinality {}).'.format(
-                    urange, int(F.asnumpy(F.max(u.tousertensor(), dim=0)))))
-            if vrange is not None and vrange <= int(F.asnumpy(F.max(v.tousertensor(), dim=0))):
-                raise DGLError('Invalid node id {} (should be less than cardinality {}).'.format(
-                    vrange, int(F.asnumpy(F.max(v.tousertensor(), dim=0)))))
-        urange = urange or (int(F.asnumpy(F.max(u.tousertensor(), dim=0))) + 1)
-        vrange = vrange or (int(F.asnumpy(F.max(v.tousertensor(), dim=0))) + 1)
+    if validate:
+        if urange is not None and urange <= int(F.asnumpy(F.max(u.tousertensor(), dim=0))):
+            raise DGLError('Invalid node id {} (should be less than cardinality {}).'.format(
+                urange, int(F.asnumpy(F.max(u.tousertensor(), dim=0)))))
+        if vrange is not None and vrange <= int(F.asnumpy(F.max(v.tousertensor(), dim=0))):
+            raise DGLError('Invalid node id {} (should be less than cardinality {}).'.format(
+                vrange, int(F.asnumpy(F.max(v.tousertensor(), dim=0)))))
+    urange = urange or (
+        0 if len(u) == 0 else (int(F.asnumpy(F.max(u.tousertensor(), dim=0))) + 1))
+    vrange = vrange or (
+        0 if len(v) == 0 else (int(F.asnumpy(F.max(v.tousertensor(), dim=0))) + 1))
 
     if utype == vtype:
         urange = vrange = max(urange, vrange)

--- a/python/dgl/convert.py
+++ b/python/dgl/convert.py
@@ -397,17 +397,22 @@ def heterograph(data_dict, num_nodes_dict=None):
         num_nodes_dict = defaultdict(int)
         for (srctype, etype, dsttype), data in data_dict.items():
             if isinstance(data, tuple):
-                nsrc = max(data[0]) + 1
-                ndst = max(data[1]) + 1
+                nsrc = (max(data[0]) + 1) if len(data[0]) > 0 else 0
+                ndst = (max(data[1]) + 1) if len(data[1]) > 0 else 0
             elif isinstance(data, list):
-                src, dst = zip(*data)
-                nsrc = max(src) + 1
-                ndst = max(dst) + 1
+                if len(data) == 0:
+                    nsrc = ndst = 0
+                else:
+                    src, dst = zip(*data)
+                    nsrc = max(src) + 1
+                    ndst = max(dst) + 1
             elif isinstance(data, sp.sparse.spmatrix):
                 nsrc = data.shape[0]
                 ndst = data.shape[1]
             elif isinstance(data, nx.Graph):
-                if srctype == dsttype:
+                if data.number_of_nodes() == 0:
+                    nsrc = ndst = 0
+                elif srctype == dsttype:
                     nsrc = ndst = data.number_of_nodes()
                 else:
                     nsrc = len({n for n, d in data.nodes(data=True) if d['bipartite'] == 0})
@@ -728,15 +733,20 @@ def create_from_edges(u, v, utype, etype, vtype, urange=None, vrange=None, valid
     """
     u = utils.toindex(u)
     v = utils.toindex(v)
-    if validate:
-        if urange is not None and urange <= int(F.asnumpy(F.max(u.tousertensor(), dim=0))):
-            raise DGLError('Invalid node id {} (should be less than cardinality {}).'.format(
-                urange, int(F.asnumpy(F.max(u.tousertensor(), dim=0)))))
-        if vrange is not None and vrange <= int(F.asnumpy(F.max(v.tousertensor(), dim=0))):
-            raise DGLError('Invalid node id {} (should be less than cardinality {}).'.format(
-                vrange, int(F.asnumpy(F.max(v.tousertensor(), dim=0)))))
-    urange = urange or (int(F.asnumpy(F.max(u.tousertensor(), dim=0))) + 1)
-    vrange = vrange or (int(F.asnumpy(F.max(v.tousertensor(), dim=0))) + 1)
+
+    if len(u) == 0 and len(v) == 0:
+        urange = vrange = 0
+    else:
+        if validate:
+            if urange is not None and urange <= int(F.asnumpy(F.max(u.tousertensor(), dim=0))):
+                raise DGLError('Invalid node id {} (should be less than cardinality {}).'.format(
+                    urange, int(F.asnumpy(F.max(u.tousertensor(), dim=0)))))
+            if vrange is not None and vrange <= int(F.asnumpy(F.max(v.tousertensor(), dim=0))):
+                raise DGLError('Invalid node id {} (should be less than cardinality {}).'.format(
+                    vrange, int(F.asnumpy(F.max(v.tousertensor(), dim=0)))))
+        urange = urange or (int(F.asnumpy(F.max(u.tousertensor(), dim=0))) + 1)
+        vrange = vrange or (int(F.asnumpy(F.max(v.tousertensor(), dim=0))) + 1)
+
     if utype == vtype:
         urange = vrange = max(urange, vrange)
         num_ntypes = 1

--- a/tests/compute/test_heterograph.py
+++ b/tests/compute/test_heterograph.py
@@ -1245,6 +1245,18 @@ def test_empty_heterograph():
     # empty networkx graph
     assert_empty(dgl.heterograph({('user', 'plays', 'game'): nx.DiGraph()}))
 
+    g = dgl.heterograph({('user', 'follows', 'user'): []})
+    assert g.number_of_nodes('user') == 0
+    assert g.number_of_edges('follows') == 0
+
+    # empty relation graph with others
+    g = dgl.heterograph({('user', 'plays', 'game'): [], ('developer', 'develops', 'game'): [(0, 0), (1, 1)]})
+    assert g.number_of_nodes('user') == 0
+    assert g.number_of_edges('plays') == 0
+    assert g.number_of_nodes('game') == 2
+    assert g.number_of_edges('develops') == 2
+    assert g.number_of_nodes('developer') == 2
+
 if __name__ == '__main__':
     test_create()
     test_query()

--- a/tests/compute/test_heterograph.py
+++ b/tests/compute/test_heterograph.py
@@ -1230,6 +1230,21 @@ def test_backward():
                                               [2., 2., 2., 2., 2.],
                                               [2., 2., 2., 2., 2.]]))
 
+def test_empty_heterograph():
+    def assert_empty(g):
+        assert g.number_of_nodes('user') == 0
+        assert g.number_of_edges('plays') == 0
+        assert g.number_of_nodes('game') == 0
+
+    # empty edge list
+    assert_empty(dgl.heterograph({('user', 'plays', 'game'): []}))
+    # empty src-dst pair
+    assert_empty(dgl.heterograph({('user', 'plays', 'game'): ([], [])}))
+    # empty sparse matrix
+    assert_empty(dgl.heterograph({('user', 'plays', 'game'): ssp.coo_matrix((0, 0))}))
+    # empty networkx graph
+    assert_empty(dgl.heterograph({('user', 'plays', 'game'): nx.DiGraph()}))
+
 if __name__ == '__main__':
     test_create()
     test_query()
@@ -1247,3 +1262,4 @@ if __name__ == '__main__':
     test_level2()
     test_updates()
     test_backward()
+    test_empty_heterograph()


### PR DESCRIPTION
## Description
Heterograph creation crashes with empty list, empty src-dst pair, or empty networkX graph.  However, creating with 0x0 sparse matrix works well.