### PR TITLE
[BUG] Fix bug in using degree_as_nlabel for GIN dataset

### DIFF
--- a/python/dgl/data/gindt.py
+++ b/python/dgl/data/gindt.py
@@ -220,7 +220,7 @@ class GINDataset(object):
                     # but usually no features means no labels, fine.
                     g.ndata['label'] = g.in_degrees()
                     # extracting unique node labels
-                    nlabel_set = nlabel_set.union(set(g.ndata['label']))
+                    nlabel_set = nlabel_set.union(set([F.as_scalar(nl) for nl in g.ndata['label']]))
 
                 nlabel_set = list(nlabel_set)
                 # in case the labels/degrees are not continuous number


### PR DESCRIPTION
## Description
In order to make the `label2idx` dictionary, tensor values should be used and not the tensor itself.

## Checklist
Please feel free to remove inapplicable items for your PR.
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] To the my best knowledge, examples are either not affected by this change,
      or have been fixed to be compatible with this change
