### PR TITLE
[bugfix] ReverseOp returns a heterograph with wrong meta graph information 

### DIFF
--- a/src/graph/heterograph_capi.cc
+++ b/src/graph/heterograph_capi.cc
@@ -5,6 +5,7 @@
  */
 #include <dgl/array.h>
 #include <dgl/packed_func_ext.h>
+#include <dgl/immutable_graph.h>
 #include <dgl/runtime/container.h>
 
 #include "../c_api_common.h"
@@ -612,6 +613,10 @@ DGL_REGISTER_GLOBAL("heterograph_index._CAPI_DGLHeteroReverse")
     }
     // node types are not changed
     const auto& num_nodes = g->NumVerticesPerType();
-    *rv = CreateHeteroGraph(hg->meta_graph(), rev_ugs, num_nodes);
+    const auto& meta_edges = hg->meta_graph()->Edges("eid");
+    const auto& rev_meta = ImmutableGraph::CreateFromCOO(
+                                                         hg->meta_graph()->NumVertices(),
+                                                         meta_edges.dst, meta_edges.src);
+    *rv = CreateHeteroGraph(rev_meta, rev_ugs, num_nodes);
   });
 }  // namespace dgl

--- a/tests/compute/test_heterograph.py
+++ b/tests/compute/test_heterograph.py
@@ -1977,6 +1977,13 @@ def test_reverse(index_dtype):
         }, index_dtype=index_dtype)
     gidx = g._graph
     r_gidx = gidx.reverse()
+
+    # metagraph
+    mg = gidx.metagraph
+    r_mg = r_gidx.metagraph
+    for etype in range(3):
+        assert mg.find_edge(etype) == r_mg.find_edge(etype)[::-1]
+
     # three node types and three edge types
     assert gidx.number_of_nodes(0) == r_gidx.number_of_nodes(0)
     assert gidx.number_of_nodes(1) == r_gidx.number_of_nodes(1)


### PR DESCRIPTION
## Description
In the implementation of ReverseOp, we return a new heterograph which holds the same metagraph as the original heterograph, which may cause troubles, e.g.
```python
>>> import dgl
>>> g = dgl.rand_bipartite(30, 40, 100)
>>> gidx = g._graph
>>> gidx.metagraph.find_edge(0)
(0, 1)
>>> revg_idx = gidx.reverse()
>>> revg.metagraph.find_edge(0)
(0, 1)
```
Note that we depend on metagraph to find src/dst node types, if we do not reverse metagraph accordingly, we will not get correct `number_of_src_nodes`, `number_of_dst_nodes` etc.

This PR proposes a workaround (though I think it's ugly) to solve this problem, however, I have some questions:
1. Does the meta_graph field in `coo_`, `in_csr_`, `out_csr_` make sense? If not, why not removing them?
2. Note that we do not expose unitgraph c pointer to users, so I don't think the metagraph field in unitgraph matters either, and any changes on `unitgraph.cc` do not affect the program's behavior actually. What really matters is my changes on `heterograph_capi.cc`.
3. Can we guarantee that all metagraphs are stored in COO format?

@classicsong , @jermainewang , @BarclayII do you have any suggestions?

## Checklist
Please feel free to remove inapplicable items for your PR.
- [x] The PR title starts with [$CATEGORY] (such as [NN], [Model], [Doc], [Feature]])
- [ ] Changes are complete (i.e. I finished coding on this PR)
- [ ] All changes have test coverage
- [ ] Code is well-documented
- [x] To the my best knowledge, examples are either not affected by this change,
      or have been fixed to be compatible with this change
- [x] Related issue is referred in this PR