### PR TITLE
[RPC] Zero copy serializer

### DIFF
--- a/include/dgl/runtime/ndarray.h
+++ b/include/dgl/runtime/ndarray.h
@@ -271,8 +271,8 @@ inline bool SaveDLTensor(dmlc::Stream* strm, const DLTensor* tensor);
 #ifndef _WIN32
 NDArray ZeroCopyLoadDLTensor(ZeroCopyStream* zc_strm);
 void ZeroCopySaveDLTensor(ZeroCopyStream* zc_strm, DLTensor* tensor,
-                                 std::shared_ptr<SharedMemory> mem);
-#endif // _WIN32
+                          std::shared_ptr<SharedMemory> mem);
+#endif  // _WIN32
 
 /*!
  * \brief Reference counted Container object used to back NDArray.

--- a/include/dgl/runtime/ndarray.h
+++ b/include/dgl/runtime/ndarray.h
@@ -270,8 +270,6 @@ inline bool SaveDLTensor(dmlc::Stream* strm, const DLTensor* tensor);
 NDArray ZeroCopyLoadDLTensor(ZeroCopyStream* zc_strm);
 void ZeroCopySaveDLTensor(ZeroCopyStream* zc_strm, DLTensor* tensor,
                                  std::shared_ptr<SharedMemory> mem);
-NDArray CreateNDArrayFromRawData(std::vector<int64_t> shape, DLDataType dtype,
-                                 DLContext ctx, void* raw);
 
 /*!
  * \brief Reference counted Container object used to back NDArray.

--- a/include/dgl/runtime/ndarray.h
+++ b/include/dgl/runtime/ndarray.h
@@ -465,6 +465,7 @@ inline bool SaveDLTensor(dmlc::Stream* strm,
 
 inline void NDArray::Save(dmlc::Stream* strm) const {
   auto zc_strm = dynamic_cast<ZeroCopyStream*>(strm);
+  // Use ZeroCopySaveDLTensor when stream is a ZeroCopyStream
   if (zc_strm) {
     ZeroCopySaveDLTensor(zc_strm, const_cast<DLTensor*>(operator->()), this->data_->mem);
     return;
@@ -474,6 +475,7 @@ inline void NDArray::Save(dmlc::Stream* strm) const {
 
 inline bool NDArray::Load(dmlc::Stream* strm) {
   auto zc_strm = dynamic_cast<ZeroCopyStream*>(strm);
+  // Use ZeroCopyLoadDLTensor when stream is a ZeroCopyStream
   if (zc_strm) {
     *this = ZeroCopyLoadDLTensor(zc_strm);
     return true;

--- a/include/dgl/runtime/ndarray.h
+++ b/include/dgl/runtime/ndarray.h
@@ -241,7 +241,6 @@ class NDArray {
   std::vector<T> ToVector() const;
 
 #ifndef _WIN32
-  // static std::shared_ptr<SharedMemory> GetSharedMem(const NDArray& tensor);
   std::shared_ptr<SharedMemory> GetSharedMem() const;
 #endif  // _WIN32
 

--- a/include/dgl/runtime/serializer.h
+++ b/include/dgl/runtime/serializer.h
@@ -11,7 +11,6 @@
 #include <dmlc/serializer.h>
 #include "c_runtime_api.h"
 #include "smart_ptr_serializer.h"
-#include "ndarray.h"
 
 namespace dmlc {
 namespace serializer {

--- a/include/dgl/runtime/shared_mem.h
+++ b/include/dgl/runtime/shared_mem.h
@@ -27,13 +27,7 @@ class SharedMemory {
    * and will be responsible for deleting it when the object is destroyed.
    */
   bool own;
-  /*
-   * \brief the name of the object.
-   *
-   * In Unix, shared memory is identified by a file. Thus, `name` is actually
-   * the file name that identifies the shared memory.
-   */
-  std::string name;
+
   /* \brief the file descripter of the shared memory. */
   int fd;
   /* \brief the address of the shared memory. */
