### PR TITLE
[Fix] Fix build on macos(clang)

### DIFF
--- a/include/dgl/runtime/packed_func.h
+++ b/include/dgl/runtime/packed_func.h
@@ -847,17 +847,22 @@ inline const char* TypeCode2Str(int type_code) {
   }
 }
 
-#ifndef _LIBCPP_SGX_NO_IOSTREAMS
-inline std::ostream& operator<<(std::ostream& os, DGLType t) {  // NOLINT(*)
-  os << TypeCode2Str(t.code);
-  if (t.code == kHandle) return os;
-  os << static_cast<int>(t.bits);
-  if (t.lanes != 1) {
-    os << 'x' << static_cast<int>(t.lanes);
-  }
-  return os;
-}
-#endif
+// C++ will look over the symbol based on Argument-dependent name lookup(ADL).
+// Therefore theoratically the operator << of DLDataType should be placed in the
+// same namespace as DLDataType (DGLType). Thus the one in c_api_common.h (in
+// global namespace) is preserved, and the one below is commented out.
+
+// #ifndef _LIBCPP_SGX_NO_IOSTREAMS
+// inline std::ostream& operator<<(std::ostream& os, const DGLType& t) {  // NOLINT(*)
+//   os << TypeCode2Str(t.code);
+//   if (t.code == kHandle) return os;
+//   os << static_cast<int>(t.bits);
+//   if (t.lanes != 1) {
+//     os << 'x' << static_cast<int>(t.lanes);
+//   }
+//   return os;
+// }
+// #endif
 
 inline std::string DGLType2String(DGLType t) {
 #ifndef _LIBCPP_SGX_NO_IOSTREAMS

--- a/include/dgl/runtime/packed_func.h
+++ b/include/dgl/runtime/packed_func.h
@@ -847,22 +847,17 @@ inline const char* TypeCode2Str(int type_code) {
   }
 }
 
-// C++ will look over the symbol based on Argument-dependent name lookup(ADL).
-// Therefore theoratically the operator << of DLDataType should be placed in the
-// same namespace as DLDataType (DGLType). Thus the one in c_api_common.h (in
-// global namespace) is preserved, and the one below is commented out.
-
-// #ifndef _LIBCPP_SGX_NO_IOSTREAMS
-// inline std::ostream& operator<<(std::ostream& os, const DGLType& t) {  // NOLINT(*)
-//   os << TypeCode2Str(t.code);
-//   if (t.code == kHandle) return os;
-//   os << static_cast<int>(t.bits);
-//   if (t.lanes != 1) {
-//     os << 'x' << static_cast<int>(t.lanes);
-//   }
-//   return os;
-// }
-// #endif
+#ifndef _LIBCPP_SGX_NO_IOSTREAMS
+inline std::ostream& operator<<(std::ostream& os, DGLType t) {  // NOLINT(*)
+  os << TypeCode2Str(t.code);
+  if (t.code == kHandle) return os;
+  os << static_cast<int>(t.bits);
+  if (t.lanes != 1) {
+    os << 'x' << static_cast<int>(t.lanes);
+  }
+  return os;
+}
+#endif
 
 inline std::string DGLType2String(DGLType t) {
 #ifndef _LIBCPP_SGX_NO_IOSTREAMS

--- a/src/c_api_common.h
+++ b/src/c_api_common.h
@@ -21,7 +21,6 @@ inline bool operator == (const DLDataType& ty1, const DLDataType& ty2) {
   return ty1.code == ty2.code && ty1.bits == ty2.bits && ty1.lanes == ty2.lanes;
 }
 
-
 /*! \brief Check whether two device contexts are the same.*/
 inline bool operator == (const DLContext& ctx1, const DLContext& ctx2) {
   return ctx1.device_type == ctx2.device_type && ctx1.device_id == ctx2.device_id;

--- a/src/c_api_common.h
+++ b/src/c_api_common.h
@@ -14,17 +14,13 @@
 #include <algorithm>
 #include <vector>
 
+using dgl::runtime::operator<<;
+
 /*! \brief Check whether two data types are the same.*/
 inline bool operator == (const DLDataType& ty1, const DLDataType& ty2) {
   return ty1.code == ty2.code && ty1.bits == ty2.bits && ty1.lanes == ty2.lanes;
 }
 
-/*! \brief Output the string representation of DLDataType.*/
-inline std::ostream& operator<<(std::ostream& os, const DLDataType& ty) {
-  return os << "code=" << static_cast<int>(ty.code)
-            << ",bits=" << static_cast<int>(ty.bits)
-            << "lanes=" << static_cast<int>(ty.lanes);
-}
 
 /*! \brief Check whether two device contexts are the same.*/
 inline bool operator == (const DLContext& ctx1, const DLContext& ctx2) {

--- a/src/c_api_common.h
+++ b/src/c_api_common.h
@@ -19,6 +19,13 @@ inline bool operator == (const DLDataType& ty1, const DLDataType& ty2) {
   return ty1.code == ty2.code && ty1.bits == ty2.bits && ty1.lanes == ty2.lanes;
 }
 
+/*! \brief Output the string representation of device context.*/
+inline std::ostream& operator<<(std::ostream& os, const DLDataType& ty) {
+  return os << "code=" << static_cast<int>(ty.code)
+            << ",bits=" << static_cast<int>(ty.bits)
+            << "lanes=" << static_cast<int>(ty.lanes);
+}
+
 /*! \brief Check whether two device contexts are the same.*/
 inline bool operator == (const DLContext& ctx1, const DLContext& ctx2) {
   return ctx1.device_type == ctx2.device_type && ctx1.device_id == ctx2.device_id;

--- a/src/c_api_common.h
+++ b/src/c_api_common.h
@@ -19,7 +19,7 @@ inline bool operator == (const DLDataType& ty1, const DLDataType& ty2) {
   return ty1.code == ty2.code && ty1.bits == ty2.bits && ty1.lanes == ty2.lanes;
 }
 
-/*! \brief Output the string representation of device context.*/
+/*! \brief Output the string representation of DLDataType.*/
 inline std::ostream& operator<<(std::ostream& os, const DLDataType& ty) {
   return os << "code=" << static_cast<int>(ty.code)
             << ",bits=" << static_cast<int>(ty.bits)


### PR DESCRIPTION
## Description
GCC and clang has different symbol lookup implementation.
Standard reference:
https://en.wikipedia.org/wiki/Argument-dependent_name_lookup

<!-- Brief description. Refer to the related issues if existed.
It'll be great if relevant reviewers can be assigned as well.-->

## Checklist
Please feel free to remove inapplicable items for your PR.
- [ ] The PR title starts with [$CATEGORY] (such as [NN], [Model], [Doc], [Feature]])
- [ ] Changes are complete (i.e. I finished coding on this PR)
- [ ] All changes have test coverage
- [ ] Code is well-documented
- [ ] To the my best knowledge, examples are either not affected by this change,
      or have been fixed to be compatible with this change
- [ ] Related issue is referred in this PR

## Changes
<!-- You could use following template
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)
-->
