### PR TITLE
[Feature] Support higher order derivative for message passing.

### DIFF
--- a/docs/source/api/python/ops.rst
+++ b/docs/source/api/python/ops.rst
@@ -87,6 +87,7 @@ graph.
 .. autosummary::
     :toctree: ../../generated/
 
+    gspmm
     u_add_e_sum
     u_sub_e_sum
     u_mul_e_sum
@@ -193,6 +194,7 @@ The following is an example showing how GSDDMM works:
 .. autosummary::
     :toctree: ../../generated/
 
+    gsddmm
     u_add_v
     u_sub_v
     u_mul_v

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -101,7 +101,7 @@ a useful manual for in-depth developers.
 
    api/python/graph
    api/python/heterograph
-   api/python/backend
+   api/python/ops
    api/python/readout
    api/python/batch_heterograph
    api/python/nn

--- a/python/dgl/backend/backend.py
+++ b/python/dgl/backend/backend.py
@@ -1377,7 +1377,7 @@ def copy_reduce(reducer, graph, target, in_data, out_size, in_map, out_map):
     """
     pass
 
-def gspmm(g, op, reduce_op, lhs_data, rhs_data):
+def gspmm(gidx, op, reduce_op, lhs_data, rhs_data):
     r""" Generalized Sparse Matrix Multiplication interface.
     It fuses two steps into one kernel.
     (1) Computes messages by :attr:`op` source node and edge features.
@@ -1395,7 +1395,7 @@ def gspmm(g, op, reduce_op, lhs_data, rhs_data):
 
     Parameters
     ----------
-    g : DGLHeteroGraph
+    gidx : HeteroGraphIndex
         The input graph.
     op : str
         The binary op's name, could be ``add``, ``sub``, ``mul``, ``div``,
@@ -1414,7 +1414,7 @@ def gspmm(g, op, reduce_op, lhs_data, rhs_data):
     """
     pass
 
-def gsddmm(g, op, lhs_data, rhs_data, lhs_target='u', rhs_target='v'):
+def gsddmm(gidx, op, lhs_data, rhs_data, lhs_target='u', rhs_target='v'):
     r""" Generalized Sampled-Dense-Dense Matrix Multiplication interface.
     It computes edge features by :attr:`op` lhs features and rhs features.
 
@@ -1428,7 +1428,7 @@ def gsddmm(g, op, lhs_data, rhs_data, lhs_target='u', rhs_target='v'):
 
     Parameters
     ----------
-    g : DGLHeteroGraph
+    g : HeteroGraphIndex
         The input graph.
     op : str
         Binary operator, could be ``add``, ``sub``, ``mul``, ``div``, ``dot``,

--- a/python/dgl/backend/backend.py
+++ b/python/dgl/backend/backend.py
@@ -1428,7 +1428,7 @@ def gsddmm(gidx, op, lhs_data, rhs_data, lhs_target='u', rhs_target='v'):
 
     Parameters
     ----------
-    g : HeteroGraphIndex
+    gidx : HeteroGraphIndex
         The input graph.
     op : str
         Binary operator, could be ``add``, ``sub``, ``mul``, ``div``, ``dot``,

--- a/python/dgl/backend/tensorflow/sparse.py
+++ b/python/dgl/backend/tensorflow/sparse.py
@@ -85,8 +85,7 @@ def _muldiv(op, x):
 def _addsub(op, x):
     return -x if op == 'sub' else x
 
-def gspmm_real(g, op, reduce_op, X, Y):
-    gidx = g._graph
+def gspmm_real(gidx, op, reduce_op, X, Y):
     out, (argX, argY) = _gspmm(gidx, op, reduce_op, X, Y)
 
     def grad(dZ):
@@ -136,18 +135,17 @@ def gspmm_real(g, op, reduce_op, X, Y):
         return dX, dY
     return out, grad
 
-def gspmm(g, op, reduce_op, X, Y):
+def gspmm(gidx, op, reduce_op, X, Y):
     @tf.custom_gradient
     def _lambda(X, Y):
-        return gspmm_real(g, op, reduce_op, X, Y)
+        return gspmm_real(gidx, op, reduce_op, X, Y)
     if X is None:
         X = tf.zeros(())
     if Y is None:
         Y = tf.zeros(())
     return _lambda(X, Y)
 
