### PR TITLE
[Windows] Work around the bug from CL 19.10

### DIFF
--- a/include/dgl/runtime/container.h
+++ b/include/dgl/runtime/container.h
@@ -689,6 +689,17 @@ inline std::vector<T> ListValueToVector(const List<Value>& list) {
   return ret;
 }
 
+// (BarclayII) Gets around error raised by MSVC compiler 19.10, the latest version
+// supported by CUDA 9.0.
+template <>
+inline std::vector<std::string> ListValueToVector(const List<Value>& list) {
+  std::vector<std::string> ret;
+  ret.reserve(list.size());
+  for (Value val : list)
+    ret.push_back(val->data.operator std::string());
+  return ret;
+}
+
 }  // namespace runtime
 }  // namespace dgl
 

--- a/include/dgl/runtime/container.h
+++ b/include/dgl/runtime/container.h
@@ -685,18 +685,10 @@ inline std::vector<T> ListValueToVector(const List<Value>& list) {
   std::vector<T> ret;
   ret.reserve(list.size());
   for (Value val : list)
-    ret.push_back(val->data);
-  return ret;
-}
-
-// (BarclayII) Gets around error raised by MSVC compiler 19.10, the latest version
-// supported by CUDA 9.0.
-template <>
-inline std::vector<std::string> ListValueToVector(const List<Value>& list) {
-  std::vector<std::string> ret;
-  ret.reserve(list.size());
-  for (Value val : list)
-    ret.push_back(val->data.operator std::string());
+    // (BarclayII) apparently MSVC 2017 CL 19.10 had trouble parsing
+    //     ret.push_back(val->data)
+    // So I kindly tell it how to properly parse it.
+    ret.push_back(val->data.operator T());
   return ret;
 }
 

--- a/python/dgl/sampling/neighbor.py
+++ b/python/dgl/sampling/neighbor.py
@@ -162,12 +162,10 @@ def sample_neighbors(g, nodes, fanout, edge_dir='in', prob=None, replace=False,
     # only set the edge IDs.
     if not _dist_training:
         if copy_ndata:
-            print(g, type(g))
             node_frames = utils.extract_node_subframes(g, None)
             utils.set_new_frames(ret, node_frames=node_frames)
 
         if copy_edata:
-            print(g, type(g))
             edge_frames = utils.extract_edge_subframes(g, induced_edges)
             utils.set_new_frames(ret, edge_frames=edge_frames)
     else:
@@ -296,12 +294,10 @@ def select_topk(g, k, weight, nodes=None, edge_dir='in', ascending=False,
 
     # handle features
     if copy_ndata:
-        print(g, type(g))
         node_frames = utils.extract_node_subframes(g, None)
         utils.set_new_frames(ret, node_frames=node_frames)
 
     if copy_edata:
-        print(g, type(g))
         edge_frames = utils.extract_edge_subframes(g, induced_edges)
         utils.set_new_frames(ret, edge_frames=edge_frames)
     return ret

--- a/tests/cpp/test_rowwise.cc
+++ b/tests/cpp/test_rowwise.cc
@@ -268,7 +268,7 @@ template <typename Idx, typename FloatType>
 void _TestCSRTopk(bool has_data) {
   auto mat = CSR<Idx>(has_data);
   FloatArray weight = NDArray::FromVector(
-      std::vector<FloatType>({.1, .0, -.1, .2, .5}));
+      std::vector<FloatType>({.1f, .0f, -.1f, .2f, .5f}));
   // -.1, .2, .1, .0, .5
   IdArray rows = NDArray::FromVector(std::vector<Idx>({0, 3}));
 
@@ -315,7 +315,7 @@ template <typename Idx, typename FloatType>
 void _TestCOOTopk(bool has_data) {
   auto mat = COO<Idx>(has_data);
   FloatArray weight = NDArray::FromVector(
-      std::vector<FloatType>({.1, .0, -.1, .2, .5}));
+      std::vector<FloatType>({.1f, .0f, -.1f, .2f, .5f}));
   // -.1, .2, .1, .0, .5
   IdArray rows = NDArray::FromVector(std::vector<Idx>({0, 3}));
 

--- a/tests/cpp/test_sampler.cc
+++ b/tests/cpp/test_sampler.cc
@@ -69,7 +69,7 @@ TEST(SampleUtilsTest, TestWithReplacement) {
 template <typename Idx, typename DType>
 void _TestWithoutReplacementOrder(RandomEngine *re) {
   // TODO(BarclayII): is there a reliable way to do this test?
-  std::vector<DType> _prob = {1e6, 1e-6, 1e-2, 1e2};
+  std::vector<DType> _prob = {1e6f, 1e-6f, 1e-2f, 1e2f};
   FloatArray prob = NDArray::FromVector(_prob);
   std::vector<Idx> ground_truth = {0, 3, 2, 1};
 


### PR DESCRIPTION
Apparently MSVC 2017 (CL 19.10) cannot parse `static_cast<std::string>(value->data)`, which blocks the compilation of CUDA 9.0 binaries.