@@ -41,7 +35,15 @@ class SharedMemory {
   /* \brief the size of the shared memory. */
   size_t size;
 
- public:
+ public: 
+  /*
+   * \brief the name of the object.
+   *
+   * In Unix, shared memory is identified by a file. Thus, `name` is actually
+   * the file name that identifies the shared memory.
+   */
+  std::string name;
+
   /*
    * \brief constructor of the shared memory.
    * \param name The file corresponding to the shared memory.

--- a/include/dgl/runtime/shared_mem.h
+++ b/include/dgl/runtime/shared_mem.h
@@ -35,7 +35,6 @@ class SharedMemory {
   /* \brief the size of the shared memory. */
   size_t size;
 
- public:
   /*
    * \brief the name of the object.
    *
@@ -43,6 +42,11 @@ class SharedMemory {
    * the file name that identifies the shared memory.
    */
   std::string name;
+
+ public:
+  /* \brief Get the filename of shared memory file
+   */
+  std::string GetName() const { return name; }
 
   /*
    * \brief constructor of the shared memory.

--- a/include/dgl/runtime/shared_mem.h
+++ b/include/dgl/runtime/shared_mem.h
@@ -35,7 +35,7 @@ class SharedMemory {
   /* \brief the size of the shared memory. */
   size_t size;
 
- public: 
+ public:
   /*
    * \brief the name of the object.
    *

--- a/include/dgl/zerocopy_serializer.h
+++ b/include/dgl/zerocopy_serializer.h
@@ -22,8 +22,13 @@
 
 namespace dgl {
 
-// StringStreamWithBuffer is backed up by a string. It stores the data pointer
-// seperately instead of directly write in to the stream.
+// StringStreamWithBuffer is backed up by a string. This class supports
+// serializing and deserializing NDArrays stored in shared memory. If the stream
+// is created for sending/recving data through network, the data pointer of the
+// NDArray will be transmitted directly without and copy. Otherwise, the stream
+// is for sending/recving data to another process on the same machine, so if an
+// NDArray is stored in shared memory, it will just record the shared memory
+// name instead of the actual data buffer.
 class StringStreamWithBuffer : public dmlc::MemoryStringStream {
  public:
   // Buffer type. Storing NDArray to maintain the reference counting to ensure

--- a/include/dgl/zerocopy_serializer.h
+++ b/include/dgl/zerocopy_serializer.h
@@ -1,0 +1,58 @@
+/*!
+ *  Copyright (c) 2020 by Contributors
+ * \file rpc/shared_mem_serializer.h
+ * \brief headers for serializer.
+ */
+#ifndef DGL_RPC_SHARED_MEM_SERIALIZER_H_
+#define DGL_RPC_SHARED_MEM_SERIALIZER_H_
+
+// #include <dgl/runtime/ndarray.h>
+#include <dmlc/io.h>
+#include <dmlc/memory_io.h>
+#include <dmlc/serializer.h>
+
+#include <queue>
+#include <string>
+#include <tuple>
+#include <vector>
+
+// #include <dgl/array.h>
+
+namespace dgl {
+
+typedef std::pair<void*, int64_t> Ptr_pair;
+
+using dmlc::MemoryStringStream;
+
+class ZeroCopyStream : public MemoryStringStream {
+ public:
+  //   explicit ZeroCopyStream(std::string* metadata_ptr)
+  //       : MemoryStringStream(metadata_ptr) {}
+
+  explicit ZeroCopyStream(std::string* metadata_ptr,
+                          std::vector<Ptr_pair>* ptr_list, bool is_local = true)
+      : MemoryStringStream(metadata_ptr),
+        is_local(is_local),
+        _ptr_list(ptr_list),
+        idx(0) {}
+
+  void push_buffer(void* data, int64_t data_byte_size) {
+    _ptr_list->emplace_back(data, data_byte_size);
+  }
+
+  Ptr_pair pop_buffer() {
+    auto ret = _ptr_list->at(idx);
+    idx++;
+    return ret;
+  }
+
+  bool is_local;
+
+ private:
+  std::vector<Ptr_pair>* _ptr_list;
+  int64_t idx;
+};
+
+}  // namespace dgl
+
+#endif  // DGL_RPC_SHARED_MEM_SERIALIZER_H_

--- a/include/dgl/zerocopy_serializer.h
+++ b/include/dgl/zerocopy_serializer.h
@@ -14,8 +14,8 @@
 #include <queue>
 #include <string>
 #include <tuple>
-#include <vector>
 #include <utility>
+#include <vector>
 
 // #include <dgl/array.h>
 
@@ -25,19 +25,20 @@ typedef std::pair<void*, int64_t> Ptr_pair;
 
 using dmlc::MemoryStringStream;
 
-
 class ZeroCopyStream : public MemoryStringStream {
  public:
- 
   /*!
-   * \brief constructor of the ZeroCopyStream. ZeroCopyStream is backed up by a string.
-   * It stores the data pointer seperately instead of directly write in to the stream.
+   * \brief constructor of the ZeroCopyStream. ZeroCopyStream is backed up by a
+   * string. It stores the data pointer seperately instead of directly write in
+   * to the stream.
    * \param metadata_ptr The string to write/load from
-   * \param ptr_list Store the zerocopy pointer information for zerocopy write/load
-   * \param is_local Means whether the write/load operation is for the same-machine operation.
-   *  For write scenario, if it's true, the write process will raise error
-   *  if the NDArray is not in shared memory. For load scenario, if it's true, the NDArray will
-   *  load from shared memory. If it's false, the NDArray will load from the pointer in ptr_list.
+   * \param ptr_list Store the zerocopy pointer information for zerocopy
+   * write/load
+   * \param is_local Means whether the write/load operation is for
+   * the same-machine operation. For write scenario, if it's true, the write
+   * process will raise error if the NDArray is not in shared memory. For load
+   * scenario, if it's true, the NDArray will load from shared memory. If it's
+   * false, the NDArray will load from the pointer in ptr_list.
    */
   explicit ZeroCopyStream(std::string* metadata_ptr,
                           std::vector<Ptr_pair>* ptr_list, bool is_local = true)
@@ -52,7 +53,6 @@ class ZeroCopyStream : public MemoryStringStream {
     _ptr_list->emplace_back(data, data_byte_size);
   }
 
-  
   /*!
    * \brief get pointer in to the ptr_list
    */

--- a/include/dgl/zerocopy_serializer.h
+++ b/include/dgl/zerocopy_serializer.h
@@ -3,8 +3,8 @@
  * \file rpc/shared_mem_serializer.h
  * \brief headers for serializer.
  */
-#ifndef DGL_RPC_SHARED_MEM_SERIALIZER_H_
-#define DGL_RPC_SHARED_MEM_SERIALIZER_H_
+#ifndef DGL_ZEROCOPY_SERIALIZER_H_
+#define DGL_ZEROCOPY_SERIALIZER_H_
 
 // #include <dgl/runtime/ndarray.h>
 #include <dmlc/io.h>
@@ -15,6 +15,7 @@
 #include <string>
 #include <tuple>
 #include <vector>
+#include <utility>
 
 // #include <dgl/array.h>
 
@@ -55,4 +56,4 @@ class ZeroCopyStream : public MemoryStringStream {
 
 }  // namespace dgl
 
-#endif  // DGL_RPC_SHARED_MEM_SERIALIZER_H_
+#endif  // DGL_ZEROCOPY_SERIALIZER_H_

--- a/include/dgl/zerocopy_serializer.h
+++ b/include/dgl/zerocopy_serializer.h
@@ -25,22 +25,37 @@ typedef std::pair<void*, int64_t> Ptr_pair;
 
 using dmlc::MemoryStringStream;
 
+
 class ZeroCopyStream : public MemoryStringStream {
  public:
-  //   explicit ZeroCopyStream(std::string* metadata_ptr)
-  //       : MemoryStringStream(metadata_ptr) {}
-
+ 
+  /*!
+   * \brief constructor of the ZeroCopyStream. ZeroCopyStream is backed up by a string.
+   * It stores the data pointer seperately instead of directly write in to the stream.
+   * \param metadata_ptr The string to write/load from
+   * \param ptr_list Store the zerocopy pointer information for zerocopy write/load
+   * \param is_local Means whether the write/load operation is for the same-machine operation.
+   *  For write scenario, if it's true, the write process will raise error
+   *  if the NDArray is not in shared memory. For load scenario, if it's true, the NDArray will
+   *  load from shared memory. If it's false, the NDArray will load from the pointer in ptr_list.
+   */
   explicit ZeroCopyStream(std::string* metadata_ptr,
                           std::vector<Ptr_pair>* ptr_list, bool is_local = true)
       : MemoryStringStream(metadata_ptr),
         is_local(is_local),
         _ptr_list(ptr_list),
         idx(0) {}
-
+  /*!
+   * \brief push pointer in to the ptr_list
+   */
   void push_buffer(void* data, int64_t data_byte_size) {
     _ptr_list->emplace_back(data, data_byte_size);
   }
 
+  
+  /*!
+   * \brief get pointer in to the ptr_list
+   */
   Ptr_pair pop_buffer() {
     auto ret = _ptr_list->at(idx);
     idx++;

--- a/python/dgl/distributed/client.py
+++ b/python/dgl/distributed/client.py
@@ -1,3 +1,5 @@
+# pylint: skip-file
+
 """Functions used by client."""
 
 def connect_to_server(server_namebook):

--- a/python/dgl/distributed/rpc.py
+++ b/python/dgl/distributed/rpc.py
@@ -1,3 +1,5 @@
+# pylint: skip-file
+
 """RPC components. They are typically functions or utilities used by both
 server and clients."""
 import abc

--- a/python/dgl/distributed/server.py
+++ b/python/dgl/distributed/server.py
@@ -1,3 +1,5 @@
+# pylint: skip-file
+
 """Functions used by server."""
 
 def start_server(clients):

--- a/python/dgl/distributed/server_state.py
+++ b/python/dgl/distributed/server_state.py
@@ -1,3 +1,5 @@
+# pylint: skip-file
+
 """Server data"""
 
 from .._ffi.object import register_object, ObjectBase

--- a/src/graph/serialize/zerocopy_serializer.cc
+++ b/src/graph/serialize/zerocopy_serializer.cc
@@ -79,8 +79,8 @@ void StringStreamWithBuffer::PushNDArray(const NDArray& tensor) {
   }
 #else
   LOG(FATAL) << "StringStreamWithBuffer is not supported on windows";
-  return nullptr;
 #endif  // _WIN32
+  return;
 }
 
 NDArray StringStreamWithBuffer::PopNDArray() {
@@ -119,7 +119,7 @@ NDArray StringStreamWithBuffer::PopNDArray() {
   }
 #else
   LOG(FATAL) << "StringStreamWithBuffer is not supported on windows";
-  return nullptr;
+  return NDArray();
 #endif  // _WIN32
 }
 

--- a/src/graph/serialize/zerocopy_serializer.cc
+++ b/src/graph/serialize/zerocopy_serializer.cc
@@ -1,0 +1,115 @@
+/*!
+ *  Copyright (c) 2020 by Contributors
+ * \file graph/serailize/zerocopy_serializer.cc
+ * \brief serializer implementation.
+ */
+
+#include <dgl/zerocopy_serializer.h>
+#include "dgl/runtime/ndarray.h"
+
+namespace dgl {
+
+using dgl::runtime::NDArray;
+
+struct RawDataTensorCtx {
+  std::vector<int64_t> shape;
+  std::vector<int64_t> stride;
+  DLManagedTensor tensor;
+};
+
+void RawDataTensoDLPackDeleter(DLManagedTensor* tensor) {
+  auto ctx = static_cast<RawDataTensorCtx*>(tensor->manager_ctx);
+  free(ctx->tensor.dl_tensor.data);
+  delete ctx;
+}
+
+NDArray CreateNDArrayFromRawData(std::vector<int64_t> shape, DLDataType dtype,
+                                 DLContext ctx, void* raw) {
+  auto dlm_tensor_ctx = new RawDataTensorCtx();
+  DLManagedTensor* dlm_tensor = &dlm_tensor_ctx->tensor;
+  dlm_tensor_ctx->shape = shape;
+  dlm_tensor->manager_ctx = dlm_tensor_ctx;
+  dlm_tensor->dl_tensor.shape = dmlc::BeginPtr(dlm_tensor_ctx->shape);
+  dlm_tensor->dl_tensor.ctx = ctx;
+  dlm_tensor->dl_tensor.ndim = static_cast<int>(shape.size());
+  dlm_tensor->dl_tensor.dtype = dtype;
+
+  dlm_tensor_ctx->stride.resize(dlm_tensor->dl_tensor.ndim, 1);
+  for (int i = dlm_tensor->dl_tensor.ndim - 2; i >= 0; --i) {
+    dlm_tensor_ctx->stride[i] =
+      dlm_tensor_ctx->shape[i + 1] * dlm_tensor_ctx->stride[i + 1];
+  }
+  dlm_tensor->dl_tensor.strides = dmlc::BeginPtr(dlm_tensor_ctx->stride);
+  dlm_tensor->dl_tensor.data = raw;
+  dlm_tensor->deleter = RawDataTensoDLPackDeleter;
+  return NDArray::FromDLPack(dlm_tensor);
+}
+
+void StringStreamWithBuffer::push_NDArray(const NDArray& tensor) {
+#ifndef _WIN32
+  auto strm = static_cast<dmlc::Stream*>(this);
+  strm->Write(tensor->ndim);
+  strm->Write(tensor->dtype);
+  int ndim = tensor->ndim;
+  strm->WriteArray(tensor->shape, ndim);
+  int type_bytes = tensor->dtype.bits / 8;
+  int64_t num_elems = 1;
+  for (int i = 0; i < ndim; ++i) {
+    num_elems *= tensor->shape[i];
+  }
+  int64_t data_byte_size = type_bytes * num_elems;
+
+  auto mem = tensor.GetSharedMem();
+  if (send_to_remote_ || !mem) {
+    // If the stream is for remote communication or the data is not stored in
+    // shared memory, serialize the data content as a buffer.
+    strm->Write<bool>(false);
+    buffer_list_.emplace_back(tensor, tensor->data, data_byte_size);
+  } else {
+    CHECK(mem) << "Tried to send non-shared-memroy tensor to local "
+                  "StringStreamWithBuffer";
+    // Serialize only the shared memory name.
+    strm->Write<bool>(true);
+    strm->Write(mem->GetName());
+  }
+#else
+  LOG(FATAL) << "StringStreamWithBuffer is not supported on windows";
+#endif  // _WIN32
+}
+
+NDArray StringStreamWithBuffer::pop_NDArray() {
+#ifndef _WIN32
+  auto strm = static_cast<dmlc::Stream*>(this);
+  int ndim;
+  DLDataType dtype;
+
+  CHECK(strm->Read(&ndim)) << "Invalid DLTensor file format";
+  CHECK(strm->Read(&dtype)) << "Invalid DLTensor file format";
+
+  std::vector<int64_t> shape(ndim);
+  if (ndim != 0) {
+    CHECK(strm->ReadArray(&shape[0], ndim)) << "Invalid DLTensor file format";
+  }
+
+  DLContext cpu_ctx;
+  cpu_ctx.device_type = kDLCPU;
+  cpu_ctx.device_id = 0;
+
+  bool is_shared_mem;
+  CHECK(strm->Read(&is_shared_mem)) << "Invalid stream read";
+  std::string sharedmem_name;
+  if (!send_to_remote_ && is_shared_mem) {
+    CHECK(strm->Read(&sharedmem_name)) << "Invalid stream read";
+    return NDArray::EmptyShared(sharedmem_name, shape, dtype, cpu_ctx, false);
+  } else {
+    auto ret = CreateNDArrayFromRawData(shape, dtype, cpu_ctx,
+                                        buffer_list_.front().data);
+    buffer_list_.pop_front();
+    return ret;
+  }
+#else
+  LOG(FATAL) << "StringStreamWithBuffer is not supported on windows";
+#endif  // _WIN32
+}
+
+}  // namespace dgl

--- a/src/graph/serialize/zerocopy_serializer.cc
+++ b/src/graph/serialize/zerocopy_serializer.cc
@@ -79,7 +79,7 @@ void StringStreamWithBuffer::PushNDArray(const NDArray& tensor) {
   }
 #else
   LOG(FATAL) << "StringStreamWithBuffer is not supported on windows";
-  return;
+  return nullptr;
 #endif  // _WIN32
 }
 
@@ -119,7 +119,7 @@ NDArray StringStreamWithBuffer::PopNDArray() {
   }
 #else
   LOG(FATAL) << "StringStreamWithBuffer is not supported on windows";
-  return;
+  return nullptr;
 #endif  // _WIN32
 }
 

--- a/src/rpc/rpc.cc
+++ b/src/rpc/rpc.cc
@@ -15,12 +15,12 @@ namespace dgl {
 namespace rpc {
 
 RPCStatus SendRPCMessage(const RPCMessage& msg) {
-  // TODO
+  // TODO(???): Implement
   return kRPCSuccess;
 }
 
 RPCStatus RecvRPCMessage(RPCMessage* msg, int32_t timeout) {
-  // TODO
+  // TODO(???): Implement
   return kRPCSuccess;
 }
 

--- a/src/rpc/rpc.h
+++ b/src/rpc/rpc.h
@@ -11,6 +11,8 @@
 #include <dmlc/thread_local.h>
 #include <cstdint>
 #include <memory>
+#include <string>
+#include <vector>
 #include "./network/communicator.h"
 #include "./server_state.h"
 

--- a/src/runtime/ndarray.cc
+++ b/src/runtime/ndarray.cc
@@ -8,6 +8,7 @@
 #include <dgl/runtime/ndarray.h>
 #include <dgl/runtime/c_runtime_api.h>
 #include <dgl/runtime/device_api.h>
+#include <dgl/runtime/shared_mem.h>
 #include "runtime_base.h"
 
 // deleter for arrays used by DLPack exporter

--- a/src/runtime/ndarray.cc
+++ b/src/runtime/ndarray.cc
@@ -374,7 +374,7 @@ NDArray ZeroCopyLoadDLTensor(ZeroCopyStream* zc_strm) {
   }
 }
 
-#endif // _WIN32
+#endif  // _WIN32
 
 }  // namespace runtime
 }  // namespace dgl

