### PR TITLE
[Test] Fix test of distributed graph

### DIFF
--- a/tests/distributed/test_dist_graph_store.py
+++ b/tests/distributed/test_dist_graph_store.py
@@ -59,6 +59,7 @@ def run_server(graph_name, server_id, num_clients, shared_mem):
     g.start()
 
 def run_client(graph_name, part_id, num_nodes, num_edges):
+    time.sleep(5)
     gpb = load_partition_book('/tmp/dist_graph/{}.json'.format(graph_name),
                               part_id, None)
     g = DistGraph("kv_ip_config.txt", graph_name, gpb=gpb)

--- a/tests/distributed/test_dist_graph_store.py
+++ b/tests/distributed/test_dist_graph_store.py
@@ -51,22 +51,14 @@ def create_random_graph(n):
     ig = create_graph_index(arr, readonly=True)
     return dgl.DGLGraph(ig)
 
-def run_server(graph_name, server_id, num_clients, shared_mem, cond_v, shared_v):
+def run_server(graph_name, server_id, num_clients, shared_mem):
     g = DistGraphServer(server_id, "kv_ip_config.txt", num_clients, graph_name,
                         '/tmp/dist_graph/{}.json'.format(graph_name),
                         disable_shared_mem=not shared_mem)
     print('start server', server_id)
-    cond_v.acquire()
-    shared_v.value += 1;
-    cond_v.notify()
-    cond_v.release()
     g.start()
 
-def run_client(graph_name, part_id, num_nodes, num_edges, num_server, cond_v, shared_v):
-    cond_v.acquire()
-    while shared_v.value < num_server:
-      cond_v.wait()
-    cond_v.release()
+def run_client(graph_name, part_id, num_nodes, num_edges):
     gpb = load_partition_book('/tmp/dist_graph/{}.json'.format(graph_name),
                               part_id, None)
     g = DistGraph("kv_ip_config.txt", graph_name, gpb=gpb)
@@ -141,11 +133,9 @@ def check_server_client(shared_mem):
     # let's just test on one partition for now.
     # We cannot run multiple servers and clients on the same machine.
     serv_ps = []
-    cond_v = Condition()
-    shared_v = Value('i', 0)
     ctx = mp.get_context('spawn')
     for serv_id in range(1):
-        p = ctx.Process(target=run_server, args=(graph_name, serv_id, 1, shared_mem, cond_v, shared_v))
+        p = ctx.Process(target=run_server, args=(graph_name, serv_id, 1, shared_mem))
         serv_ps.append(p)
         p.start()
 
@@ -153,7 +143,7 @@ def check_server_client(shared_mem):
     for cli_id in range(1):
         print('start client', cli_id)
         p = ctx.Process(target=run_client, args=(graph_name, cli_id, g.number_of_nodes(),
-                                                 g.number_of_edges(), 1, cond_v, shared_v))
+                                                 g.number_of_edges()))
         p.start()
         cli_ps.append(p)
 


### PR DESCRIPTION
## Description
When testing servers and clients, it's possible that clients run before the servers and somehow clients cannot connect to servers correctly sometimes. One option is to create barriers between servers and clients to synchronize servers and clients. However, it somehow prevents clients from running the tests. Making clients sleep seems to work better. However, this is a temporary fix. We need to figure out why sometimes the clients cannot connect the servers.

## Checklist
Please feel free to remove inapplicable items for your PR.
- [ ] The PR title starts with [$CATEGORY] (such as [NN], [Model], [Doc], [Feature]])
- [ ] Changes are complete (i.e. I finished coding on this PR)
- [ ] All changes have test coverage
- [ ] Code is well-documented
- [ ] To the my best knowledge, examples are either not affected by this change,
      or have been fixed to be compatible with this change
- [ ] Related issue is referred in this PR

## Changes
<!-- You could use following template
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)
-->
