### PR TITLE
[Bug] Fix redundant gradient sync code in GraphSAGE Multi-GPU examples

### DIFF
--- a/examples/pytorch/gcmc/data.py
+++ b/examples/pytorch/gcmc/data.py
@@ -513,7 +513,7 @@ class MovieLens(object):
         else:
             raise NotImplementedError
 
-        TEXT = torchtext.data.Field(tokenize='spacy')
+        TEXT = torchtext.data.Field(tokenize='spacy', tokenizer_language='en_core_web_sm')
         embedding = torchtext.vocab.GloVe(name='840B', dim=300)
 
         title_embedding = np.zeros(shape=(self.movie_info.shape[0], 300), dtype=np.float32)

--- a/examples/pytorch/graphsage/train_cv_multi_gpu.py
+++ b/examples/pytorch/graphsage/train_cv_multi_gpu.py
@@ -332,12 +332,6 @@ def run(proc_id, n_gpus, args, devices, data):
             # backward
             optimizer.zero_grad()
             loss.backward()
-            if n_gpus > 1:
-                for param in model.parameters():
-                    if param.requires_grad and param.grad is not None:
-                        th.distributed.all_reduce(param.grad.data,
-                                                  op=th.distributed.ReduceOp.SUM)
-                        param.grad.data /= n_gpus
             optimizer.step()
             if proc_id == 0:
                 iter_tput.append(len(seeds) * n_gpus / (time.time() - tic_step))

--- a/examples/pytorch/graphsage/train_sampling_multi_gpu.py
+++ b/examples/pytorch/graphsage/train_sampling_multi_gpu.py
@@ -207,13 +207,6 @@ def run(proc_id, n_gpus, args, devices, data):
             loss = loss_fcn(batch_pred, batch_labels)
             optimizer.zero_grad()
             loss.backward()
-
-            if n_gpus > 1:
-                for param in model.parameters():
-                    if param.requires_grad and param.grad is not None:
-                        th.distributed.all_reduce(param.grad.data,
-                                                  op=th.distributed.ReduceOp.SUM)
-                        param.grad.data /= n_gpus
             optimizer.step()
 
             if proc_id == 0:


### PR DESCRIPTION
Also fixes a bug in GCMC where spacy preprocessing crashes with a "cannot find model 'en'" error.