### PR TITLE
Fix segment_reduce() ignoring tailing 0 segments

### DIFF
--- a/python/dgl/ops/segment.py
+++ b/python/dgl/ops/segment.py
@@ -50,7 +50,8 @@ def segment_reduce(seglen, value, reducer='sum'):
     if len(u) != len(v):
         raise DGLError("Invalid seglen array:", seglen,
                        ". Its summation must be equal to value.shape[0].")
-    g = convert.heterograph({('_U', '_E', '_V'): (u, v)})
+    num_nodes = {'_U': len(u), '_V': len(seglen)}
+    g = convert.heterograph({('_U', '_E', '_V'): (u, v)}, num_nodes_dict=num_nodes)
     g.srcdata['h'] = value
     g.update_all(fn.copy_u('h', 'm'), getattr(fn, reducer)('m', 'h'))
     return g.dstdata['h']


### PR DESCRIPTION
## Description

[segment_reduce()](https://github.com/dmlc/dgl/blob/7e0107c395b24fa55e080dee3903552430008b48/python/dgl/ops/segment.py#L9) supports zeor-length segments. But it fails if the zero-length segments is at the end of `seglen`. 

For example,
```python
import dgl
import torch

val = torch.ones(10, 3)
seg = torch.tensor([1, 0, 5, 4, 0])
x = dgl.ops.segment.segment_reduce(seg, val, "sum")
```

yields a value for `x` as 
```
tensor([[1., 1., 1.],
        [0., 0., 0.],
        [5., 5., 5.],
        [4., 4., 4.]])
```
but it should be

```
tensor([[1., 1., 1.],
        [0., 0., 0.],
        [5., 5., 5.],
        [4., 4., 4.],
        [0., 0., 0.]])
```

This PR fixes this. 