### PR TITLE
Add return value to `G.readonly` to be consistent with PyTorch's convention

### DIFF
--- a/python/dgl/graph.py
+++ b/python/dgl/graph.py
@@ -3840,6 +3840,10 @@ class DGLGraph(DGLBaseGraph):
         ----------
         readonly_state : bool, optional
             New readonly state of the graph, defaults to True.
+        
+        Returns
+        ----------
+        The current DGLGraph object
 
         Examples
         --------
@@ -3862,6 +3866,7 @@ class DGLGraph(DGLBaseGraph):
         """
         if readonly_state != self.is_readonly:
             self._graph.readonly(readonly_state)
+        return self
 
     def __repr__(self):
         ret = ('DGLGraph(num_nodes={node}, num_edges={edge},\n'


### PR DESCRIPTION
## Description
Add return value to `G.readonly` to be consistent with PyTorch's convention

## Checklist
Please feel free to remove inapplicable items for your PR.
- [ ] The PR title starts with [$CATEGORY] (such as [NN], [Model], [Doc], [Feature]])
- [ ] Changes are complete (i.e. I finished coding on this PR)
- [ ] All changes have test coverage
- [ ] Code is well-documented
- [ ] To the my best knowledge, examples are either not affected by this change,
      or have been fixed to be compatible with this change
- [ ] Related issue is referred in this PR

## Changes
<!-- You could use following template
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)
-->
