### PR TITLE
[Tutorial] Fix warnings due to PyTorch deprecation.

### DIFF
--- a/tutorials/models/1_gnn/1_gcn.py
+++ b/tutorials/models/1_gnn/1_gcn.py
@@ -108,8 +108,8 @@ def load_cora_data():
     data = citegrh.load_cora()
     features = th.FloatTensor(data.features)
     labels = th.LongTensor(data.labels)
-    train_mask = th.ByteTensor(data.train_mask)
-    test_mask = th.ByteTensor(data.test_mask)
+    train_mask = th.BoolTensor(data.train_mask)
+    test_mask = th.BoolTensor(data.test_mask)
     g = data.graph
     # add self loop
     g.remove_edges_from(nx.selfloop_edges(g))

--- a/tutorials/models/1_gnn/9_gat.py
+++ b/tutorials/models/1_gnn/9_gat.py
@@ -276,7 +276,7 @@ def load_cora_data():
     data = citegrh.load_cora()
     features = torch.FloatTensor(data.features)
     labels = torch.LongTensor(data.labels)
-    mask = torch.ByteTensor(data.train_mask)
+    mask = torch.BoolTensor(data.train_mask)
     g = data.graph
     # add self loop
     g.remove_edges_from(nx.selfloop_edges(g))


### PR DESCRIPTION
## Description

With the latest version of PyTorch, a lot of warnings have been printed for deprecation messages, which should be fixed.

<img width="972" alt="截屏2020-01-12上午1 31 13" src="https://user-images.githubusercontent.com/19576924/72208306-0f28c100-34dc-11ea-8bea-2859652d38d1.png">

## Checklist
Please feel free to remove inapplicable items for your PR.
- [x] The PR title starts with [$CATEGORY] (such as [NN], [Model], [Doc], [Feature]])
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage
- [x] Code is well-documented
- [x] To the my best knowledge, examples are either not affected by this change,
      or have been fixed to be compatible with this change
- [x] Related issue is referred in this PR

## Changes
Replace `ByteTensor` with `BoolTensor` for node mask in loss computation.