### PR TITLE
[WIP][Feature] Neighbor sampler

### DIFF
--- a/include/dgl/array.h
+++ b/include/dgl/array.h
@@ -296,10 +296,9 @@ COOMatrix COOTranspose(COOMatrix coo);
 /*!
  * \brief Convert COO matrix to CSR matrix.
  * \param coo Input coo matrix
- * \param sorted Whether to sort column indices per row.
  * \return a coo matrix
  */
-COOMatrix COOToCSR(COOMatrix coo, bool sorted);
+CSRMatrix COOToCSR(COOMatrix coo);
 
 /*!
  * \brief Slice rows of the given matrix and return.


### PR DESCRIPTION
## Description
This PR is going to implement neighbor samplers and related.  Namely:

* `sample_neighbors`
* `sample_neighbors_topk`
* `create_graph_from_paths`
* `to_simple_graph`
* `compact_graphs`
* `in_subgraph`
* `out_subgraph`

Note that since the graphs returned by neighbor sampling would have the same node ID space as the original one, using CSR is not storage-efficient (O(N)).  Therefore I'm thinking of either

* Add a "Force COO" option on the graphs; graphs returned by neighbor sampling are always stored in COO.
* Support Doubly Compressed Sparse Row format; graphs returned by neighbor sampling are stored in DCSR instead.

Right now I'm going for the first option since we have *some* COO support.  If someone could confirm that DCSR is more efficient than COO by a significant margin even on small graphs (@jermainewang @zheng-da do you have any experience with DCSR?), then I would switch to the second option instead.

(Forgive me that I forgot to create a "draft" PR...)

## Checklist
Please feel free to remove inapplicable items for your PR.
- [ ] The PR title starts with [$CATEGORY] (such as [NN], [Model], [Doc], [Feature]])
- [ ] Changes are complete (i.e. I finished coding on this PR)
- [ ] All changes have test coverage
- [ ] Code is well-documented
- [ ] To the my best knowledge, examples are either not affected by this change,
      or have been fixed to be compatible with this change
- [ ] Related issue is referred in this PR
