### PR TITLE
[$Doc] Update install from source instructions for Arm64

### DIFF
--- a/docs/source/install/index.rst
+++ b/docs/source/install/index.rst
@@ -124,12 +124,12 @@ for the same purpose.
       cmake -DUSE_CUDA=ON ..
       make -j4
 
-Finally, upgrade the python depedencies, then call for Python binding.
+Finally, upgrade the python depedencies, then install Python binding.
 
 .. code:: bash
 
    cd ../python
-   pip3 install --user cython numpy networkx scipy
+   pip3 install --user  numpy networkx scipy
    python setup.py install
 
 macOS

--- a/docs/source/install/index.rst
+++ b/docs/source/install/index.rst
@@ -86,7 +86,7 @@ Download the source files from GitHub.
 
    git submodule update --init --recursive
 
-Linux
+Linux (for x86-64 and Arm64)
 `````
 
 Install the system packages for building the shared library. For Debian and Ubuntu
@@ -124,11 +124,12 @@ for the same purpose.
       cmake -DUSE_CUDA=ON ..
       make -j4
 
-Finally, install the Python binding.
+Finally, upgrade the python depedencies, then call for Python binding.
 
 .. code:: bash
 
    cd ../python
+   pip3 install --user cython numpy networkx scipy
    python setup.py install
 
 macOS


### PR DESCRIPTION
Confirm Arm64 can be built from source on linux.
Tested for compile and accuracy on Graviton2 servers (EC2 C6g, M6g, R6g)
Explicit installation of dependencies, in cases wheels not yet available for specific targets

## Description
<!-- Brief description. Refer to the related issues if existed.
It'll be great if relevant reviewers can be assigned as well.-->

## Checklist
Please feel free to remove inapplicable items for your PR.
- [x] The PR title starts with [$CATEGORY] (such as [NN], [Model], [Doc], [Feature]])
- [x] Changes are complete (i.e. I finished coding on this PR)
- [ ] All changes have test coverage
- [ ] Code is well-documented
- [x] To the my best knowledge, examples are either not affected by this change,
      or have been fixed to be compatible with this change
- [ ] Related issue is referred in this PR

## Changes
<!-- You could use following template
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)
-->
