### PR TITLE
[Example][WIP] Layer-dependent Importance Sampling

### DIFF
--- a/examples/pytorch/ladies/ladies.py
+++ b/examples/pytorch/ladies/ladies.py
@@ -1,0 +1,60 @@
+import torch
+import dgl
+import dgl.function as fn
+
+def compute_prob(g, seed_nodes, weight):
+    out_frontier = dgl.reverse(dgl.in_subgraph(g, seed_nodes), copy_edata=True)
+    if out_frontier.number_of_edges() == 0:
+        return torch.zeros(g.number_of_nodes(), device=g.device), torch.zeros(0, device=g.device)
+
+    if weight is None:
+        edge_weight = torch.ones(out_frontier.number_of_edges()).to(weight)
+    else:
+        edge_weight = out_frontier.edata[weight]
+    with out_frontier.local_scope():
+        # Sample neighbors on the previous layer
+        out_frontier.edata['w'] = edge_weight
+        out_frontier.edata['w'] = out_frontier.edata['w'] ** 2
+        out_frontier.update_all(fn.copy_e('w', 'm'), fn.sum('m', 'prob'))
+        prob = out_frontier.ndata['prob']
+        return prob, edge_weight
+
+class LADIESNeighborSampler(dgl.dataloading.BlockSampler):
+    def __init__(self, nodes_per_layer, weight=None, out_weight=None, replace=False):
+        super().__init__(len(nodes_per_layer), return_eids=True)
+        self.nodes_per_layer = nodes_per_layer
+        self.weight = weight
+        self.replace = replace
+        self.out_weight = out_weight
+
+    def sample_frontier(self, block_id, g, seed_nodes):
+        seed_nodes = torch.stack(seed_nodes)
+        num_nodes = self.nodes_per_layer[block_id]
+        prob, edge_weight = compute_prob(g, seed_nodes, self.weight)
+        candidate_nodes = torch.nonzero(prob, as_tuple=True)[0]
+
+        if not self.replace and len(candidate_nodes) < num_nodes:
+            neighbor_nodes = candidate_nodes
+        else:
+            neighbor_nodes = torch.multinomial(
+                prob, self.nodes_per_layer[block_id], replacement=self.replace)
+        neighbor_nodes = torch.cat([seed_nodes, neighbor_nodes])
+        neighbor_nodes = torch.unique(neighbor_nodes)
+
+        neighbor_graph = dgl.in_subgraph(g, seed_nodes)
+        neighbor_graph = dgl.out_subgraph(g, neighbor_nodes)
+
+        # Compute output edge weight
+        if self.out_weight is not None:
+            with neighbor_graph.local_scope():
+                neighbor_graph.edata['P'] = edge_weight
+                neighbor_graph.ndata['S'] = prob
+                neighbor_graph.apply_edges(dgl.function.e_div_u('P', 'S', 'P_tilde'))
+                neighbor_graph.update_all(
+                    dgl.function.copy_e('P_tilde', 'P_tilde'),
+                    dgl.function.sum('P_tilde', 'P_tilde_sum'))
+                neighbor_graph.apply_edges(dgl.function.e_div_v('P_tilde', 'P_tilde_sum', 'P_tilde'))
+                w = neighbor_graph.edata['P_tilde']
+            neighbor_graph.edata[self.out_weight] = w
+
+        return neighbor_graph

--- a/examples/pytorch/ladies/ladies.py
+++ b/examples/pytorch/ladies/ladies.py
@@ -2,6 +2,7 @@ import torch
 import dgl
 import dgl.function as fn
 from collections import Counter
+import numpy as np
 
 def compute_prob(g, seed_nodes, weight):
     out_frontier = dgl.reverse(dgl.in_subgraph(g, seed_nodes), copy_edata=True)

