### PR TITLE
[Bug?] Remove debug message from __getattr__ of FFI objects

### DIFF
--- a/python/dgl/_ffi/_ctypes/object.py
+++ b/python/dgl/_ffi/_ctypes/object.py
@@ -49,7 +49,6 @@ class ObjectBase(object):
     def __getattr__(self, name):
         if name == 'handle':
             raise AttributeError("'handle' is a reserved attribute name that should not be used")
-        print('in get attr:', name)
         ret_val = DGLValue()
         ret_type_code = ctypes.c_int()
         ret_success = ctypes.c_int()


### PR DESCRIPTION
A debug message `in get attr` will be printed if an attribute is read from an FFI object.