### PR TITLE
[Feature?] BUG_ON macro and sanity check of FindEdges

### DIFF
--- a/include/dgl/runtime/c_runtime_api.h
+++ b/include/dgl/runtime/c_runtime_api.h
@@ -540,6 +540,21 @@ DGL_DLL int DGLStreamStreamSynchronize(int device_type,
                                        DGLStreamHandle src,
                                        DGLStreamHandle dst);
 
+/*!
+ * \brief Bug report macro.
+ *
+ * This serves as a sanity check on system side to make sure the code is correct by
+ * checking whether a condition always holds for complex reasons.  Failing the
+ * condition signifies a system bug instead of users giving invalid inputs or using
+ * the functionality incorrectly.
+ *
+ * Hints the user to file a bug report if the condition fails.
+ */
+#define BUG_ON(cond) \
+  CHECK(cond) << "A bug has been occurred.  " \
+                 "Please file a bug report at https://github.com/dmlc/dgl/issues.  " \
+                 "Message: "
+
 #ifdef __cplusplus
 }  // DGL_EXTERN_C
 #endif

--- a/src/graph/immutable_graph.cc
+++ b/src/graph/immutable_graph.cc
@@ -325,6 +325,8 @@ std::pair<dgl_id_t, dgl_id_t> COO::FindEdge(dgl_id_t eid) const {
 
 EdgeArray COO::FindEdges(IdArray eids) const {
   CHECK(aten::IsValidIdArray(eids)) << "Invalid edge id array";
+  BUG_ON(aten::IsNullArray(adj_.data)) <<
+    "FindEdges requires the internal COO matrix not having EIDs.";
   return EdgeArray{aten::IndexSelect(adj_.row, eids),
                    aten::IndexSelect(adj_.col, eids),
                    eids};

--- a/src/graph/unit_graph.cc
+++ b/src/graph/unit_graph.cc
@@ -232,6 +232,8 @@ class UnitGraph::COO : public BaseHeteroGraph {
 
   EdgeArray FindEdges(dgl_type_t etype, IdArray eids) const override {
     CHECK(aten::IsValidIdArray(eids)) << "Invalid edge id array";
+    CHECK(aten::IsNullArray(adj_.data)) <<
+      "[BUG] FindEdges requires the internal COO matrix not having EIDs.  Please report.";
     return EdgeArray{aten::IndexSelect(adj_.row, eids),
                      aten::IndexSelect(adj_.col, eids),
                      eids};

--- a/src/graph/unit_graph.cc
+++ b/src/graph/unit_graph.cc
@@ -232,8 +232,8 @@ class UnitGraph::COO : public BaseHeteroGraph {
 
   EdgeArray FindEdges(dgl_type_t etype, IdArray eids) const override {
     CHECK(aten::IsValidIdArray(eids)) << "Invalid edge id array";
-    CHECK(aten::IsNullArray(adj_.data)) <<
-      "[BUG] FindEdges requires the internal COO matrix not having EIDs.  Please report.";
+    BUG_ON(aten::IsNullArray(adj_.data)) <<
+      "FindEdges requires the internal COO matrix not having EIDs.";
     return EdgeArray{aten::IndexSelect(adj_.row, eids),
                      aten::IndexSelect(adj_.col, eids),
                      eids};


### PR DESCRIPTION
## Description

The implementation of `FindEdges` requires that the COO matrix does *not* have a `data` array.  This is true because currently the only place where COO can have `data` is when it is converted from a CSR/CSC, and we currently do not directly create a CSR/CSC in any place.  Since things may change in the future, I'm preemptively adding this sanity check to prevent it from throwing us off with incorrect results.