### PR TITLE
[BUGFIX] metis partition should generate a subgraph to the original graph.

### DIFF
--- a/python/dgl/transform.py
+++ b/python/dgl/transform.py
@@ -595,12 +595,14 @@ def metis_partition(g, k, extra_cached_hops=0):
         The key is the partition Id and the value is the DGLGraph of the partition.
     '''
     # METIS works only on symmetric graphs.
+    # The METIS runs on the symmetric graph to generate the node assignment to partitions.
     sym_g = to_bidirected(g, readonly=True)
     node_part = _CAPI_DGLMetisPartition(sym_g._graph, k)
     if len(node_part) == 0:
         return None
 
     node_part = utils.toindex(node_part)
+    # Then we split the original graph into parts based on the METIS partitioning results.
     parts = partition_graph_with_halo(g, node_part, extra_cached_hops)
     node_part = node_part.tousertensor()
     for part_id in parts:

--- a/python/dgl/transform.py
+++ b/python/dgl/transform.py
@@ -595,8 +595,8 @@ def metis_partition(g, k, extra_cached_hops=0):
         The key is the partition Id and the value is the DGLGraph of the partition.
     '''
     # METIS works only on symmetric graphs.
-    g = to_bidirected(g, readonly=True)
-    node_part = _CAPI_DGLMetisPartition(g._graph, k)
+    sym_g = to_bidirected(g, readonly=True)
+    node_part = _CAPI_DGLMetisPartition(sym_g._graph, k)
     if len(node_part) == 0:
         return None
 


### PR DESCRIPTION
## Description
metis partition should generate a subgraph from the original graph, instead from a temporary graph.

## Checklist
Please feel free to remove inapplicable items for your PR.
- [ ] The PR title starts with [$CATEGORY] (such as [NN], [Model], [Doc], [Feature]])
- [ ] Changes are complete (i.e. I finished coding on this PR)
- [ ] All changes have test coverage
- [ ] Code is well-documented
- [ ] To the my best knowledge, examples are either not affected by this change,
      or have been fixed to be compatible with this change
- [ ] Related issue is referred in this PR

## Changes
<!-- You could use following template
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)
-->
