### PR TITLE
[Doc] New style of code blocks with prompts; copy button

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -47,6 +47,7 @@ extensions = [
     'sphinx.ext.intersphinx',
     'sphinx.ext.graphviz',
     'sphinx_gallery.gen_gallery',
+    'sphinx_copybutton',
 ]
 
 # Add any paths that contain templates here, relative to this directory.
@@ -221,3 +222,7 @@ if dglbackend == 'mxnet':
     sphinx_gallery_conf['filename_pattern'] = "/*(?<=mx)\.py"
 if dglbackend == 'pytorch':
     sphinx_gallery_conf['filename_pattern'] = "/*(?<!mx)\.py"
+
+# sphinx-copybutton tool
+copybutton_prompt_text = r'>>> |\.\.\. '
+copybutton_prompt_is_regexp = True

--- a/docs/source/guide/graph-feature.rst
+++ b/docs/source/guide/graph-feature.rst
@@ -6,28 +6,29 @@
 The nodes and edges of a :class:`~dgl.DGLGraph` can have several user-defined named features for
 storing graph-specific properties of the nodes and edges. These features can be accessed
 via the :py:attr:`~dgl.DGLGraph.ndata` and :py:attr:`~dgl.DGLGraph.edata` interface. For example, the following code creates two node
-features (named ``'x'`` and ``'y'`` in lines 5 and 9) and one edge feature (named ``'x'`` in line 6).
+features (named ``'x'`` and ``'y'`` in lines 8 and 15) and one edge feature (named ``'x'`` in line 9).
 
-.. code::
+.. code-block:: python
+    :linenos:
 
-    01. >>> import dgl
-    02. >>> import torch as th
-    03. >>> g = dgl.graph(([0, 0, 1, 5], [1, 2, 2, 0])) # 6 nodes, 4 edges
-    04. >>> g
-        Graph(num_nodes=6, num_edges=4,
-              ndata_schemes={}
-              edata_schemes={})
-    05. >>> g.ndata['x'] = th.ones(g.num_nodes(), 3)               # node feature of length 3
-    06. >>> g.edata['x'] = th.ones(g.num_edges(), dtype=th.int32)  # scalar integer feature
-    07. >>> g
-        Graph(num_nodes=6, num_edges=4,
-              ndata_schemes={'x' : Scheme(shape=(3,), dtype=torch.float32)}
-              edata_schemes={'x' : Scheme(shape=(,), dtype=torch.int32)})
-    08. >>> # different names can have different shapes
-    09. >>> g.ndata['y'] = th.randn(g.num_nodes(), 5)
-    10. >>> g.ndata['x'][1]                  # get node 1's feature
-        tensor([1., 1., 1.])
-    11. >>> g.edata['x'][th.tensor([0, 3])]  # get features of edge 0 and 3
+    >>> import dgl
+    >>> import torch as th
+    >>> g = dgl.graph(([0, 0, 1, 5], [1, 2, 2, 0])) # 6 nodes, 4 edges
+    >>> g
+    Graph(num_nodes=6, num_edges=4,
+          ndata_schemes={}
+          edata_schemes={})
+    >>> g.ndata['x'] = th.ones(g.num_nodes(), 3)               # node feature of length 3
+    >>> g.edata['x'] = th.ones(g.num_edges(), dtype=th.int32)  # scalar integer feature
+    >>> g
+    Graph(num_nodes=6, num_edges=4,
+          ndata_schemes={'x' : Scheme(shape=(3,), dtype=torch.float32)}
+          edata_schemes={'x' : Scheme(shape=(,), dtype=torch.int32)})
+    >>> # different names can have different shapes
+    >>> g.ndata['y'] = th.randn(g.num_nodes(), 5)
+    >>> g.ndata['x'][1]                  # get node 1's feature
+    tensor([1., 1., 1.])
+    >>> g.edata['x'][th.tensor([0, 3])]  # get features of edge 0 and 3
         tensor([1, 1], dtype=torch.int32)
 
 Important facts about the :py:attr:`~dgl.DGLGraph.ndata`/:py:attr:`~dgl.DGLGraph.edata` interface:
@@ -46,7 +47,7 @@ Important facts about the :py:attr:`~dgl.DGLGraph.ndata`/:py:attr:`~dgl.DGLGraph
 
 For weighted graphs, one can store the weights as an edge feature as below.
 
-.. code::
+.. code-block:: python
 
     >>> # edges 0->1, 0->2, 0->3, 1->3
     >>> edges = th.tensor([0, 0, 0, 1]), th.tensor([1, 2, 3, 3])


### PR DESCRIPTION
## Description
@classicsong brought up an issue on a code cell with manually numbered lines.  I don't like the appearance so I'm replacing it with `:lineno:` tag.

Also @classicsong mentioned that people wants to copy the code without prompts and outputs.  I found a solution using `sphinx-copybutton` extension.  Please check it out.

In the future developer's guide, we should put together another section settling the documentation style as well.