--- a/src/runtime/ndarray.cc
+++ b/src/runtime/ndarray.cc
@@ -280,6 +280,7 @@ template std::vector<float> NDArray::ToVector<float>() const;
 template std::vector<double> NDArray::ToVector<double>() const;
 
 
+#ifndef _WIN32
 struct RawDataTensorCtx {
   std::vector<int64_t> shape;
   std::vector<int64_t> stride;
@@ -372,6 +373,8 @@ NDArray ZeroCopyLoadDLTensor(ZeroCopyStream* zc_strm) {
     return CreateNDArrayFromRawData(shape, dtype, cpu_ctx, ptr_pair.first);
   }
 }
+
+#endif // _WIN32
 
 }  // namespace runtime
 }  // namespace dgl

--- a/src/runtime/ndarray.cc
+++ b/src/runtime/ndarray.cc
@@ -329,8 +329,9 @@ void ZeroCopySaveDLTensor(ZeroCopyStream* zc_strm, DLTensor* tensor,
     strm->Write<bool>(true);
     strm->Write(mem->name);
   } else {
-    if (!zc_strm->is_local){
-      LOG(FATAL) << "Serializing a non-shared-memory tensor to a local ZeroCopyStream is not supported.";
+    if (!zc_strm->is_local) {
+      LOG(FATAL) << "Serializing a non-shared-memory tensor to a local "
+                    "ZeroCopyStream is not supported.";
     }
     strm->Write<bool>(false);
   }

--- a/src/runtime/ndarray.cc
+++ b/src/runtime/ndarray.cc
@@ -290,7 +290,7 @@ std::shared_ptr<SharedMemory> NDArray::GetSharedMem() const {
 void NDArray::Save(dmlc::Stream* strm) const {
   auto zc_strm = dynamic_cast<StringStreamWithBuffer*>(strm);
   if (zc_strm) {
-    zc_strm->push_NDArray(*this);
+    zc_strm->PushNDArray(*this);
     return;
   }
   SaveDLTensor(strm, const_cast<DLTensor*>(operator->()));
@@ -299,7 +299,7 @@ void NDArray::Save(dmlc::Stream* strm) const {
 bool NDArray::Load(dmlc::Stream* strm) {
   auto zc_strm = dynamic_cast<StringStreamWithBuffer*>(strm);
   if (zc_strm) {
-    *this = zc_strm->pop_NDArray();
+    *this = zc_strm->PopNDArray();
     return true;
   }
   uint64_t header, reserved;

--- a/src/runtime/ndarray.cc
+++ b/src/runtime/ndarray.cc
@@ -9,6 +9,7 @@
 #include <dgl/runtime/c_runtime_api.h>
 #include <dgl/runtime/device_api.h>
 #include <dgl/runtime/shared_mem.h>
+#include <dgl/zerocopy_serializer.h>
 #include "runtime_base.h"
 
 // deleter for arrays used by DLPack exporter
@@ -279,102 +280,75 @@ template std::vector<uint64_t> NDArray::ToVector<uint64_t>() const;
 template std::vector<float> NDArray::ToVector<float>() const;
 template std::vector<double> NDArray::ToVector<double>() const;
 
-
 #ifndef _WIN32
-struct RawDataTensorCtx {
-  std::vector<int64_t> shape;
-  std::vector<int64_t> stride;
-  DLManagedTensor tensor;
-};
+std::shared_ptr<SharedMemory> NDArray::GetSharedMem() const {
+  return this->data_->mem;
+}
+#endif  // _WIN32
 
-void RawDataTensoDLPackDeleter(DLManagedTensor* tensor) {
-  auto ctx = static_cast<RawDataTensorCtx*>(tensor->manager_ctx);
-  free(ctx->tensor.dl_tensor.data);
-  delete ctx;
+
+void NDArray::Save(dmlc::Stream* strm) const {
+  auto zc_strm = dynamic_cast<StringStreamWithBuffer*>(strm);
+  if (zc_strm) {
+    zc_strm->push_NDArray(*this);
+    return;
+  }
+  SaveDLTensor(strm, const_cast<DLTensor*>(operator->()));
 }
 
-NDArray CreateNDArrayFromRawData(std::vector<int64_t> shape, DLDataType dtype,
-                             DLContext ctx, void* raw) {
-  auto dlm_tensor_ctx = new RawDataTensorCtx();
-  DLManagedTensor* dlm_tensor = &dlm_tensor_ctx->tensor;
-  dlm_tensor_ctx->shape = shape;
-  dlm_tensor->manager_ctx = dlm_tensor_ctx;
-  dlm_tensor->dl_tensor.shape = dmlc::BeginPtr(dlm_tensor_ctx->shape);
-  dlm_tensor->dl_tensor.ctx = ctx;
-  dlm_tensor->dl_tensor.ndim = static_cast<int>(shape.size());
-  dlm_tensor->dl_tensor.dtype = dtype;
-
-  dlm_tensor_ctx->stride.resize(dlm_tensor->dl_tensor.ndim, 1);
-  for (int i = dlm_tensor->dl_tensor.ndim - 2; i >= 0; --i) {
-    dlm_tensor_ctx->stride[i] = dlm_tensor_ctx->shape[i+1] * dlm_tensor_ctx->stride[i+1];
+bool NDArray::Load(dmlc::Stream* strm) {
+  auto zc_strm = dynamic_cast<StringStreamWithBuffer*>(strm);
+  if (zc_strm) {
+    *this = zc_strm->pop_NDArray();
+    return true;
   }
-  dlm_tensor->dl_tensor.strides = dmlc::BeginPtr(dlm_tensor_ctx->stride);
-  dlm_tensor->dl_tensor.data = raw;
-  dlm_tensor->deleter = RawDataTensoDLPackDeleter;
-  return NDArray::FromDLPack(dlm_tensor);
-}
-
-void ZeroCopySaveDLTensor(ZeroCopyStream* zc_strm, DLTensor* tensor,
-                                 std::shared_ptr<SharedMemory> mem) {
-  auto strm = static_cast<dmlc::Stream*>(zc_strm);
-  strm->Write(tensor->ndim);
-  strm->Write(tensor->dtype);
-  int ndim = tensor->ndim;
-  strm->WriteArray(tensor->shape, ndim);
-  int type_bytes = tensor->dtype.bits / 8;
-  int64_t num_elems = 1;
-  for (int i = 0; i < ndim; ++i) {
-    num_elems *= tensor->shape[i];
-  }
-  int64_t data_byte_size = type_bytes * num_elems;
-  if (mem) {
-    strm->Write<bool>(true);
-    strm->Write(mem->name);
-  } else {
-    if (!zc_strm->is_local) {
-      LOG(FATAL) << "Serializing a non-shared-memory tensor to a local "
-                    "ZeroCopyStream is not supported.";
-    }
-    strm->Write<bool>(false);
-  }
-  zc_strm->push_buffer(tensor->data, data_byte_size);
-}
-
-NDArray ZeroCopyLoadDLTensor(ZeroCopyStream* zc_strm) {
-  auto strm = static_cast<dmlc::Stream*>(zc_strm);
+  uint64_t header, reserved;
+  CHECK(strm->Read(&header))
+      << "Invalid DLTensor file format";
+  CHECK(strm->Read(&reserved))
+      << "Invalid DLTensor file format";
+  CHECK(header == kDGLNDArrayMagic)
+      << "Invalid DLTensor file format";
+  DLContext ctx;
   int ndim;
   DLDataType dtype;
-
-  CHECK(strm->Read(&ndim)) << "Invalid DLTensor file format";
-  CHECK(strm->Read(&dtype)) << "Invalid DLTensor file format";
-
+  CHECK(strm->Read(&ctx))
+      << "Invalid DLTensor file format";
+  CHECK(strm->Read(&ndim))
+      << "Invalid DLTensor file format";
+  CHECK(strm->Read(&dtype))
+      << "Invalid DLTensor file format";
+  CHECK_EQ(ctx.device_type, kDLCPU)
+      << "Invalid DLTensor context: can only save as CPU tensor";
   std::vector<int64_t> shape(ndim);
   if (ndim != 0) {
-    CHECK(strm->ReadArray(&shape[0], ndim)) << "Invalid DLTensor file format";
+    CHECK(strm->ReadArray(&shape[0], ndim))
+        << "Invalid DLTensor file format";
   }
-
-  DLContext cpu_ctx;
-  cpu_ctx.device_type = kDLCPU;
-  cpu_ctx.device_id = 0;
-
-  bool is_shared_mem;
-  CHECK(strm->Read(&is_shared_mem)) << "Invalid stream read";
-  std::string sharedmem_name;
-  if (zc_strm->is_local) {
-    if (is_shared_mem) {
-      CHECK(strm->Read(&sharedmem_name)) << "Invalid stream read";
-      return NDArray::EmptyShared(sharedmem_name, shape, dtype, cpu_ctx, false);
-    } else {
-      LOG(FATAL)
-        << "Unsupport non-shared memory deserialization on the same machine";
-    }
-  } else {
-    Ptr_pair ptr_pair = zc_strm->pop_buffer();
-    return CreateNDArrayFromRawData(shape, dtype, cpu_ctx, ptr_pair.first);
+  NDArray ret = NDArray::Empty(shape, dtype, ctx);
+  int64_t num_elems = 1;
+  int elem_bytes = (ret->dtype.bits + 7) / 8;
+  for (int i = 0; i < ret->ndim; ++i) {
+    num_elems *= ret->shape[i];
   }
+  int64_t data_byte_size;
+  CHECK(strm->Read(&data_byte_size))
+      << "Invalid DLTensor file format";
+  CHECK(data_byte_size == num_elems * elem_bytes)
+      << "Invalid DLTensor file format";
+  if (data_byte_size != 0)  {
+    // strm->Read will return the total number of elements successfully read.
+    // Therefore if data_byte_size is zero, the CHECK below would fail.
+    CHECK(strm->Read(ret->data, data_byte_size))
+        << "Invalid DLTensor file format";
+  }
+  if (!DMLC_IO_NO_ENDIAN_SWAP) {
+    dmlc::ByteSwap(ret->data, elem_bytes, num_elems);
+  }
+  *this = ret;
+  return true;
 }
 
-#endif  // _WIN32
 
 }  // namespace runtime
 }  // namespace dgl

--- a/tests/cpp/test_zerocopy_serialize.cc
+++ b/tests/cpp/test_zerocopy_serialize.cc
@@ -12,6 +12,8 @@
 #include "../../src/graph/unit_graph.h"
 #include "./common.h"
 
+#ifndef _WIN32
+
 using namespace dgl;
 using namespace dgl::aten;
 using namespace dmlc;
@@ -136,3 +138,5 @@ TEST(ZeroCopySerialize, HeteroGraph) {
   EXPECT_EQ(gptr->NumVertices(0), 9);
   EXPECT_EQ(gptr->NumVertices(1), 8);
 }
+
+#endif  // _WIN32

--- a/tests/cpp/test_zerocopy_serialize.cc
+++ b/tests/cpp/test_zerocopy_serialize.cc
@@ -52,10 +52,10 @@ TEST(ZeroCopySerialize, NDArray) {
   static_cast<dmlc::Stream *>(&zc_write_strm)->Write(tensor1);
   static_cast<dmlc::Stream *>(&zc_write_strm)->Write(tensor2);
 
-  LOG(INFO) << nonzerocopy_blob.size() << std::endl;
-  LOG(INFO) << zerocopy_blob.size() << std::endl;
+  EXPECT_EQ(nonzerocopy_blob.size() - zerocopy_blob.size(), 126)
+    << "Invalid save";
 
-  std::vector<void*> new_ptr_list;
+  std::vector<void *> new_ptr_list;
   // Use memcpy to mimic remote machine reconstruction
   for (auto ptr : zc_write_strm.buffer_list()) {
     auto new_ptr = malloc(ptr.size);
@@ -86,8 +86,8 @@ TEST(ZeroCopySerialize, SharedMem) {
   StringStreamWithBuffer zc_write_strm(&zerocopy_blob, false);
   static_cast<dmlc::Stream *>(&zc_write_strm)->Write(shared_tensor);
 
-  LOG(INFO) << nonzerocopy_blob.size();
-  LOG(INFO) << zerocopy_blob.size();
+  EXPECT_EQ(nonzerocopy_blob.size() - zerocopy_blob.size(), 51)
+    << "Invalid save";
 
   NDArray loadtensor1, loadtensor2;
   StringStreamWithBuffer zc_read_strm(&zerocopy_blob, false);
@@ -117,10 +117,10 @@ TEST(ZeroCopySerialize, HeteroGraph) {
   StringStreamWithBuffer zc_write_strm(&zerocopy_blob, true);
   static_cast<dmlc::Stream *>(&zc_write_strm)->Write(hrptr);
 
-  LOG(INFO) << "Non zerocopy size: " << nonzerocopy_blob.size() << std::endl;
-  LOG(INFO) << "Zerocopy size: " << zerocopy_blob.size() << std::endl;
+  EXPECT_EQ(nonzerocopy_blob.size() - zerocopy_blob.size(), 745)
+    << "Invalid save";
 
-  std::vector<void*> new_ptr_list;
+  std::vector<void *> new_ptr_list;
   // Use memcpy to mimic remote machine reconstruction
   for (auto ptr : zc_write_strm.buffer_list()) {
     auto new_ptr = malloc(ptr.size);

--- a/tests/cpp/test_zerocopy_serialize.cc
+++ b/tests/cpp/test_zerocopy_serialize.cc
@@ -1,0 +1,100 @@
+#include <dgl/array.h>
+#include <dgl/zerocopy_serializer.h>
+#include <dmlc/memory_io.h>
+#include <gtest/gtest.h>
+
+#include <algorithm>
+#include <iostream>
+#include <vector>
+
+#include "./common.h"
+
+using namespace dgl;
+using namespace dgl::aten;
+using namespace dmlc;
+// Function to convert an idarray to string
+std::string IdArrayToStr(IdArray arr) {
+  arr = arr.CopyTo(DLContext{kDLCPU, 0});
+  int64_t len = arr->shape[0];
+  std::ostringstream oss;
+  oss << "(" << len << ")[";
+  if (arr->dtype.bits == 32) {
+    int32_t* data = static_cast<int32_t*>(arr->data);
+    for (int64_t i = 0; i < len; ++i) {
+      oss << data[i] << " ";
+    }
+  } else {
+    int64_t* data = static_cast<int64_t*>(arr->data);
+    for (int64_t i = 0; i < len; ++i) {
+      oss << data[i] << " ";
+    }
+  }
+  oss << "]";
+  return oss.str();
+}
+
+
+TEST(ZeroCopySerialize, NDArray) {
+  auto tensor1 = VecToIdArray<int64_t>({1, 2, 5, 3});
+  auto tensor2 = VecToIdArray<int64_t>({6, 6, 5, 7});
+
+  std::string nonzerocopy_blob;
+  dmlc::MemoryStringStream ifs(&nonzerocopy_blob);
+  static_cast<dmlc::Stream *>(&ifs)->Write(tensor1);
+  static_cast<dmlc::Stream *>(&ifs)->Write(tensor2);
+
+  std::string zerocopy_blob;
+  std::vector<Ptr_pair> ptr_list;
+  ZeroCopyStream zc_write_strm(&zerocopy_blob, &ptr_list);
+  static_cast<dmlc::Stream *>(&zc_write_strm)->Write(tensor1);
+  static_cast<dmlc::Stream *>(&zc_write_strm)->Write(tensor2);
+
+  LOG(INFO) << nonzerocopy_blob.size() << std::endl;
+  LOG(INFO) << zerocopy_blob.size() << std::endl;
+
+  std::vector<Ptr_pair> new_ptr_list;
+  // Use memcpy to mimic remote machine reconstruction
+  for (Ptr_pair ptr : ptr_list) {
+    auto new_ptr = malloc(ptr.second);
+    memcpy(new_ptr, ptr.first, ptr.second);
+    new_ptr_list.emplace_back(new_ptr, ptr.second);
+  }
+
+  NDArray loadtensor1, loadtensor2;
+  ZeroCopyStream zc_read_strm(&zerocopy_blob, &new_ptr_list, false);
+  static_cast<dmlc::Stream *>(&zc_read_strm)->Read(&loadtensor1);
+  static_cast<dmlc::Stream *>(&zc_read_strm)->Read(&loadtensor2);
+
+//   auto ptr_list = zc_strm;
+
+
+
+  //   dmlc::MemoryStringStream ofs(&blob);
+}
+
+
+TEST(ZeroCopySerialize, SharedMem) {  
+  auto tensor1 = VecToIdArray<int64_t>({1, 2, 5, 3});
+  DLDataType dtype = {kDLInt, 64, 1};
+  std::vector<int64_t> shape {4};
+  DLContext cpu_ctx = {kDLCPU, 0};
+  auto shared_tensor = NDArray::EmptyShared("test", shape, dtype, cpu_ctx, true);
+  shared_tensor.CopyFrom(tensor1);
+
+  std::string nonzerocopy_blob;
+  dmlc::MemoryStringStream ifs(&nonzerocopy_blob);
+  static_cast<dmlc::Stream *>(&ifs)->Write(shared_tensor);
+
+  std::string zerocopy_blob;
+  std::vector<Ptr_pair> ptr_list;
+  ZeroCopyStream zc_write_strm(&zerocopy_blob, &ptr_list);
+  static_cast<dmlc::Stream *>(&zc_write_strm)->Write(shared_tensor);
+
+  LOG(INFO) << nonzerocopy_blob.size();
+  LOG(INFO) << zerocopy_blob.size();
+
+  NDArray loadtensor1, loadtensor2;
+  ZeroCopyStream zc_read_strm(&zerocopy_blob, nullptr, true);
+  static_cast<dmlc::Stream *>(&zc_read_strm)->Read(&loadtensor1);
+
+}


### PR DESCRIPTION
## Description
Currently non-shared-memory NDArray is not supported in same-machine inter-process serialization. (If you serialize a non-shared-memory NDArray, and deserialize it on the same machine, it will raise error.)

## Checklist
Please feel free to remove inapplicable items for your PR.
- [ ] The PR title starts with [$CATEGORY] (such as [NN], [Model], [Doc], [Feature]])
- [ ] Changes are complete (i.e. I finished coding on this PR)
- [ ] All changes have test coverage
- [ ] Code is well-documented
- [ ] To the my best knowledge, examples are either not affected by this change,
      or have been fixed to be compatible with this change
- [ ] Related issue is referred in this PR

## Changes
<!-- You could use following template
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)
-->
