### PR TITLE
[KVStore] add init_data() on client

### DIFF
--- a/python/dgl/contrib/dis_kvstore.py
+++ b/python/dgl/contrib/dis_kvstore.py
@@ -857,8 +857,9 @@ class KVClient(object):
         self._data_store[name+'-part-'] = partition_book
         self._has_data.add(name+'-g2l-')
         self._has_data.add(name+'-part-')
+        # Read new data from shared-memory created by server
         shape, data_type = self._read_data_shape_type(name+'-data-shape-'+str(self._machine_id))
-        assert data_type == get_type_str()[dtype]
+        assert data_type == get_type_str(dtype)
         shared_data = empty_shared_mem(name+'-data-', False, shape, dtype)
         dlpack = shared_data.to_dlpack()
         self._data_store[name+'-data-'] = F.zerocopy_from_dlpack(dlpack)

--- a/python/dgl/contrib/dis_kvstore.py
+++ b/python/dgl/contrib/dis_kvstore.py
@@ -474,7 +474,7 @@ class KVServer(object):
                     c_ptr=None)
                 _send_kv_msg(self._sender, back_msg, msg.rank)
             # Init new data
-            elif msg.type == KVStoreMsg.NEW_DATA:
+            elif msg.type == KVMsgType.NEW_DATA:
                 assert msg.rank == 0
                 data_str, target_name = msg.name.split('|')
                 data_name, date_type = self._deserialize_shared_tensor(data_str)

--- a/python/dgl/contrib/dis_kvstore.py
+++ b/python/dgl/contrib/dis_kvstore.py
@@ -860,7 +860,7 @@ class KVClient(object):
         # Read new data from shared-memory created by server
         shape, data_type = self._read_data_shape_type(name+'-data-shape-'+str(self._machine_id))
         assert data_type == get_type_str(dtype)
-        shared_data = empty_shared_mem(name+'-data-', False, shape, dtype)
+        shared_data = empty_shared_mem(name+'-data-', False, shape, data_type)
         dlpack = shared_data.to_dlpack()
         self._data_store[name+'-data-'] = F.zerocopy_from_dlpack(dlpack)
         self._has_data.add(name+'-data-')

--- a/python/dgl/contrib/dis_kvstore.py
+++ b/python/dgl/contrib/dis_kvstore.py
@@ -21,7 +21,6 @@ if os.name != 'nt':
     import fcntl
     import struct
 
