### PR TITLE
[hotfix] Set reduce results to all zero for nodes with zero in-degrees.

### DIFF
--- a/python/dgl/backend/pytorch/tensor.py
+++ b/python/dgl/backend/pytorch/tensor.py
@@ -277,7 +277,7 @@ def full_1d(length, fill_value, dtype, ctx):
     return th.full((length,), fill_value, dtype=dtype, device=ctx)
 
 def nonzero_1d(input):
-    x = th.nonzero(input).squeeze()
+    x = th.nonzero(input, as_tuple=False).squeeze()
     return x if x.dim() == 1 else x.view(-1)
 
 def sort_1d(input):

--- a/tests/compute/test_sparse.py
+++ b/tests/compute/test_sparse.py
@@ -116,9 +116,6 @@ def test_spmm(idtype, g, shp, msg, reducer):
     e = F.attach_grad(F.clone(he))
     with F.record_grad():
         v = gspmm(g, msg, reducer, u, e)
-        non_degree_indices = F.tensor(
-            np.nonzero(F.asnumpy(g.in_degrees()) != 0)[0])
-        v = F.gather_row(v, non_degree_indices)
         if g.number_of_edges() > 0:
             F.backward(F.reduce_sum(v))
             if msg != 'copy_rhs':
@@ -129,7 +126,7 @@ def test_spmm(idtype, g, shp, msg, reducer):
     with F.record_grad():
         g.update_all(udf_msg[msg], udf_reduce[reducer])
         if g.number_of_edges() > 0:
-            v1 = F.gather_row(g.dstdata['v'], non_degree_indices)
+            v1 = g.dstdata['v']
             assert F.allclose(v, v1)
             print('forward passed')
 


### PR DESCRIPTION
## Description
Previously DGL has undefined behavior for reduce result on zero-degree nodes. This PR sets them to all zero:
```python
>>> import dgl
Using backend: pytorch
>>> import torch as th
>>> g = dgl.graph(([0, 1, 2, 3], [1, 2, 3, 4]))
>>> x = th.rand(5, 10)
>>> dgl.ops.copy_u_max(g, x)
tensor([[0.0000, 0.0000, 0.0000, 0.0000, 0.0000, 0.0000, 0.0000, 0.0000, 0.0000,
         0.0000],
        [0.3055, 0.1600, 0.7976, 0.1421, 0.8501, 0.0036, 0.4006, 0.8031, 0.9568,
         0.0552],
        [0.9056, 0.5081, 0.6965, 0.5684, 0.6408, 0.7829, 0.3059, 0.5300, 0.2697,
         0.8028],
        [0.0622, 0.6697, 0.1060, 0.4937, 0.7166, 0.7528, 0.2282, 0.4664, 0.4180,
         0.6400],
        [0.6326, 0.5684, 0.7983, 0.8936, 0.5530, 0.8989, 0.5928, 0.4090, 0.0238,
         0.5744]])
>>> 

```

## Checklist
Please feel free to remove inapplicable items for your PR.
- [x] The PR title starts with [$CATEGORY] (such as [NN], [Model], [Doc], [Feature]])
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage
- [x] Code is well-documented
- [x] To the my best knowledge, examples are either not affected by this change,
      or have been fixed to be compatible with this change
- [x] Related issue is referred in this PR