--- a/examples/pytorch/ladies/ladies2.py
+++ b/examples/pytorch/ladies/ladies2.py
@@ -1,0 +1,129 @@
+import dgl
+import torch
+import numba
+from numba.core import types
+from numba.typed import Dict
+import numpy as np
+
+@numba.njit
+def find_indices_in(a, b):
+    d = Dict.empty(key_type=types.int64, value_type=types.int64)
+    for i, v in enumerate(b):
+        d[v] = i
+    ai = np.zeros_like(a)
+    for i, v in enumerate(a):
+        ai[i] = d.get(v, -1)
+    return ai
+
+@numba.jit
+def union(*arrays):
+    # Faster than np.union1d and torch.unique(torch.cat(...))
+    s = set()
+    for a in arrays:
+        s.update(a)
+    a = np.asarray(list(s))
+    return a
+
+
+class LADIESNeighborSampler(dgl.dataloading.BlockSampler):
+    def __init__(self, nodes_per_layer, weight='w', out_weight='w', replace=False):
+        super().__init__(len(nodes_per_layer), return_eids=False)
+        self.nodes_per_layer = nodes_per_layer
+        self.edge_weight = weight
+        self.output_weight = out_weight
+        self.replace = replace
+
+    
+    def compute_prob(self, g, seed_nodes, weight, exclude_eids):
+        """
+        g : the whole graph
+        seed_nodes : the output nodes for the current layer
+        weight : the weight of the edges
+
+        return : the unnormalized probability of the candidate nodes, as well as the subgraph
+                 containing all the edges from the candidate nodes to the output nodes.
+        """
+        insg = dgl.in_subgraph(g, seed_nodes)
+        insg = self._exclude_eids(insg, exclude_eids)
+        insg = dgl.compact_graphs(insg, seed_nodes)
+        out_frontier = dgl.reverse(insg, copy_edata=True)
+        weight = weight[out_frontier.edata[dgl.EID]]
+        prob = dgl.ops.copy_e_sum(out_frontier, weight ** 2)
+        return prob, insg
+
+    
+    def select_neighbors(self, seed_nodes, cand_nodes, prob, num, replace):
+        """
+        seed_nodes : output nodes
+        cand_nodes : candidate nodes.  Must contain all output nodes in @seed_nodes
+        prob : unnormalized probability of each candidate node
+        num : number of neighbors to sample
+
+        return : the set of input nodes in terms of their indices in @cand_nodes, and also the indices of
+                 seed nodes in the selected nodes.
+        """
+        # The returned nodes should be a union of seed_nodes plus @num nodes from cand_nodes.
+        # Because compute_prob returns a compacted subgraph and a list of probabilities,
+        # we need to find the corresponding local IDs of the resulting union in the subgraph
+        # so that we can compute the edge weights of the block.
+        # This is why we need a find_indices_in() function.
+        neighbor_nodes_idx = torch.multinomial(prob, num, replacement=replace).cpu().numpy()
+        _i = neighbor_nodes_idx
+        seed_nodes_idx = find_indices_in(seed_nodes.cpu().numpy(), cand_nodes.cpu().numpy())
+        assert seed_nodes_idx.min() != -1
+        neighbor_nodes_idx = union(neighbor_nodes_idx, seed_nodes_idx)
+        seed_nodes_local_idx = torch.from_numpy(find_indices_in(seed_nodes_idx, neighbor_nodes_idx))
+        assert seed_nodes_idx.min().item() != -1
+        neighbor_nodes_idx = torch.from_numpy(neighbor_nodes_idx)
+        return neighbor_nodes_idx, seed_nodes_local_idx, cand_nodes.cpu().numpy()[_i]
+
+    
+    def generate_block(self, insg, neighbor_nodes_idx, seed_nodes_local_idx, P_sg, W_sg, weight_name,
+                       return_eids):
+        """
+        insg : the subgraph yielded by compute_prob()
+        neighbor_nodes_idx : the sampled nodes from the subgraph @insg, yielded by select_neighbors()
+        seed_nodes_local_idx : the indices of seed nodes in the selected neighbor nodes, also yielded
+                               by select_neighbors()
+        P_sg : unnormalized probability of each node being sampled, yielded by compute_prob()
+        W_sg : edge weights of @insg
+
+        return : the block.
+        """
+        sg = insg.subgraph(neighbor_nodes_idx)
+        nids = insg.ndata[dgl.NID][sg.ndata[dgl.NID]]
+        P = P_sg[neighbor_nodes_idx]
+        W = W_sg[sg.edata[dgl.EID]]
+        W_tilde = dgl.ops.e_div_u(sg, W, P)
+        W_tilde_sum = dgl.ops.copy_e_sum(sg, W_tilde)
+        W_tilde = dgl.ops.e_div_v(sg, W_tilde, W_tilde_sum)
+
+        block = dgl.to_block(sg, seed_nodes_local_idx)
+        block.edata[weight_name] = W_tilde
+        # correct node ID mapping
+        block.srcdata[dgl.NID] = nids[block.srcdata[dgl.NID]]
+        block.dstdata[dgl.NID] = nids[block.dstdata[dgl.NID]]
+
+        if return_eids:
+            sg_eids = insg.edata[dgl.EID][sg.edata[dgl.EID]]
+            block.edata[dgl.EID] = sg_eids[block.edata[dgl.EID]]
+        return block
+
+    
+    def sample_blocks(self, g, seed_nodes, exclude_eids=None):
+        blocks = []
+        exclude_eids = self._convert_exclude_eids(exclude_eids)
+        for block_id in reversed(range(self.num_layers)):
+            num_nodes_to_sample = self.nodes_per_layer[block_id]
+            W = g.edata[self.edge_weight]
+            prob, insg = self.compute_prob(g, seed_nodes, W, exclude_eids)
+            cand_nodes = insg.ndata[dgl.NID]
+            neighbor_nodes_idx, seed_nodes_local_idx, _i = self.select_neighbors(
+                seed_nodes, cand_nodes, prob, num_nodes_to_sample, self.replace)
+            block = self.generate_block(
+                insg, neighbor_nodes_idx, seed_nodes_local_idx, prob,
+                W[insg.edata[dgl.EID]], self.output_weight, self.return_eids)
+            seed_nodes = block.srcdata[dgl.NID]
+            block.create_formats_()
+            blocks.insert(0, block)
+        return blocks