-
 def read_ip_config(filename):
     """Read network configuration information of kvstore from file.
 
@@ -76,6 +75,29 @@ def read_ip_config(filename):
         print("Error: data format on each line should be: [ip] [base_port] [server_count]")
 
     return server_namebook
+
+
+def get_type_str(dtype):
+    """Get data type string
+    """
+    if 'float16' in str(dtype):
+        return 'float16'
+    elif 'float32' in str(dtype):
+        return 'float32'
+    elif 'float64' in str(dtype):
+        return 'float64'
+    elif 'uint8' in str(dtype):
+        return 'uint8'
+    elif 'int8' in str(dtype):
+        return 'int8'
+    elif 'int16' in str(dtype):
+        return 'int16'
+    elif 'int32' in str(dtype):
+        return 'int32'
+    elif 'int64' in str(dtype):
+        return 'int64'
+    else:
+        raise RuntimeError('Unknown data type: %s' % str(dtype))
 
 
 class KVServer(object):
@@ -184,12 +206,13 @@ class KVServer(object):
         if global2local is not None: # Create shared-tensor
             if isinstance(global2local, list):
                 global2local = F.tensor(global2local)
+            assert 'int64' == get_type_str(F.dtype(global2local)), 'global2local must be int64 type.'
             shared_data = empty_shared_mem(name+'-g2l-', True, global2local.shape, 'int64')
             dlpack = shared_data.to_dlpack()
             self._data_store[name+'-g2l-'] = F.zerocopy_from_dlpack(dlpack)
             self._data_store[name+'-g2l-'][:] = global2local[:]
             # write data information to temp file that can be read by other processes
-            self._write_data_shape(name+'-g2l-shape-'+str(self._machine_id), global2local)
+            self._write_data_shape_type(name+'-g2l-shape-'+str(self._machine_id), global2local)
             self._open_file_list.append(name+'-g2l-shape-'+str(self._machine_id))
         else: # Read shared-tensor
             while True:
@@ -198,7 +221,8 @@ class KVServer(object):
                     break
                 else:
                     time.sleep(2) # wait until the file been created
-            data_shape = self._read_data_shape(name+'-g2l-shape-'+str(self._machine_id))
+            data_shape, data_type = self._read_data_shape_type(name+'-g2l-shape-'+str(self._machine_id))
+            assert data_type == 'int64'
             shared_data = empty_shared_mem(name+'-g2l-', False, data_shape, 'int64')
             dlpack = shared_data.to_dlpack()
             self._data_store[name+'-g2l-'] = F.zerocopy_from_dlpack(dlpack)
@@ -223,11 +247,12 @@ class KVServer(object):
         if partition_book is not None: # Create shared-tensor
             if isinstance(partition_book, list):
                 partition_book = F.tensor(partition_book)
+            assert 'int64' == get_type_str(F.dtype(partition_book)), 'partition_book must be int64 type.'
             shared_data = empty_shared_mem(name+'-part-', True, partition_book.shape, 'int64')
             dlpack = shared_data.to_dlpack()
             self._data_store[name+'-part-'] = F.zerocopy_from_dlpack(dlpack)
             self._data_store[name+'-part-'][:] = partition_book[:]
-            self._write_data_shape(name+'-part-shape-'+str(self._machine_id), partition_book)
+            self._write_data_shape_type(name+'-part-shape-'+str(self._machine_id), partition_book)
             self._open_file_list.append(name+'-part-shape-'+str(self._machine_id))
         else: # Read shared-tensor
             while True:
@@ -236,7 +261,8 @@ class KVServer(object):
                     break
                 else:
                     time.sleep(2) # wait until the file been created    
-            data_shape = self._read_data_shape(name+'-part-shape-'+str(self._machine_id))
+            data_shape, data_type = self._read_data_shape_type(name+'-part-shape-'+str(self._machine_id))
+            assert data_type == 'int64'
             shared_data = empty_shared_mem(name+'-part-', False, data_shape, 'int64')
             dlpack = shared_data.to_dlpack()
             self._data_store[name+'-part-'] = F.zerocopy_from_dlpack(dlpack)
@@ -259,11 +285,12 @@ class KVServer(object):
         assert len(name) > 0, 'name cannot be empty.'
 
         if data_tensor is not None: # Create shared-tensor
-            shared_data = empty_shared_mem(name+'-data-', True, data_tensor.shape, 'float32')
+            data_type = get_type_str(F.dtype(data_tensor))
+            shared_data = empty_shared_mem(name+'-data-', True, data_tensor.shape, data_type)
             dlpack = shared_data.to_dlpack()
             self._data_store[name+'-data-'] = F.zerocopy_from_dlpack(dlpack)
             self._data_store[name+'-data-'][:] = data_tensor[:]
-            self._write_data_shape(name+'-data-shape-'+str(self._machine_id), data_tensor)
+            self._write_data_shape_type(name+'-data-shape-'+str(self._machine_id), data_tensor)
             self._open_file_list.append(name+'-data-shape-'+str(self._machine_id))
         else: # Read shared-tensor
             while True:
@@ -271,8 +298,8 @@ class KVServer(object):
                     break
                 else:
                     time.sleep(2) # wait until the file been created
-            data_shape = self._read_data_shape(name+'-data-shape-'+str(self._machine_id))
-            shared_data = empty_shared_mem(name+'-data-', False, data_shape, 'float32')
+            data_shape, data_type = self._read_data_shape_type(name+'-data-shape-'+str(self._machine_id))
+            shared_data = empty_shared_mem(name+'-data-', False, data_shape, data_type)
             dlpack = shared_data.to_dlpack()
             self._data_store[name+'-data-'] = F.zerocopy_from_dlpack(dlpack)
 
@@ -479,7 +506,7 @@ class KVServer(object):
         ----------
         name : str
             tensor name
-        dtype : str
+        dtype : dtype
             data type
 
         Returns
@@ -491,17 +518,11 @@ class KVServer(object):
 
         str_data = name
         str_data += '/'
-        if 'float32' in str(dtype):
-            str_data += 'float32'
-        elif 'int64' in str(dtype):
-            str_data += 'int64'
-        else:
-            raise RuntimeError('We can only process int64 and float32 shared-memory tensor now.')
-
+        str_data += get_type_str(dtype)
         return str_data
 
 
-    def _write_data_shape(self, filename, data):
+    def _write_data_shape_type(self, filename, data):
         """Write data shape to a temp file.
 
         Parameters
