### PR TITLE
[Doc] Fix GraphConv math notation

### DIFF
--- a/python/dgl/nn/mxnet/conv/graphconv.py
+++ b/python/dgl/nn/mxnet/conv/graphconv.py
@@ -103,7 +103,7 @@ class GraphConv(gluon.Block):
           dimensions, :math:`N` is the number of nodes.
         * Output shape: :math:`(N, *, \text{out_feats})` where all but the last dimension are
           the same shape as the input.
-        * Weight shape: "math:`(\text{in_feats}, \text{out_feats})`.
+        * Weight shape: :math:`(\text{in_feats}, \text{out_feats})`.
 
         Parameters
         ----------

--- a/python/dgl/nn/pytorch/conv/graphconv.py
+++ b/python/dgl/nn/pytorch/conv/graphconv.py
@@ -109,7 +109,7 @@ class GraphConv(nn.Module):
           dimensions, :math:`N` is the number of nodes.
         * Output shape: :math:`(N, *, \text{out_feats})` where all but the last dimension are
           the same shape as the input.
-        * Weight shape: "math:`(\text{in_feats}, \text{out_feats})`.
+        * Weight shape: :math:`(\text{in_feats}, \text{out_feats})`.
 
         Parameters
         ----------

--- a/python/dgl/nn/tensorflow/conv/graphconv.py
+++ b/python/dgl/nn/tensorflow/conv/graphconv.py
@@ -106,7 +106,7 @@ class GraphConv(layers.Layer):
           dimensions, :math:`N` is the number of nodes.
         * Output shape: :math:`(N, *, \text{out_feats})` where all but the last dimension are
           the same shape as the input.
-        * Weight shape: "math:`(\text{in_feats}, \text{out_feats})`.
+        * Weight shape: :math:`(\text{in_feats}, \text{out_feats})`.
 
         Parameters
         ----------


### PR DESCRIPTION
## Description

Simple fix to math notation in GraphConv documentation. Without this, math is not formatted correctly: https://docs.dgl.ai/en/0.4.x/api/python/nn.pytorch.html#graphconv

## Checklist

- [x] The PR title starts with [$CATEGORY] (such as [NN], [Model], [Doc], [Feature]])
- [x] Changes are complete (i.e. I finished coding on this PR)