### PR TITLE
[TEST] Use random port to test SocketCommunicator

### DIFF
--- a/tests/cpp/socket_communicator_test.cc
+++ b/tests/cpp/socket_communicator_test.cc
@@ -8,6 +8,11 @@
 #include <string>
 #include <thread>
 #include <vector>
+#include <fstream>
+#include <streambuf>
+
+#include <stdlib.h>
+#include <time.h>
 
 #include "../src/rpc/network/msg_queue.h"
 #include "../src/rpc/network/socket_communicator.h"
@@ -132,6 +137,13 @@ TEST(SocketCommunicatorTest, SendAndRecv) {
   WSADATA wsaData;
   DWORD retcode, exitcode;
 
+  srand((unsigned)time(NULL));
+  int port = (rand() % (5000-3000+1))+ 3000;
+  std::string ip_addr = "socket://127.0.0.1:" + std::to_string(port);
+  std::ofstream out("addr.txt");
+  out << ip_addr;
+  out.close();
+
   ASSERT_EQ(::WSAStartup(MAKEWORD(2, 2), &wsaData), 0);
 
   hThreads[0] = ::CreateThread(NULL, 0, _ClientThreadFunc, NULL, 0, NULL);  // client
@@ -153,8 +165,12 @@ TEST(SocketCommunicatorTest, SendAndRecv) {
 
 static void start_client() {
   sleep(1);
+  std::ifstream t("addr.txt");
+  std::string ip_addr((std::istreambuf_iterator<char>(t)),
+                       std::istreambuf_iterator<char>());
+  t.close();
   SocketSender sender(kQueueSize);
-  sender.AddReceiver("socket://127.0.0.1:8001", 0);
+  sender.AddReceiver(ip_addr.c_str(), 0);
   sender.Connect();
   char* str_data = new char[9];
   memcpy(str_data, "123456789", 9);
@@ -165,8 +181,12 @@ static void start_client() {
 }
 
 static bool start_server() {
+  std::ifstream t("addr.txt");
+  std::string ip_addr((std::istreambuf_iterator<char>(t)),
+                       std::istreambuf_iterator<char>());
+  t.close();
   SocketReceiver receiver(kQueueSize);
-  receiver.Wait("socket://127.0.0.1:8001", 1);
+  receiver.Wait(ip_addr.c_str(), 1);
   Message msg;
   EXPECT_EQ(receiver.RecvFrom(&msg, 0), REMOVE_SUCCESS);
   receiver.Finalize();


### PR DESCRIPTION
## Description
Use random port to test SocketCommunicator avoid port re-binding.

## Checklist
Please feel free to remove inapplicable items for your PR.
- [ ] The PR title starts with [$CATEGORY] (such as [NN], [Model], [Doc], [Feature]])
- [ ] Changes are complete (i.e. I finished coding on this PR)
- [ ] All changes have test coverage
- [ ] Code is well-documented
- [ ] To the my best knowledge, examples are either not affected by this change,
      or have been fixed to be compatible with this change
- [ ] Related issue is referred in this PR

## Changes
<!-- You could use following template
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)
-->
