### PR TITLE
[Backend][Regression] Rolling back interactive backend selection

### DIFF
--- a/python/dgl/backend/__init__.py
+++ b/python/dgl/backend/__init__.py
@@ -20,6 +20,7 @@ def _gen_missing_api(api, mod_name):
 
 
 def load_backend(mod_name):
+    print('Using backend: %s' % mod_name, file=sys.stderr)
     mod = importlib.import_module('.%s' % mod_name, __name__)
     thismod = sys.modules[__name__]
     for api in backend.__dict__.keys():
@@ -62,13 +63,12 @@ def get_preferred_backend():
             backend_name = config_dict.get('backend', '').lower()
 
     if (backend_name in ['tensorflow', 'mxnet', 'pytorch']):
-        return backend_name 
-    else:
-        while not(backend_name in ['tensorflow', 'mxnet', 'pytorch']):
-            print("DGL does not detect a valid backend option. Which backend would you like to work with?")
-            backend_name = input("Backend choice (pytorch, mxnet or tensorflow): ").lower()
-        set_default_backend(backend_name)
         return backend_name
+    else:
+        print("DGL backend not selected or invalid.  "
+              "Assuming PyTorch for now.", file=sys.stderr)
+        set_default_backend('pytorch')
+        return 'pytorch'
 
 
 load_backend(get_preferred_backend())

--- a/python/dgl/backend/set_default_backend.py
+++ b/python/dgl/backend/set_default_backend.py
@@ -9,8 +9,9 @@ def set_default_backend(backend_name):
     config_path = os.path.join(default_dir, 'config.json')
     with open(config_path, "w") as config_file: 
         json.dump({'backend': backend_name.lower()}, config_file)
-    print('Set the default backend to "{}". You can change it in the '
-          '~/.dgl/config.json file or export the DGLBACKEND environment variable.'.format(
+    print('Setting the default backend to "{}". You can change it in the '
+          '~/.dgl/config.json file or export the DGLBACKEND environment variable.  '
+          'Valid options are: pytorch, mxnet, tensorflow (all lowercase)'.format(
               backend_name))
 
 if __name__ == "__main__":


### PR DESCRIPTION
DGL currently asks for backend selection in standard input, which makes some automation (e.g. pip/docker installation) crash.  This reverts to the previous behavior of assuming PyTorch when backend is not given.  However, it also prints a warning in standard error asking for users to change the backend explicitly in either config file or `DGLBACKEND` environment variable if they wish.