### PR TITLE
[hotfix] Only filling zeros for isolated nodes in min/max reducer

### DIFF
--- a/python/dgl/ops/spmm.py
+++ b/python/dgl/ops/spmm.py
@@ -62,7 +62,9 @@ def gspmm(g, op, reduce_op, lhs_data, rhs_data):
     ret = gspmm_internal(g._graph, op,
                          'sum' if reduce_op == 'mean' else reduce_op,
                          lhs_data, rhs_data)
-    ret = F.replace_inf_with_zero(ret)
+    # Replace infinity with zero for isolated nodes when reducer is min/max
+    if reduce_op in ['min', 'max']:
+        ret = F.replace_inf_with_zero(ret)
 
     # divide in degrees for mean reducer.
     if reduce_op == 'mean':


### PR DESCRIPTION
## Description
The result tensor in spmm with sum reducer is initialized with all zeros, no need to set them to zeros again.

## Checklist
Please feel free to remove inapplicable items for your PR.
- [x] The PR title starts with [$CATEGORY] (such as [NN], [Model], [Doc], [Feature]])
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage
- [x] Code is well-documented
- [x] To the my best knowledge, examples are either not affected by this change,
      or have been fixed to be compatible with this change
- [x] Related issue is referred in this PR

