### PR TITLE
[hotfix] Remove usage of deprecated API `adjacency_matrix_scipy'`

### DIFF
--- a/python/dgl/transform.py
+++ b/python/dgl/transform.py
@@ -386,7 +386,7 @@ def khop_adj(g, k):
             [1., 3., 3., 1., 0.],
             [0., 1., 3., 3., 1.]])
     """
-    adj_k = g.adjacency_matrix_scipy(return_edge_ids=False) ** k
+    adj_k = g.adj(scipy_fmt=g.formats()['created'][0]) ** k
     return F.tensor(adj_k.todense().astype(np.float32))
 
 def khop_graph(g, k):
@@ -435,7 +435,7 @@ def khop_graph(g, k):
              edata_schemes={})
     """
     n = g.number_of_nodes()
-    adj_k = g.adjacency_matrix_scipy(transpose=True, return_edge_ids=False) ** k
+    adj_k = g.adj(transpose=True, scipy_fmt=g.formats()['created'][0]) ** k
     adj_k = adj_k.tocoo()
     multiplicity = adj_k.data
     row = np.repeat(adj_k.row, multiplicity)
@@ -687,7 +687,7 @@ def laplacian_lambda_max(g):
     rst = []
     for g_i in g_arr:
         n = g_i.number_of_nodes()
-        adj = g_i.adjacency_matrix_scipy(return_edge_ids=False).astype(float)
+        adj = g_i.adj(scipy_fmt=g_i.formats()['created'][0]).astype(float)
         norm = sparse.diags(F.asnumpy(g_i.in_degrees()).clip(1) ** -0.5, dtype=float)
         laplacian = sparse.eye(n) - norm * adj * norm
         rst.append(sparse.linalg.eigs(laplacian, 1, which='LM',

--- a/tests/compute/test_graph.py
+++ b/tests/compute/test_graph.py
@@ -253,24 +253,13 @@ def test_scipy_adjmat():
     g.add_nodes(10)
     g.add_edges(range(9), range(1, 10))
 
-    adj_0 = g.adjacency_matrix_scipy()
-    adj_1 = g.adjacency_matrix_scipy(fmt='coo')
+    adj_0 = g.adj(scipy_fmt='csr')
+    adj_1 = g.adj(scipy_fmt='coo')
     assert np.array_equal(adj_0.toarray(), adj_1.toarray())
 
-    adj_t0 = g.adjacency_matrix_scipy(transpose=True)
-    adj_t_1 = g.adjacency_matrix_scipy(transpose=True, fmt='coo')
+    adj_t0 = g.adj(transpose=True, scipy_fmt='csr')
+    adj_t_1 = g.adj(transpose=True, scipy_fmt='coo')
     assert np.array_equal(adj_0.toarray(), adj_1.toarray())
-
-    g.readonly()
-    adj_2 = g.adjacency_matrix_scipy()
-    adj_3 = g.adjacency_matrix_scipy(fmt='coo')
-    assert np.array_equal(adj_2.toarray(), adj_3.toarray())
-    assert np.array_equal(adj_0.toarray(), adj_2.toarray())
-
-    adj_t2 = g.adjacency_matrix_scipy(transpose=True)
-    adj_t3 = g.adjacency_matrix_scipy(transpose=True, fmt='coo')
-    assert np.array_equal(adj_t2.toarray(), adj_t3.toarray())
-    assert np.array_equal(adj_t0.toarray(), adj_t2.toarray())
 
 def test_incmat():
     g = dgl.DGLGraph()


### PR DESCRIPTION
## Description
As described in the title.

## Checklist
Please feel free to remove inapplicable items for your PR.
- [x] The PR title starts with [$CATEGORY] (such as [NN], [Model], [Doc], [Feature]])
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage
- [x] Code is well-documented
- [x] To the my best knowledge, examples are either not affected by this change,
      or have been fixed to be compatible with this change
- [x] Related issue is referred in this PR