### PR TITLE
Fix crashing on SIOCGIFADDR

### DIFF
--- a/python/dgl/distributed/rpc_client.py
+++ b/python/dgl/distributed/rpc_client.py
@@ -18,10 +18,21 @@ def local_ip4_addr_list():
     for if_nidx in socket.if_nameindex():
         name = if_nidx[1]
         sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
-        ip_addr = socket.inet_ntoa(fcntl.ioctl(
-            sock.fileno(),
-            0x8915,  # SIOCGIFADDR
-            struct.pack('256s', name[:15].encode("UTF-8")))[20:24])
+        try:
+            ip_of_ni = fcntl.ioctl(sock.fileno(),
+                                   0x8915,  # SIOCGIFADDR
+                                   struct.pack('256s', name[:15].encode("UTF-8")))
+        except OSError as e:
+            if e.errno == 99: # EADDRNOTAVAIL
+                print("Warning!",
+                      "Interface: {}".format(name),
+                      "IP address not available for interface.",
+                      sep='\n')
+                continue
+            else:
+                raise e
+
+        ip_addr = socket.inet_ntoa(ip_of_ni[20:24])
         nic.add(ip_addr)
     return nic
 


### PR DESCRIPTION

## Description
During scanning the list of interfaces,
some of them can be configured invalidly:
lack of ip, link down etc.
This patch handles the error
and inform about problem with concrete interface.

## Checklist
Please feel free to remove inapplicable items for your PR.
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] Code is well-documented


## Changes
Added handling of invalidly configured network interfaces from the list.
