### PR TITLE
[Bugfix] Fix corrupted memory when using multi-processing

### DIFF
--- a/python/dgl/transform.py
+++ b/python/dgl/transform.py
@@ -898,8 +898,6 @@ def to_block(g, dst_nodes=None, include_dst_in_src=True):
 
     new_graph_index, src_nodes_nd, induced_edges_nd = _CAPI_DGLToBlock(
         g._graph, dst_nodes_nd, include_dst_in_src)
-    src_nodes = [F.zerocopy_from_dgl_ndarray(nodes_nd.data) for nodes_nd in src_nodes_nd]
-    dst_nodes = [F.zerocopy_from_dgl_ndarray(nodes_nd) for nodes_nd in dst_nodes_nd]
 
     # The new graph duplicates the original node types to SRC and DST sets.
     new_ntypes = ([ntype for ntype in g.ntypes], [ntype for ntype in g.ntypes])
@@ -907,8 +905,9 @@ def to_block(g, dst_nodes=None, include_dst_in_src=True):
     assert new_graph.is_unibipartite  # sanity check
 
     for i, ntype in enumerate(g.ntypes):
-        new_graph.srcnodes[ntype].data[NID] = src_nodes[i]
-        new_graph.dstnodes[ntype].data[NID] = dst_nodes[i]
+        new_graph.srcnodes[ntype].data[NID] = F.zerocopy_from_dgl_ndarray(src_nodes_nd[i].data)
+    for ntype, dst_nids in dst_nodes.items():
+        new_graph.dstnodes[ntype].data[NID] = dst_nids
 
     for i, canonical_etype in enumerate(g.canonical_etypes):
         induced_edges = F.zerocopy_from_dgl_ndarray(induced_edges_nd[i].data)

--- a/python/dgl/transform.py
+++ b/python/dgl/transform.py
@@ -906,8 +906,11 @@ def to_block(g, dst_nodes=None, include_dst_in_src=True):
 
     for i, ntype in enumerate(g.ntypes):
         new_graph.srcnodes[ntype].data[NID] = F.zerocopy_from_dgl_ndarray(src_nodes_nd[i].data)
-    for ntype, dst_nids in dst_nodes.items():
-        new_graph.dstnodes[ntype].data[NID] = dst_nids
+        if ntype in dst_nodes:
+            new_graph.dstnodes[ntype].data[NID] = dst_nodes[ntype]
+        else:
+            # For empty dst node sets, still create empty mapping arrays.
+            new_graph.dstnodes[ntype].data[NID] = F.tensor([], dtype=F.int64)
 
     for i, canonical_etype in enumerate(g.canonical_etypes):
         induced_edges = F.zerocopy_from_dgl_ndarray(induced_edges_nd[i].data)


### PR DESCRIPTION
## Description
<!-- Brief description. Refer to the related issues if existed.
It'll be great if relevant reviewers can be assigned as well.-->

When sampling with multi-processing, the sampler sometimes returns a corrupted original node ID array for destination nodes. The problem seems to be due to:
1. A PyTorch array is converted to a DGL array via DLPack.
1. It is then converted back to PyTorch array via DLPack. There is no data modification in the middle, so the conversion is actually redundant.
1. The array is then transmitted to another process via multi-processing mechanism.

The patch attempts to fix this by removing the redundant steps 1 and 2, though I haven't thoroughly verified whether the problem is completely solved.

## Checklist
Please feel free to remove inapplicable items for your PR.
- [x] The PR title starts with [$CATEGORY] (such as [NN], [Model], [Doc], [Feature]])
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage
- [x] Code is well-documented
- [x] To the my best knowledge, examples are either not affected by this change,
      or have been fixed to be compatible with this change