### PR TITLE
[Distributed] Change rsync to scp of copy_files.py

### DIFF
--- a/tools/copy_files.py
+++ b/tools/copy_files.py
@@ -9,9 +9,9 @@ import logging
 import json
 import copy
 
-def copy_file(file_name, ip, workspace):
+def copy_file(file_name, ip, workspace, param):
     print('copy {} to {}'.format(file_name, ip + ':' + workspace + '/'))
-    cmd = 'rsync -e \"ssh -o StrictHostKeyChecking=no\" -arvc ' + file_name + ' ' + ip + ':' + workspace + '/'
+    cmd = 'scp ' + param + ' ' + file_name + ' ' + ip + ':' + workspace + '/'
     subprocess.check_call(cmd, shell = True)
 
 def exec_cmd(ip, cmd):
@@ -92,7 +92,7 @@ def main():
         copy_file(part_files['edge_feats'], ip, remote_path)
         copy_file(part_files['part_graph'], ip, remote_path)
         # copy script folder
-        copy_file(args.script_folder, ip, args.workspace)
+        copy_file(args.script_folder, ip, args.workspace, '-r')
 
 
 def signal_handler(signal, frame):

--- a/tools/copy_files.py
+++ b/tools/copy_files.py
@@ -9,7 +9,7 @@ import logging
 import json
 import copy
 
-def copy_file(file_name, ip, workspace, param):
+def copy_file(file_name, ip, workspace, param=''):
     print('copy {} to {}'.format(file_name, ip + ':' + workspace + '/'))
     cmd = 'scp ' + param + ' ' + file_name + ' ' + ip + ':' + workspace + '/'
     subprocess.check_call(cmd, shell = True)


### PR DESCRIPTION
## Description
Change rsync to scp of copy_files.py because rsync is very slow for big files.

## Checklist
Please feel free to remove inapplicable items for your PR.
- [ ] The PR title starts with [$CATEGORY] (such as [NN], [Model], [Doc], [Feature]])
- [ ] Changes are complete (i.e. I finished coding on this PR)
- [ ] All changes have test coverage
- [ ] Code is well-documented
- [ ] To the my best knowledge, examples are either not affected by this change,
      or have been fixed to be compatible with this change
- [ ] Related issue is referred in this PR

## Changes
<!-- You could use following template
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)
-->
