### PR TITLE
no tuple input for heteroconv and each submodule call will take tuple

### DIFF
--- a/python/dgl/nn/pytorch/hetero.py
+++ b/python/dgl/nn/pytorch/hetero.py
@@ -135,38 +135,25 @@ class HeteroGraphConv(nn.Module):
         if mod_kwargs is None:
             mod_kwargs = {}
         outputs = {nty : [] for nty in g.dsttypes}
-        if isinstance(inputs, tuple) or g.is_block:
-            if isinstance(inputs, tuple):
-                src_inputs, dst_inputs = inputs
-            else:
-                src_inputs = inputs
-                dst_inputs = {k: v[:g.number_of_dst_nodes(k)] for k, v in inputs.items()}
 
-            for stype, etype, dtype in g.canonical_etypes:
-                rel_graph = g[stype, etype, dtype]
-                if rel_graph.number_of_edges() == 0:
-                    continue
-                if stype not in src_inputs or dtype not in dst_inputs:
-                    continue
-                dstdata = self.mods[etype](
-                    rel_graph,
-                    (src_inputs[stype], dst_inputs[dtype]),
-                    *mod_args.get(etype, ()),
-                    **mod_kwargs.get(etype, {}))
-                outputs[dtype].append(dstdata)
+        if g.is_block:
+            src_inputs = inputs
+            dst_inputs = {k: v[:g.number_of_dst_nodes(k)] for k, v in inputs.items()}
         else:
-            for stype, etype, dtype in g.canonical_etypes:
-                rel_graph = g[stype, etype, dtype]
-                if rel_graph.number_of_edges() == 0:
-                    continue
-                if stype not in inputs:
-                    continue
-                dstdata = self.mods[etype](
-                    rel_graph,
-                    inputs[stype],
-                    *mod_args.get(etype, ()),
-                    **mod_kwargs.get(etype, {}))
-                outputs[dtype].append(dstdata)
+            src_inputs = dst_inputs = inputs
+
+        for stype, etype, dtype in g.canonical_etypes:
+            rel_graph = g[stype, etype, dtype]
+            if rel_graph.number_of_edges() == 0:
+                continue
+            if stype not in src_inputs or dtype not in dst_inputs:
+                continue
+            dstdata = self.mods[etype](
+                rel_graph,
+                (src_inputs[stype], dst_inputs[dtype]),
+                *mod_args.get(etype, ()),
+                **mod_kwargs.get(etype, {}))
+            outputs[dtype].append(dstdata)
         rsts = {}
         for nty, alist in outputs.items():
             if len(alist) != 0:


### PR DESCRIPTION
## Description

Current HeteroConv implementation seems not updated with some graph code change. Put the fix here:
1.Now we have g.is_block, HeteroConv will never receive tuple as input now;
2.For the nn module call for each relation, we will force each input is a bipartite graph and its tuple features.

## Checklist
Please feel free to remove inapplicable items for your PR.
- [ ] The PR title starts with [$CATEGORY] (such as [NN], [Model], [Doc], [Feature]])
- [ ] Changes are complete (i.e. I finished coding on this PR)
- [ ] All changes have test coverage
- [ ] Code is well-documented
- [ ] To the my best knowledge, examples are either not affected by this change,
      or have been fixed to be compatible with this change
- [ ] Related issue is referred in this PR

## Changes
<!-- You could use following template
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)
-->
