### PR TITLE
[Performance] fixing performance on heterogeneous graph creation in specific cases

### DIFF
--- a/python/dgl/convert.py
+++ b/python/dgl/convert.py
@@ -448,19 +448,19 @@ def heterograph(data_dict, num_nodes_dict=None, index_dtype='int64'):
         num_nodes_dict = defaultdict(int)
         for (srctype, etype, dsttype), data in data_dict.items():
             if isinstance(data, tuple):
-                src = utils.toindex(data[0]).tousertensor()
-                dst = utils.toindex(data[1]).tousertensor()
-                nsrc = (F.max(src, 0) + 1) if len(src) > 0 else 0
-                ndst = (F.max(dst, 0) + 1) if len(dst) > 0 else 0
+                src = utils.toindex(data[0]).tonumpy()
+                dst = utils.toindex(data[1]).tonumpy()
+                nsrc = (src.max() + 1) if len(src) > 0 else 0
+                ndst = (dst.max() + 1) if len(dst) > 0 else 0
             elif isinstance(data, list):
                 if len(data) == 0:
                     nsrc = ndst = 0
                 else:
                     src, dst = zip(*data)
-                    src = utils.toindex(src).tousertensor()
-                    dst = utils.toindex(dst).tousertensor()
-                    nsrc = F.max(src, 0) + 1
-                    ndst = F.max(dst, 0) + 1
+                    src = utils.toindex(src).tonumpy()
+                    dst = utils.toindex(dst).tonumpy()
+                    nsrc = src.max() + 1
+                    ndst = dst.max() + 1
             elif isinstance(data, sp.sparse.spmatrix):
                 nsrc = data.shape[0]
                 ndst = data.shape[1]

--- a/python/dgl/convert.py
+++ b/python/dgl/convert.py
@@ -448,15 +448,19 @@ def heterograph(data_dict, num_nodes_dict=None, index_dtype='int64'):
         num_nodes_dict = defaultdict(int)
         for (srctype, etype, dsttype), data in data_dict.items():
             if isinstance(data, tuple):
-                nsrc = (max(data[0]) + 1) if len(data[0]) > 0 else 0
-                ndst = (max(data[1]) + 1) if len(data[1]) > 0 else 0
+                src = utils.toindex(data[0]).tousertensor()
+                dst = utils.toindex(data[1]).tousertensor()
+                nsrc = (F.max(src, 0) + 1) if len(src) > 0 else 0
+                ndst = (F.max(dst, 0) + 1) if len(dst) > 0 else 0
             elif isinstance(data, list):
                 if len(data) == 0:
                     nsrc = ndst = 0
                 else:
                     src, dst = zip(*data)
-                    nsrc = max(src) + 1
-                    ndst = max(dst) + 1
+                    src = utils.toindex(src).tousertensor()
+                    dst = utils.toindex(dst).tousertensor()
+                    nsrc = F.max(src, 0) + 1
+                    ndst = F.max(dst, 0) + 1
             elif isinstance(data, sp.sparse.spmatrix):
                 nsrc = data.shape[0]
                 ndst = data.shape[1]


### PR DESCRIPTION
In `dgl.heterograph()`, inferring number of nodes for each types uses Python's builtin `max()` function which operates very slowly on tensors.  This fix uses `utils.toindex()` instead.