--- a/examples/pytorch/ladies/ladies3.py
+++ b/examples/pytorch/ladies/ladies3.py
@@ -1,0 +1,91 @@
+import torch
+import dgl
+import dgl.function as fn
+from collections import Counter
+import numpy as np
+import scipy.sparse as ssp
+import numba
+from numba.core import types
+from numba.typed import Dict
+import time
+
+def row_normalize(mx):
+    """Row-normalize sparse matrix"""
+    rowsum = np.array(mx.sum(1))
+    r_inv = np.power(rowsum, -1).flatten()
+    r_inv[np.isinf(r_inv)] = 0.
+    r_mat_inv = ssp.diags(r_inv)
+
+    mx = r_mat_inv.dot(mx)
+    return mx
+
+import numpy as np
+@numba.njit
+def sumbykey(keys, values):
+    d = Dict.empty(key_type=types.int64, value_type=types.float32)
+    for k, v in zip(keys, values):
+        if k not in d:
+            d[k] = v
+        else:
+            d[k] += v
+    k = np.asarray(list(d.keys()))
+    v = np.asarray(list(d.values()))
+    return k, v
+
+def sum_rows(csr):
+    indices = csr.indices
+    data = csr.data
+    new_indices, new_data = sumbykey(indices, data)
+    return ssp.csr_matrix((new_data, new_indices, np.array([0, len(new_indices)])), shape=(1, csr.shape[1]))
+
+class LADIESNeighborSampler(dgl.dataloading.BlockSampler):
+    def __init__(self, g, nodes_per_layer, weight=None, out_weight=None, replace=False):
+        super().__init__(len(nodes_per_layer), return_eids=True)
+        self.nodes_per_layer = nodes_per_layer
+        self.weight = weight
+        self.replace = replace
+        self.out_weight = out_weight
+        self.g = g
+        rows, cols = g.edges()
+        self.lap_matrix = ssp.csr_matrix((
+            self.g.edata[weight].cpu().numpy() if weight is not None else
+            np.ones(self.g.num_edges(), dtype='float32'),
+            (cols.cpu().numpy(), rows.cpu().numpy())),
+            shape=(g.num_nodes(), g.num_nodes()))
+        self.eid_matrix = ssp.csr_matrix((
+            np.arange(self.g.num_edges()),
+            (cols.cpu().numpy(), rows.cpu().numpy())),
+            shape=(g.num_nodes(), g.num_nodes()))
+        self.T = 0
+
+    def sample_frontier(self, block_id, g, seed_nodes):
+        t0 = time.time()
+        seed_nodes = seed_nodes.cpu().numpy()
+        U = self.lap_matrix[seed_nodes, :]
+
+        U_sqr = U.multiply(U)
+        p = sum_rows(U_sqr.tocsr())
+        p.data /= p.data.sum()
+
+        s_num = min(p.nnz, self.nodes_per_layer[block_id])
+        p_indices = p.indices
+        p_data = p.data
+
+        after_nodes = np.random.choice(p_indices, s_num, p=p_data, replace=self.replace)
+        after_nodes = np.unique(np.concatenate([after_nodes, seed_nodes]))
+
+        p.data = 1 / p.data
+        adj = U[:, after_nodes].multiply(p[:, after_nodes])
+        adj = row_normalize(adj)
+        adj_data = adj.data
+        tt = time.time()
+        self.T += tt - t0
+
+        eids = self.eid_matrix[seed_nodes, :]
+        eids = eids[:, after_nodes]
+        eid_data = eids.data
+
+        # To copy edge features and node features I use edge_subgraph.
+        frontier = g.edge_subgraph(eid_data, preserve_nodes=True)
+        frontier.edata[self.out_weight] = torch.from_numpy(adj_data)
+        return frontier

