### PR TITLE
[Example] Fix Rgcn hetero nonedetermistic in graph and model initialization

### DIFF
--- a/examples/pytorch/rgcn-hetero/README.md
+++ b/examples/pytorch/rgcn-hetero/README.md
@@ -68,17 +68,17 @@ python3 test_classify.py -d aifb --gpu 0 --model_path "aifb.pt"
 MUTAG:
 ```
 python3 entity_classify.py -d mutag --l2norm 5e-4 --n-bases 30 --testing --gpu 0 --model_path "mutag.pt"
-python3 test_classify.py -d mutag --l2norm 5e-4 --n-bases 30 --gpu 0 --model_path "mutag.pt"
+python3 test_classify.py -d mutag --n-bases 30 --gpu 0 --model_path "mutag.pt"
 ```
 
 BGS:
 ```
 python3 entity_classify.py -d bgs --l2norm 5e-4 --n-bases 40 --testing --gpu 0 --model_path "bgs.pt"
-python3 test_classify.py -d bgs --l2norm 5e-4 --n-bases 40 --gpu 0 --model_path "bgs.pt"
+python3 test_classify.py -d bgs --n-bases 40 --gpu 0 --model_path "bgs.pt"
 ```
 
 AM:
 ```
 python3 entity_classify.py -d am --l2norm 5e-4 --n-bases 40 --testing --gpu 0 --model_path "am.pt"
-python3 test_classify.py -d am --l2norm 5e-4 --n-bases 40 --gpu 0 --model_path "am.pt"
+python3 test_classify.py -d am --n-bases 40 --gpu 0 --model_path "am.pt"
 ```

--- a/examples/pytorch/rgcn-hetero/README.md
+++ b/examples/pytorch/rgcn-hetero/README.md
@@ -55,3 +55,30 @@ AM: accuracy 91.41% (DGL), 89.29% (paper)
 ```
 python3 entity_classify.py -d am --l2norm 5e-4 --n-bases 40 --testing --gpu 0
 ```
+
+### Offline Inferencing
+Trained Model can be exported by providing '--model\_path <PATH>' parameter to entity\_classify.py. And then test\_classify.py can load the saved model and do the testing offline.
+
+AIFB:
+```
+python3 entity_classify.py -d aifb --testing --gpu 0 --model_path "aifb.pt"
+python3 test_classify.py -d aifb --gpu 0 --model_path "aifb.pt"
+```
+
+MUTAG:
+```
+python3 entity_classify.py -d mutag --l2norm 5e-4 --n-bases 30 --testing --gpu 0 --model_path "mutag.pt"
+python3 test_classify.py -d mutag --l2norm 5e-4 --n-bases 30 --gpu 0 --model_path "mutag.pt"
+```
+
+BGS:
+```
+python3 entity_classify.py -d bgs --l2norm 5e-4 --n-bases 40 --testing --gpu 0 --model_path "bgs.pt"
+python3 test_classify.py -d bgs --l2norm 5e-4 --n-bases 40 --gpu 0 --model_path "bgs.pt"
+```
+
+AM:
+```
+python3 entity_classify.py -d am --l2norm 5e-4 --n-bases 40 --testing --gpu 0 --model_path "am.pt"
+python3 test_classify.py -d am --l2norm 5e-4 --n-bases 40 --gpu 0 --model_path "am.pt"
+```

--- a/examples/pytorch/rgcn-hetero/entity_classify.py
+++ b/examples/pytorch/rgcn-hetero/entity_classify.py
@@ -220,6 +220,7 @@ class EntityClassify(nn.Module):
         self.h_dim = h_dim
         self.out_dim = out_dim
         self.rel_names = list(set(g.etypes))
+        self.rel_names.sort()
         self.num_bases = None if num_bases < 0 else num_bases
         self.num_hidden_layers = num_hidden_layers
         self.dropout = dropout

--- a/examples/pytorch/rgcn-hetero/entity_classify.py
+++ b/examples/pytorch/rgcn-hetero/entity_classify.py
@@ -156,11 +156,11 @@ class RelGraphConvHeteroEmbed(nn.Module):
         self.self_loop = self_loop
 
         # create weight embeddings for each node for each relation
-        self.embeds = nn.ParameterList()
+        self.embeds = nn.ParameterDict()
         for srctype, etype, dsttype in g.canonical_etypes:
             embed = nn.Parameter(th.Tensor(g.number_of_nodes(srctype), self.embed_size))
             nn.init.xavier_uniform_(embed, gain=nn.init.calculate_gain('relu'))
