### PR TITLE
[Bugfix] fix TUDataset labelling issue (#2165)

### DIFF
--- a/python/dgl/data/tu.py
+++ b/python/dgl/data/tu.py
@@ -276,7 +276,13 @@ class TUDataset(DGLBuiltinDataset):
     Notes
     -----
     Graphs may have node labels, node attributes, edge labels, and edge attributes,
-    varing from different dataset. 
+    varing from different dataset.
+
+    Labels are mapped to :math:`\lbrace 0,\cdots,n-1 \rbrace` where :math:`n` is the
+    number of labels (some datasets have raw labels :math:`\lbrace -1, 1 \rbrace` which
+    will be mapped to :math:`\lbrace 0, 1 \rbrace`). In previous versions, the minimum
+    label was added so that :math:`\lbrace -1, 1 \rbrace` was mapped to
+    :math:`\lbrace 0, 2 \rbrace`.
     """
 
     _url = r"https://www.chrsmrrs.com/graphkerneldatasets/{}.zip"

--- a/python/dgl/data/tu.py
+++ b/python/dgl/data/tu.py
@@ -292,7 +292,7 @@ class TUDataset(DGLBuiltinDataset):
             loadtxt(self._file_path("A"), delimiter=",").astype(int))
         DS_indicator = self._idx_from_zero(
             loadtxt(self._file_path("graph_indicator"), delimiter=",").astype(int))
-        DS_graph_labels = self._idx_from_zero(
+        DS_graph_labels = self._idx_reset(
             loadtxt(self._file_path("graph_labels"), delimiter=",").astype(int))
 
         g = dgl_graph(([], []))
@@ -386,6 +386,14 @@ class TUDataset(DGLBuiltinDataset):
     @staticmethod
     def _idx_from_zero(idx_tensor):
         return idx_tensor - np.min(idx_tensor)
+
+    @staticmethod
+    def _idx_reset(idx_tensor):
+        """Maps n unique labels to {0, ..., n-1} in an ordered fashion."""
+        labels = np.unique(idx_tensor)
+        relabel_map = {x: i for i, x in enumerate(labels)}
+        new_idx_tensor = np.vectorize(relabel_map.get)(idx_tensor)
+        return new_idx_tensor
 
     def statistics(self):
         return self.graph_lists[0].ndata['feat'].shape[1], \

--- a/python/dgl/data/tu.py
+++ b/python/dgl/data/tu.py
@@ -276,7 +276,7 @@ class TUDataset(DGLBuiltinDataset):
     Notes
     -----
     Graphs may have node labels, node attributes, edge labels, and edge attributes,
-    varing from different dataset. This class does not perform additional process.
+    varing from different dataset. 
     """
 
     _url = r"https://www.chrsmrrs.com/graphkerneldatasets/{}.zip"


### PR DESCRIPTION
## Description
Fixes issue #2165.

## Checklist
Please feel free to remove inapplicable items for your PR.
- [x] The PR title starts with [$CATEGORY] (such as [NN], [Model], [Doc], [Feature]])
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage
- [x] Code is well-documented
- [x] To the my best knowledge, examples are either not affected by this change,
      or have been fixed to be compatible with this change
- [x] Related issue is referred in this PR

## Changes
The graph labels are processed using the new static method `_idx_reset ` instead of the old static method `_idx_from_zero`. This new method remaps the labels to {0, ..., n-1} where n is the number of labels. Previously some datasets have labels {-1, 1} which were being mapped to {0, 2}, this change maps them to {0, 1}. 

I changed the notes since this class does perform additional process to the labels (before and after this fix). 