--- a/examples/pytorch/ladies/model.py
+++ b/examples/pytorch/ladies/model.py
@@ -45,7 +45,7 @@ class Model(nn.Module):
         self.convs.append(GraphConv(n_hidden, n_classes))
 
     def forward(self, blocks, x):
-        for i, (conv, block) in enumerate(zip(self.convs, self.blocks)):
+        for i, (conv, block) in enumerate(zip(self.convs, blocks)):
             x = conv(block, x, block.edata['w'])
             if i != len(self.convs) - 1:
                 x = F.relu(x)

--- a/examples/pytorch/ladies/model.py
+++ b/examples/pytorch/ladies/model.py
@@ -1,0 +1,80 @@
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+import dgl
+import dgl.function as fn
+import tqdm
+
+def normalized_laplacian_edata(g, weight=None):
+    with g.local_scope():
+        if weight is None:
+            weight = 'W'
+            g.edata[weight] = torch.ones(g.number_of_edges(), device=g.device)
+        g_rev = dgl.reverse(g, copy_edata=True)
+        g.update_all(fn.copy_e(weight, weight), fn.sum(weight, 'v'))
+        g_rev.update_all(fn.copy_e(weight, weight), fn.sum(weight, 'u'))
+        g.ndata['u'] = g_rev.ndata['u']
+        g.apply_edges(lambda edges: {'w': edges.data[weight] / torch.sqrt(edges.src['u'] * edges.dst['v'])})
+        return g.edata['w']
+
+
+class GraphConv(nn.Module):
+    def __init__(self, in_feats, n_classes):
+        super().__init__()
+        self.W = nn.Linear(in_feats, n_classes)
+
+    def forward(self, g, x, w):
+        with g.local_scope():
+            g.srcdata['x'] = self.W(x)
+            g.edata['w'] = w
+            g.update_all(fn.u_mul_e('x', 'w', 'm'), fn.sum('m', 'y'))
+            return g.dstdata['y']
+
+
+class Model(nn.Module):
+    def __init__(self, in_feats, n_hidden, n_classes, n_layers):
+        super().__init__()
+
+        self.n_hidden = n_hidden
+        self.n_classes = n_classes
+
+        self.convs = nn.ModuleList()
+        self.convs.append(GraphConv(in_feats, n_hidden))
+        for i in range(n_layers - 2):
+            self.convs.append(GraphConv(n_hidden, n_hidden))
+        self.convs.append(GraphConv(n_hidden, n_classes))
+
+    def forward(self, blocks, x):
+        for i, (conv, block) in enumerate(zip(self.convs, self.blocks)):
+            x = conv(block, x, block.edata['w'])
+            if i != len(self.convs) - 1:
+                x = F.relu(x)
+        return x
+
+    def inference(self, g, x, w, batch_size, device, num_workers):
+        for l, layer in enumerate(self.convs):
+            y = torch.zeros(g.number_of_nodes(), self.n_hidden if l != len(self.layers) - 1 else self.n_classes)
+
+            sampler = dgl.dataloading.MultiLayerFullNeighborSampler(1)
+            dataloader = dgl.dataloading.NodeDataLoader(
+                g,
+                torch.arange(g.number_of_nodes()),
+                sampler,
+                batch_size=batch_size,
+                shuffle=True,
+                drop_last=False,
+                num_workers=num_workers)
+
+            for input_nodes, output_nodes, blocks in tqdm.tqdm(dataloader):
+                block = blocks[0]
+
+                block = block.int().to(device)
+                h = x[input_nodes].to(device)
+                h = layer(block, h)
+                if l != len(self.layers) - 1:
+                    h = F.relu(h)
+
+                y[output_nodes] = h.cpu()
+
+            x = y
+        return y

