### PR TITLE
[bugfix] Fix crash due to unfound attribute

### DIFF
--- a/python/dgl/data/dgl_dataset.py
+++ b/python/dgl/data/dgl_dataset.py
@@ -87,6 +87,8 @@ class DGLDataset(object):
 
         if save_dir is None:
             self._save_dir = self._raw_dir
+        else:
+            self._save_dir = save_dir
 
         self._load()
 


### PR DESCRIPTION
## Description
<!-- Brief description. Refer to the related issues if existed.
It'll be great if relevant reviewers can be assigned as well.-->

An unexpected `AttributeError` exception is launched whenever the user defines `save_dir` on `DGLDataset` instantiation and uses `self._save_dir`  within `has_cache` method.

## Changes
<!-- You could use following template
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)
-->
Initializes the attribute `self._save_dir` in all cases.