-            self.embeds.append(embed)
+            self.embeds["{}-{}-{}".format(srctype, etype, dsttype)] = embed
 
         # bias
         if self.bias:
@@ -189,7 +189,7 @@ class RelGraphConvHeteroEmbed(nn.Module):
         g = self.g.local_var()
         funcs = {}
         for i, (srctype, etype, dsttype) in enumerate(g.canonical_etypes):
-            g.nodes[srctype].data['embed-%d' % i] = self.embeds[i]
+            g.nodes[srctype].data['embed-%d' % i] = self.embeds["{}-{}-{}".format(srctype, etype, dsttype)]
             funcs[(srctype, etype, dsttype)] = (fn.copy_u('embed-%d' % i, 'm'), fn.mean('m', 'h'))
         g.multi_update_all(funcs, 'sum')
         
@@ -285,7 +285,6 @@ def main(args):
         labels = labels.cuda()
         train_idx = train_idx.cuda()
         test_idx = test_idx.cuda()
-        labels = labels.cuda()
 
     # create model
     model = EntityClassify(g,
@@ -324,6 +323,8 @@ def main(args):
         print("Epoch {:05d} | Train Acc: {:.4f} | Train Loss: {:.4f} | Valid Acc: {:.4f} | Valid loss: {:.4f} | Time: {:.4f}".
               format(epoch, train_acc, loss.item(), val_acc, val_loss.item(), np.average(dur)))
     print()
+    if args.model_path is not None:
+        th.save(model.state_dict(), args.model_path)
 
     model.eval()
     logits = model.forward()[category_id]
@@ -350,6 +351,8 @@ if __name__ == '__main__':
             help="number of training epochs")
     parser.add_argument("-d", "--dataset", type=str, required=True,
             help="dataset to use")
+    parser.add_argument("--model_path", type=str, default=None,
+            help='path for save the model')
     parser.add_argument("--l2norm", type=float, default=0,
             help="l2 norm coef")
     parser.add_argument("--use-self-loop", default=False, action='store_true',

--- a/examples/pytorch/rgcn-hetero/test_classify.py
+++ b/examples/pytorch/rgcn-hetero/test_classify.py
@@ -44,13 +44,11 @@ def main(args):
                            num_classes,
                            num_bases=args.n_bases,
                            num_hidden_layers=args.n_layers - 2,
-                           dropout=args.dropout,
                            use_self_loop=args.use_self_loop)
-
-    if use_cuda:
-        model.cuda()
     # training loop
     model.load_state_dict(th.load(args.model_path))
+    if use_cuda:
+        model.cuda()
 
     print("start testing...")
     model.eval()
@@ -62,8 +60,6 @@ def main(args):
     
 if __name__ == '__main__':
     parser = argparse.ArgumentParser(description='RGCN')
-    parser.add_argument("--dropout", type=float, default=0,
-            help="dropout probability")
     parser.add_argument("--n-hidden", type=int, default=16,
             help="number of hidden units")
     parser.add_argument("--gpu", type=int, default=-1,
@@ -78,8 +74,6 @@ if __name__ == '__main__':
             help="dataset to use")
     parser.add_argument("--model_path", type=str,
             help='path of the model to load from')
-    parser.add_argument("--l2norm", type=float, default=0,
-            help="l2 norm coef")
     parser.add_argument("--use-self-loop", default=False, action='store_true',
             help="include self feature as a special relation")
 