--- a/examples/pytorch/ladies/train.py
+++ b/examples/pytorch/ladies/train.py
@@ -45,7 +45,7 @@ def train(g, n_classes, args):
             for step, (input_nodes, seeds, blocks) in enumerate(tq):
                 blocks = [block.to(device) for block in blocks]
                 batch_inputs = blocks[0].srcdata['features']
-                batch_labels = blocks[-1].dstdata['labels']
+                batch_labels = blocks[-1].dstdata['label']
 
                 batch_pred = model(blocks, batch_inputs)
                 loss = F.cross_entropy(batch_pred, batch_labels)
@@ -77,7 +77,7 @@ def train(g, n_classes, args):
 
 if __name__ == '__main__':
     g = dgl.graph((torch.randint(0, 2000, (10000,)), torch.randint(0, 2000, (10000,))))
-    g = dgl.to_simple(dgl.add_reverse_edges(g))
+    g = dgl.to_simple(dgl.add_reverse_edges(g), return_counts=None)
     g.ndata['features'] = torch.randn(2000, 15)
     g.ndata['label'] = torch.randint(0, 5, (2000,))
     g.ndata['mask'] = torch.randint(0, 10, (2000,))
@@ -91,6 +91,6 @@ if __name__ == '__main__':
         'batch_size': 10,
         'hidden_dim': 8,
         'lr': 1e-4,
-        'num_nodes': '60,40,20',
+        'num_nodes': '20,20,20',
         'device': 'cpu'}
     train(g, 5, args)

--- a/examples/pytorch/ladies/train.py
+++ b/examples/pytorch/ladies/train.py
@@ -5,7 +5,7 @@ import tqdm
 import numpy as np
 from collections import Counter
 from model import *
-from ladies import *
+from ladies2 import *
 
 def compute_acc(pred, label):
     return (pred.argmax(1) == label).float().mean()

--- a/examples/pytorch/ladies/train.py
+++ b/examples/pytorch/ladies/train.py
@@ -37,6 +37,9 @@ def train(g, n_classes, args):
         shuffle=True,
         drop_last=False,
         num_workers=args['num_workers'])
+    for _ in tqdm.trange(5000):
+        for batch in train_dataloader:
+            pass
 
     model = Model(in_feats, args['hidden_dim'], n_classes, len(num_nodes))
     model = model.to(device)
@@ -80,6 +83,8 @@ def train(g, n_classes, args):
 if __name__ == '__main__':
     src = torch.randint(0, 2000, (10000,))
     dst = torch.randint(0, 2000, (10000,))
+    src = torch.cat([src, torch.arange(50, 70).repeat_interleave(2000)])
+    dst = torch.cat([dst, torch.arange(0, 2000).repeat_interleave(20)])
     g = dgl.graph((src, dst))
     g = dgl.to_simple(dgl.add_reverse_edges(g), return_counts=None)
     g.ndata['features'] = torch.randn(2000, 15)