@@ -518,6 +539,8 @@ class KVServer(object):
 
         shape = F.shape(data)
         str_data = ''
+        str_data += get_type_str(F.dtype(data))
+        str_data += '|'
         f = open(filename, "a");
         for s in shape:
             str_data += str(s)
@@ -526,7 +549,7 @@ class KVServer(object):
         f.close()
 
 
-    def _read_data_shape(self, filename):
+    def _read_data_shape_type(self, filename):
         """Read data shape from a tmp file.
 
         Parameters
@@ -544,12 +567,13 @@ class KVServer(object):
         f = open(filename, "r")
         str_data = f.read()
         data_list = str_data.split('|')
+        data_type = data_list[0]
         data_shape = []
-        for i in range(len(data_list)-1):
+        for i in range(1, len(data_list)-1):
             data_shape.append(int(data_list[i]))
         f.close()
 
-        return data_shape
+        return data_shape, data_type
 
 
     def _default_push_handler(self, name, ID, data, target):
@@ -721,7 +745,8 @@ class KVClient(object):
                         break
                     else:
                         time.sleep(2) # wait until the file been created 
-                shape = self._read_data_shape(tensor_name+'shape-'+str(self._machine_id))
+                shape, data_type = self._read_data_shape_type(tensor_name+'shape-'+str(self._machine_id))
+                assert data_type == dtype
                 shared_data = empty_shared_mem(tensor_name, False, shape, dtype)
                 dlpack = shared_data.to_dlpack()
                 self._data_store[tensor_name] = F.zerocopy_from_dlpack(dlpack)
@@ -1124,7 +1149,7 @@ class KVClient(object):
         f.close()
 
 
-    def _read_data_shape(self, filename):
+    def _read_data_shape_type(self, filename):
         """Read data shape from a tmp file.
 
         Parameters
@@ -1142,13 +1167,13 @@ class KVClient(object):
         f = open(filename, "r")
         str_data = f.read()
         data_list = str_data.split('|')
+        data_type = data_list[0]
         data_shape = []
-        for i in range(len(data_list)-1):
+        for i in range(1, len(data_list)-1):
             data_shape.append(int(data_list[i]))
-
         f.close()
 
-        return data_shape
+        return data_shape, data_type
 
 
     def _takeId(self, elem):

--- a/python/dgl/contrib/dis_kvstore.py
+++ b/python/dgl/contrib/dis_kvstore.py
@@ -478,8 +478,7 @@ class KVServer(object):
                 assert msg.rank == 0
                 data_str, target_name = msg.name.split('|')
                 data_name, date_type = self._deserialize_shared_tensor(data_str)
-                dtype_dict = F.data_type_dict()
-                dtype = dtype_dict[data_type]
+                dtype = F.data_type_dict[data_type]
                 data_shape = F.asnumpy(msg.id).tolist()
                 if self._server_id % self._group_count == 0: # master server
                     data_tensor = F.zeros(data_shape, dtype, F.cpu())

--- a/python/dgl/contrib/dis_kvstore.py
+++ b/python/dgl/contrib/dis_kvstore.py
@@ -477,7 +477,7 @@ class KVServer(object):
             elif msg.type == KVMsgType.NEW_DATA:
                 assert msg.rank == 0
                 data_str, target_name = msg.name.split('|')
-                data_name, date_type = self._deserialize_shared_tensor(data_str)
+                data_name, data_type = self._deserialize_shared_tensor(data_str)
                 dtype = F.data_type_dict[data_type]
                 data_shape = F.asnumpy(msg.id).tolist()
                 if self._server_id % self._group_count == 0: # master server

--- a/python/dgl/contrib/dis_kvstore.py
+++ b/python/dgl/contrib/dis_kvstore.py
@@ -850,7 +850,7 @@ class KVClient(object):
                         name=data_str,
                         id=None,
                         data=None,
-                        shape=F.tensor(partitioned_shape)
+                        shape=F.tensor(partitioned_shape),
                         c_ptr=None)
                     _send_kv_msg(self._sender, msg, server_id)
             # recv confirmation message from server nodes

