### PR TITLE
[Test] Fix the random seed in test_kernel.py and fix the _print_error

### DIFF
--- a/tests/compute/test_kernel.py
+++ b/tests/compute/test_kernel.py
@@ -5,8 +5,6 @@ import numpy as np
 import backend as F
 from itertools import product
 
-np.random.seed(31)
-
 def udf_copy_src(edges):
     return {'m': edges.src['u']}
 
@@ -36,6 +34,7 @@ def generate_feature(g, broadcast='none', binary_op='none'):
     """Create graph with src, edge, dst feature. broadcast can be 'u',
     'e', 'v', 'none'
     """
+    np.random.seed(31)
     nv = g.number_of_nodes()
     ne = g.number_of_edges()
     if binary_op == 'dot':
@@ -303,8 +302,21 @@ def test_all_binary_builtins():
         def _print_error(a, b):
             print("ERROR: Test {}_{}_{}_{} broadcast: {} partial: {}".
                   format(lhs, binary_op, rhs, reducer, broadcast, partial))
-            print("lhs", F.asnumpy(lhs).tolist())
-            print("rhs", F.asnumpy(rhs).tolist())
+            if lhs == 'u':
+                lhs_data = hu
+            elif lhs == 'v':
+                lhs_data = hv
+            elif lhs == 'e':
+                lhs_data = he
+
+            if rhs == 'u':
+                rhs_data = hu
+            elif rhs == 'v':
+                rhs_data = hv
+            elif rhs == 'e':
+                rhs_data = he
+            print("lhs", F.asnumpy(lhs_data).tolist())
+            print("rhs", F.asnumpy(rhs_data).tolist())
             for i, (x, y) in enumerate(zip(F.asnumpy(a).flatten(), F.asnumpy(b).flatten())):
                 if not np.allclose(x, y, rtol, atol):
                     print('@{} {} v.s. {}'.format(i, x, y))

--- a/tests/compute/test_sampler.py
+++ b/tests/compute/test_sampler.py
@@ -668,9 +668,9 @@ def check_weighted_negative_sampler(mode, exclude_positive, neg_size):
 def check_positive_edge_sampler():
     g = generate_rand_graph(1000)
     num_edges = g.number_of_edges()
-    edge_weight = F.copy_to(F.tensor(np.full((num_edges,), 1, dtype=np.float32)), F.cpu())
+    edge_weight = F.copy_to(F.tensor(np.full((num_edges,), 0.1, dtype=np.float32)), F.cpu())
 
-    edge_weight[num_edges-1] = num_edges ** 3
+    edge_weight[num_edges-1] = num_edges ** 2
     EdgeSampler = getattr(dgl.contrib.sampling, 'EdgeSampler')
 
     # Correctness check


### PR DESCRIPTION
## Description
The tensor generated for test cases in test_kernel.py is not deterministic for each CI run. This may incur some known failure cases (e.g., for l_op_r_max case, when two value in the max reduce stage are identical and are both the max value, this will fail the pytorch test_kernel test). Set the numpy seed each time it invoke generate_feature will eliminate this problem.

Also fix the print error in _print_error, which will crash every time when the test failed. 

#958

## Checklist
Please feel free to remove inapplicable items for your PR.
- [x] The PR title starts with [$CATEGORY] (such as [NN], [Model], [Doc], [Feature]])
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage
- [x] Code is well-documented
- [x] To the my best knowledge, examples are either not affected by this change,
      or have been fixed to be compatible with this change
- [x] Related issue is referred in this PR

## Changes
<!-- You could use following template
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)
-->
