### PR TITLE
Improve install from source to support Graviton2

### DIFF
--- a/docs/source/install/index.rst
+++ b/docs/source/install/index.rst
@@ -84,7 +84,7 @@ Download the source files from GitHub.
 
    git submodule update --init --recursive
 
-Linux
+Linux (x86 and Arm64)
 `````
 
 Install the system packages for building the shared library. For Debian and Ubuntu
@@ -122,11 +122,12 @@ for the same purpose.
       cmake -DUSE_CUDA=ON ..
       make -j4
 
-Finally, install the Python binding.
+Finally, upgrade the python depedencies, then call for Python binding.
 
 .. code:: bash
 
    cd ../python
+   pip3 install --user cython numpy networkx scipy 
    python setup.py install
 
 macOS


### PR DESCRIPTION
linux install instruction would work on arm64
updating python dependencies to work on arm64 where precompiled wheels may not exist

## Description
<!-- Brief description. Refer to the related issues if existed.
It'll be great if relevant reviewers can be assigned as well.-->

## Checklist
Please feel free to remove inapplicable items for your PR.
- [ ] The PR title starts with [$CATEGORY] (such as [NN], [Model], [Doc], [Feature]])
- [ ] Changes are complete (i.e. I finished coding on this PR)
- [ ] All changes have test coverage
- [ ] Code is well-documented
- [ ] To the my best knowledge, examples are either not affected by this change,
      or have been fixed to be compatible with this change
- [ ] Related issue is referred in this PR

## Changes
<!-- You could use following template
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)
-->
