### PR TITLE
[Bug] Fixing creation of DGLGraph crashing with no edge from node 0

### DIFF
--- a/python/dgl/graph.py
+++ b/python/dgl/graph.py
@@ -1332,7 +1332,7 @@ class DGLGraph(DGLBaseGraph):
 
         Notes
         -----
-        The nodes and edges in the graph would be re-indexed after the removal.
+        The edges in the graph would be re-indexed after the removal.  The nodes are preserved.
 
         Examples
         --------

--- a/python/dgl/graph_index.py
+++ b/python/dgl/graph_index.py
@@ -1171,9 +1171,6 @@ def from_edge_list(elist, readonly):
     src_ids = utils.toindex(src)
     dst_ids = utils.toindex(dst)
     num_nodes = max(src.max(), dst.max()) + 1
-    min_nodes = min(src.min(), dst.min())
-    if min_nodes != 0:
-        raise DGLError('Invalid edge list. Nodes must start from 0.')
     return from_coo(num_nodes, src_ids, dst_ids, readonly)
 
 def map_to_subgraph_nid(induced_nodes, parent_nids):


### PR DESCRIPTION
Creating `DGLGraph` from edge list will crash if node 0 does not have any edge.

Also fixes a documentation mistake in `DGLGraph.remove_edges`.