### PR TITLE
[Hotfix] fix excessive warnings

### DIFF
--- a/python/dgl/_ffi/function.py
+++ b/python/dgl/_ffi/function.py
@@ -284,7 +284,8 @@ def _init_api_prefix(module_name, prefix):
     module = sys.modules[module_name]
 
     for name in list_global_func_names():
-        if not name.startswith('_deprecate') and name.startswith("_"):
+        if name.startswith("_") and not name.startswith('_deprecate'):
+            # internal APIs are ignored
             continue
         name_split = name.rsplit('.', 1)
         if name_split[0] != prefix:
@@ -304,7 +305,8 @@ def _init_api_prefix(module_name, prefix):
 
 def _init_internal_api():
     for name in list_global_func_names():
-        if not name.startswith("_"):
+        if not name.startswith("_") or name.startswith('_deprecate'):
+            # normal APIs are ignored
             continue
         target_module = sys.modules["dgl._api_internal"]
         fname = name


### PR DESCRIPTION
## Description
<!-- Brief description. Refer to the related issues if existed.
It'll be great if relevant reviewers can be assigned as well.-->

Fix excessive warnings like `Warning: invalid API name "_deprecate.runtime.degree_bucketing._CAPI_DGLDegreeBucketing".`

## Checklist
Please feel free to remove inapplicable items for your PR.
- [x] The PR title starts with [$CATEGORY] (such as [NN], [Model], [Doc], [Feature]])
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage
- [x] Code is well-documented
- [x] To the my best knowledge, examples are either not affected by this change,
      or have been fixed to be compatible with this change