### PR TITLE
[KG][Optimization] Remove copy from parent in minibatch generation

### DIFF
--- a/apps/kg/dataloader/sampler.py
+++ b/apps/kg/dataloader/sampler.py
@@ -240,7 +240,6 @@ class EvalDataset(object):
                 with open(os.path.join(args.data_path, args.dataset, pickle_name), 'wb') as graph_file:
                     pickle.dump(g, graph_file)
         self.g = g
-
         self.num_train = len(dataset.train[0])
         self.num_valid = len(dataset.valid[0])
         self.num_test = len(dataset.test[0])

--- a/tests/compute/test_sampler.py
+++ b/tests/compute/test_sampler.py
@@ -670,7 +670,7 @@ def check_positive_edge_sampler():
     num_edges = g.number_of_edges()
     edge_weight = F.copy_to(F.tensor(np.full((num_edges,), 1, dtype=np.float32)), F.cpu())
 
-    edge_weight[num_edges-1] = num_edges ** 2
+    edge_weight[num_edges-1] = num_edges ** 3
     EdgeSampler = getattr(dgl.contrib.sampling, 'EdgeSampler')
 
     # Correctness check


### PR DESCRIPTION
## Description
copy_from_parent() is costy, so remove it:

Test:
python3 train.py —model TransE_l2 —dataset *Freebase* —batch_size 1000 —neg_sample_size 200 —hidden_dim 400 —gamma 10 —lr 0.1 —max_step 400000 —batch_size_eval 1000 -adv —num_proc 32 —gpu 0 1 2 3 4 5 6 7 —mix_cpu_gpu —regularization_coef 1e-9 

with copy_from_parent() 
sample: 14.238, forward: 15.154, backward: 4.530, update: 21.823
sample: 14.256, forward: 15.383, backward: 4.454, update: 21.402

without copy_from_parent() 
sample: 9.380, forward: 15.485, backward: 4.348, update: 21.533
sample: 8.249, forward: 16.283, backward: 4.341, update: 21.670


## Checklist
Please feel free to remove inapplicable items for your PR.
- [x] The PR title starts with [$CATEGORY] (such as [NN], [Model], [Doc], [Feature]])
- [x] Changes are complete (i.e. I finished coding on this PR)
- [ ] All changes have test coverage
- [x] Code is well-documented
- [x] To the my best knowledge, examples are either not affected by this change,
      or have been fixed to be compatible with this change
- [ ] Related issue is referred in this PR

## Changes
<!-- You could use following template
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)
-->
