### PR TITLE
[Doc] Fix typos in env vars docs

### DIFF
--- a/docs/source/env_var.rst
+++ b/docs/source/env_var.rst
@@ -5,9 +5,9 @@ Backend Options
 ---------------
 * ``DGLBACKEND``:
     * Values: String (default='pytorch')
-    * The backend deep lerarning framework for DGL.
+    * The backend deep learning framework for DGL.
     * Choices:
-        * 'pytorch': use PyTorch as the backend implentation.
+        * 'pytorch': use PyTorch as the backend implementation.
         * 'mxnet': use Apache MXNet as the backend implementation.
 
 Data Repository


### PR DESCRIPTION
## Description

Simply typo fixes in documentation.

## Checklist

- [x] The PR title starts with [$CATEGORY] (such as [NN], [Model], [Doc], [Feature]])
- [x] Changes are complete (i.e. I finished coding on this PR)