### PR TITLE
[Bugfix][Performance] Fix Column to copy 'self.index' to location of 'self.storage' only on read, and use kwargs.

### DIFF
--- a/python/dgl/frame.py
+++ b/python/dgl/frame.py
@@ -149,7 +149,7 @@ class Column(object):
         col = self.clone()
         col.device = (device, kwargs)
         if self.index is not None:
-            col.index = F.copy_to(self.index, device)
+            col.index = F.copy_to(self.index, device, **kwargs)
         return col
 
     def __getitem__(self, rowids):

--- a/python/dgl/frame.py
+++ b/python/dgl/frame.py
@@ -254,13 +254,13 @@ class Column(object):
         if self.index is None:
             return Column(self.storage, self.scheme, rowids, self.device)
         else:
-            index = self.index
-            if F.context(index) != F.context(rowids):
+            if F.context(self.index) != F.context(rowids):
+                # make sure index and row ids are on the same context
                 kwargs = {}
                 if self.device is not None:
                     kwargs = self.device[1]
-                index = F.copy_to(self.index, F.context(rowids), **kwargs)
-            return Column(self.storage, self.scheme, F.gather_row(index, rowids), self.device)
+                rowids = F.copy_to(rowids, F.context(self.index), **kwargs)
+            return Column(self.storage, self.scheme, F.gather_row(self.index, rowids), self.device)
 
     @staticmethod
     def create(data):


### PR DESCRIPTION
## Description
Currently, when `Column.to(device)` is called, the index is copied to the device immediately, and the storage waits to be copied lazily. However, because the index and the storage need to reside on the same device in order to perform `gather_row()`, the index ends up getting copied again in the reverse direction. Furthermore, while the `kwargs` gets passed to the framework's copy method for the storage, it does not get passed for copying the index.

As seen in the below image of the graphsage example on the reddit dataset, this results in a large number of copy operations, including copying `self.index` to the gpu, only to copy it back to the cpu.

![original_data_to_device](https://user-images.githubusercontent.com/63612878/95525412-e0674a80-0988-11eb-962f-60e61085841e.png)




## Checklist
Please feel free to remove inapplicable items for your PR.
- [x] The PR title starts with [$CATEGORY] (such as [NN], [Model], [Doc], [Feature]])
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage
- [x] Code is well-documented
- [x] To the my best knowledge, examples are either not affected by this change,
      or have been fixed to be compatible with this change

## Changes

This PR fixes this, by only copying the index to the device of the storage, using the kwargs. In the below image, the number of copies to the GPU is greatly reduced and are all in the same direction (h2d):

![this_branch_data_to_device](https://user-images.githubusercontent.com/63612878/95525473-10165280-0989-11eb-9ca4-0b055ebcdd41.png)
