### PR TITLE
[Bug Fix] Add boundary check for heterograph build with card as input

### DIFF
--- a/python/dgl/convert.py
+++ b/python/dgl/convert.py
@@ -1011,7 +1011,8 @@ def create_from_networkx_bipartite(nx_graph,
                 dst.append(bottom_map[e[1]])
     src = utils.toindex(src)
     dst = utils.toindex(dst)
-    g = create_from_edges(src, dst, utype, etype, vtype,
+    g = create_from_edges(
+        src, dst, utype, etype, vtype,
         len(top_nodes), len(bottom_nodes), validate=False)
 
     # TODO attributes

--- a/python/dgl/convert.py
+++ b/python/dgl/convert.py
@@ -737,11 +737,11 @@ def create_from_edges(u, v, utype, etype, vtype, urange=None, vrange=None, valid
     v = utils.toindex(v)
 
     if validate:
-        if urange is not None and len(u) > 0 and
+        if urange is not None and len(u) > 0 and \
             urange <= int(F.asnumpy(F.max(u.tousertensor(), dim=0))):
             raise DGLError('Invalid node id {} (should be less than cardinality {}).'.format(
                 urange, int(F.asnumpy(F.max(u.tousertensor(), dim=0)))))
-        if vrange is not None and len(v) > 0 and
+        if vrange is not None and len(v) > 0 and \
             vrange <= int(F.asnumpy(F.max(v.tousertensor(), dim=0))):
             raise DGLError('Invalid node id {} (should be less than cardinality {}).'.format(
                 vrange, int(F.asnumpy(F.max(v.tousertensor(), dim=0)))))

--- a/python/dgl/convert.py
+++ b/python/dgl/convert.py
@@ -746,10 +746,12 @@ def create_from_edges(u, v, utype, etype, vtype, urange=None, vrange=None, valid
     vrange = vrange or (
         0 if len(v) == 0 else (int(F.asnumpy(F.max(v.tousertensor(), dim=0))) + 1))
 
-    assert urange > int(F.asnumpy(F.max(u.tousertensor(), dim=0))), \
-        "The urange from card should be larger than max u node_id"
-    assert vrange > int(F.asnumpy(F.max(v.tousertensor(), dim=0))), \
-        "The vrange from card should be larger than max v node_id"
+    if len(u) > 0:
+        assert urange > int(F.asnumpy(F.max(u.tousertensor(), dim=0))), \
+            "The urange from card should be larger than max u node_id"
+    if len(v) > 0:
+        assert vrange > int(F.asnumpy(F.max(v.tousertensor(), dim=0))), \
+            "The vrange from card should be larger than max v node_id"
 
     if utype == vtype:
         urange = vrange = max(urange, vrange)

--- a/python/dgl/convert.py
+++ b/python/dgl/convert.py
@@ -746,6 +746,11 @@ def create_from_edges(u, v, utype, etype, vtype, urange=None, vrange=None, valid
     vrange = vrange or (
         0 if len(v) == 0 else (int(F.asnumpy(F.max(v.tousertensor(), dim=0))) + 1))
 
+    assert urange > int(F.asnumpy(F.max(u.tousertensor(), dim=0))), \
+        "The urange from card should be larger than max u node_id"
+    assert vrange > int(F.asnumpy(F.max(v.tousertensor(), dim=0))), \
+        "The vrange from card should be larger than max v node_id"
+
     if utype == vtype:
         urange = vrange = max(urange, vrange)
         num_ntypes = 1

--- a/python/dgl/convert.py
+++ b/python/dgl/convert.py
@@ -433,7 +433,8 @@ def heterograph(data_dict, num_nodes_dict=None):
         if isinstance(data, DGLHeteroGraph):
             rel_graphs.append(data)
         elif srctype == dsttype:
-            rel_graphs.append(graph(data, srctype, etype, 
+            rel_graphs.append(graph(
+                data, srctype, etype,
                 card=num_nodes_dict[srctype], validate=False))
         else:
             rel_graphs.append(bipartite(
@@ -736,10 +737,12 @@ def create_from_edges(u, v, utype, etype, vtype, urange=None, vrange=None, valid
     v = utils.toindex(v)
 
     if validate:
-        if urange is not None and len(u) > 0 and urange <= int(F.asnumpy(F.max(u.tousertensor(), dim=0))):
+        if urange is not None and len(u) > 0 and
+            urange <= int(F.asnumpy(F.max(u.tousertensor(), dim=0))):
             raise DGLError('Invalid node id {} (should be less than cardinality {}).'.format(
                 urange, int(F.asnumpy(F.max(u.tousertensor(), dim=0)))))
-        if vrange is not None and len(v) > 0 and vrange <= int(F.asnumpy(F.max(v.tousertensor(), dim=0))):
+        if vrange is not None and len(v) > 0 and
+            vrange <= int(F.asnumpy(F.max(v.tousertensor(), dim=0))):
             raise DGLError('Invalid node id {} (should be less than cardinality {}).'.format(
                 vrange, int(F.asnumpy(F.max(v.tousertensor(), dim=0)))))
     urange = urange or (
@@ -1008,7 +1011,8 @@ def create_from_networkx_bipartite(nx_graph,
                 dst.append(bottom_map[e[1]])
     src = utils.toindex(src)
     dst = utils.toindex(dst)
-    g = create_from_edges(src, dst, utype, etype, vtype, len(top_nodes), len(bottom_nodes), validate=False)
+    g = create_from_edges(src, dst, utype, etype, vtype,
+        len(top_nodes), len(bottom_nodes), validate=False)
 
     # TODO attributes
     assert node_attrs is None, 'Retrieval of node attributes are not supported yet.'

--- a/tests/compute/test_heterograph.py
+++ b/tests/compute/test_heterograph.py
@@ -630,6 +630,27 @@ def test_to_device():
         hg = hg.to(F.cuda())
         assert hg is not None
 
+def test_convert_bound():
+    def _test_bipartite_bound(data, card):
+        try:
+            dgl.bipartite(data, card=card)
+        except AssertionError:
+            return
+        assert False, 'bipartite bound test with wrong uid failed'
+
+    def _test_graph_bound(data, card):
+        try:
+            dgl.graph(data, card=card)
+        except AssertionError:
+            return
+        assert False, 'graph bound test with wrong uid failed'
+
+    _test_bipartite_bound(([1,2],[1,2]),(2,3))
+    _test_bipartite_bound(([0,1],[1,4]),(2,3))
+    _test_graph_bound(([1,3],[1,2]), 3)
+    _test_graph_bound(([0,1],[1,3]),3)
+
+
 def test_convert():
     hg = create_test_heterograph()
     hs = []
@@ -1265,6 +1286,7 @@ if __name__ == '__main__':
     test_view()
     test_view1()
     test_flatten()
+    test_convert_bound()
     test_convert()
     test_to_device()
     test_transform()

--- a/tests/compute/test_heterograph.py
+++ b/tests/compute/test_heterograph.py
@@ -634,14 +634,14 @@ def test_convert_bound():
     def _test_bipartite_bound(data, card):
         try:
             dgl.bipartite(data, card=card)
-        except AssertionError:
+        except dgl.DGLError:
             return
         assert False, 'bipartite bound test with wrong uid failed'
 
     def _test_graph_bound(data, card):
         try:
             dgl.graph(data, card=card)
-        except AssertionError:
+        except dgl.DGLError:
             return
         assert False, 'graph bound test with wrong uid failed'
 

--- a/tests/compute/test_kernel.py
+++ b/tests/compute/test_kernel.py
@@ -303,8 +303,8 @@ def test_all_binary_builtins():
         def _print_error(a, b):
             print("ERROR: Test {}_{}_{}_{} broadcast: {} partial: {}".
                   format(lhs, binary_op, rhs, reducer, broadcast, partial))
-            print("lhs", F.asnumpy(lhs).tolist())
-            print("rhs", F.asnumpy(rhs).tolist())
+            print("lhs", F.asnumpy(hu).tolist())
+            print("rhs", F.asnumpy(hv).tolist())
             for i, (x, y) in enumerate(zip(F.asnumpy(a).flatten(), F.asnumpy(b).flatten())):
                 if not np.allclose(x, y, rtol, atol):
                     print('@{} {} v.s. {}'.format(i, x, y))

--- a/tests/compute/test_kernel.py
+++ b/tests/compute/test_kernel.py
@@ -303,8 +303,8 @@ def test_all_binary_builtins():
         def _print_error(a, b):
             print("ERROR: Test {}_{}_{}_{} broadcast: {} partial: {}".
                   format(lhs, binary_op, rhs, reducer, broadcast, partial))
-            print("lhs", F.asnumpy(hu).tolist())
-            print("rhs", F.asnumpy(hv).tolist())
+            print("lhs", F.asnumpy(lhs).tolist())
+            print("rhs", F.asnumpy(rhs).tolist())
             for i, (x, y) in enumerate(zip(F.asnumpy(a).flatten(), F.asnumpy(b).flatten())):
                 if not np.allclose(x, y, rtol, atol):
                     print('@{} {} v.s. {}'.format(i, x, y))


### PR DESCRIPTION
## Description
Building graph using dgl.bipartite or dgl.graph with both **data** and **card** set may crash when the node id provied in **data** is larger than the size specified in **card**.

Add boundary check for both dgl.bipartite and dgl.graph creation.

#1190 

## Checklist
Please feel free to remove inapplicable items for your PR.
- [x] The PR title starts with [$CATEGORY] (such as [NN], [Model], [Doc], [Feature]])
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage
- [ ] Code is well-documented
- [x] To the my best knowledge, examples are either not affected by this change,
      or have been fixed to be compatible with this change
- [x] Related issue is referred in this PR

## Changes
<!-- You could use following template
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)
-->
