### PR TITLE
[Distributed] change the argument name of copy_files script.

### DIFF
--- a/examples/pytorch/graphsage/experimental/README.md
+++ b/examples/pytorch/graphsage/experimental/README.md
@@ -49,7 +49,7 @@ the location of the partition configuration file).
 python3 ~/dgl/tools/copy_files.py \
 --ip_config ip_config.txt \
 --workspace ~/graphsage \
---rel_data_path ogb-product \
+--data_path ogb-product \
 --part_config data/ogb-product.json \
 --script_folder ~/dgl_code
 ```

--- a/examples/pytorch/rgcn/experimental/README.md
+++ b/examples/pytorch/rgcn/experimental/README.md
@@ -43,13 +43,13 @@ cp /home/ubuntu/dgl/examples/pytorch/rgcn/experimental/entity_classify_dist.py ~
 The command below copies partition data, ip config file, as well as training scripts to the machines in the cluster.
 The configuration of the cluster is defined by `ip_config.txt`.
 The data is copied to `~/rgcn/ogbn-mag` on each of the remote machines.
-`--rel_data_path` specifies the relative path in the workspace where the partitioned data will be stored.
+`--data_path` specifies the relative path in the workspace where the partitioned data will be stored.
 `--part_config` specifies the location of the partitioned data in the local machine (a user only needs to specify
 the location of the partition configuration file). `--script_folder` specifies the location of the training scripts.
 ```bash
 python ~/dgl/tools/copy_files.py --ip_config ip_config.txt \
                                  --workspace ~/rgcn \
-                                 --rel_data_path data \
+                                 --data_path data \
 				 --part_config data/ogbn-mag.json \
 			         --script_folder ~/dgl_code
 ```

--- a/tools/copy_files.py
+++ b/tools/copy_files.py
@@ -24,7 +24,7 @@ def main():
                         help='Path of user directory of distributed tasks. \
                         This is used to specify a destination location where \
                         data are copied to on remote machines.')
-    parser.add_argument('--rel_data_path', type=str, required=True,
+    parser.add_argument('--data_path', type=str, required=True,
                         help='Relative path in workspace to store the partition data.')
     parser.add_argument('--part_config', type=str, required=True,
                         help='The partition config file. The path is on the local machine.')
@@ -56,35 +56,35 @@ def main():
         if not isinstance(node_map, list):
             assert node_map[-4:] == '.npy', 'node map should be stored in a NumPy array.'
             tmp_part_metadata['node_map'] = '{}/{}/node_map.npy'.format(args.workspace,
-                                                                        args.rel_data_path)
+                                                                        args.data_path)
         if not isinstance(edge_map, list):
             assert edge_map[-4:] == '.npy', 'edge map should be stored in a NumPy array.'
             tmp_part_metadata['edge_map'] = '{}/{}/edge_map.npy'.format(args.workspace,
-                                                                        args.rel_data_path)
+                                                                        args.data_path)
 
         for part_id in range(num_parts):
             part_files = tmp_part_metadata['part-{}'.format(part_id)]
-            part_files['edge_feats'] = '{}/part{}/edge_feat.dgl'.format(args.rel_data_path, part_id)
-            part_files['node_feats'] = '{}/part{}/node_feat.dgl'.format(args.rel_data_path, part_id)
-            part_files['part_graph'] = '{}/part{}/graph.dgl'.format(args.rel_data_path, part_id)
+            part_files['edge_feats'] = '{}/part{}/edge_feat.dgl'.format(args.data_path, part_id)
+            part_files['node_feats'] = '{}/part{}/node_feat.dgl'.format(args.data_path, part_id)
+            part_files['part_graph'] = '{}/part{}/graph.dgl'.format(args.data_path, part_id)
     tmp_part_config = '/tmp/{}.json'.format(graph_name)
     with open(tmp_part_config, 'w') as outfile:
         json.dump(tmp_part_metadata, outfile, sort_keys=True, indent=4)
 
     # Copy ip config.
     for part_id, ip in enumerate(hosts):
-        remote_path = '{}/{}'.format(args.workspace, args.rel_data_path)
+        remote_path = '{}/{}'.format(args.workspace, args.data_path)
         exec_cmd(ip, 'mkdir -p {}'.format(remote_path))
 
         copy_file(args.ip_config, ip, args.workspace)
-        copy_file(tmp_part_config, ip, '{}/{}'.format(args.workspace, args.rel_data_path))
+        copy_file(tmp_part_config, ip, '{}/{}'.format(args.workspace, args.data_path))
         node_map = part_metadata['node_map']
         edge_map = part_metadata['edge_map']
         if not isinstance(node_map, list):
             copy_file(node_map, ip, tmp_part_metadata['node_map'])
         if not isinstance(edge_map, list):
             copy_file(edge_map, ip, tmp_part_metadata['edge_map'])
-        remote_path = '{}/{}/part{}'.format(args.workspace, args.rel_data_path, part_id)
+        remote_path = '{}/{}/part{}'.format(args.workspace, args.data_path, part_id)
         exec_cmd(ip, 'mkdir -p {}'.format(remote_path))
 
         part_files = part_metadata['part-{}'.format(part_id)]


### PR DESCRIPTION
## Description
To make the argument names consistent, it's better to change `rel_data_path` to `data_path`.

## Checklist
Please feel free to remove inapplicable items for your PR.
- [ ] The PR title starts with [$CATEGORY] (such as [NN], [Model], [Doc], [Feature]])
- [ ] Changes are complete (i.e. I finished coding on this PR)
- [ ] All changes have test coverage
- [ ] Code is well-documented
- [ ] To the my best knowledge, examples are either not affected by this change,
      or have been fixed to be compatible with this change
- [ ] Related issue is referred in this PR

## Changes
<!-- You could use following template
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)
-->