-def gsddmm_real(g, op, X, Y, lhs_target, rhs_target):
-    gidx = g._graph
+def gsddmm_real(gidx, op, X, Y, lhs_target, rhs_target):
     out = _gsddmm(gidx, op, X, Y, lhs_target, rhs_target)
 
     def grad(dZ):
@@ -196,10 +194,10 @@ def gsddmm_real(g, op, X, Y, lhs_target, rhs_target):
         return dX, dY
     return out, grad
 
-def gsddmm(g, op, X, Y, lhs_target='u', rhs_target='v'):
+def gsddmm(gidx, op, X, Y, lhs_target='u', rhs_target='v'):
     @tf.custom_gradient
     def _lambda(X, Y):
-        return gsddmm_real(g, op, X, Y, lhs_target, rhs_target)
+        return gsddmm_real(gidx, op, X, Y, lhs_target, rhs_target)
     if X is None:
         X = tf.zeros(())
     if Y is None:

--- a/python/dgl/ops/sddmm.py
+++ b/python/dgl/ops/sddmm.py
@@ -2,10 +2,45 @@
 from itertools import product
 import sys
 
-from ..backend import gsddmm
+from ..backend import gsddmm as gsddmm_internal
 
 __all__ = ['gsddmm', 'copy_u', 'copy_v']
 
+def gsddmm(g, op, lhs_data, rhs_data, lhs_target='u', rhs_target='v'):
+    r""" Generalized Sampled-Dense-Dense Matrix Multiplication interface.
+    It computes edge features by :attr:`op` lhs features and rhs features.
+
+    .. math::
+        x_{e} = \phi(x_{lhs}, x_{rhs}), \forall (u,e,v)\in \mathcal{G}
+
+    where :math:`x_{e}` is the returned feature on edges and :math:`x_u`,
+    :math:`x_v` refers to :attr:`u`, :attr:`v` respectively. :math:`\phi`
+    is the binary operator :attr:`op`, and :math:`\mathcal{G}` is the graph
+    we apply gsddmm on: :attr:`g`. $lhs$ and $rhs$ are one of $u,v,e$'s.
+
+    Parameters
+    ----------
+    g : DGLGraph
+        The input graph.
+    op : str
+        Binary operator, could be ``add``, ``sub``, ``mul``, ``div``, ``dot``,
+        ``copy_lhs``, ``copy_rhs``.
+    lhs_data : tensor or None
+        The left operand, could be None if it's not required by op.
+    rhs_data : tensor or None
+        The right operand, could be None if it's not required by op.
+    lhs_target: str
+        Choice of `u`(source), `e`(edge) or `v`(destination) for left operand.
+    rhs_target: str
+        Choice of `u`(source), `e`(edge) or `v`(destination) for right operand.
+
+    Returns
+    -------
+    tensor
+        The result tensor.
+    """
+    return gsddmm_internal(
+        g._graph, op, lhs_data, rhs_data, lhs_target, rhs_target)
 
 def _gen_sddmm_func(lhs_target, rhs_target, binary_op):
     name = "{}_{}_{}".format(lhs_target, binary_op, rhs_target)

--- a/python/dgl/ops/spmm.py
+++ b/python/dgl/ops/spmm.py
@@ -1,9 +1,46 @@
 """dgl spmm operator module."""
 import sys
-from ..backend import gspmm
+from ..backend import gspmm as gspmm_internal
 
 __all__ = ['gspmm']
 