--- a/examples/pytorch/rgcn-hetero/test_classify.py
+++ b/examples/pytorch/rgcn-hetero/test_classify.py
@@ -1,0 +1,88 @@
+"""Infering Relational Data with Graph Convolutional Networks
+"""
+import argparse
+import torch as th
+from functools import partial
+import torch.nn.functional as F
+
+from dgl.data.rdf import AIFB, MUTAG, BGS, AM
+from entity_classify import EntityClassify
+
+def main(args):
+    # load graph data
+    if args.dataset == 'aifb':
+        dataset = AIFB()
+    elif args.dataset == 'mutag':
+        dataset = MUTAG()
+    elif args.dataset == 'bgs':
+        dataset = BGS()
+    elif args.dataset == 'am':
+        dataset = AM()
+    else:
+        raise ValueError()
+
+    g = dataset.graph
+    category = dataset.predict_category
+    num_classes = dataset.num_classes
+    test_idx = dataset.test_idx
+    labels = dataset.labels
+    category_id = len(g.ntypes)
+    for i, ntype in enumerate(g.ntypes):
+        if ntype == category:
+            category_id = i
+
+    # check cuda
+    use_cuda = args.gpu >= 0 and th.cuda.is_available()
+    if use_cuda:
+        th.cuda.set_device(args.gpu)
+        labels = labels.cuda()
+        test_idx = test_idx.cuda()
+
+    # create model
+    model = EntityClassify(g,
+                           args.n_hidden,
+                           num_classes,
+                           num_bases=args.n_bases,
+                           num_hidden_layers=args.n_layers - 2,
+                           dropout=args.dropout,
+                           use_self_loop=args.use_self_loop)
+
+    if use_cuda:
+        model.cuda()
+    # training loop
+    model.load_state_dict(th.load(args.model_path))
+
+    print("start testing...")
+    model.eval()
+    logits = model.forward()[category_id]
+    test_loss = F.cross_entropy(logits[test_idx], labels[test_idx])
+    test_acc = th.sum(logits[test_idx].argmax(dim=1) == labels[test_idx]).item() / len(test_idx)
+    print("Test Acc: {:.4f} | Test loss: {:.4f}".format(test_acc, test_loss.item()))
+    print()
+    
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser(description='RGCN')
+    parser.add_argument("--dropout", type=float, default=0,
+            help="dropout probability")
+    parser.add_argument("--n-hidden", type=int, default=16,
+            help="number of hidden units")
+    parser.add_argument("--gpu", type=int, default=-1,
+            help="gpu")
+    parser.add_argument("--lr", type=float, default=1e-2,
+            help="learning rate")
+    parser.add_argument("--n-bases", type=int, default=-1,
+            help="number of filter weight matrices, default: -1 [use all]")
+    parser.add_argument("--n-layers", type=int, default=2,
+            help="number of propagation rounds")
+    parser.add_argument("-d", "--dataset", type=str, required=True,
+            help="dataset to use")
+    parser.add_argument("--model_path", type=str,
+            help='path of the model to load from')
+    parser.add_argument("--l2norm", type=float, default=0,
+            help="l2 norm coef")
+    parser.add_argument("--use-self-loop", default=False, action='store_true',
+            help="include self feature as a special relation")
+
+    args = parser.parse_args()
+    print(args)
+    main(args)

--- a/python/dgl/data/rdf.py
+++ b/python/dgl/data/rdf.py
@@ -142,7 +142,12 @@ class RDFGraphDataset:
         dst = []
         ntid = []
         etid = []
-        for i, (sbj, pred, obj) in enumerate(raw_tuples):
+        sorted_tuples = []
+        for t in raw_tuples:
+            sorted_tuples.append(t)
+        sorted_tuples.sort()
+
+        for i, (sbj, pred, obj) in enumerate(sorted_tuples):
             if i % self._print_every == 0:
                 print('Processed %d tuples, found %d valid tuples.' % (i, len(src)))
             sbjent = self.parse_entity(sbj)


### PR DESCRIPTION
## Description
RGCN-hetero model should be reloadable for further online and offline inference. But there are several none-deterministic points:
1. For rdf loader, if the graph caching is cleaned, the order of rdf triples loaded changes from run to run
2. For the model nn.Parameters (L160, entity\_classify.py), as g.canonical_etypes is none-deterministic from run to run, we should use torch.nn.ParameterDict() to store the tensors for different nodetype so that they can be loaded in inference step.
3. EntityClassify.rel_names (L222, entity\_classify.py) is not deterministic, which cause a random order of assigning basis_weight tensor for each relation type.

Also we provide an example of how to load the pre-trained model and do the inference (test) separately from traning. 

Updating the Readme.

#1240 

## Checklist
Please feel free to remove inapplicable items for your PR.
- [x] The PR title starts with [$CATEGORY] (such as [NN], [Model], [Doc], [Feature]])
- [x] Changes are complete (i.e. I finished coding on this PR)
- [ ] All changes have test coverage
- [x] Code is well-documented
- [ ] To the my best knowledge, examples are either not affected by this change,
      or have been fixed to be compatible with this change
- [x] Related issue is referred in this PR

## Changes
<!-- You could use following template
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)
-->