--- a/examples/pytorch/ladies/train.py
+++ b/examples/pytorch/ladies/train.py
@@ -1,0 +1,96 @@
+import torch
+import torch.nn.functional as F
+import dgl
+import tqdm
+from model import *
+from ladies import *
+
+def compute_acc(pred, label):
+    return (pred.argmax(1) == label).mean()
+
+def train(g, n_classes, args):
+    in_feats = g.ndata['features'].shape[1]
+    device = args['device']
+    train_nid = torch.nonzero(g.ndata['train_mask'], as_tuple=True)[0]
+    val_nid = torch.nonzero(g.ndata['val_mask'], as_tuple=True)[0]
+    test_nid = torch.nonzero(g.ndata['test_mask'], as_tuple=True)[0]
+
+    g.edata['weight'] = normalized_laplacian_edata(g)
+
+    num_nodes = [int(n) for n in args['num_nodes'].split(',')]
+    sampler = LADIESNeighborSampler(num_nodes, weight='weight', out_weight='w', replace=False)
+    train_dataloader = dgl.dataloading.NodeDataLoader(
+        g,
+        train_nid,
+        sampler,
+        batch_size=args['batch_size'],
+        shuffle=True,
+        drop_last=False,
+        num_workers=args['num_workers'])
+    val_dataloader = dgl.dataloading.NodeDataLoader(
+        g,
+        val_nid,
+        sampler,
+        batch_size=args['batch_size'],
+        shuffle=True,
+        drop_last=False,
+        num_workers=args['num_workers'])
+
+    model = Model(in_feats, args['hidden_dim'], n_classes, len(num_nodes))
+    model = model.to(device)
+    opt = torch.optim.Adam(model.parameters(), lr=args['lr'])
+
+    for epoch in range(args['num_epochs']):
+        with tqdm.tqdm(train_dataloader) as tq:
+            for step, (input_nodes, seeds, blocks) in enumerate(tq):
+                blocks = [block.to(device) for block in blocks]
+                batch_inputs = blocks[0].srcdata['features']
+                batch_labels = blocks[-1].dstdata['labels']
+
+                batch_pred = model(blocks, batch_inputs)
+                loss = F.cross_entropy(batch_pred, batch_labels)
+                acc = compute_acc(batch_pred, batch_labels)
+
+                opt.zero_grad()
+                loss.backward()
+                opt.step()
+
+                tq.set_postfix({'loss': '%.06f' % loss.item(), 'acc': '%.03f' % acc.item()})
+
+        with tqdm.tqdm(val_dataloader) as tq:
+            all_labels = []
+            all_pred = []
+            for step, (input_nodes, seeds, blocks) in enumerate(tq):
+                blocks = [block.to(device) for block in blocks]
+                batch_inputs = blocks[0].srcdata['features']
+                batch_labels = blocks[-1].dstdata['labels']
+
+                batch_pred = model(blocks, batch_inputs)
+
+                all_labels.append(batch_labels)
+                all_pred.append(batch_pred)
+
+            all_labels = torch.cat(all_labels, 0)
+            all_pred = torch.cat(all_pred, 0)
+            print('Val Acc', compute_acc(all_pred, all_labels))
+
+
+if __name__ == '__main__':
+    g = dgl.graph((torch.randint(0, 2000, (10000,)), torch.randint(0, 2000, (10000,))))
+    g = dgl.to_simple(dgl.add_reverse_edges(g))
+    g.ndata['features'] = torch.randn(2000, 15)
+    g.ndata['label'] = torch.randint(0, 5, (2000,))
+    g.ndata['mask'] = torch.randint(0, 10, (2000,))
+    g.ndata['train_mask'] = g.ndata['mask'] < 8
+    g.ndata['val_mask'] = g.ndata['mask'] == 8
+    g.ndata['test_mask'] = g.ndata['mask'] == 9
+
+    args = {
+        'num_epochs': 1,
+        'num_workers': 0,
+        'batch_size': 10,
+        'hidden_dim': 8,
+        'lr': 1e-4,
+        'num_nodes': '60,40,20',
+        'device': 'cpu'}
+    train(g, 5, args)

--- a/python/dgl/dataloading/dataloader.py
+++ b/python/dgl/dataloading/dataloader.py
@@ -185,6 +185,36 @@ class BlockSampler(object):
         """
         raise NotImplementedError
 
+    @staticmethod
+    def _convert_exclude_eids(exclude_eids):
+        return _tensor_or_dict_to_numpy(exclude_eids) if exclude_eids is not None else None
+
+    def _exclude_eids(self, frontier, exclude_eids):
+        """Remove the specific edge IDs from the given frontier.
+        """
+        if exclude_eids is not None:
+            parent_eids = frontier.edata[EID]
+            parent_eids_np = _tensor_or_dict_to_numpy(parent_eids)
+            located_eids = _locate_eids_to_exclude(parent_eids_np, exclude_eids)
+            if not isinstance(located_eids, Mapping):
+                # (BarclayII) If frontier already has a EID field and located_eids is empty,
+                # the returned graph will keep EID intact.  Otherwise, EID will change
+                # to the mapping from the new graph to the old frontier.
+                # So we need to test if located_eids is empty, and do the remapping ourselves.
+                if len(located_eids) > 0:
+                    frontier = transform.remove_edges(frontier, located_eids)
+                    frontier.edata[EID] = F.gather_row(parent_eids, frontier.edata[EID])
+            else:
+                # (BarclayII) remove_edges only accepts removing one type of edges,
+                # so I need to keep track of the edge IDs left one by one.
+                new_eids = parent_eids.copy()
+                for k, v in located_eids.items():
+                    if len(v) > 0:
+                        frontier = transform.remove_edges(frontier, v, etype=k)
+                        new_eids[k] = F.gather_row(parent_eids[k], frontier.edges[k].data[EID])
+                frontier.edata[EID] = new_eids
+        return frontier
+
     def sample_blocks(self, g, seed_nodes, exclude_eids=None):
         """Generate the a list of blocks given the output nodes.
 
