### PR TITLE
[Performance] Dynamic cpu kernel for SpMMSumCsr 

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -20,3 +20,6 @@
 [submodule "third_party/phmap"]
 	path = third_party/phmap
 	url = https://github.com/greg7mdp/parallel-hashmap.git
+[submodule "third_party/xbyak"]
+	path = third_party/xbyak
+	url = https://github.com/herumi/xbyak

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -49,6 +49,7 @@ include_directories("third_party/minigun/minigun")
 include_directories("third_party/minigun/third_party/moderngpu/src")
 include_directories("third_party/cub/")
 include_directories("third_party/phmap/")
+include_directories("third_party/xbyak/")
 
 # initial variables
 set(DGL_LINKER_LIBS "")

--- a/include/intel/cpu_support.h
+++ b/include/intel/cpu_support.h
@@ -1,0 +1,156 @@
+/*!
+ *  Copyright (c) 2019 by Contributors
+ * \file intel/cpu_support.h
+ * \brief Intel CPU support
+ */
+#ifndef INTEL_CPU_SUPPORT_H_
+#define INTEL_CPU_SUPPORT_H_
+#include <memory>
+#include <type_traits>
+#include "xbyak/xbyak.h"
+#include "xbyak/xbyak_util.h"
+namespace intel {
+#define log_intel(x) if (IntelKernel<T>::log_enabled()) { std::cout << x << std::endl; }
+#ifndef log_intel
+#define log_intel(x)
+#endif
+template<class T>
+using Uptr = std::unique_ptr<T>;
+
+template<class T>
+struct IntelKernel {
+      static int64_t getValue() {
+        int64_t v = 0;
+        const char *label = "DGL_CPU_INTEL_KERNEL_ENABLED";
+        const char *ptr = std::getenv(label);
+        if (ptr) {
+          v = atoll(ptr);
+          log_intel(label << "=>" << v);
+        }
+        return v;
+      }
+
+      static int64_t enabled() {
+        static int64_t r = IntelKernel<T>::getValue();
+        return r;
+      }
+
+      static int log_enabled() {
+        static int r = (std::getenv("DGL_CPU_INTEL_KERNEL_LOG")) ? 1 : 0;
+        return r;
+      }
+};
+
+template <class T, int has_specialization = 0>
+class elem_wise_add_update : public Xbyak::CodeGenerator {
+    typedef elem_wise_add_update<T> self;
+    /* [performance] skip static check*/
+    int64_t size;
+
+    /* [functional] Does kernel is applicable on this machine ? */
+    bool applicable;
+
+    /* [performance-functional] use kernel when input size >= min_size */
+    int64_t min_size;
+
+ public:
+     void prolog() {
+        push(r8);
+        push(r9);
+     }
+
+      void epilog() {
+        pop(r9);
+        pop(r8);
+      }
+    explicit elem_wise_add_update(int64_t _size) :
+     size(_size), applicable(false), min_size(IntelKernel<T>::enabled()) {
+      static Xbyak::util::Cpu current_cpu;
+      /* input => { src=RSI , dst=RDI , size=RDX } */
+
+      /* Default case for all */
+      if (current_cpu.has(Xbyak::util::Cpu::tAVX512F)) {
+        prolog();
+        /* prepare REMAINDER */
+        mov(r8, rdx);  // rdx => size
+        and_(r8, 0xf);  // r8_modulo = size/(sizeof(zmm)/sizeof(float))
+        xor_(r9, r9);  // reset r9
+        cmp(rdx, 0x10);  // if ( size < 16 ) {  }
+        jl("remainder");
+
+        /*  decrease  divident */
+        sub(rdx, r8);  // prepare alignment chunks
+        cmp(rdx, 0);  // do we have any full chunks ?
+        jz("remainder");
+
+        L("for_i");
+        /* load first part of mem to zmm0*/
+        vmovups(zmm0, ptr[rdi + r9 * 4]);
+        /* load second part of mem to zmm1*/
+        vmovups(zmm1, ptr[rsi + r9 * 4]);
+        /* zmm2 = zmm0 + zmm1 */
+        vaddps(zmm2, zmm0, zmm1);
+        /* save output to dst*/
+        vmovups(ptr[rdi + r9 * 4], zmm2);
+        add(r9, 16);  // r9+=sizeof(zmm)/sizeof(float)
+        cmp(rdx, r9);  // more full chunks ?
+        jnz("for_i");
+
+        L("remainder");
+        cmp(r8, 0);  //  do we have a remainder ?
+        jz("done");
+        xor_(rax, rax);
+        /* prepare a bitmask for k1 */
+        mov(rax, 1);
+        mov(rcx, r8);
+        sal(rax, cl);
+        dec(rax);  // k1= (1 << r8 )-1
+        kmovw(k1, eax);  // set bitmask
+        /* same logic as above but with mask */
+        /* vmovups zmm0{k1},ZMMWORD PTR [rdi+r9*4] */
+        const uint8_t ptr_3[7] = {0x62, 0xb1, 0x7c, 0x49, 0x10, 0x04, 0x8f};
+        db(ptr_3, sizeof(ptr_3) / sizeof(uint8_t));
+        /* vmovups zmm1{k1},ZMMWORD PTR [rsi+r9*4] */
+        const uint8_t ptr_2[7] = {0x62, 0xb1, 0x7c, 0x49, 0x10, 0x0c, 0x8e};
+        db(ptr_2, sizeof(ptr_2) / sizeof(uint8_t));
+        /*  zmm2 = zmm0 + zmm1 */
+        vaddps(zmm2, zmm0, zmm1);
+        /* vmovups ZMMWORD PTR [rdi+r9*4]{k1},zmm2  */
+        const uint8_t ptr_1[7] = {0x62, 0xB1, 0x7C, 0x49, 0x11, 0x14, 0x8F};
+        db(ptr_1, sizeof(ptr_1) / sizeof(uint8_t));
+        L("done");
+
+        epilog();
+        applicable = true;
+        log_intel("*** AVX512F cpu kernel is ready for size=" << size << " ***");
+      }
+      ret();
+    }
+
+    bool is_applicable() const {
+      return applicable;
+    }
+
+    /*[functional] generate a new kernel for this size*/
+    template<class R>
+    typename std::enable_if<has_specialization, R>::type
+    require_new_instance(int64_t _size) {
+      return  (_size != size) && (_size >= min_size);
+    }
+
+    /*[performance] if specialization doesn't exist skip allocation use always default case */
+    template <class R>
+    typename std::enable_if<!has_specialization, R>::type
+    require_new_instance(int64_t _size) {
+      return false;
+    }
+
+     template<class ... P>
+     void run(P ... args) {
+         ((void(*)(P...))(this)->getCode())(args...);
+     }
+};
+
+}  // namespace intel
+
+#endif  // INTEL_CPU_SUPPORT_H_

