### PR TITLE
[GPU][Allocations] Use shared workspace for normal GPU allocations

### DIFF
--- a/docs/source/env_var.rst
+++ b/docs/source/env_var.rst
@@ -22,3 +22,11 @@ Data Repository
 * ``DGL_DOWNLOAD_DIR``:
     * Values: String (default="${HOME}/.dgl")
     * The local directory to cache the downloaded data.
+
+GPU Options
+-----------
+* ``DGL_USE_CUDA_MEMORY_POOL``:
+    * values: `true`/`1` to enable, or `false`/`0` to disable (default=`false`).
+    * If enabled, GPU allocations will be saved to pool, to be re-used for
+    * subsequent allocatoins. This may enable faster execution at the cost
+      of higher memory consumption.

--- a/include/dgl/runtime/device_api.h
+++ b/include/dgl/runtime/device_api.h
@@ -82,8 +82,7 @@ class DeviceAPI {
   virtual void* AllocDataSpace(DGLContext ctx,
                                size_t nbytes,
                                size_t alignment,
-                               DGLType type_hint)
-  {
+                               DGLType type_hint) {
     return AllocRawDataSpace(ctx, nbytes, alignment, type_hint);
   }
   /*!
@@ -97,8 +96,7 @@ class DeviceAPI {
    * \param ctx The device context to perform operation.
    * \param ptr The data space.
    */
-  virtual void FreeDataSpace(DGLContext ctx, void* ptr)
-  {
+  virtual void FreeDataSpace(DGLContext ctx, void* ptr) {
       FreeRawDataSpace(ctx, ptr);
   }
   /*!

--- a/include/dgl/runtime/device_api.h
+++ b/include/dgl/runtime/device_api.h
@@ -58,6 +58,19 @@ class DeviceAPI {
    */
   virtual void GetAttr(DGLContext ctx, DeviceAttrKind kind, DGLRetValue* rv) = 0;
   /*!
+   * \brief Allocate a data space on device using system mechanisms.
+   * \param ctx The device context to perform operation.
+   * \param nbytes The number of bytes in memory.
+   * \param alignment The alignment of the memory.
+   * \param type_hint The type of elements. Only needed by certain backends such
+   * as OpenGL, as nbytes & alignment are sufficient for most backends.
+   * \return The allocated device pointer.
+   */
+  virtual void* AllocRawDataSpace(DGLContext ctx,
+                               size_t nbytes,
+                               size_t alignment,
+                               DGLType type_hint) = 0;
+  /*!
    * \brief Allocate a data space on device.
    * \param ctx The device context to perform operation.
    * \param nbytes The number of bytes in memory.
@@ -69,13 +82,25 @@ class DeviceAPI {
   virtual void* AllocDataSpace(DGLContext ctx,
                                size_t nbytes,
                                size_t alignment,
-                               DGLType type_hint) = 0;
+                               DGLType type_hint)
+  {
+    return AllocRawDataSpace(ctx, nbytes, alignment, type_hint);
+  }
   /*!
-   * \brief Free a data space on device.
+   * \brief Free a data space on device using system mechanisms.
    * \param ctx The device context to perform operation.
    * \param ptr The data space.
    */
-  virtual void FreeDataSpace(DGLContext ctx, void* ptr) = 0;
+  virtual void FreeRawDataSpace(DGLContext ctx, void* ptr) = 0;
+  /*!
+   * \brief Free a data space on the device.
+   * \param ctx The device context to perform operation.
+   * \param ptr The data space.
+   */
+  virtual void FreeDataSpace(DGLContext ctx, void* ptr)
+  {
+      FreeRawDataSpace(ctx, ptr);
+  }
   /*!
    * \brief copy data from one place to another
    * \param from The source array.

--- a/include/dgl/runtime/ndarray.h
+++ b/include/dgl/runtime/ndarray.h
@@ -217,6 +217,16 @@ class NDArray {
                                      DLContext ctx,
                                      bool is_create);
   /*!
+   * \brief Create an empty NDArray using raw memory allocations.
+   * \param shape The shape of the new array.
+   * \param dtype The data type of the new array.
+   * \param ctx The context of the Array.
+   * \return The created Array
+   */
+  DGL_DLL static NDArray EmptyRaw(std::vector<int64_t> shape,
+                               DLDataType dtype,
+                               DLContext ctx);
+  /*!
    * \brief Get the size of the array in the number of bytes.
    */
   size_t GetSize() const;

--- a/src/dataloading/async_transferer.cc
+++ b/src/dataloading/async_transferer.cc
@@ -65,7 +65,7 @@ TransferId AsyncTransferer::StartTransfer(
 
   DLDataType dtype = src->dtype;
   std::vector<int64_t> shape(src->shape, src->shape+src->ndim);
-  t.dst = NDArray::Empty(shape, dtype, dst_ctx);
+  t.dst = NDArray::EmptyRaw(shape, dtype, dst_ctx);
 
   if (stream_) {
     #ifdef DGL_USE_CUDA

--- a/src/runtime/c_runtime_api.cc
+++ b/src/runtime/c_runtime_api.cc
@@ -101,11 +101,11 @@ DeviceAPI* DeviceAPI::Get(DGLContext ctx, bool allow_missing) {
 void* DeviceAPI::AllocWorkspace(DGLContext ctx,
                                 size_t size,
                                 DGLType type_hint) {
-  return AllocDataSpace(ctx, size, kTempAllocaAlignment, type_hint);
+  return AllocRawDataSpace(ctx, size, kTempAllocaAlignment, type_hint);
 }
 
 void DeviceAPI::FreeWorkspace(DGLContext ctx, void* ptr) {
-  FreeDataSpace(ctx, ptr);
+  FreeRawDataSpace(ctx, ptr);
 }
 
 DGLStreamHandle DeviceAPI::CreateStream(DGLContext ctx) {

--- a/src/runtime/cpu_device_api.cc
+++ b/src/runtime/cpu_device_api.cc
@@ -20,7 +20,8 @@ class CPUDeviceAPI final : public DeviceAPI {
       *rv = 1;
     }
   }
-  void* AllocDataSpace(DGLContext ctx,
+
+  void* AllocRawDataSpace(DGLContext ctx,
                        size_t nbytes,
                        size_t alignment,
                        DGLType type_hint) final {
@@ -38,7 +39,7 @@ class CPUDeviceAPI final : public DeviceAPI {
     return ptr;
   }
 
-  void FreeDataSpace(DGLContext ctx, void* ptr) final {
+  void FreeRawDataSpace(DGLContext ctx, void* ptr) final {
 #if _MSC_VER || defined(__MINGW32__)
     _aligned_free(ptr);
 #else

--- a/src/runtime/cuda/cuda_device_api.cc
+++ b/src/runtime/cuda/cuda_device_api.cc
@@ -14,32 +14,28 @@
 namespace dgl {
 namespace runtime {
 
-class ThreadSafeWorkspacePool
-{
-  public:
-    ThreadSafeWorkspacePool(
-        DLDeviceType device_type,
-        std::shared_ptr<DeviceAPI> device) :
-      pool_(device_type, device),
-      mtx_()
-    {
-    }
+class ThreadSafeWorkspacePool {
+ public:
+  ThreadSafeWorkspacePool(
+      DLDeviceType device_type,
+      std::shared_ptr<DeviceAPI> device) :
+    pool_(device_type, device),
+    mtx_() {
+  }
 
-    void* AllocWorkspace(DGLContext ctx, size_t size)
-    {
-      std::lock_guard<std::mutex> guard(mtx_);
-      return pool_.AllocWorkspace(ctx, size);
-    }
+  void* AllocWorkspace(DGLContext ctx, size_t size) {
+    std::lock_guard<std::mutex> guard(mtx_);
+    return pool_.AllocWorkspace(ctx, size);
+  }
 
-    void FreeWorkspace(DGLContext ctx, void* ptr)
-    {
-      std::lock_guard<std::mutex> guard(mtx_);
-      pool_.FreeWorkspace(ctx, ptr);
-    }
+  void FreeWorkspace(DGLContext ctx, void* ptr) {
+    std::lock_guard<std::mutex> guard(mtx_);
+    pool_.FreeWorkspace(ctx, ptr);
+  }
 
-  private:
-    WorkspacePool pool_;
-    std::mutex mtx_;
+ private:
+  WorkspacePool pool_;
+  std::mutex mtx_;
 };
 
 static ThreadSafeWorkspacePool& getGlobalCudaWorkspace();
@@ -127,7 +123,7 @@ class CUDADeviceAPI final : public DeviceAPI {
   }
 
   void FreeDataSpace(DGLContext ctx, void* ptr) final {
-    getGlobalCudaWorkspace().FreeWorkspace(ctx, ptr); 
+    getGlobalCudaWorkspace().FreeWorkspace(ctx, ptr);
   }
 
   void* AllocRawDataSpace(DGLContext ctx,
@@ -241,8 +237,7 @@ class CUDADeviceAPI final : public DeviceAPI {
   }
 };
 
-ThreadSafeWorkspacePool& getGlobalCudaWorkspace()
-{
+ThreadSafeWorkspacePool& getGlobalCudaWorkspace() {
   static ThreadSafeWorkspacePool pool(kDLGPU, CUDADeviceAPI::Global());
   return pool;
 }

--- a/src/runtime/cuda/cuda_device_api.cc
+++ b/src/runtime/cuda/cuda_device_api.cc
@@ -4,44 +4,42 @@
  * \brief GPU specific API
  */
 #include <dgl/runtime/device_api.h>
-
 #include <dmlc/thread_local.h>
 #include <dgl/runtime/registry.h>
 #include <cuda_runtime.h>
-#include <mutex>
+#include <algorithm>
+#include <string>
 #include "cuda_common.h"
+#include "cuda_memory_pool.h"
 
 namespace dgl {
 namespace runtime {
 
-class ThreadSafeWorkspacePool {
- public:
-  ThreadSafeWorkspacePool(
-      DLDeviceType device_type,
-      std::shared_ptr<DeviceAPI> device) :
-    pool_(device_type, device),
-    mtx_() {
-  }
+namespace {
+constexpr const char * const kUseMemoryPoolString = "DGL_USE_CUDA_MEMORY_POOL";
+}
 
-  void* AllocWorkspace(DGLContext ctx, size_t size) {
-    std::lock_guard<std::mutex> guard(mtx_);
-    return pool_.AllocWorkspace(ctx, size);
-  }
-
-  void FreeWorkspace(DGLContext ctx, void* ptr) {
-    std::lock_guard<std::mutex> guard(mtx_);
-    pool_.FreeWorkspace(ctx, ptr);
-  }
-
- private:
-  WorkspacePool pool_;
-  std::mutex mtx_;
-};
-
-static ThreadSafeWorkspacePool& getGlobalCudaWorkspace();
+CudaMemoryPool& GetGlobalCudaMemoryPool();
 
 class CUDADeviceAPI final : public DeviceAPI {
  public:
+  CUDADeviceAPI() : use_memory_pool_(false) {
+    char * const use_str = std::getenv(kUseMemoryPoolString);
+
+    if (use_str) {
+      std::string value(use_str);
+      std::transform(value.begin(), value.end(), value.begin(),
+          [](char c) {return static_cast<char>(std::tolower(c)); });
+      if (value == "true" || value == "1") {
+        use_memory_pool_ = true;
+      } else if (value == "false" || value == "0") {
+        use_memory_pool_ = false;
+      } else {
+        LOG(WARNING) << "Unknown value for " << kUseMemoryPoolString
+            << " '" << use_str << "', ignoring." << std::endl;
+      }
+    }
+  }
   void SetDevice(DGLContext ctx) final {
     CUDA_CALL(cudaSetDevice(ctx.device_id));
   }
@@ -116,14 +114,23 @@ class CUDADeviceAPI final : public DeviceAPI {
 
   void* AllocDataSpace(DGLContext ctx,
                        size_t nbytes,
-                       size_t /* alignment */,
-                       DGLType /* type_hint */) final {
-    void *ret = getGlobalCudaWorkspace().AllocWorkspace(ctx, nbytes);
+                       size_t alignment,
+                       DGLType type_hint) final {
+    void * ret;
+    if (use_memory_pool_) {
+      ret = GetGlobalCudaMemoryPool().Alloc(ctx, nbytes);
+    } else {
+      ret = AllocRawDataSpace(ctx, nbytes, alignment, type_hint);
+    }
     return ret;
   }
 
   void FreeDataSpace(DGLContext ctx, void* ptr) final {
-    getGlobalCudaWorkspace().FreeWorkspace(ctx, ptr);
+    if (use_memory_pool_) {
+      GetGlobalCudaMemoryPool().Free(ctx, ptr);
+    } else {
+      FreeRawDataSpace(ctx, ptr);
+    }
   }
 
   void* AllocRawDataSpace(DGLContext ctx,
@@ -224,6 +231,8 @@ class CUDADeviceAPI final : public DeviceAPI {
   }
 
  private:
+  bool use_memory_pool_;
+
   static void GPUCopy(const void* from,
                       void* to,
                       size_t size,
@@ -237,8 +246,8 @@ class CUDADeviceAPI final : public DeviceAPI {
   }
 };
 
-ThreadSafeWorkspacePool& getGlobalCudaWorkspace() {
-  static ThreadSafeWorkspacePool pool(kDLGPU, CUDADeviceAPI::Global());
+CudaMemoryPool& GetGlobalCudaMemoryPool() {
+  static CudaMemoryPool pool(CUDADeviceAPI::Global());
   return pool;
 }
 

--- a/src/runtime/cuda/cuda_device_api.cc
+++ b/src/runtime/cuda/cuda_device_api.cc
@@ -8,12 +8,41 @@
 #include <dmlc/thread_local.h>
 #include <dgl/runtime/registry.h>
 #include <cuda_runtime.h>
+#include <mutex>
 #include "cuda_common.h"
 
 namespace dgl {
 namespace runtime {
 
-static WorkspacePool& getGlobalCudaWorkspace();
+class ThreadSafeWorkspacePool
+{
+  public:
+    ThreadSafeWorkspacePool(
+        DLDeviceType device_type,
+        std::shared_ptr<DeviceAPI> device) :
+      pool_(device_type, device),
+      mtx_()
+    {
+    }
+
+    void* AllocWorkspace(DGLContext ctx, size_t size)
+    {
+      std::lock_guard<std::mutex> guard(mtx_);
+      return pool_.AllocWorkspace(ctx, size);
+    }
+
+    void FreeWorkspace(DGLContext ctx, void* ptr)
+    {
+      std::lock_guard<std::mutex> guard(mtx_);
+      pool_.FreeWorkspace(ctx, ptr);
+    }
+
+  private:
+    WorkspacePool pool_;
+    std::mutex mtx_;
+};
+
+static ThreadSafeWorkspacePool& getGlobalCudaWorkspace();
 
 class CUDADeviceAPI final : public DeviceAPI {
  public:
@@ -88,16 +117,12 @@ class CUDADeviceAPI final : public DeviceAPI {
     }
     *rv = value;
   }
+
   void* AllocDataSpace(DGLContext ctx,
                        size_t nbytes,
-                       size_t alignment,
-                       DGLType type_hint) final {
-
-
-    CHECK_EQ(256 % alignment, 0U)
-        << "CUDA space is aligned at 256 bytes";
+                       size_t /* alignment */,
+                       DGLType /* type_hint */) final {
     void *ret = getGlobalCudaWorkspace().AllocWorkspace(ctx, nbytes);
-
     return ret;
   }
 
@@ -216,10 +241,9 @@ class CUDADeviceAPI final : public DeviceAPI {
   }
 };
 
-WorkspacePool& getGlobalCudaWorkspace()
+ThreadSafeWorkspacePool& getGlobalCudaWorkspace()
 {
-  static WorkspacePool pool(kDLGPU, CUDADeviceAPI::Global());
-
+  static ThreadSafeWorkspacePool pool(kDLGPU, CUDADeviceAPI::Global());
   return pool;
 }
 

--- a/src/runtime/cuda/cuda_memory_pool.cc
+++ b/src/runtime/cuda/cuda_memory_pool.cc
@@ -1,15 +1,18 @@
 /*!
  *  Copyright (c) 2017-2020 by Contributors
  * \file cuda_device_api.cc
- * \brief Memory pool implementation for GPU. 
+ * \brief Memory pool implementation for GPU.
  */
 
 #include "cuda_memory_pool.h"
-#include "cuda_common.h"
 
 #include <cuda_runtime.h>
 #include <mutex>
 #include <cstdlib>
+#include <map>
+#include <algorithm>
+
+#include "cuda_common.h"
 
 namespace dgl {
 namespace runtime {
@@ -32,7 +35,7 @@ constexpr const size_t kMaxAllocMultiple = 2;
  * 100 MB of memory at one time, we cannot have more than 200 MB allocated.
  */
 constexpr const size_t kMaxTotalMultiple = 2;
-}
+}  // namespace
 
 class CudaMemoryPool::Pool {
  public:
@@ -100,17 +103,11 @@ class CudaMemoryPool::Pool {
     total_unused_ += e.size;
   }
 
-  size_t TotalUnused() const
-  {
-    return total_unused_;
-  }
-
   size_t TotalUsed() const {
     return total_ - total_unused_;
   }
 
-  size_t TotalSize() const
-  {
+  size_t TotalSize() const {
     return total_;
   }
 
@@ -134,9 +131,9 @@ class CudaMemoryPool::Pool {
 
   std::mutex mtx_;
 
-  size_t AllocSize(const size_t nbytes) const
-  {
-    return std::max(kCudaPageSize, (nbytes + (kCudaPageSize - 1)) / kCudaPageSize * kCudaPageSize);
+  size_t AllocSize(const size_t nbytes) const {
+    return std::max(kCudaPageSize,
+        (nbytes + (kCudaPageSize - 1)) / kCudaPageSize * kCudaPageSize);
   }
 
   void Release(DGLContext ctx, DeviceAPI* device) {
@@ -152,8 +149,7 @@ class CudaMemoryPool::Pool {
 };
 
 CudaMemoryPool::CudaMemoryPool(
-    std::shared_ptr<DeviceAPI> device) : array_(), device_(device)
-{
+    std::shared_ptr<DeviceAPI> device) : array_(), device_(device) {
   int nDevices;
   CUDA_CALL(cudaGetDeviceCount(&nDevices));
   array_.resize(nDevices);
@@ -177,5 +173,5 @@ CudaMemoryPool::Pool* const CudaMemoryPool::GetMemoryPool(const size_t device_id
   return array_[device_id];
 }
 
-}
-}
+}  // namespace runtime
+}  // namespace dgl

--- a/src/runtime/cuda/cuda_memory_pool.cc
+++ b/src/runtime/cuda/cuda_memory_pool.cc
@@ -1,0 +1,181 @@
+/*!
+ *  Copyright (c) 2017-2020 by Contributors
+ * \file cuda_device_api.cc
+ * \brief Memory pool implementation for GPU. 
+ */
+
+#include "cuda_memory_pool.h"
+#include "cuda_common.h"
+
+#include <cuda_runtime.h>
+#include <mutex>
+#include <cstdlib>
+
+namespace dgl {
+namespace runtime {
+
+namespace {
+
+/*! \brief The minimum size of the pool before considering freeing space in
+ * bytes. Currently set to 64MB. */
+constexpr const size_t kMinPoolSize = 64 << 20;
+constexpr const size_t kCudaPageSize = 4096;
+
+/*! \brief The maximum ratio of allocation size, to allocation use. That is,
+ * a multiple of 2 means that an allocation is 4MB, can be used for requests no
+ * smaller than 2 MB.
+ */
+constexpr const size_t kMaxAllocMultiple = 2;
+
+/*! \brief The maximum ratio of allocated memory to the maximum amount of
+ * memory used so far. That is, for a multiple of 2, if we have use at most
+ * 100 MB of memory at one time, we cannot have more than 200 MB allocated.
+ */
+constexpr const size_t kMaxTotalMultiple = 2;
+}
+
+class CudaMemoryPool::Pool {
+ public:
+  // constructor
+  Pool() : total_(0), total_unused_(0), max_used_(0),
+    free_list_(), allocated_(), mtx_() {
+  }
+
+  // allocate from pool
+  void* Alloc(DGLContext ctx, DeviceAPI* const device, size_t nbytes) {
+    std::lock_guard<std::mutex> guard(mtx_);
+
+    // Allocate align to page.
+    nbytes = AllocSize(nbytes);
+
+    Entry e;
+    auto iter = free_list_.lower_bound(nbytes);
+
+    if (iter == free_list_.end() || iter->second.size > kMaxAllocMultiple*nbytes) {
+      // if we have no allocation big enough, or that is not a large waste
+      // of space, allocate new space
+
+      if (TotalSize() > std::max(kMinPoolSize, kMaxTotalMultiple*max_used_)) {
+        // If we have allocated more than twice the most we have ever used,
+        // cleanup currently unused memory
+        Release(ctx, device);
+      }
+
+      // allocate a new page
+      DGLType type;
+      type.code = kDLUInt;
+      type.bits = 8;
+      type.lanes = 1;
+
+      e.size = nbytes;
+      e.data = device->AllocRawDataSpace(ctx, nbytes, kTempAllocaAlignment, type);
+      total_ += e.size;
+    } else {
+      // use previously allocated space
+      e = iter->second;
+      free_list_.erase(iter);
+      total_unused_ -= e.size;
+    }
+
+    allocated_.emplace(e.data, e);
+
+    if (TotalUsed() > max_used_) {
+      max_used_ = TotalUsed();
+    }
+
+    return e.data;
+  }
+
+  // free resource back to pool
+  void Free(void* data) {
+    std::lock_guard<std::mutex> guard(mtx_);
+
+    auto iter = allocated_.find(data);
+    CHECK(iter != allocated_.end()) << "trying to free things that has not been allocated";
+
+    Entry e = iter->second;
+    allocated_.erase(iter);
+
+    free_list_.emplace(e.size, e);
+    total_unused_ += e.size;
+  }
+
+  size_t TotalUnused() const
+  {
+    return total_unused_;
+  }
+
+  size_t TotalUsed() const {
+    return total_ - total_unused_;
+  }
+
+  size_t TotalSize() const
+  {
+    return total_;
+  }
+
+ private:
+  /*! \brief a single entry in the pool */
+  struct Entry {
+    void* data;
+    size_t size;
+  };
+  size_t total_;
+  size_t total_unused_;
+  size_t max_used_;
+
+  /*! \brief Mapping of sizes to free items. There may be multiple items of
+   * the same size. */
+  std::multimap<size_t, Entry> free_list_;
+
+  /*! \brief Mappings of addresses, to allocation data. Each address must
+   * be unique. */
+  std::map<void*, Entry> allocated_;
+
+  std::mutex mtx_;
+
+  size_t AllocSize(const size_t nbytes) const
+  {
+    return std::max(kCudaPageSize, (nbytes + (kCudaPageSize - 1)) / kCudaPageSize * kCudaPageSize);
+  }
+
+  void Release(DGLContext ctx, DeviceAPI* device) {
+    for (auto kv : free_list_) {
+      device->FreeRawDataSpace(ctx, kv.second.data);
+      total_ -= kv.second.size;
+      total_unused_ -= kv.second.size;
+    }
+    free_list_.clear();
+
+    CHECK_EQ(total_unused_, 0);
+  }
+};
+
+CudaMemoryPool::CudaMemoryPool(
+    std::shared_ptr<DeviceAPI> device) : array_(), device_(device)
+{
+  int nDevices;
+  CUDA_CALL(cudaGetDeviceCount(&nDevices));
+  array_.resize(nDevices);
+  for (int d = 0; d < nDevices; ++d) {
+    array_[d] = new CudaMemoryPool::Pool();
+  }
+}
+
+void* CudaMemoryPool::Alloc(DGLContext ctx, size_t size) {
+  Pool* const pool = GetMemoryPool(ctx.device_id);
+  return pool->Alloc(ctx, device_.get(), size);
+}
+
+void CudaMemoryPool::Free(DGLContext ctx, void* ptr) {
+  Pool* const pool = GetMemoryPool(ctx.device_id);
+  pool->Free(ptr);
+}
+
+CudaMemoryPool::Pool* const CudaMemoryPool::GetMemoryPool(const size_t device_id) {
+  CHECK(device_id < array_.size());
+  return array_[device_id];
+}
+
+}
+}

--- a/src/runtime/cuda/cuda_memory_pool.h
+++ b/src/runtime/cuda/cuda_memory_pool.h
@@ -1,0 +1,38 @@
+/*!
+ *  Copyright (c) 2020 by Contributors
+ * \file cuda_memory_pool.h
+ * \brief Memory pool for GPU. 
+ */
+
+#ifndef DGL_RUNTIME_CUDA_CUDA_MEMORY_POOL_H_
+#define DGL_RUNTIME_CUDA_CUDA_MEMORY_POOL_H_
+
+#include "dgl/runtime/c_runtime_api.h"
+#include "dgl/runtime/device_api.h"
+#include <memory>
+#include <vector>
+
+namespace dgl {
+namespace runtime {
+
+class CudaMemoryPool
+{
+  public:
+    CudaMemoryPool(std::shared_ptr<DeviceAPI> device);
+
+    void* Alloc(DGLContext ctx, size_t size);
+
+    void Free(DGLContext ctx, void* ptr);
+
+  private:
+    class Pool; 
+    std::vector<Pool*> array_;
+    std::shared_ptr<DeviceAPI> device_;
+
+    Pool* const GetMemoryPool(size_t device_id);
+};
+
+}
+}
+
+#endif

--- a/src/runtime/cuda/cuda_memory_pool.h
+++ b/src/runtime/cuda/cuda_memory_pool.h
@@ -1,38 +1,59 @@
 /*!
  *  Copyright (c) 2020 by Contributors
  * \file cuda_memory_pool.h
- * \brief Memory pool for GPU. 
+ * \brief Memory pool for GPU.
  */
 
 #ifndef DGL_RUNTIME_CUDA_CUDA_MEMORY_POOL_H_
 #define DGL_RUNTIME_CUDA_CUDA_MEMORY_POOL_H_
 
-#include "dgl/runtime/c_runtime_api.h"
-#include "dgl/runtime/device_api.h"
 #include <memory>
 #include <vector>
+#include "dgl/runtime/c_runtime_api.h"
+#include "dgl/runtime/device_api.h"
 
 namespace dgl {
 namespace runtime {
 
-class CudaMemoryPool
-{
-  public:
-    CudaMemoryPool(std::shared_ptr<DeviceAPI> device);
+class CudaMemoryPool {
+ public:
+   /*!
+    * \brief Create a new CudaMemoryPool for reducing repeat calls to
+    * cudaMalloc() and cudaFree().
+    *
+    * @param device The cuda device API to use.
+    */
+  explicit CudaMemoryPool(std::shared_ptr<DeviceAPI> device);
 
-    void* Alloc(DGLContext ctx, size_t size);
 
-    void Free(DGLContext ctx, void* ptr);
+  /*!
+   * \brief Create an allocation in ctx of at least size bytes.
+   *
+   * @param ctx The context to get an allocation for.
+   * @param size The size of the space required in bytes.
+   *
+   * @return A pointer to the allocated space.
+   */
+  void* Alloc(DGLContext ctx, size_t size);
 
-  private:
-    class Pool; 
-    std::vector<Pool*> array_;
-    std::shared_ptr<DeviceAPI> device_;
 
-    Pool* const GetMemoryPool(size_t device_id);
+  /**
+   * @brief Free an allocation in ctx pointed to by ptr.
+   *
+   * @param ctx The context to release an allocation from.
+   * @param ptr The pointer to the allocation.
+   */
+  void Free(DGLContext ctx, void* ptr);
+
+ private:
+  class Pool;
+  std::vector<Pool*> array_;
+  std::shared_ptr<DeviceAPI> device_;
+
+  Pool* const GetMemoryPool(size_t device_id);
 };
 
-}
-}
+}  // namespace runtime
+}  // namespace dgl
 
-#endif
+#endif  // DGL_RUNTIME_CUDA_CUDA_MEMORY_POOL_H_

--- a/src/runtime/workspace_pool.cc
+++ b/src/runtime/workspace_pool.cc
@@ -74,7 +74,7 @@ class WorkspacePool::Pool {
     } else {
       int index = static_cast<int>(allocated_.size()) - 2;
       for (; index > 0 && allocated_[index].data != data; --index) {}
-      CHECK_GT(index, 0) << "trying to free things that has not been allocated: " << data;
+      CHECK_GT(index, 0) << "trying to free things that has not been allocated";
       e = allocated_[index];
       allocated_.erase(allocated_.begin() + index);
     }

--- a/src/runtime/workspace_pool.cc
+++ b/src/runtime/workspace_pool.cc
@@ -38,12 +38,12 @@ class WorkspacePool::Pool {
       free_list_.pop_back();
       if (e.size < nbytes) {
         // resize the page
-        device->FreeDataSpace(ctx, e.data);
-        e.data = device->AllocDataSpace(ctx, nbytes, kTempAllocaAlignment, type);
+        device->FreeRawDataSpace(ctx, e.data);
+        e.data = device->AllocRawDataSpace(ctx, nbytes, kTempAllocaAlignment, type);
         e.size = nbytes;
       }
     } else if (free_list_.size() == 1) {
-      e.data = device->AllocDataSpace(ctx, nbytes, kTempAllocaAlignment, type);
+      e.data = device->AllocRawDataSpace(ctx, nbytes, kTempAllocaAlignment, type);
       e.size = nbytes;
     } else {
       if (free_list_.back().size >= nbytes) {
@@ -56,8 +56,8 @@ class WorkspacePool::Pool {
         // resize the page
         e = free_list_.back();
         free_list_.pop_back();
-        device->FreeDataSpace(ctx, e.data);
-        e.data = device->AllocDataSpace(ctx, nbytes, kTempAllocaAlignment, type);
+        device->FreeRawDataSpace(ctx, e.data);
+        e.data = device->AllocRawDataSpace(ctx, nbytes, kTempAllocaAlignment, type);
         e.size = nbytes;
       }
     }
@@ -74,7 +74,7 @@ class WorkspacePool::Pool {
     } else {
       int index = static_cast<int>(allocated_.size()) - 2;
       for (; index > 0 && allocated_[index].data != data; --index) {}
-      CHECK_GT(index, 0) << "trying to free things that has not been allocated";
+      CHECK_GT(index, 0) << "trying to free things that has not been allocated: " << data;
       e = allocated_[index];
       allocated_.erase(allocated_.begin() + index);
     }
@@ -96,7 +96,7 @@ class WorkspacePool::Pool {
   void Release(DGLContext ctx, DeviceAPI* device) {
     CHECK_EQ(allocated_.size(), 1);
     for (size_t i = 1; i < free_list_.size(); ++i) {
-      device->FreeDataSpace(ctx, free_list_[i].data);
+      device->FreeRawDataSpace(ctx, free_list_[i].data);
     }
     free_list_.clear();
   }

--- a/tests/cpp/test_allocations.cc
+++ b/tests/cpp/test_allocations.cc
@@ -1,0 +1,120 @@
+/*!
+ *  Copyright (c) 2020 by Contributors
+ * \file tests/cpp/test_allocations.cc
+ * \brief Test the three categories of allocated space on CPU and GPU.
+ */
+
+#include <gtest/gtest.h>
+#include <dgl/runtime/device_api.h>
+#include "./common.h"
+
+namespace {
+constexpr size_t ALIGNMENT = sizeof(void*);
+}  // namespace
+
+using namespace dgl;
+
+template<typename T>
+void _TestAllocatedSpace(
+    DGLContext ctx,
+    T * space,
+    const size_t num) {
+  auto device = runtime::DeviceAPI::Get(ctx);
+  std::vector<T> source(num, 0);
+  for (size_t i = 0; i < num; ++i) {
+    source[i] = static_cast<T>(i);
+  }
+
+  std::vector<T> dest(num);
+
+  const size_t space_size = num*sizeof(T);
+
+  // make sure copy to the allocation works
+  device->CopyDataFromTo(
+      source.data(), 0, space, 0, space_size,
+      DGLContext{kDLCPU, 0}, ctx, DGLType{}, 0); 
+
+  device->CopyDataFromTo(
+      space, 0,
+      dest.data(), 0,
+      space_size,
+      ctx, DGLContext{kDLCPU, 0}, DGLType{}, 0); 
+
+  for (size_t i = 0; i < num; ++i) {
+    ASSERT_EQ(dest[i], source[i]);
+  }
+}
+
+
+template<typename T>
+void _TestWorkspace(DGLContext ctx) {
+  auto device = runtime::DeviceAPI::Get(ctx);
+  const size_t num = 8123;
+  const size_t workspace_size = num*sizeof(T);
+  T * workspace = static_cast<T*>(device->AllocWorkspace(ctx, workspace_size));
+
+  _TestAllocatedSpace(ctx, workspace, num);
+
+  device->FreeWorkspace(ctx, workspace);
+}
+
+
+template<typename T>
+void _TestDataspace(DGLContext ctx) {
+  auto device = runtime::DeviceAPI::Get(ctx);
+  const size_t num = 8123;
+  const size_t dataspace_size = num*sizeof(T);
+  T * dataspace = static_cast<T*>(device->AllocDataSpace(ctx,
+      dataspace_size, ALIGNMENT, {}));
+
+  _TestAllocatedSpace(ctx, dataspace, num);
+
+  device->FreeDataSpace(ctx, dataspace);
+}
+
+template<typename T>
+void _TestRawDataspace(DGLContext ctx) {
+  auto device = runtime::DeviceAPI::Get(ctx);
+  const size_t num = 8123;
+  const size_t dataspace_size = num*sizeof(T);
+  T * dataspace = static_cast<T*>(device->AllocRawDataSpace(ctx,
+      dataspace_size, ALIGNMENT, {}));
+
+  _TestAllocatedSpace(ctx, dataspace, num);
+
+  device->FreeRawDataSpace(ctx, dataspace);
+}
+
+TEST(AllocationsTest, CPUWorkspace) {
+  _TestWorkspace<int32_t>(CPU);
+  _TestWorkspace<int64_t>(CPU);
+}
+
+
+TEST(AllocationsTest, CPUDataspace) {
+  _TestDataspace<int32_t>(CPU);
+  _TestDataspace<int64_t>(CPU);
+}
+
+
+TEST(AllocationsTest, CPURaw) {
+  _TestRawDataspace<int32_t>(CPU);
+  _TestRawDataspace<int64_t>(CPU);
+}
+
+#ifdef DGL_USE_CUDA
+TEST(AllocationsTest, GPUWorkspace) {
+  _TestWorkspace<int32_t>(GPU);
+  _TestWorkspace<int64_t>(GPU);
+}
+
+TEST(AllocationsTest, GPURaw) {
+  _TestDataspace<int32_t>(GPU);
+  _TestDataspace<int64_t>(GPU);
+}
+
+TEST(AllocationsTest, GPU) {
+  _TestRawDataspace<int32_t>(GPU);
+  _TestRawDataspace<int64_t>(GPU);
+}
+#endif

--- a/tests/scripts/task_unit_test.sh
+++ b/tests/scripts/task_unit_test.sh
@@ -38,4 +38,7 @@ python3 -m pytest -v --junitxml=pytest_backend.xml tests/$DGLBACKEND || fail "ba
 export OMP_NUM_THREADS=1
 if [ $2 != "gpu" ]; then
     python3 -m pytest -v --junitxml=pytest_distributed.xml tests/distributed || fail "distributed"
+else
+    # test GPU workspace allocations
+    DGL_USE_CUDA_MEMORY_POOL=1 python3 -m pytest -v --junitxml=pytest_workspace.xml tests/compute/test_basics.py || fail "basic-gpu-workspace"
 fi


### PR DESCRIPTION
## Description
Repeated `cudaMalloc()` and `cudaFree()` calls can be expensive, and in addition, cudaFree() requires synchronizing with the device, which can prevent overlapping CPU and GPU work. This PR makes it so all CUDA allocations go through a `WorkspacePool::Pool` object, ensuring we re-use allocations many times, amortizing the cost of `cudaMalloc()` and `cudaFree()`, and avoid synchronizing with the device unnecessarily. These changes are only enabled through the environment variable `DGL_USE_CUDA_MEMORY_POOL`, otherwise the regular allocation path is taken.

In the worst case, this allocator uses 4x the memory necessary, by having half of the allocations in use, and all of those only using 50% of the allocated space. However, this has little impact on the overall memory usage, as the graph index arrays (which is almost all of the data allocated DGL), are much smaller than the weights and feature data allocated by the backend.

I could refactor this PR around the "TensorDispatcher" in https://github.com/dmlc/dgl/pull/2328, and have the memory pool here simply be another allocator that can be selected.

## Checklist
Please feel free to remove inapplicable items for your PR.
- [x] The PR title starts with [$CATEGORY] (such as [NN], [Model], [Doc], [Feature]])
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage (looking at the current testing code, I believe both the CPU and GPU allocations are executed, but I can't say I'm 100% sure).
- [x] Code is well-documented
- [x] To the my best knowledge, examples are either not affected by this change,
      or have been fixed to be compatible with this change

## Changes

This PR adds two new methods to `DeviceAPI`: `AllocRawDataSpace()` and `FreeRawDataSpace()` to explicitly by-pass workspace allocations, where as the `AllocDataSpace()` and `FreeDataSpace()` methods in the `CUDADeviceAPI` class now uses a shared workspace to make all allocations.

Below are two profiles from Nvidia Nsight Systems, showing the GPU utilization in the forward pass of RGCN (this is the CSR generation and SpMM operations):

Master branch:
![cuda_without_workspace_profile](https://user-images.githubusercontent.com/63612878/95261960-2af99300-07e0-11eb-88dd-e273049e4b72.png)

This PR:
![cuda_workspace_profile](https://user-images.githubusercontent.com/63612878/95261963-2f25b080-07e0-11eb-8a7f-f8ff4bbf8094.png)
