### PR TITLE
[Distributed] turn off recording on embeddings in the inference.

### DIFF
--- a/python/dgl/backend/backend.py
+++ b/python/dgl/backend/backend.py
@@ -1474,6 +1474,11 @@ def is_no_grad(x):
     """
     pass
 
+def is_recording():
+    """ Test if the execution is recording gradients.
+    """
+    pass
+
 class record_grad(object):
     """Context manager that records the gradients"""
     def __init__(self):

--- a/python/dgl/backend/mxnet/tensor.py
+++ b/python/dgl/backend/mxnet/tensor.py
@@ -605,6 +605,9 @@ def grad(x):
 def is_no_grad(x):
     return (x != 0).sum() == 0
 
+def is_recording():
+    return mx.autograd.is_recording()
+
 record_grad = mx.autograd.record
 
 class no_grad(object):

--- a/python/dgl/backend/pytorch/tensor.py
+++ b/python/dgl/backend/pytorch/tensor.py
@@ -517,6 +517,9 @@ def grad(x):
 def is_no_grad(x):
     return x.grad is None or (x.grad == 0).all()
 
+def is_recording():
+    return th.is_grad_enabled()
+
 class record_grad(object):
     def __init__(self):
         pass

--- a/python/dgl/backend/tensorflow/tensor.py
+++ b/python/dgl/backend/tensorflow/tensor.py
@@ -685,6 +685,9 @@ def grad(x):
 def is_no_grad(x):
     return cgrad.is_no_grad(x)
 
+def is_recording():
+    raise NotImplementedError("Tensorflow doesn't support is_recording")
+
 no_grad = None
 
 initialize_context()

--- a/python/dgl/distributed/sparse_emb.py
+++ b/python/dgl/distributed/sparse_emb.py
@@ -41,8 +41,10 @@ class SparseNodeEmbedding:
         self._trace = []
 
     def __call__(self, idx):
-        emb = F.attach_grad(self._tensor[idx])
-        self._trace.append((idx, emb))
+        emb = self._tensor[idx]
+        if F.is_recording():
+            emb = F.attach_grad(emb)
+            self._trace.append((idx, emb))
         return emb
 
 class SparseAdagradUDF:


### PR DESCRIPTION
## Description
When recording data access from embeddings, we need to know whether the operation runs in the training mode or inference mode. We need to check if the system is recording all operators.

## Checklist
Please feel free to remove inapplicable items for your PR.
- [ ] The PR title starts with [$CATEGORY] (such as [NN], [Model], [Doc], [Feature]])
- [ ] Changes are complete (i.e. I finished coding on this PR)
- [ ] All changes have test coverage
- [ ] Code is well-documented
- [ ] To the my best knowledge, examples are either not affected by this change,
      or have been fixed to be compatible with this change
- [ ] Related issue is referred in this PR

## Changes
<!-- You could use following template
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)
-->
