### PR TITLE
[hotfix] IsContiguous failed when tensor's size on first dimension is 1.

### DIFF
--- a/src/runtime/ndarray.cc
+++ b/src/runtime/ndarray.cc
@@ -137,7 +137,10 @@ bool NDArray::IsContiguous() const {
   CHECK(data_ != nullptr);
   if (data_->dl_tensor.strides == nullptr)
     return true;
-  for (int i = 0; i < data_->dl_tensor.ndim - 1; ++i) {
+  int i = 0;
+  if (data_->dl_tensor.ndim > 0 && data_->dl_tensor.shape[0] == 1)
+    i = 1;  // See https://github.com/dmlc/dgl/issues/2118
+  for (; i < data_->dl_tensor.ndim - 1; ++i) {
     if (data_->dl_tensor.strides[i] !=
         data_->dl_tensor.shape[i+1] * data_->dl_tensor.strides[i+1])
       return false;

--- a/src/runtime/ndarray.cc
+++ b/src/runtime/ndarray.cc
@@ -137,15 +137,18 @@ bool NDArray::IsContiguous() const {
   CHECK(data_ != nullptr);
   if (data_->dl_tensor.strides == nullptr)
     return true;
-  int i = 0;
-  if (data_->dl_tensor.ndim > 0 && data_->dl_tensor.shape[0] == 1)
-    i = 1;  // See https://github.com/dmlc/dgl/issues/2118
-  for (; i < data_->dl_tensor.ndim - 1; ++i) {
-    if (data_->dl_tensor.strides[i] !=
-        data_->dl_tensor.shape[i+1] * data_->dl_tensor.strides[i+1])
-      return false;
+
+  // See https://github.com/dmlc/dgl/issues/2118 and PyTorch's compute_contiguous() implementation
+  int64_t z = 1;
+  for (int64_t i = data_->dl_tensor.ndim - 1; i >= 0; --i) {
+    if (data_->dl_tensor.shape[i] != 1) {
+      if (data_->dl_tensor.strides[i] == z)
+        z *= data_->dl_tensor.shape[i];
+      else
+        return false;
+    }
   }
-  return data_->dl_tensor.strides[data_->dl_tensor.ndim - 1] == 1;
+  return true;
 }
 
 NDArray NDArray::CreateView(std::vector<int64_t> shape,


### PR DESCRIPTION
## Description
See #2118 .

When tensor's size on first dimension is 1, the stride on first dimension does not strictly equals the production of sizes on following dimensions:
```python
>>> torch.randn((1, 5, 3))[:, :3, :].contiguous().stride()  # (15, 3, 1), however, we expect (9, 3, 1)
```

## Checklist
Please feel free to remove inapplicable items for your PR.
- [x] The PR title starts with [$CATEGORY] (such as [NN], [Model], [Doc], [Feature]])
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage
- [x] Code is well-documented
- [x] To the my best knowledge, examples are either not affected by this change,
      or have been fixed to be compatible with this change
- [x] Related issue is referred in this PR