--- a/python/dgl/contrib/dis_kvstore.py
+++ b/python/dgl/contrib/dis_kvstore.py
@@ -478,7 +478,8 @@ class KVServer(object):
                 assert msg.rank == 0
                 data_str, target_name = msg.name.split('|')
                 data_name, date_type = self._deserialize_shared_tensor(data_str)
-                dtype = F.data_type_dict()[data_type]
+                dtype_dict = F.data_type_dict()
+                dtype = dtype_dict[data_type]
                 data_shape = F.asnumpy(msg.id).tolist()
                 if self._server_id % self._group_count == 0: # master server
                     data_tensor = F.zeros(data_shape, dtype, F.cpu())

--- a/python/dgl/network.py
+++ b/python/dgl/network.py
@@ -192,6 +192,7 @@ class KVMsgType(Enum):
     PULL_BACK = 5
     BARRIER = 6
     IP_ID = 7
+    NEW_DATA = 8
 
 
 KVStoreMsg = namedtuple("KVStoreMsg", "type rank name id data c_ptr")
@@ -225,7 +226,7 @@ def _send_kv_msg(sender, msg, recv_id):
     recv_id : int
         receiver's ID
     """
-    if msg.type == KVMsgType.PULL:
+    if msg.type == KVMsgType.PULL or msg_type == KVMsgType.NEW_DATA:
         tensor_id = F.zerocopy_to_dgl_ndarray(msg.id)
         _CAPI_SenderSendKVMsg(
             sender,

--- a/python/dgl/network.py
+++ b/python/dgl/network.py
@@ -276,7 +276,7 @@ def _recv_kv_msg(receiver):
     msg_ptr = CAPI_ReceiverRecvKVMsg(receiver)
     msg_type = KVMsgType(_CAPI_ReceiverGetKVMsgType(msg_ptr))
     rank = _CAPI_ReceiverGetKVMsgRank(msg_ptr)
-    if msg.type == KVMsgType.PULL or msg.type == KVMsgType.NEW_DATA:
+    if msg_type == KVMsgType.PULL or msg_type == KVMsgType.NEW_DATA:
         name = _CAPI_ReceiverGetKVMsgName(msg_ptr)
         tensor_id = F.zerocopy_from_dgl_ndarray(_CAPI_ReceiverGetKVMsgID(msg_ptr))
         msg = KVStoreMsg(

--- a/python/dgl/network.py
+++ b/python/dgl/network.py
@@ -226,7 +226,7 @@ def _send_kv_msg(sender, msg, recv_id):
     recv_id : int
         receiver's ID
     """
