### PR TITLE
[Distributed] Set the number of threads correctly to speed up

### DIFF
--- a/python/dgl/distributed/dist_context.py
+++ b/python/dgl/distributed/dist_context.py
@@ -1,6 +1,5 @@
 """Initialize the distributed services"""
 
-import os
 import multiprocessing as mp
 import traceback
 import atexit

--- a/python/dgl/distributed/dist_context.py
+++ b/python/dgl/distributed/dist_context.py
@@ -9,7 +9,7 @@ from .constants import MAX_QUEUE_SIZE
 from .kvstore import init_kvstore, close_kvstore
 from .rpc_client import connect_to_server, shutdown_servers
 from .role import init_role
-from .._ffi.function import _init_api
+from .. import utils
 
 SAMPLER_POOL = None
 NUM_SAMPLER_WORKERS = 0
@@ -30,7 +30,7 @@ def _init_rpc(ip_config, max_queue_size, net_type, role):
     ''' This init function is called in the worker processes.
     '''
     try:
-        _CAPI_DGLSetOMPThreads(1)
+        utils.set_num_threads(1)
         connect_to_server(ip_config, max_queue_size, net_type)
         init_role(role)
         init_kvstore(ip_config, role)
@@ -55,6 +55,7 @@ def initialize(ip_config, num_workers=0, max_queue_size=MAX_QUEUE_SIZE, net_type
     """
     rpc.reset()
     ctx = mp.get_context("spawn")
+    utils.set_num_threads(1)
     global SAMPLER_POOL
     global NUM_SAMPLER_WORKERS
     if num_workers > 0:
@@ -112,5 +113,3 @@ def exit_client():
     join_finalize_worker()
     close_kvstore()
     atexit.unregister(exit_client)
-
-_init_api("dgl.distributed.dist_context")

--- a/python/dgl/distributed/dist_context.py
+++ b/python/dgl/distributed/dist_context.py
@@ -1,9 +1,11 @@
 """Initialize the distributed services"""
 
+import os
 import multiprocessing as mp
 import traceback
 import atexit
 import time
+import torch as th
 from . import rpc
 from .constants import MAX_QUEUE_SIZE
 from .kvstore import init_kvstore, close_kvstore
@@ -29,6 +31,8 @@ def _init_rpc(ip_config, max_queue_size, net_type, role):
     ''' This init function is called in the worker processes.
     '''
     try:
+        os.environ['OMP_NUM_THREADS'] = '1'
+        th.set_num_threads(1)
         connect_to_server(ip_config, max_queue_size, net_type)
         init_role(role)
         init_kvstore(ip_config, role)

--- a/python/dgl/distributed/dist_context.py
+++ b/python/dgl/distributed/dist_context.py
@@ -26,11 +26,11 @@ def get_sampler_pool():
     return SAMPLER_POOL, NUM_SAMPLER_WORKERS
 
 
-def _init_rpc(ip_config, max_queue_size, net_type, role):
+def _init_rpc(ip_config, max_queue_size, net_type, role, num_threads):
     ''' This init function is called in the worker processes.
     '''
     try:
-        utils.set_num_threads(1)
+        utils.set_num_threads(num_threads)
         connect_to_server(ip_config, max_queue_size, net_type)
         init_role(role)
         init_kvstore(ip_config, role)
@@ -40,7 +40,8 @@ def _init_rpc(ip_config, max_queue_size, net_type, role):
         raise e
 
 
-def initialize(ip_config, num_workers=0, max_queue_size=MAX_QUEUE_SIZE, net_type='socket'):
+def initialize(ip_config, num_workers=0, max_queue_size=MAX_QUEUE_SIZE, net_type='socket',
+               num_worker_threads=1):
     """Init rpc service
     ip_config: str
         File path of ip_config file
@@ -52,6 +53,8 @@ def initialize(ip_config, num_workers=0, max_queue_size=MAX_QUEUE_SIZE, net_type
         it will not allocate 20GB memory at once.
     net_type : str
         Networking type. Current options are: 'socket'.
+    num_worker_threads: int
+        The number of threads in a worker process.
     """
     rpc.reset()
     ctx = mp.get_context("spawn")
@@ -61,7 +64,7 @@ def initialize(ip_config, num_workers=0, max_queue_size=MAX_QUEUE_SIZE, net_type
     if num_workers > 0:
         SAMPLER_POOL = ctx.Pool(
             num_workers, initializer=_init_rpc, initargs=(ip_config, max_queue_size,
-                                                          net_type, 'sampler'))
+                                                          net_type, 'sampler', num_worker_threads))
     NUM_SAMPLER_WORKERS = num_workers
     connect_to_server(ip_config, max_queue_size, net_type)
     init_role('default')

--- a/python/dgl/distributed/dist_context.py
+++ b/python/dgl/distributed/dist_context.py
@@ -10,6 +10,7 @@ from .constants import MAX_QUEUE_SIZE
 from .kvstore import init_kvstore, close_kvstore
 from .rpc_client import connect_to_server, shutdown_servers
 from .role import init_role
+from .._ffi.function import _init_api
 
 SAMPLER_POOL = None
 NUM_SAMPLER_WORKERS = 0

--- a/python/dgl/distributed/dist_context.py
+++ b/python/dgl/distributed/dist_context.py
@@ -113,4 +113,4 @@ def exit_client():
     close_kvstore()
     atexit.unregister(exit_client)
 
-_init_api("dgl.utils")
+_init_api("dgl.distributed.dist_context")

--- a/python/dgl/distributed/dist_context.py
+++ b/python/dgl/distributed/dist_context.py
@@ -58,7 +58,6 @@ def initialize(ip_config, num_workers=0, max_queue_size=MAX_QUEUE_SIZE, net_type
     """
     rpc.reset()
     ctx = mp.get_context("spawn")
-    utils.set_num_threads(1)
     global SAMPLER_POOL
     global NUM_SAMPLER_WORKERS
     if num_workers > 0:

--- a/python/dgl/distributed/dist_context.py
+++ b/python/dgl/distributed/dist_context.py
@@ -5,7 +5,6 @@ import multiprocessing as mp
 import traceback
 import atexit
 import time
-import torch as th
 from . import rpc
 from .constants import MAX_QUEUE_SIZE
 from .kvstore import init_kvstore, close_kvstore
@@ -31,8 +30,7 @@ def _init_rpc(ip_config, max_queue_size, net_type, role):
     ''' This init function is called in the worker processes.
     '''
     try:
-        os.environ['OMP_NUM_THREADS'] = '1'
-        th.set_num_threads(1)
+        _CAPI_DGLSetOMPThreads(1)
         connect_to_server(ip_config, max_queue_size, net_type)
         init_role(role)
         init_kvstore(ip_config, role)
@@ -114,3 +112,5 @@ def exit_client():
     join_finalize_worker()
     close_kvstore()
     atexit.unregister(exit_client)
+
+_init_api("dgl.utils")

--- a/python/dgl/utils/internal.py
+++ b/python/dgl/utils/internal.py
@@ -796,6 +796,13 @@ def extract_subframes(graph, nodes, edges):
     return node_frames, edge_frames
 
 def set_num_threads(num_threads):
+    """Set the number of OMP threads in the process.
+
+    Parameters
+    ----------
+    num_threads : int
+        The number of OMP threads in the process.
+    """
     _CAPI_DGLSetOMPThreads(num_threads)
 
 _init_api("dgl.utils.internal")

--- a/python/dgl/utils/internal.py
+++ b/python/dgl/utils/internal.py
@@ -9,6 +9,7 @@ import numpy as np
 from ..base import DGLError, dgl_warning, NID, EID
 from .. import backend as F
 from .. import ndarray as nd
+from .._ffi.function import _init_api
 
 class InconsistentDtypeException(DGLError):
     """Exception class for inconsistent dtype between graph and tensor"""
@@ -793,3 +794,8 @@ def extract_subframes(graph, nodes, edges):
             subf[EID] = ind_edges
             edge_frames.append(subf)
     return node_frames, edge_frames
+
+def set_num_threads(num_threads):
+    _CAPI_DGLSetOMPThreads(num_threads)
+
+_init_api("dgl.utils.internal")

--- a/src/runtime/utils.cc
+++ b/src/runtime/utils.cc
@@ -1,0 +1,22 @@
+/*!
+ *  Copyright (c) 2020 by Contributors
+ * \file utils.cc
+ * \brief DGL util functions
+ */
+
+#include <omp.h>
+
+#include <dgl/packed_func_ext.h>
+#include "../c_api_common.h"
+
+using namespace dgl::runtime;
+
+namespace dgl {
+
+DGL_REGISTER_GLOBAL("utils._CAPI_DGLSetOMPThreads")
+.set_body([] (DGLArgs args, DGLRetValue* rv) {
+    int num_threads = args[0];
+    omp_set_num_threads(num_threads);
+  });
+
+}  // namespace dgl

--- a/src/runtime/utils.cc
+++ b/src/runtime/utils.cc
@@ -13,7 +13,7 @@ using namespace dgl::runtime;
 
 namespace dgl {
 
-DGL_REGISTER_GLOBAL("distributed.dist_context._CAPI_DGLSetOMPThreads")
+DGL_REGISTER_GLOBAL("utils.internal._CAPI_DGLSetOMPThreads")
 .set_body([] (DGLArgs args, DGLRetValue* rv) {
     int num_threads = args[0];
     omp_set_num_threads(num_threads);

--- a/src/runtime/utils.cc
+++ b/src/runtime/utils.cc
@@ -13,7 +13,7 @@ using namespace dgl::runtime;
 
 namespace dgl {
 
-DGL_REGISTER_GLOBAL("utils._CAPI_DGLSetOMPThreads")
+DGL_REGISTER_GLOBAL("distributed.dist_context._CAPI_DGLSetOMPThreads")
 .set_body([] (DGLArgs args, DGLRetValue* rv) {
     int num_threads = args[0];
     omp_set_num_threads(num_threads);

--- a/tools/launch.py
+++ b/tools/launch.py
@@ -38,6 +38,7 @@ def submit_jobs(args, udf_command):
     client_count_per_machine = int(args.num_client / len(hosts))
     # launch server tasks
     server_cmd = 'DGL_ROLE=server'
+    server_cmd = server_cmd + ' ' + 'OMP_NUM_THREADS=' + str(args.num_server_threads)
     server_cmd = server_cmd + ' ' + 'DGL_NUM_CLIENT=' + str(args.num_client)
     server_cmd = server_cmd + ' ' + 'DGL_CONF_PATH=' + str(args.part_config)
     server_cmd = server_cmd + ' ' + 'DGL_IP_CONFIG=' + str(args.ip_config)
@@ -91,6 +92,10 @@ def main():
                         help='The file (in workspace) of the partition config')
     parser.add_argument('--ip_config', type=str,
                         help='The file (in workspace) of IP configuration for server processes')
+    parser.add_argument('--num_server_threads', type=int, default=1,
+                        help='The number of OMP threads in the server process. \
+                        It should be small if server processes and trainer processes run on \
+                        the same machine. By default, it is 1.')
     args, udf_command = parser.parse_known_args()
     assert len(udf_command) == 1, 'Please provide user command line.'
     assert args.num_client > 0, '--num_client must be a positive number.'


### PR DESCRIPTION
## Description
When running all processes (trainer, sampler and server) together on the same set of machines, every process is competing for CPU resources. We need to set up the threads correctly to reduce the conflicts on CPU. The sampler processes and the server processes should use fewer threads.

## Checklist
Please feel free to remove inapplicable items for your PR.
- [ ] The PR title starts with [$CATEGORY] (such as [NN], [Model], [Doc], [Feature]])
- [ ] Changes are complete (i.e. I finished coding on this PR)
- [ ] All changes have test coverage
- [ ] Code is well-documented
- [ ] To the my best knowledge, examples are either not affected by this change,
      or have been fixed to be compatible with this change
- [ ] Related issue is referred in this PR

## Changes
<!-- You could use following template
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)
-->
