### PR TITLE
[API] remove the expand_as_pair call

### DIFF
--- a/examples/pytorch/rgcn-hetero/model.py
+++ b/examples/pytorch/rgcn-hetero/model.py
@@ -101,7 +101,13 @@ class RelGraphConvLayer(nn.Module):
                      for i, w in enumerate(th.split(weight, 1, dim=0))}
         else:
             wdict = {}
-        inputs_src, inputs_dst = dglnn.expand_as_pair(inputs, g)
+
+        if g.is_block:
+            inputs_src = inputs
+            inputs_dst = {k: v[:g.number_of_dst_nodes(k)] for k, v in inputs.items()}
+        else:
+            inputs_src, inputs_dst = inputs
+
         hs = self.conv(g, inputs, mod_kwargs=wdict)
 
         def _apply(ntype, h):


### PR DESCRIPTION
Previously the RGCN example calls `expand_as_pair` function to automatically do feature slicing.  This will be removed and we shall recommend users to do the slicing manually if they were to write their custom NN module to work with blocks, as per the user guide.