### PR TITLE
[Doc] Fix link to backends docs

### DIFF
--- a/docs/source/install/backend.rst
+++ b/docs/source/install/backend.rst
@@ -1,3 +1,5 @@
+.. _backends:
+
 Working with different backends
 ===============================
 
@@ -22,7 +24,7 @@ size smaller than 2^32. To enable large graph training, *build* MXNet with ``USE
 flag. See `this FAQ <https://mxnet.apache.org/api/faq/large_tensor_support>`_ for more information.
 
 MXNet 1.5 and later has an option to enable Numpy shape mode for ``NDArray`` objects, some DGL models
-need this mode to be enabled to run correctly. However, this mode may not compatible with pretrained 
+need this mode to be enabled to run correctly. However, this mode may not compatible with pretrained
 model parameters with this mode disabled, e.g. pretrained models from GluonCV and GluonNLP.
 By setting ``DGL_MXNET_SET_NP_SHAPE``, users can switch this mode on or off.
 

--- a/docs/source/install/index.rst
+++ b/docs/source/install/index.rst
@@ -14,8 +14,7 @@ DGL works with the following operating systems:
 DGL requires Python version 3.5 or later. Python 3.4 or earlier is not
 tested. Python 2 support is coming.
 
-DGL supports multiple tensor libraries as backends, e.g., PyTorch, MXNet. For requirements on backends and how to select one, see
-`Working with different backends`_.
+DGL supports multiple tensor libraries as backends, e.g., PyTorch, MXNet. For requirements on backends and how to select one, see :ref:`backends`.
 
 Starting at version 0.3, DGL is separated into CPU and CUDA builds.  The builds share the
 same Python package name. If you install DGL with a CUDA 9 build after you install the
@@ -46,7 +45,7 @@ For CPU builds, run the following command to install with ``pip``.
 .. code:: bash
 
    pip install dgl
-   
+
 For CUDA builds, run one of the following commands and specify the CUDA version.
 
 .. code:: bash
@@ -54,7 +53,7 @@ For CUDA builds, run one of the following commands and specify the CUDA version.
    pip install dgl           # For CPU Build
    pip install dgl-cu90      # For CUDA 9.0 Build
    pip install dgl-cu92      # For CUDA 9.2 Build
-   pip install dgl-cu100     # For CUDA 10.0 Build   
+   pip install dgl-cu100     # For CUDA 10.0 Build
    pip install dgl-cu101     # For CUDA 10.1 Build
 
 For the most current nightly build from master branch, run one of the following commands.


### PR DESCRIPTION
## Description

The link to https://docs.dgl.ai/install/backend.html is broken in https://docs.dgl.ai/install/index.html#system-requirements

## Checklist

- [x] The PR title starts with [$CATEGORY] (such as [NN], [Model], [Doc], [Feature]])
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] To the my best knowledge, examples are either not affected by this change,
      or have been fixed to be compatible with this change

## Changes

- [x] Use appropriate Sphinx cross-referencing syntax