### PR TITLE
[Doc] correct PinSAGE knn example syntax

### DIFF
--- a/examples/pytorch/pinsage/README.md
+++ b/examples/pytorch/pinsage/README.md
@@ -25,7 +25,7 @@ interacted.  The distance between two items are measured by Euclidean distance o
 item embeddings, which are learned as outputs of PinSAGE.
 
 ```
-python model.py data.pkl --num-epochs 300 --num-workers 2 --device cuda:0 data.pkl --hidden-dims 64
+python model.py data.pkl --num-epochs 300 --num-workers 2 --device cuda:0 --hidden-dims 64
 ```
 
 The HITS@10 is 0.01241, compared to 0.01220 with SLIM with the same dimensionality.


### PR DESCRIPTION
## Description
remove the duplicate dataset_path from the PinSAGE example

## Checklist
Please feel free to remove inapplicable items for your PR.
- [x] The PR title starts with [$CATEGORY] (such as [NN], [Model], [Doc], [Feature]])
- [x] Changes are complete (i.e. I finished coding on this PR)
- [ ] All changes have test coverage
- [x] Code is well-documented
- [x] To the my best knowledge, examples are either not affected by this change,
      or have been fixed to be compatible with this change
- [ ] Related issue is referred in this PR

## Changes
<!-- You could use following template
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)
-->
