### PR TITLE
[Bugfix] Fix GAT on PPI

### DIFF
--- a/examples/pytorch/gat/README.md
+++ b/examples/pytorch/gat/README.md
@@ -46,6 +46,7 @@ Results
 | Cora     | 84.02(0.40)   | 0.0113  | 0.0982 (**8.7x**)   | 0.0424 (**3.8x**)   |
 | Citeseer | 70.91(0.79)   | 0.0111  | n/a                 | n/a                 |
 | Pubmed   | 78.57(0.75)   | 0.0115  | n/a                 | n/a                 |
+| PPI      | 0.9836        | n/a     | n/a                 | n/a                 | 
 
 * All the accuracy numbers are obtained after 300 epochs.
 * The time measures how long it takes to train one epoch.

--- a/examples/pytorch/gat/train_ppi.py
+++ b/examples/pytorch/gat/train_ppi.py
@@ -35,7 +35,7 @@ def evaluate(feats, model, subgraph, labels, loss_fcn):
             layer.g = subgraph
         output = model(feats.float())
         loss_data = loss_fcn(output, labels.float())
-        predict = np.where(output.data.cpu().numpy() >= 0.5, 1, 0)
+        predict = np.where(output.data.cpu().numpy() >= 0., 1, 0)
         score = f1_score(labels.data.cpu().numpy(),
                          predict, average='micro')
         return score, loss_data.item()
@@ -109,7 +109,7 @@ def main(args):
                 val_loss_list.append(val_loss)
             mean_score = np.array(score_list).mean()
             mean_val_loss = np.array(val_loss_list).mean()
-            print("F1-Score: {:.4f} ".format(mean_score))
+            print("Val F1-Score: {:.4f} ".format(mean_score))
             # early stop
             if mean_score > best_score or best_loss > mean_val_loss:
                 if mean_score > best_score and best_loss > mean_val_loss:
@@ -128,7 +128,7 @@ def main(args):
         feats = feats.to(device)
         labels = labels.to(device)
         test_score_list.append(evaluate(feats, model, subgraph, labels.float(), loss_fcn)[0])
-    print("F1-Score: {:.4f}".format(np.array(test_score_list).mean()))
+    print("Test F1-Score: {:.4f}".format(np.array(test_score_list).mean()))
 
 if __name__ == '__main__':
     parser = argparse.ArgumentParser(description='GAT')


### PR DESCRIPTION
## Description
As reported in [thread 979](https://discuss.dgl.ai/t/bug-reported-the-evaluation-function-of-gat-ppi/979), previously the f1 evaluation for PPI is wrong. Since sigmoid has not been applied to the model output, the output values are logits rather than probabilities and the threshold for binary classification should be 0 rather than 0.5. Recall that sigmoid takes the form 1 / 1 + e^{-z}.

## Checklist
Please feel free to remove inapplicable items for your PR.
- [x] The PR title starts with [$CATEGORY] (such as [NN], [Model], [Doc], [Feature]])
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage
- [x] Code is well-documented
- [x] To the my best knowledge, examples are either not affected by this change,
      or have been fixed to be compatible with this change
- [x] Related issue is referred in this PR