--- a/src/array/cpu/spmm.h
+++ b/src/array/cpu/spmm.h
@@ -10,13 +10,16 @@
 #include <dgl/bcast.h>
 #include <limits>
 #include <algorithm>
-
+#include "spmm_binary_ops.h"
+#if !defined(_WIN32)
+#include "intel/cpu_support.h"
+#endif
 namespace dgl {
 namespace aten {
 namespace cpu {
 
 /*!
- * \brief CPU kernel of SpMM on Csr format.
+ * \brief CPU kernelCore of SpMM on Csr format.
  * \param bcast Broadcast information.
  * \param csr The Csr matrix.
  * \param ufeat The feature on source nodes.
@@ -25,12 +28,12 @@ namespace cpu {
  * \note it uses node parallel strategy, different threads are responsible
  *       for the computation of different nodes.
  */
-template <typename IdType, typename DType, typename Op>
-void SpMMSumCsr(
-    const BcastOff& bcast,
+template<class IdType, class DType , class Op>
+struct SpMMSumCsrCore {
+    static inline void call(const BcastOff& bcast,
     const CSRMatrix& csr,
     NDArray ufeat, NDArray efeat,
-    NDArray out) {
+    NDArray out ) {
   const bool has_idx = !IsNullArray(csr.data);
   const IdType* indptr = csr.indptr.Ptr<IdType>();
   const IdType* indices = csr.indices.Ptr<IdType>();
@@ -57,9 +60,90 @@ void SpMMSumCsr(
         const DType *rhs_off =
             Op::use_rhs ? W + eid * rhs_dim + rhs_add : nullptr;
         out_off[k] += Op::Call(lhs_off, rhs_off);
+          }
+       }
+    }
+  }
+};
+
+/*!
+ * \brief CPU kernelCore of SpMM<float> specialization CopyLhs.
+ * \param bcast Broadcast information.
+ * \param csr The Csr matrix.
+ * \param ufeat The feature on source nodes.
+ * \param efeat The feature on edges.
+ * \param out The result feature on destination nodes.
+ * \note it uses node parallel strategy, different threads are responsible
+ *       for the computation of different nodes.
+ */
+#if !defined(_WIN32)
+template <class IdType>
+struct SpMMSumCsrCore<IdType, float, dgl::aten::cpu::op::CopyLhs<float>> {
+        static inline void call(const BcastOff &bcast,
+                                const CSRMatrix &csr,
+                                NDArray ufeat, NDArray efeat,
+                                NDArray out) {
+          typedef float DType;
+          const IdType *indptr = csr.indptr.Ptr<IdType>();
+          const IdType *indices = csr.indices.Ptr<IdType>();
+          const DType *X = ufeat.Ptr<DType>();
+          int64_t dim = bcast.out_len,
+                  lhs_dim = bcast.lhs_len;
+          DType *O = out.Ptr<DType>();
+          typedef intel::elem_wise_add_update<DType> ElemWiseUpd;
+
+          /* Prepare an assembler code for this paricular dimension */
+          thread_local intel::Uptr<ElemWiseUpd> th_cpu_spec((intel::IntelKernel<DType>::enabled())
+           ? new ElemWiseUpd(dim) : nullptr);
+          /* Check if the code has been created */
+          ElemWiseUpd *cpu_spec = (th_cpu_spec && th_cpu_spec->is_applicable())
+           ? th_cpu_spec.get() : nullptr;
+          if (cpu_spec && cpu_spec->require_new_instance<bool>(dim)) {
+            th_cpu_spec.reset(new ElemWiseUpd(dim));
+            cpu_spec = (th_cpu_spec && th_cpu_spec->is_applicable()) ? th_cpu_spec.get() : nullptr;
+          }
+
+#pragma omp parallel for
+  for (IdType rid = 0; rid < csr.num_rows; ++rid) {
+    const IdType row_start = indptr[rid], row_end = indptr[rid + 1];
+    DType *out_off = O + rid * dim;
+    std::fill(out_off, out_off + dim, 0);
+    for (IdType j = row_start; j < row_end; ++j) {
+      const IdType cid = indices[j];
+      if (!bcast.use_bcast && cpu_spec) {
+          /* Forward to cpu asm kernel */
+          cpu_spec->run(out_off, X + cid * lhs_dim , dim);
+          continue;
+      }
+      for (int64_t k = 0; k < dim; ++k) {
+        const int64_t lhs_add = bcast.use_bcast ? bcast.lhs_offset[k] : k;
+        typedef dgl::aten::cpu::op::CopyLhs<DType> Op;
+        const DType *lhs_off =
+        Op::use_lhs ? X + cid * lhs_dim + lhs_add : nullptr;
+        out_off[k] += Op::Call(lhs_off, nullptr);
+        }
       }
     }
   }
+};
+#endif
+/*!
+ * \brief CPU kernel of SpMM on Csr format.
+ * \param bcast Broadcast information.
+ * \param csr The Csr matrix.
+ * \param ufeat The feature on source nodes.
+ * \param efeat The feature on edges.
+ * \param out The result feature on destination nodes.
+ * \note it uses node parallel strategy, different threads are responsible
+ *       for the computation of different nodes.
+ */
+template <typename IdType, typename DType, typename Op>
+void SpMMSumCsr(
+    const BcastOff& bcast,
+    const CSRMatrix& csr,
+    NDArray ufeat, NDArray efeat,
+    NDArray out) {
+    SpMMSumCsrCore<IdType, DType, Op>::call(bcast, csr, ufeat, efeat, out);
 }
 
 /*!
@@ -120,10 +204,10 @@ void SpMMSumCoo(
  * \param ufeat The feature on source nodes.
  * \param efeat The feature on edges.
  * \param out The result feature on destination nodes.
- * \param argu Arg-Min/Max on source nodes, which refers the source node indices 
+ * \param argu Arg-Min/Max on source nodes, which refers the source node indices
  *        correspond to the minimum/maximum values of reduction result on
  *        destination nodes. It's useful in computing gradients of Min/Max reducer.
- * \param arge Arg-Min/Max on edges. which refers the source node indices 
+ * \param arge Arg-Min/Max on edges. which refers the source node indices
  *        correspond to the minimum/maximum values of reduction result on
  *        destination nodes. It's useful in computing gradients of Min/Max reducer.
  * \note It uses node parallel strategy, different threads are responsible
@@ -187,10 +271,10 @@ void SpMMCmpCsr(
  * \param ufeat The feature on source nodes.
  * \param efeat The feature on edges.
  * \param out The result feature on destination nodes.
- * \param argu Arg-Min/Max on source nodes, which refers the source node indices 
+ * \param argu Arg-Min/Max on source nodes, which refers the source node indices
  *        correspond to the minimum/maximum values of reduction result on
  *        destination nodes. It's useful in computing gradients of Min/Max reducer.
- * \param arge Arg-Min/Max on edges. which refers the source node indices 
+ * \param arge Arg-Min/Max on edges. which refers the source node indices
  *        correspond to the minimum/maximum values of reduction result on
  *        destination nodes. It's useful in computing gradients of Min/Max reducer.
  * \note it uses node parallel strategy, different threads are responsible
@@ -245,123 +329,6 @@ void SpMMCmpCoo(
     }
   }
 }
-
-namespace op {
-
-//////////////////////////////// binary operators on CPU ////////////////////////////////
-template <typename DType>
-struct Add {
-  static constexpr bool use_lhs = true;
-  static constexpr bool use_rhs = true;
-  inline static DType Call(const DType* lhs_off, const DType* rhs_off) {
-    return *lhs_off + *rhs_off;
-  }
-};
-template <typename DType> constexpr bool Add<DType>::use_lhs;
-template <typename DType> constexpr bool Add<DType>::use_rhs;
-
-template <typename DType>
-struct Sub {
-  static constexpr bool use_lhs = true;
-  static constexpr bool use_rhs = true;
-  inline static DType Call(const DType* lhs_off, const DType* rhs_off) {
-    return *lhs_off - *rhs_off;
-  }
-};
-template <typename DType> constexpr bool Sub<DType>::use_lhs;
-template <typename DType> constexpr bool Sub<DType>::use_rhs;
-
-template <typename DType>
-struct Mul {
-  static constexpr bool use_lhs = true;
-  static constexpr bool use_rhs = true;
-  inline static DType Call(const DType* lhs_off, const DType* rhs_off) {
-    return *lhs_off * *rhs_off;
-  }
-};
-template <typename DType> constexpr bool Mul<DType>::use_lhs;
-template <typename DType> constexpr bool Mul<DType>::use_rhs;
-
-template <typename DType>
-struct Div {
-  static constexpr bool use_lhs = true;
-  static constexpr bool use_rhs = true;
-  inline static DType Call(const DType* lhs_off, const DType* rhs_off) {
-    return *lhs_off / *rhs_off;
-  }
-};
-template <typename DType> constexpr bool Div<DType>::use_lhs;
-template <typename DType> constexpr bool Div<DType>::use_rhs;
-
-template <typename DType>
-struct CopyLhs {
-  static constexpr bool use_lhs = true;
-  static constexpr bool use_rhs = false;
-  inline static DType Call(const DType* lhs_off, const DType* ) {
-    return *lhs_off;
-  }
-};
-template <typename DType> constexpr bool CopyLhs<DType>::use_lhs;
-template <typename DType> constexpr bool CopyLhs<DType>::use_rhs;
-
-template <typename DType>
-struct CopyRhs {
-  static constexpr bool use_lhs = false;
-  static constexpr bool use_rhs = true;
-  inline static DType Call(const DType* , const DType* rhs_off) {
-    return *rhs_off;
-  }
-};
-template <typename DType> constexpr bool CopyRhs<DType>::use_lhs;
-template <typename DType> constexpr bool CopyRhs<DType>::use_rhs;
-
-//////////////////////////////// Reduce operators on CPU ////////////////////////////////
-template <typename DType>
-struct Max {
-  static constexpr DType zero = -std::numeric_limits<DType>::infinity();
-  // return true if accum should be replaced
-  inline static DType Call(DType accum, DType val) {
-    return accum < val;
-  }
-};
-template <typename DType> constexpr DType Max<DType>::zero;
-
-template <typename DType>
-struct Min {
-  static constexpr DType zero = std::numeric_limits<DType>::infinity();
-  // return true if accum should be replaced
-  inline static DType Call(DType accum, DType val) {
-    return accum > val;
-  }
-};
-template <typename DType> constexpr DType Min<DType>::zero;
-
-#define SWITCH_OP(op, Op, ...)                                      \
-  do {                                                              \
-    if ((op) == "add") {                                            \
-      typedef dgl::aten::cpu::op::Add<DType> Op;                    \
-      { __VA_ARGS__ }                                               \
-    } else if ((op) == "sub") {                                     \
-      typedef dgl::aten::cpu::op::Sub<DType> Op;                    \
-      { __VA_ARGS__ }                                               \
-    } else if ((op) == "mul") {                                     \
-      typedef dgl::aten::cpu::op::Mul<DType> Op;                    \
-      { __VA_ARGS__ }                                               \
-    } else if ((op) == "div") {                                     \
-      typedef dgl::aten::cpu::op::Div<DType> Op;                    \
-      { __VA_ARGS__ }                                               \
-    } else if ((op) == "copy_lhs") {                                \
-      typedef dgl::aten::cpu::op::CopyLhs<DType> Op;                \
-      { __VA_ARGS__ }                                               \
-    } else if ((op) == "copy_rhs") {                                \
-      typedef dgl::aten::cpu::op::CopyRhs<DType> Op;                \
-      { __VA_ARGS__ }                                               \
-    } else {                                                        \
-      LOG(FATAL) << "Unsupported SpMM binary operator: " << op;     \
-    }                                                               \
-  } while (0)
-
-}  // namespace op
 
 }  // namespace cpu
 }  // namespace aten

--- a/src/array/cpu/spmm_binary_ops.h
+++ b/src/array/cpu/spmm_binary_ops.h
@@ -1,0 +1,136 @@
+/*!
+ *  Copyright (c) 2020 by Contributors
+ * \file array/cpu/spmm_binary_ops.h
+ * \brief SPMM CPU Binary ops.
+ */
+#ifndef DGL_ARRAY_CPU_SPMM_BINARY_OPS_H_
+#define DGL_ARRAY_CPU_SPMM_BINARY_OPS_H_
+#include <dgl/array.h>
+#include <dgl/bcast.h>
+#include <limits>
+namespace dgl {
+namespace aten {
+namespace cpu {
+namespace op {
+
+//////////////////////////////// binary operators on CPU ////////////////////////////////
+template <typename DType>
+struct Add {
+  static constexpr bool use_lhs = true;
+  static constexpr bool use_rhs = true;
+  inline static DType Call(const DType* lhs_off, const DType* rhs_off) {
+    return *lhs_off + *rhs_off;
+  }
+};
+template <typename DType> constexpr bool Add<DType>::use_lhs;
+template <typename DType> constexpr bool Add<DType>::use_rhs;
+
+template <typename DType>
+struct Sub {
+  static constexpr bool use_lhs = true;
+  static constexpr bool use_rhs = true;
+  inline static DType Call(const DType* lhs_off, const DType* rhs_off) {
+    return *lhs_off - *rhs_off;
+  }
+};
+template <typename DType> constexpr bool Sub<DType>::use_lhs;
+template <typename DType> constexpr bool Sub<DType>::use_rhs;
+
+template <typename DType>
+struct Mul {
+  static constexpr bool use_lhs = true;
+  static constexpr bool use_rhs = true;
+  inline static DType Call(const DType* lhs_off, const DType* rhs_off) {
+    return *lhs_off * *rhs_off;
+  }
+};
+template <typename DType> constexpr bool Mul<DType>::use_lhs;
+template <typename DType> constexpr bool Mul<DType>::use_rhs;
+
+template <typename DType>
+struct Div {
+  static constexpr bool use_lhs = true;
+  static constexpr bool use_rhs = true;
+  inline static DType Call(const DType* lhs_off, const DType* rhs_off) {
+    return *lhs_off / *rhs_off;
+  }
+};
+template <typename DType> constexpr bool Div<DType>::use_lhs;
+template <typename DType> constexpr bool Div<DType>::use_rhs;
+
+template <typename DType>
+struct CopyLhs {
+  static constexpr bool use_lhs = true;
+  static constexpr bool use_rhs = false;
+  inline static DType Call(const DType* lhs_off, const DType* ) {
+    return *lhs_off;
+  }
+};
+template <typename DType> constexpr bool CopyLhs<DType>::use_lhs;
+template <typename DType> constexpr bool CopyLhs<DType>::use_rhs;
+
+template <typename DType>
+struct CopyRhs {
+  static constexpr bool use_lhs = false;
+  static constexpr bool use_rhs = true;
+  inline static DType Call(const DType* , const DType* rhs_off) {
+    return *rhs_off;
+  }
+};
+template <typename DType> constexpr bool CopyRhs<DType>::use_lhs;
+template <typename DType> constexpr bool CopyRhs<DType>::use_rhs;
+
+//////////////////////////////// Reduce operators on CPU ////////////////////////////////
+template <typename DType>
+struct Max {
+  static constexpr DType zero = -std::numeric_limits<DType>::infinity();
+  // return true if accum should be replaced
+  inline static DType Call(DType accum, DType val) {
+    return accum < val;
+  }
+};
+template <typename DType> constexpr DType Max<DType>::zero;
+
+template <typename DType>
+struct Min {
+  static constexpr DType zero = std::numeric_limits<DType>::infinity();
+  // return true if accum should be replaced
+  inline static DType Call(DType accum, DType val) {
+    return accum > val;
+  }
+};
+template <typename DType> constexpr DType Min<DType>::zero;
+
+#define SWITCH_OP(op, Op, ...)                                      \
+  do {                                                              \
+    if ((op) == "add") {                                            \
+      typedef dgl::aten::cpu::op::Add<DType> Op;                    \
+      { __VA_ARGS__ }                                               \
+    } else if ((op) == "sub") {                                     \
+      typedef dgl::aten::cpu::op::Sub<DType> Op;                    \
+      { __VA_ARGS__ }                                               \
+    } else if ((op) == "mul") {                                     \
+      typedef dgl::aten::cpu::op::Mul<DType> Op;                    \
+      { __VA_ARGS__ }                                               \
+    } else if ((op) == "div") {                                     \
+      typedef dgl::aten::cpu::op::Div<DType> Op;                    \
+      { __VA_ARGS__ }                                               \
+    } else if ((op) == "copy_lhs") {                                \
+      typedef dgl::aten::cpu::op::CopyLhs<DType> Op;                \
+      { __VA_ARGS__ }                                               \
+    } else if ((op) == "copy_rhs") {                                \
+      typedef dgl::aten::cpu::op::CopyRhs<DType> Op;                \
+      { __VA_ARGS__ }                                               \
+    } else {                                                        \
+      LOG(FATAL) << "Unsupported SpMM binary operator: " << op;     \
+    }                                                               \
+  } while (0)
+
+}  // namespace op
+
+
+}  // namespace cpu
+}  // namespace aten
+}  // namespace dgl
+
+#endif  // DGL_ARRAY_CPU_SPMM_BINARY_OPS_H_


### PR DESCRIPTION
* support AVX512

* env DGL_CPU_INTEL_KERNEL_ENABLED=1

* env DGL_CPU_INTEL_KERNEL_LOG=1

* no specialization

## Description
This feature allows to use dynamic kernels.  
Depends on dimension you can create a dedicated assembly code without unnecessary checks and conditions – it helps CPU to be faster.  
Currently there is only one default code for all types of dimensions, specializations are in progress.
The engine uses AVX512 to compute element_wise(). 
To activate the feature set an environment variable DGL_CPU_INTEL_KERNEL_ENABLED=1 
The cache with the code is assigned to main thread and distributed between OMP pool threads, 
if dimension will be changed and a specialization exists then a new kernel will be generated and assigned as a main kernel.