@@ -210,34 +240,13 @@ class BlockSampler(object):
         For the concept of frontiers and blocks, please refer to User Guide Section 6 [TODO].
         """
         blocks = []
-        exclude_eids = (
-            _tensor_or_dict_to_numpy(exclude_eids) if exclude_eids is not None else None)
+        exclude_eids = self._convert_exclude_eids(exclude_eids)
         for block_id in reversed(range(self.num_layers)):
             frontier = self.sample_frontier(block_id, g, seed_nodes)
 
             # Removing edges from the frontier for link prediction training falls
             # into the category of frontier postprocessing
-            if exclude_eids is not None:
-                parent_eids = frontier.edata[EID]
-                parent_eids_np = _tensor_or_dict_to_numpy(parent_eids)
-                located_eids = _locate_eids_to_exclude(parent_eids_np, exclude_eids)
-                if not isinstance(located_eids, Mapping):
-                    # (BarclayII) If frontier already has a EID field and located_eids is empty,
-                    # the returned graph will keep EID intact.  Otherwise, EID will change
-                    # to the mapping from the new graph to the old frontier.
-                    # So we need to test if located_eids is empty, and do the remapping ourselves.
-                    if len(located_eids) > 0:
-                        frontier = transform.remove_edges(frontier, located_eids)
-                        frontier.edata[EID] = F.gather_row(parent_eids, frontier.edata[EID])
-                else:
-                    # (BarclayII) remove_edges only accepts removing one type of edges,
-                    # so I need to keep track of the edge IDs left one by one.
-                    new_eids = parent_eids.copy()
-                    for k, v in located_eids.items():
-                        if len(v) > 0:
-                            frontier = transform.remove_edges(frontier, v, etype=k)
-                            new_eids[k] = F.gather_row(parent_eids[k], frontier.edges[k].data[EID])
-                    frontier.edata[EID] = new_eids
+            frontier = self._exclude_eids(frontier, exclude_eids)
 
             block = transform.to_block(frontier, seed_nodes)
 

--- a/python/dgl/dataloading/dataloader.py
+++ b/python/dgl/dataloading/dataloader.py
@@ -185,8 +185,7 @@ class BlockSampler(object):
         """
         raise NotImplementedError
 
-    @staticmethod
-    def _convert_exclude_eids(exclude_eids):
+    def _convert_exclude_eids(self, exclude_eids):
         return _tensor_or_dict_to_numpy(exclude_eids) if exclude_eids is not None else None
 
     def _exclude_eids(self, frontier, exclude_eids):


### PR DESCRIPTION
## Description
This is a PR implementing the LADIES sampling algorithm as per https://arxiv.org/abs/1911.07323.

I currently included three implementations of `LADIESNeighborSampler`, of which
* `ladies.py` overloads `sample_frontier` like what `MultiLayerNeighborSampler` does, but costs O(|V|) memory where |V| is number of vertices in the whole graph.
* `ladies2.py` overloads `sample_blocks` directly, which is more complicated.  The efficiency is the same as that of `ladies.py`.
* `ladies3.py` overloads `sample_frontier` but uses `scipy.sparse`.  I think that has the cleanest code.  The `edge_subgraph` seems redundant and I think directly constructing a block from a sparse matrix makes more sense.

Please take a look of those implementations and tell me which implementation looks the most comfortable.

I use `numba` for speeding up computations such as `reduce_sum` of a scipy sparse matrix, or finding the positions of an array of elements in another array.  That is essentially `map_from_parent_nid` we had previously.

## Checklist
Please feel free to remove inapplicable items for your PR.
- [x] The PR title starts with [$CATEGORY] (such as [NN], [Model], [Doc], [Feature]])
- [ ] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage
- [ ] Code is well-documented
- [x] To the my best knowledge, examples are either not affected by this change,
      or have been fixed to be compatible with this change
