### PR TITLE
[Hotfix] Fix partition of distributed rgcn example for 0.5.1

### DIFF
--- a/examples/pytorch/rgcn/experimental/partition_graph.py
+++ b/examples/pytorch/rgcn/experimental/partition_graph.py
@@ -50,7 +50,7 @@ def load_ogb(dataset, global_norm):
             if ntype == category:
                 category_id = i
 
-        g = dgl.to_homo(hg)
+        g = dgl.to_homogeneous(hg, edata=['norm'])
         if global_norm:
             u, v, eid = g.all_edges(form='all')
             _, inverse_index, count = th.unique(v, return_inverse=True, return_counts=True)


### PR DESCRIPTION
## Description
to_homogeneous needs to pass edge feature list for saving the features in the generated g.

## Checklist
Please feel free to remove inapplicable items for your PR.
- [x] The PR title starts with [$CATEGORY] (such as [NN], [Model], [Doc], [Feature]])
- [x] Changes are complete (i.e. I finished coding on this PR)
- [ ] All changes have test coverage
- [ ] Code is well-documented
- [x] To the my best knowledge, examples are either not affected by this change,
      or have been fixed to be compatible with this change
- [ ] Related issue is referred in this PR

## Changes
<!-- You could use following template
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)
-->
