### PR TITLE
[Doc] Same typos as 0.5.x

### DIFF
--- a/docs/source/guide/nn-forward.rst
+++ b/docs/source/guide/nn-forward.rst
@@ -52,11 +52,11 @@ The math formulas for SAGEConv are:
 .. math::
 
     h_{dst}^{(l+1)} = \sigma \left(W \cdot \mathrm{concat}
-           (h_{dst}^{l}, h_{\mathcal{N}(dst)}^{l+1} + b) \right)
+           (h_{dst}^{l}, h_{\mathcal{N}(dst)}^{l+1}) + b \right)
 
 .. math::
 
-    h_{dst}^{(l+1)} = \mathrm{norm}(h_{dst}^{l})
+    h_{dst}^{(l+1)} = \mathrm{norm}(h_{dst}^{l+1})
 
 One needs to specify the source node feature ``feat_src`` and destination
 node feature ``feat_dst`` according to the graph type.


### PR DESCRIPTION
Some of SAGEGraph equation has typos as I mentioned in 0.5.x

## Description
<!-- Brief description. Refer to the related issues if existed.
It'll be great if relevant reviewers can be assigned as well.-->

## Checklist
Please feel free to remove inapplicable items for your PR.
- [x] The PR title starts with [$CATEGORY] (such as [NN], [Model], [Doc], [Feature]])
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage
- [x] Code is well-documented
- [x] To the my best knowledge, examples are either not affected by this change,
      or have been fixed to be compatible with this change
- [x] Related issue is referred in this PR

## Changes
<!-- You could use following template
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)
-->
