### PR TITLE
[CI] Fix parallel msbuild

### DIFF
--- a/tests/scripts/build_dgl.bat
+++ b/tests/scripts/build_dgl.bat
@@ -6,6 +6,11 @@ DEL /S /Q build
 DEL /S /Q _download
 MD build
 
+SET _MSPDBSRV_ENDPOINT_=%BUILD_TAG%
+SET TMP=%WORKSPACE%\\tmp
+SET TEMP=%WORKSPACE%\\tmp
+SET TMPDIR=%WORKSPACE%\\tmp
+
 PUSHD build
 CALL "C:\Program Files (x86)\Microsoft Visual Studio\2017\BuildTools\VC\Auxiliary\Build\vcvars64.bat"
 cmake -DCMAKE_CXX_FLAGS="/DDGL_EXPORTS" -DUSE_OPENMP=ON -Dgtest_force_shared_crt=ON -DDMLC_FORCE_SHARED_CRT=ON -DBUILD_CPP_TEST=1 -DCMAKE_CONFIGURATION_TYPES="Release" .. -G "Visual Studio 15 2017 Win64" || EXIT /B 1


### PR DESCRIPTION
According to https://issues.jenkins-ci.org/browse/JENKINS-9104 MSBuild has trouble running parallel builds unless each MSBuild instance is run with a unique MSPDBSRV endpoint.  I observed occasional Windows build failures and I guess this may be one of the reasons.