+
+def gspmm(g, op, reduce_op, lhs_data, rhs_data):
+    r""" Generalized Sparse Matrix Multiplication interface.
+    It fuses two steps into one kernel.
+    (1) Computes messages by :attr:`op` source node and edge features.
+    (2) Aggregate the messages by :attr:`reduce_op` as the features on destination nodes.
+
+    .. math::
+        x_v = \psi_{(u, v, e)\in \mathcal{G}}(\rho(x_u, x_e))
+
+    where :math:`x_v` is the returned feature on destination nodes, and :math`x_u`,
+    :math:`x_e` refers to :attr:`u`, :attr:`e` respectively. :math:`\rho` means binary
+    operator :attr:`op` and :math:`\psi` means reduce operator :attr:`reduce_op`,
+    :math:`\mathcal{G}` is the graph we apply gspmm on: :attr:`g`.
+
+    Note that this function does not handle gradients.
+
+    Parameters
+    ----------
+    g : DGLGraph
+        The input graph.
+    op : str
+        The binary op's name, could be ``add``, ``sub``, ``mul``, ``div``,
+        ``copy_lhs``, ``copy_rhs``.
+    reduce_op : str
+        Reduce operator, could be ``sum``, ``max``, ``min``.
+    lhs_data : tensor or None
+        The left operand, could be None if it's not required by the op.
+    rhs_data : tensor or None
+        The right operand, could be None if it's not required by the op.
+
+    Returns
+    -------
+    tensor
+        The result tensor.
+    """
+    return gspmm_internal(g._graph, op, reduce_op, lhs_data, rhs_data)
 
 def _gen_spmm_func(binary_op, reduce_op):
     name = "u_{}_e_{}".format(binary_op, reduce_op)

--- a/python/dgl/sparse.py
+++ b/python/dgl/sparse.py
@@ -109,9 +109,7 @@ def _gspmm(gidx, op, reduce_op, u, e):
 
     Notes
     -----
-    This function does not handle gradients, and for scalar input features,
-    we expand its dimension with an additional dimension of length one. (e.g.
-    (90,) to (90, 1) for a graph with 90 nodes/edges).
+    This function does not handle gradients.
     """
     if gidx.number_of_etypes() != 1:
         raise DGLError("We only support gspmm on graph with one edge type")
@@ -192,9 +190,7 @@ def _gsddmm(gidx, op, lhs, rhs, lhs_target='u', rhs_target='v'):
 
     Notes
     -----
-    This function does not handle gradients, and for scalar input features,
-    we expand its dimension with an additional dimension of length one. (e.g.
-    (90,) to (90, 1) for a graph with 90 nodes/edges).
+    This function does not handle gradients.
     """
     if gidx.number_of_etypes() != 1:
         raise DGLError("We only support gsddmm on graph with one edge type")

--- a/tests/compute/test_sparse.py
+++ b/tests/compute/test_sparse.py
@@ -1,4 +1,4 @@
-from dgl.backend import gspmm, gsddmm
+from dgl.ops import gspmm, gsddmm
 from utils import parametrize_dtype
 import dgl
 import random


### PR DESCRIPTION
## Description
Duplicate of #1864 , the previous PR was closed because `graph_refactor` branch was merged.

------------previous context----------------
As described in #1863 , currently dgl's message passing function do not support 2nd-order derivative. This could be fixed by forcing backward function to call operators with autograd.

For the following code:
```python
import dgl
import torch as th
import dgl.ops as F
from torch.autograd import grad

x = th.rand(3, 4, requires_grad=True)
g = dgl.rand_graph(3, 9)
y = F.u_mul_v(g, x, x)
loss = y.sum()
x_grad = grad(loss, [x], create_graph=True)[0]
x_grad.sum().backward()
print(x.grad)
```

Before:
```
Traceback (most recent call last):
  File "***.py", line 11, in <module>
    x_grad[0].sum().backward()
  File "/home/expye/anaconda3/lib/python3.7/site-packages/torch/tensor.py", line 198, in backward
    torch.autograd.backward(self, gradient, retain_graph, create_graph)
  File "/home/expye/anaconda3/lib/python3.7/site-packages/torch/autograd/__init__.py", line 100, in backward
    allow_unreachable=True)  # allow_unreachable flag
RuntimeError: element 0 of tensors does not require grad and does not have a grad_fn
```

After:
```
tensor([[6., 6., 6., 6.],
        [6., 6., 6., 6.],
        [6., 6., 6., 6.]])
```

This PR might introduce some extra python overhead, need investigating how serious it is.

## Checklist
Please feel free to remove inapplicable items for your PR.
- [x] The PR title starts with [$CATEGORY] (such as [NN], [Model], [Doc], [Feature]])
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage
- [x] Code is well-documented
- [x] To the my best knowledge, examples are either not affected by this change,
      or have been fixed to be compatible with this change
- [x] Related issue is referred in this PR