-    if msg.type == KVMsgType.PULL or msg.type == KVMsgType.NEW_DATA:
+    if msg.type in (KVMsgType.PULL, KVMsgType.NEW_DATA):
         tensor_id = F.zerocopy_to_dgl_ndarray(msg.id)
         _CAPI_SenderSendKVMsg(
             sender,
@@ -276,7 +276,7 @@ def _recv_kv_msg(receiver):
     msg_ptr = CAPI_ReceiverRecvKVMsg(receiver)
     msg_type = KVMsgType(_CAPI_ReceiverGetKVMsgType(msg_ptr))
     rank = _CAPI_ReceiverGetKVMsgRank(msg_ptr)
-    if msg_type == KVMsgType.PULL or msg_type == KVMsgType.NEW_DATA:
+    if msg_type in (KVMsgType.PULL, KVMsgType.NEW_DATA):
         name = _CAPI_ReceiverGetKVMsgName(msg_ptr)
         tensor_id = F.zerocopy_from_dgl_ndarray(_CAPI_ReceiverGetKVMsgID(msg_ptr))
         msg = KVStoreMsg(

--- a/python/dgl/network.py
+++ b/python/dgl/network.py
@@ -226,7 +226,7 @@ def _send_kv_msg(sender, msg, recv_id):
     recv_id : int
         receiver's ID
     """
-    if msg.type == KVMsgType.PULL or msg_type == KVMsgType.NEW_DATA:
+    if msg.type == KVMsgType.PULL or msg.type == KVMsgType.NEW_DATA:
         tensor_id = F.zerocopy_to_dgl_ndarray(msg.id)
         _CAPI_SenderSendKVMsg(
             sender,
@@ -276,7 +276,7 @@ def _recv_kv_msg(receiver):
     msg_ptr = CAPI_ReceiverRecvKVMsg(receiver)
     msg_type = KVMsgType(_CAPI_ReceiverGetKVMsgType(msg_ptr))
     rank = _CAPI_ReceiverGetKVMsgRank(msg_ptr)
-    if msg_type == KVMsgType.PULL:
+    if msg.type == KVMsgType.PULL or msg.type == KVMsgType.NEW_DATA:
         name = _CAPI_ReceiverGetKVMsgName(msg_ptr)
         tensor_id = F.zerocopy_from_dgl_ndarray(_CAPI_ReceiverGetKVMsgID(msg_ptr))
         msg = KVStoreMsg(

--- a/src/graph/network.cc
+++ b/src/graph/network.cc
@@ -492,9 +492,9 @@ static void send_kv_message(network::Sender* sender,
         kv_msg->msg_type != kInitMsg) {
       meta.AddArray(kv_msg->data);
     }
-    if (kv_msg.msg_type != kPullMsg &&
-        kv_msg.msg_type != kPushMsg &&
-        kv_msg.msg_type != kPullBackMsg) {
+    if (kv_msg->msg_type != kPullMsg &&
+        kv_msg->msg_type != kPushMsg &&
+        kv_msg->msg_type != kPullBackMsg) {
       meta.AddArray(kv_msg->shape);
     }
     int64_t meta_size = 0;
@@ -530,9 +530,9 @@ static void send_kv_message(network::Sender* sender,
       CHECK_EQ(sender->Send(send_data_msg, recv_id), ADD_SUCCESS);
     }
     // Send shape NDArray
-    if (kv_msg.msg_type != kPullMsg &&
-        kv_msg.msg_type != kPushMsg &&
-        kv_msg.msg_type != kPullBackMsg) {
+    if (kv_msg->msg_type != kPullMsg &&
+        kv_msg->msg_type != kPushMsg &&
+        kv_msg->msg_type != kPullBackMsg) {
       Message send_shape_msg;
       send_shape_msg.data = static_cast<char*>(kv_msg->shape->data);
       send_shape_msg.size = kv_msg->shape.GetSize();
@@ -594,9 +594,9 @@ static KVStoreMsg* recv_kv_message(network::Receiver* receiver) {
       AUTO_FREE);
   }
   // Recv Shape 
-  if (kv_msg.msg_type != kPullMsg &&
-      kv_msg.msg_type != kPushMsg &&
-      kv_msg.msg_type != kPullBackMsg) {
+  if (kv_msg->msg_type != kPullMsg &&
+      kv_msg->msg_type != kPushMsg &&
+      kv_msg->msg_type != kPullBackMsg) {
     Message recv_shape_msg;
     CHECK_EQ(receiver->RecvFrom(&recv_shape_msg, send_id), REMOVE_SUCCESS);
     int64_t ndim = meta.data_shape_[0];

--- a/src/graph/network.cc
+++ b/src/graph/network.cc
@@ -593,7 +593,7 @@ static KVStoreMsg* recv_kv_message(network::Receiver* receiver) {
       recv_data_msg.data,
       AUTO_FREE);
   }
-  // Recv Shape 
+  // Recv Shape
   if (kv_msg->msg_type != kPullMsg &&
       kv_msg->msg_type != kPushMsg &&
       kv_msg->msg_type != kPullBackMsg) {

--- a/src/graph/network.cc
+++ b/src/graph/network.cc
@@ -581,8 +581,8 @@ DGL_REGISTER_GLOBAL("network._CAPI_SenderSendKVMsg")
       if (kv_msg.msg_type != kIPIDMsg) {
         kv_msg.id = args[args_count++];
       }
-      if (kv_msg.msg_type != kPullMsg && 
-          kv_msg.msg_type != kIPIDMsg && 
+      if (kv_msg.msg_type != kPullMsg &&
+          kv_msg.msg_type != kIPIDMsg &&
           kv_msg.msg_type != kNewDataMsg) {
         kv_msg.data = args[args_count++];
       }

--- a/src/graph/network.cc
+++ b/src/graph/network.cc
@@ -486,7 +486,7 @@ static void send_kv_message(network::Sender* sender,
     // Send ArrayMeta
     ArrayMeta meta(kv_msg->msg_type);
     meta.AddArray(kv_msg->id);
-    if (kv_msg->msg_type != kPullMsg) {
+    if (kv_msg->msg_type != kPullMsg && kv_msg->msg_type != kNewDataMsg) {
       meta.AddArray(kv_msg->data);
     }
     int64_t meta_size = 0;
@@ -506,7 +506,7 @@ static void send_kv_message(network::Sender* sender,
     send_id_msg.deallocator = [id](Message*) {};
     CHECK_EQ(sender->Send(send_id_msg, recv_id), ADD_SUCCESS);
     // Send data NDArray
-    if (kv_msg->msg_type != kPullMsg) {
+    if (kv_msg->msg_type != kPullMsg && kv_msg->msg_type != kNewDataMsg) {
       Message send_data_msg;
       send_data_msg.data = static_cast<char*>(kv_msg->data->data);
       send_data_msg.size = kv_msg->data.GetSize();
@@ -548,7 +548,7 @@ static KVStoreMsg* recv_kv_message(network::Receiver* receiver) {
     recv_id_msg.data,
     AUTO_FREE);
   // Recv Data NDArray
-  if (kv_msg->msg_type != kPullMsg) {
+  if (kv_msg->msg_type != kPullMsg && kv_msg->msg_type != kNewDataMsg) {
     Message recv_data_msg;
     CHECK_EQ(receiver->RecvFrom(&recv_data_msg, send_id), REMOVE_SUCCESS);
     CHECK_GE(meta.data_shape_[2], 1);
@@ -581,7 +581,9 @@ DGL_REGISTER_GLOBAL("network._CAPI_SenderSendKVMsg")
       if (kv_msg.msg_type != kIPIDMsg) {
         kv_msg.id = args[args_count++];
       }
-      if (kv_msg.msg_type != kPullMsg && kv_msg.msg_type != kIPIDMsg) {
+      if (kv_msg.msg_type != kPullMsg && 
+          kv_msg.msg_type != kIPIDMsg && 
+          kv_msg.msg_type != kNewDataMsg) {
         kv_msg.data = args[args_count++];
       }
     }

--- a/src/graph/network.cc
+++ b/src/graph/network.cc
@@ -607,7 +607,7 @@ static KVStoreMsg* recv_kv_message(network::Receiver* receiver) {
     }
     kv_msg->shape = CreateNDArrayFromRaw(
       vec_shape,
-      DLDataType{kDLFloat, 32, 1},
+      DLDataType{kDLInt, 64, 1},
       DLContext{kDLCPU, 0},
       recv_shape_msg.data,
       AUTO_FREE);

--- a/src/graph/network.cc
+++ b/src/graph/network.cc
@@ -609,8 +609,8 @@ static KVStoreMsg* recv_kv_message(network::Receiver* receiver) {
       vec_shape,
       DLDataType{kDLFloat, 32, 1},
       DLContext{kDLCPU, 0},
-      recv_data_msg.data,
-      AUTO_FREE);  
+      recv_shape_msg.data,
+      AUTO_FREE);
   }
   return kv_msg;
 }

--- a/src/graph/network.h
+++ b/src/graph/network.h
@@ -64,11 +64,7 @@ enum MessageType {
   /*!
    * \brief IP and ID msg for KVStore
    */  
-  kIPIDMsg = 7,
-  /*!
-   * \brief New data msg for KVStore
-   */  
-  kNewDataMsg = 8
+  kIPIDMsg = 7
 };
 
 /*!
@@ -198,6 +194,10 @@ class KVStoreMsg {
   * \brief data matrix
   */
   NDArray data;
+  /*!
+  * \brief data shape
+  */
+  NDArray shape;
 };
 
 }  // namespace network

--- a/src/graph/network.h
+++ b/src/graph/network.h
@@ -64,7 +64,11 @@ enum MessageType {
   /*!
    * \brief IP and ID msg for KVStore
    */  
-  kIPIDMsg = 7
+  kIPIDMsg = 7,
+  /*!
+   * \brief New data msg for KVStore
+   */  
+  kNewDataMsg = 8
 };
 
 /*!

--- a/tests/compute/test_kvstore.py
+++ b/tests/compute/test_kvstore.py
@@ -40,7 +40,7 @@ def start_client():
     my_client = KVClient(server_namebook=server_namebook)
     my_client.connect()
 
-    y_client.init_data(name='data_2', shape=[num_entries, dim_size], dtype=F.float32, target_name='data_0')
+    my_client.init_data(name='data_2', shape=[num_entries, dim_size], dtype=F.float32, target_name='data_0')
 
     name_list = my_client.get_data_name_list()
     assert len(name_list) == 3

--- a/tests/compute/test_kvstore.py
+++ b/tests/compute/test_kvstore.py
@@ -40,10 +40,13 @@ def start_client():
     my_client = KVClient(server_namebook=server_namebook)
     my_client.connect()
 
+    y_client.init_data(name='data_2', shape=[num_entries, dim_size], dtype=F.float32, target_name='data_0')
+
     name_list = my_client.get_data_name_list()
-    assert len(name_list) == 2
+    assert len(name_list) == 3
     assert 'data_0' in name_list
     assert 'data_1' in name_list
+    assert 'data_2' in name_list
 
     meta_0 = my_client.get_data_meta('data_0')
     assert meta_0[0] == F.float32
@@ -53,12 +56,19 @@ def start_client():
     assert meta_1[0] == F.float32
     assert_array_equal(meta_1[2], partition_1)
 
-    my_client.push(name='data_0', id_tensor=F.tensor([0, 1, 2]), data_tensor=F.tensor([[1.,1.,1.],[2.,2.,2.],[3.,3.,3.]]))
+    meta_2 = my_client.get_data_meta('data_2')
+    assert meta_2[0] == F.float32
+    assert_array_equal(meta_2[2], partition_0)
 
-    res = my_client.pull(name='data_0', id_tensor=F.tensor([0, 1, 2]))
+    my_client.push(name='data_0', id_tensor=F.tensor([0, 1, 2]), data_tensor=F.tensor([[1.,1.,1.],[2.,2.,2.],[3.,3.,3.]]))
+    my_client.push(name='data_2', id_tensor=F.tensor([0, 1, 2]), data_tensor=F.tensor([[1.,1.,1.],[2.,2.,2.],[3.,3.,3.]]))
 
     target = F.tensor([[1.,1.,1.],[2.,2.,2.],[3.,3.,3.]])
 
+    res = my_client.pull(name='data_0', id_tensor=F.tensor([0, 1, 2]))
+    assert_array_equal(res, target)
+
+    res = my_client.pull(name='data_2', id_tensor=F.tensor([0, 1, 2]))
     assert_array_equal(res, target)
 
     my_client.shut_down()


### PR DESCRIPTION
## Description

Server side:

```
    my_server = KVServer(server_id=0, server_namebook=server_namebook, num_client=1)
    my_server.set_global2local(name='data_0', global2local=g2l_0)
    my_server.set_global2local(name='data_1', global2local=g2l_1)
    my_server.set_partition_book(name='data_0', partition_book=partition_0)
    my_server.set_partition_book(name='data_1', partition_book=partition_1)
    my_server.init_data(name='data_0', data_tensor=data_0)
    my_server.init_data(name='data_1', data_tensor=data_1)

    my_server.start()
```

client side:

```
    my_client = KVClient(server_namebook=server_namebook)
    my_client.connect()
    # data_2 has the same partition_book and g2l with data_0 by setting target_name = 'data_0'
    my_client.init_data(name='data_2', shape=my_shape, dtype=F.float32, target_name='data_0')
```

Then the client can access `data_0`, `data_1`, and `data_2` . Note that,` my_client.init_data()` should be invoked by all the clients, and all the clients will be blocked until the server and client finish initialization. Then, the client can get their own data partition.

For now, all the new data will be initialized to zeros.

## Checklist
Please feel free to remove inapplicable items for your PR.
- [ ] The PR title starts with [$CATEGORY] (such as [NN], [Model], [Doc], [Feature]])
- [ ] Changes are complete (i.e. I finished coding on this PR)
- [ ] All changes have test coverage
- [ ] Code is well-documented
- [ ] To the my best knowledge, examples are either not affected by this change,
      or have been fixed to be compatible with this change
- [ ] Related issue is referred in this PR

## Changes
<!-- You could use following template
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)
-->
