### PR TITLE
[kernel] Select GE-SpMM when feature size is large.

### DIFF
--- a/src/array/cuda/ge_spmm.cuh
+++ b/src/array/cuda/ge_spmm.cuh
@@ -53,7 +53,7 @@ __global__ void GESpMMKernel(
             const Idx eid = left + i; 
             const Idx cid = __ldg(indices + eid);
             const Idx offset = feat_len * cid + fid;
-            if (BinaryOp == CopyLhs) {
+            if (BinaryOp::use_rhs) {
               ReduceOp::Call(&accum_0, &argu_0, &arge_0,
                 BinaryOp::Call(ufeat + offset, efeat + eid), cid, eid);
               ReduceOp::Call(&accum_1, &argu_1, &arge_1,

--- a/src/array/cuda/ge_spmm.cuh
+++ b/src/array/cuda/ge_spmm.cuh
@@ -107,7 +107,7 @@ __global__ void GESpMMKernel(
             const Idx offset = feat_len * cid + fid;
             if (BinaryOp::use_rhs) {
               ReduceOp::Call(&accum_0, &argu_0, &arge_0,
-                BinaryOp::Call(BinaryOp::use_lhs ? ufeat + offset ? nullptr, efeat + eid), cid, eid);
+                BinaryOp::Call(BinaryOp::use_lhs ? ufeat + offset : nullptr, efeat + eid), cid, eid);
               if (right_inbound)
                 ReduceOp::Call(&accum_1, &argu_1, &arge_1,
                   BinaryOp::Call(BinaryOp::use_lhs ? ufeat + offset + 32 : nullptr, efeat + eid), cid, eid);
@@ -126,7 +126,7 @@ __global__ void GESpMMKernel(
             const Idx offset = feat_len * cid + fid;
             if (BinaryOp::use_rhs) {
               ReduceOp::Call(&accum_0, &argu_0, &arge_0,
-                BinaryOp::Call(BinaryOp::use_lhs ? ufeat + offset ? nullptr, efeat + eid), cid, eid);
+                BinaryOp::Call(BinaryOp::use_lhs ? ufeat + offset : nullptr, efeat + eid), cid, eid);
               if (right_inbound)
                 ReduceOp::Call(&accum_1, &argu_1, &arge_1,
                   BinaryOp::Call(BinaryOp::use_lhs ? ufeat + offset + 32 : nullptr, efeat + eid), cid, eid);

--- a/src/array/cuda/ge_spmm.cuh
+++ b/src/array/cuda/ge_spmm.cuh
@@ -22,63 +22,115 @@ namespace cuda {
  * \brief: TODO(zihao)
  */
 template <typename Idx, typename DType,
-          typename BinaryOp, typename ReduceOp,
-	  bool UseEdgeFeat = false>
+          typename BinaryOp, typename ReduceOp>
 __global__ void GESpMMSumKernel(
     const DType* __restrict__ ufeat,
     const DType* __restrict__ efeat,
     DType* __restrict__ out,
     const Idx* __restrict__ indptr,
     const Idx* __restrict__ indices,
-    int64_t num_rows, int64_t num_cols, int64_t nnz,
+    int64_t num_rows, int64_t num_cols,
     int64_t feat_len) {
   extern __shared__ DType array[];
   Idx* col = (Idx*)array;
   DType* val = array + 32 * sizeof(Idx);
-  int sm_offset = 32 * threadIdx.y;
 
   int ty = blockIdx.y * blockDim.y + threadIdx.y;  // iterate over destination nodes
-  const Idx stride_x = blockDim.x * gridDim.x * 64;
-  const Idx stride_x = blockDim.y * gridDim.y;
+  const Idx stride_x = blockDim.x * gridDim.x * 64,
+            stride_y = blockDim.y * gridDim.y;
+  const Idx sm_offset = 32 * threadIdx.y;
+
   while (ty < num_rows) {
     const Idx rid = ty;
     const Idx low = indptr[ty], high = indptr[ty + 1];
     const Idx tx = threadIdx.x;
-    int cid = (blockIdx.x << 6) + tx;  // iterate over feature dimension
-    while (cid < feat_dim) {
+    int cid = (blockIdx.x * 64) + tx;  // iterate over feature dimension
+
+    if (cid < feat_dim) {
       DType accum_0 = ReduceOp::zero,
             accum_1 = ReduceOp::zero;
+      Idx argu_0 = 0, arge_0 = 0,
+          argu_1 = 0, arge_1 = 0;
+
       for (int left = low; left < high; left += 32) {
         col[sm_offset + tx] = indices[low + tx]; 
-	if (UseEdgeFeat)
-	  val[sm_offset + tx] = efeat[low + tx];
+	      if (BinaryOp::use_rhs)
+	        val[sm_offset + tx] = efeat[low + tx];
+
         __syncwarp();
 
 #pragma unroll
-        for (int i = 0; i < 32 && left + i < high; ++i) {
-          const Idx offset = feat_len * col[sm_offset + i] + cid;
-	  if (UseEdgeFeat) {
-	    const DType weight = val[sm_offset + i];
-	    accum_0 += ufeat[offset] * weight;
-	    if (cid + 32 < feat_len)
-	      accum_1 += ufeat[offset + 32] * weight;
-	  } else {
-	    accum_0 += ufeat[offset];
-	    if (cid + 32 < feat_len)
-	      accum_1 += ufeat[offset + 32];
-	  }
+        for (int i = 0; i < 32; ++i) {
+          if (left + i < high) {
+            const Idx offset = feat_len * col[sm_offset + i] + cid;
+            if (BinaryOp::use_rhs) {
+              const DType weight = val[sm_offset + i];
+              ReduceOp::Call(&accum_0, &argu_0, &arge_0,
+                BinaryOp::Call(ufeat + offset, &weight), cid, eid);
+              if (cid + 32 < feat_len)
+                accum_1 += BinaryOp::Call(ufeat + offset + 32, &weight);
+            } else {
+              ReduceOp::Call(&accum_0, &argu_0, &arge_0,
+                ufeat[offset], cid, eid);
+              if (cid + 32 < feat_len)
+                ReduceOp::Call(&accum_1, &argu_1, &arge_1,
+                  ufeat[offset + 32], cid, eid);
+            }
+          }
         }
+
         __syncwarp();
       } 
+
       out[feat_len * rid + cid] = accum_0;
-      if (cid + 32 < feat_len)
+      if (ReduceOp::require_arg && BinaryOp::use_lhs)
+        arg_u[feat_len * rid + cid] = argu_0;
+      if (ReduceOp::require_arg && BinaryOp::rhs_rhs)
+        arg_e[feat_len * rid + cid] = arge_0;
+
+      if (cid + 32 < feat_len) {
         out[feat_len * rid + cid + 32] = accum_1;
-      cid += stride_x;
+        if (ReduceOp::require_arg && BinaryOp::use_rhs)
+          arg_e[feat_len * rid + cid + 32] = argu_1;
+        if (ReduceOp::require_arg && BinaryOp::use_rhs)
+          arg_e[feat_len * rid + cid + 32] = arge_1; 
+      }
     }
     ty += stride_y;
   }
 }
 
+template <typename Idx, typename DType,
+          typename BinaryOp, typename ReduceOp>
+void GESpMMCsr(
+    const CSRMatrix& csr,
+    NDArray ufeat, NDArray efeat,
+    NDArray out, NDArray argu, NDArray arge,
+    int64_t feat_len) {
+  const Idx *indptr = csr.indptr.Ptr<Idx>();
+  const Idx *indices = csr.indices.Ptr<Idx>();
+  const DType *ufeat_data = ufeat.Ptr<DType>();
+  const DType *efeat_data = efeat.Ptr<DType>();
+  DType *out_data = out.Ptr<DType>();
+  Idx *argu_data = argu.Ptr<Idx>();
+  Idx *arge_data = arge.Ptr<Idx>();
+
+  auto* thr_entry = runtime::CUDAThreadEntry::ThreadLocal();
+  
+  const int ntx = 32;
+  const int nty = 8;
+  const int nbx = (feat_len + (ntx * 2) - 1) / (ntx * 2);
+  const int nby = FindNumBlocks<'y'>((csr.num_rows + nty - 1) / nty);
+  const dim3 nblks(nbx, nby);
+  const dim3 nthrs(ntx, nty);
+  const int sh_mem_size = 8 * 32 * sizeof(Idx) + (BinaryOp::use_rhs ? 8 * 32 * sizeof(DType) : 0);
+  CUDA_KERNEL_CALL((GESpMMSumKernel<Idx, DType, BinaryOp, ReduceOp>),
+      nblks, nthrs, sh_mem_size, th_entry->stream,
+      ufeat_data, efeat_data, out_data, argu_data, arge_data,
+      indptr, indices,
+      csr.num_row, csr.num_cols,
+      feat_len);
+}
 
 }  // namespace cuda
 }  // namespace aten

--- a/src/array/cuda/ge_spmm.cuh
+++ b/src/array/cuda/ge_spmm.cuh
@@ -55,9 +55,9 @@ __global__ void GESpMMKernel(
             const Idx offset = feat_len * cid + fid;
             if (BinaryOp::use_rhs) {
               ReduceOp::Call(&accum_0, &argu_0, &arge_0,
-                BinaryOp::Call(BinaryOp::use_lhs ? ufeat + offset : nullptr, efeat + eid), cid, eid);
+                BinaryOp::Call(ufeat + offset, efeat + eid), cid, eid);
               ReduceOp::Call(&accum_1, &argu_1, &arge_1,
-                BinaryOp::Call(BinaryOp::use_lhs ? ufeat + offset + 32 : nullptr, efeat + eid), cid, eid);
+                BinaryOp::Call(ufeat + offset + 32, efeat + eid), cid, eid);
             } else {
               ReduceOp::Call(&accum_0, &argu_0, &arge_0,
                 ufeat[offset], cid, eid);
@@ -72,9 +72,9 @@ __global__ void GESpMMKernel(
             const Idx offset = feat_len * cid + fid;
             if (BinaryOp::use_rhs) {
               ReduceOp::Call(&accum_0, &argu_0, &arge_0,
-                BinaryOp::Call(BinaryOp::use_lhs ? ufeat + offset : nullptr, efeat + eid), cid, eid);
+                BinaryOp::Call(ufeat + offset, efeat + eid), cid, eid);
               ReduceOp::Call(&accum_1, &argu_1, &arge_1,
-                BinaryOp::Call(BinaryOp::use_lhs ? ufeat + offset + 32 : nullptr, efeat + eid), cid, eid);
+                BinaryOp::Call(ufeat + offset + 32, efeat + eid), cid, eid);
             } else {
               ReduceOp::Call(&accum_0, &argu_0, &arge_0,
                 ufeat[offset], cid, eid);
@@ -107,10 +107,10 @@ __global__ void GESpMMKernel(
             const Idx offset = feat_len * cid + fid;
             if (BinaryOp::use_rhs) {
               ReduceOp::Call(&accum_0, &argu_0, &arge_0,
-                BinaryOp::Call(BinaryOp::use_lhs ? ufeat + offset : nullptr, efeat + eid), cid, eid);
+                BinaryOp::Call(ufeat + offset, efeat + eid), cid, eid);
               if (right_inbound)
                 ReduceOp::Call(&accum_1, &argu_1, &arge_1,
-                  BinaryOp::Call(BinaryOp::use_lhs ? ufeat + offset + 32 : nullptr, efeat + eid), cid, eid);
+                  BinaryOp::Call(ufeat + offset + 32, efeat + eid), cid, eid);
             } else {
               ReduceOp::Call(&accum_0, &argu_0, &arge_0,
                 ufeat[offset], cid, eid);
@@ -126,10 +126,10 @@ __global__ void GESpMMKernel(
             const Idx offset = feat_len * cid + fid;
             if (BinaryOp::use_rhs) {
               ReduceOp::Call(&accum_0, &argu_0, &arge_0,
-                BinaryOp::Call(BinaryOp::use_lhs ? ufeat + offset : nullptr, efeat + eid), cid, eid);
+                BinaryOp::Call(ufeat + offset, efeat + eid), cid, eid);
               if (right_inbound)
                 ReduceOp::Call(&accum_1, &argu_1, &arge_1,
-                  BinaryOp::Call(BinaryOp::use_lhs ? ufeat + offset + 32 : nullptr, efeat + eid), cid, eid);
+                  BinaryOp::Call(ufeat + offset + 32, efeat + eid), cid, eid);
             } else {
               ReduceOp::Call(&accum_0, &argu_0, &arge_0,
                 ufeat[offset], cid, eid);

--- a/src/array/cuda/ge_spmm.cuh
+++ b/src/array/cuda/ge_spmm.cuh
@@ -60,7 +60,7 @@ __global__ void GESpMMKernel(
                 BinaryOp::Call(ufeat + offset + 32, efeat + eid), cid, eid);
             } else {
               ReduceOp::Call(&accum_0, &argu_0, &arge_0,
-                ufeat[offset], fid, eid);
+                ufeat[offset], cid, eid);
               ReduceOp::Call(&accum_1, &argu_1, &arge_1,
                 ufeat[offset + 32], cid, eid);
             }
@@ -77,7 +77,7 @@ __global__ void GESpMMKernel(
                 BinaryOp::Call(ufeat + offset + 32, efeat + eid), cid, eid);
             } else {
               ReduceOp::Call(&accum_0, &argu_0, &arge_0,
-                ufeat[offset], fid, eid);
+                ufeat[offset], cid, eid);
               ReduceOp::Call(&accum_1, &argu_1, &arge_1,
                 ufeat[offset + 32], cid, eid);
             }
@@ -113,7 +113,7 @@ __global__ void GESpMMKernel(
                   BinaryOp::Call(ufeat + offset + 32, efeat + eid), cid, eid);
             } else {
               ReduceOp::Call(&accum_0, &argu_0, &arge_0,
-                ufeat[offset], fid, eid);
+                ufeat[offset], cid, eid);
               if (right_inbound)
                 ReduceOp::Call(&accum_1, &argu_1, &arge_1,
                   ufeat[offset + 32], cid, eid);
@@ -132,7 +132,7 @@ __global__ void GESpMMKernel(
                   BinaryOp::Call(ufeat + offset + 32, efeat + eid), cid, eid);
             } else {
               ReduceOp::Call(&accum_0, &argu_0, &arge_0,
-                ufeat[offset], fid, eid);
+                ufeat[offset], cid, eid);
               if (right_inbound)
                 ReduceOp::Call(&accum_1, &argu_1, &arge_1,
                   ufeat[offset + 32], cid, eid);

--- a/src/array/cuda/ge_spmm.cuh
+++ b/src/array/cuda/ge_spmm.cuh
@@ -35,8 +35,8 @@ __global__ void GESpMMKernel(
     const Idx* __restrict__ indices,
     const int64_t num_rows, const int64_t num_cols,
     const int64_t feat_len) {
-  const Idx rid = blockIdx.y * blockDim.y + threadIdx.y;  // over vertices dimension
-  const Idx fid = (blockIdx.x * 64) + threadIdx.x;        // over feature dimension
+  const Idx rid = blockIdx.x * blockDim.y + threadIdx.y;  // over vertices dimension
+  const Idx fid = (blockIdx.y * 64) + threadIdx.x;        // over feature dimension
 
   if (rid < num_rows && fid < feat_len) {
     const Idx low = __ldg(indptr + rid), high = __ldg(indptr + rid + 1);
@@ -45,7 +45,7 @@ __global__ void GESpMMKernel(
     Idx argu_0 = 0, arge_0 = 0,
         argu_1 = 0, arge_1 = 0;
 
-    if (blockIdx.x != gridDim.x - 1) {
+    if (blockIdx.y != gridDim.y - 1) {
       for (Idx left = low; left < high; left += 32) {
         if (left + 32 < high) {
 #pragma unroll
@@ -177,8 +177,8 @@ void GESpMMCsr(
   
   const int ntx = 32;
   const int nty = 32;
-  const int nbx = (feat_len + (ntx * 2) - 1) / (ntx * 2);
-  const int nby = (csr.num_rows + nty - 1) / nty;
+  const int nby = (feat_len + (ntx * 2) - 1) / (ntx * 2);
+  const int nbx = (csr.num_rows + nty - 1) / nty;
   const dim3 nblks(nbx, nby);
   const dim3 nthrs(ntx, nty);
   const int sh_mem_size = 0;

--- a/src/array/cuda/ge_spmm.cuh
+++ b/src/array/cuda/ge_spmm.cuh
@@ -55,9 +55,9 @@ __global__ void GESpMMKernel(
             const Idx offset = feat_len * cid + fid;
             if (BinaryOp::use_rhs) {
               ReduceOp::Call(&accum_0, &argu_0, &arge_0,
-                BinaryOp::Call(ufeat + offset, efeat + eid), cid, eid);
+                BinaryOp::Call(BinaryOp::use_lhs ? ufeat + offset : nullptr, efeat + eid), cid, eid);
               ReduceOp::Call(&accum_1, &argu_1, &arge_1,
-                BinaryOp::Call(ufeat + offset + 32, efeat + eid), cid, eid);
+                BinaryOp::Call(BinaryOp::use_lhs ? ufeat + offset + 32 : nullptr, efeat + eid), cid, eid);
             } else {
               ReduceOp::Call(&accum_0, &argu_0, &arge_0,
                 ufeat[offset], cid, eid);
@@ -72,9 +72,9 @@ __global__ void GESpMMKernel(
             const Idx offset = feat_len * cid + fid;
             if (BinaryOp::use_rhs) {
               ReduceOp::Call(&accum_0, &argu_0, &arge_0,
-                BinaryOp::Call(ufeat + offset, efeat + eid), cid, eid);
+                BinaryOp::Call(BinaryOp::use_lhs ? ufeat + offset : nullptr, efeat + eid), cid, eid);
               ReduceOp::Call(&accum_1, &argu_1, &arge_1,
-                BinaryOp::Call(ufeat + offset + 32, efeat + eid), cid, eid);
+                BinaryOp::Call(BinaryOp::use_lhs ? ufeat + offset + 32 : nullptr, efeat + eid), cid, eid);
             } else {
               ReduceOp::Call(&accum_0, &argu_0, &arge_0,
                 ufeat[offset], cid, eid);
@@ -107,10 +107,10 @@ __global__ void GESpMMKernel(
             const Idx offset = feat_len * cid + fid;
             if (BinaryOp::use_rhs) {
               ReduceOp::Call(&accum_0, &argu_0, &arge_0,
-                BinaryOp::Call(ufeat + offset, efeat + eid), cid, eid);
+                BinaryOp::Call(BinaryOp::use_lhs ? ufeat + offset ? nullptr, efeat + eid), cid, eid);
               if (right_inbound)
                 ReduceOp::Call(&accum_1, &argu_1, &arge_1,
-                  BinaryOp::Call(ufeat + offset + 32, efeat + eid), cid, eid);
+                  BinaryOp::Call(BinaryOp::use_lhs ? ufeat + offset + 32 : nullptr, efeat + eid), cid, eid);
             } else {
               ReduceOp::Call(&accum_0, &argu_0, &arge_0,
                 ufeat[offset], cid, eid);
@@ -126,10 +126,10 @@ __global__ void GESpMMKernel(
             const Idx offset = feat_len * cid + fid;
             if (BinaryOp::use_rhs) {
               ReduceOp::Call(&accum_0, &argu_0, &arge_0,
-                BinaryOp::Call(ufeat + offset, efeat + eid), cid, eid);
+                BinaryOp::Call(BinaryOp::use_lhs ? ufeat + offset ? nullptr, efeat + eid), cid, eid);
               if (right_inbound)
                 ReduceOp::Call(&accum_1, &argu_1, &arge_1,
-                  BinaryOp::Call(ufeat + offset + 32, efeat + eid), cid, eid);
+                  BinaryOp::Call(BinaryOp::use_lhs ? ufeat + offset + 32 : nullptr, efeat + eid), cid, eid);
             } else {
               ReduceOp::Call(&accum_0, &argu_0, &arge_0,
                 ufeat[offset], cid, eid);

--- a/src/array/cuda/ge_spmm.cuh
+++ b/src/array/cuda/ge_spmm.cuh
@@ -54,11 +54,10 @@ __global__ void GESpMMKernel(
             const Idx cid = __ldg(indices + eid);
             const Idx offset = feat_len * cid + fid;
             if (BinaryOp::use_rhs) {
-              const DType weight = efeat[eid];
               ReduceOp::Call(&accum_0, &argu_0, &arge_0,
-                BinaryOp::Call(ufeat + offset, &weight), cid, eid);
+                BinaryOp::Call(ufeat + offset, efeat + eid), cid, eid);
               ReduceOp::Call(&accum_1, &argu_1, &arge_1,
-                BinaryOp::Call(ufeat + offset + 32, &weight), cid, eid);
+                BinaryOp::Call(ufeat + offset + 32, efeat + eid), cid, eid);
             } else {
               ReduceOp::Call(&accum_0, &argu_0, &arge_0,
                 ufeat[offset], fid, eid);
@@ -72,11 +71,10 @@ __global__ void GESpMMKernel(
             const Idx cid = __ldg(indices + eid);
             const Idx offset = feat_len * cid + fid;
             if (BinaryOp::use_rhs) {
-              const DType weight = efeat[eid];
               ReduceOp::Call(&accum_0, &argu_0, &arge_0,
-                BinaryOp::Call(ufeat + offset, &weight), cid, eid);
+                BinaryOp::Call(ufeat + offset, efeat + eid), cid, eid);
               ReduceOp::Call(&accum_1, &argu_1, &arge_1,
-                BinaryOp::Call(ufeat + offset + 32, &weight), cid, eid);
+                BinaryOp::Call(ufeat + offset + 32, efeat + eid), cid, eid);
             } else {
               ReduceOp::Call(&accum_0, &argu_0, &arge_0,
                 ufeat[offset], fid, eid);
@@ -108,12 +106,11 @@ __global__ void GESpMMKernel(
             const Idx cid = __ldg(indices + eid); 
             const Idx offset = feat_len * cid + fid;
             if (BinaryOp::use_rhs) {
-              const DType weight = efeat[eid];
               ReduceOp::Call(&accum_0, &argu_0, &arge_0,
-                BinaryOp::Call(ufeat + offset, &weight), cid, eid);
+                BinaryOp::Call(ufeat + offset, efeat + eid), cid, eid);
               if (right_inbound)
                 ReduceOp::Call(&accum_1, &argu_1, &arge_1,
-                  BinaryOp::Call(ufeat + offset + 32, &weight), cid, eid);
+                  BinaryOp::Call(ufeat + offset + 32, efeat + eid), cid, eid);
             } else {
               ReduceOp::Call(&accum_0, &argu_0, &arge_0,
                 ufeat[offset], fid, eid);
@@ -128,12 +125,11 @@ __global__ void GESpMMKernel(
             const Idx cid = __ldg(indices + eid); 
             const Idx offset = feat_len * cid + fid;
             if (BinaryOp::use_rhs) {
-              const DType weight = efeat[eid];
               ReduceOp::Call(&accum_0, &argu_0, &arge_0,
-                BinaryOp::Call(ufeat + offset, &weight), cid, eid);
+                BinaryOp::Call(ufeat + offset, efeat + eid), cid, eid);
               if (right_inbound)
                 ReduceOp::Call(&accum_1, &argu_1, &arge_1,
-                  BinaryOp::Call(ufeat + offset + 32, &weight), cid, eid);
+                  BinaryOp::Call(ufeat + offset + 32, efeat + eid), cid, eid);
             } else {
               ReduceOp::Call(&accum_0, &argu_0, &arge_0,
                 ufeat[offset], fid, eid);

--- a/src/array/cuda/ge_spmm.cuh
+++ b/src/array/cuda/ge_spmm.cuh
@@ -47,7 +47,7 @@ __global__ void GESpMMKernel(
 
     if (blockIdx.y != gridDim.y - 1) {
       for (Idx left = low; left < high; left += 32) {
-        if (left + 32 < high) {
+        if (left + 32 <= high) {
 #pragma unroll
           for (Idx i = 0; i < 32; ++i) {
             const Idx eid = left + i; 
@@ -70,7 +70,7 @@ __global__ void GESpMMKernel(
             const Idx eid = left + i; 
             const Idx cid = __ldg(indices + eid);
             const Idx offset = feat_len * cid + fid;
-            if (BinaryOp == CopyLhs) {
+            if (BinaryOp::use_rhs) {
               ReduceOp::Call(&accum_0, &argu_0, &arge_0,
                 BinaryOp::Call(ufeat + offset, efeat + eid), cid, eid);
               ReduceOp::Call(&accum_1, &argu_1, &arge_1,
@@ -85,7 +85,7 @@ __global__ void GESpMMKernel(
         }
 
         out[feat_len * rid + fid] = accum_0;
-        if (ReduceOp::require_arg && BinaryOp::use_lhs)
+        if (ReduceOp::require_arg && BinaryOp::use_rhs)
           arg_u[feat_len * rid + fid] = argu_0;
         if (ReduceOp::require_arg && BinaryOp::use_rhs)
           arg_e[feat_len * rid + fid] = arge_0;
@@ -100,13 +100,13 @@ __global__ void GESpMMKernel(
       bool left_inbound = fid < feat_len,
            right_inbound = fid + 32 < feat_len;
       for (int left = low; left < high; left += 32) {
-        if (left + 32 < high) {
+        if (left + 32 <= high) {
 #pragma unroll
           for (int i = 0; i < 32; ++i) {
             const Idx eid = left + i; 
             const Idx cid = __ldg(indices + eid); 
             const Idx offset = feat_len * cid + fid;
-            if (BinaryOp == CopyLhs) {
+            if (BinaryOp::use_rhs) {
               if (left_inbound)
                 ReduceOp::Call(&accum_0, &argu_0, &arge_0,
                   BinaryOp::Call(ufeat + offset, efeat + eid), cid, eid);
@@ -127,7 +127,7 @@ __global__ void GESpMMKernel(
             const Idx eid = left + i; 
             const Idx cid = __ldg(indices + eid); 
             const Idx offset = feat_len * cid + fid;
-            if (BinaryOp == CopyLhs) {
+            if (BinaryOp::use_rhs) {
               if (left_inbound)
                 ReduceOp::Call(&accum_0, &argu_0, &arge_0,
                   BinaryOp::Call(ufeat + offset, efeat + eid), cid, eid);
@@ -147,7 +147,7 @@ __global__ void GESpMMKernel(
 
         if (left_inbound) {
           out[feat_len * rid + fid] = accum_0;
-          if (ReduceOp::require_arg && BinaryOp::use_lhs)
+          if (ReduceOp::require_arg && BinaryOp::use_rhs)
             arg_u[feat_len * rid + fid] = argu_0;
           if (ReduceOp::require_arg && BinaryOp::use_rhs)
             arg_e[feat_len * rid + fid] = arge_0;

--- a/src/array/cuda/ge_spmm.cuh
+++ b/src/array/cuda/ge_spmm.cuh
@@ -1,0 +1,42 @@
+/*!
+ * Copyright (c) 2020 by Contributors
+ * \file array/cuda/ge_spmm.cuh
+ * \brief GE-SpMM CUDA kernel function header.
+ */
+#ifndef DGL_ARRAY_CUDA_GE_SPMM_CUH_
+#define DGL_ARRAY_CUDA_GE_SPMM_CUH_
+
+#include "macro.cuh"
+#include "atomic.cuh"
+#include "../../runtime/cuda/cuda_common.h"
+#include "./utils.h"
+
+namespace dgl {
+
+using namespace cuda;
+
+namespace aten {
+namespace cuda {
+
+/*! 
+ * \brief: TODO(zihao)
+ */
+template <typename Idx, typename DType,
+          typename BinaryOp, typename ReduceOp>
+__global__ void GESpMMCsrKernel(
+    const DType* __restrict__ ufeat,
+    const DType* __restrict__ efeat,
+    DType* __restrict__ out,
+    Idx* __restrict__ arg_u,
+    Idx* __restrict__ arg_e,
+    int64_t N, int64_t M, int64_t E,
+    int64_t feat_len) {
+  // TODO(zihao)
+}
+
+
+}  // namespace cuda
+}  // namespace aten
+}  // namespace dgl
+
+#endif

--- a/src/array/cuda/ge_spmm.cuh
+++ b/src/array/cuda/ge_spmm.cuh
@@ -38,7 +38,7 @@ __global__ void GESpMMKernel(
   const Idx rid = blockIdx.x * blockDim.y + threadIdx.y;  // over vertices dimension
   const Idx fid = (blockIdx.y * 64) + threadIdx.x;        // over feature dimension
 
-  if (rid < num_rows) {
+  if (rid < num_rows && fid < feat_len) {
     const Idx low = __ldg(indptr + rid), high = __ldg(indptr + rid + 1);
     DType accum_0 = ReduceOp::zero,
           accum_1 = ReduceOp::zero;
@@ -97,8 +97,7 @@ __global__ void GESpMMKernel(
           arg_e[feat_len * rid + fid + 32] = arge_1; 
       }
     } else {
-      bool left_inbound = fid < feat_len,
-           right_inbound = fid + 32 < feat_len;
+      bool right_inbound = fid + 32 < feat_len;
       for (int left = low; left < high; left += 32) {
         if (left + 32 <= high) {
 #pragma unroll
@@ -107,16 +106,14 @@ __global__ void GESpMMKernel(
             const Idx cid = __ldg(indices + eid); 
             const Idx offset = feat_len * cid + fid;
             if (BinaryOp::use_rhs) {
-              if (left_inbound)
-                ReduceOp::Call(&accum_0, &argu_0, &arge_0,
-                  BinaryOp::Call(ufeat + offset, efeat + eid), cid, eid);
+              ReduceOp::Call(&accum_0, &argu_0, &arge_0,
+                BinaryOp::Call(ufeat + offset, efeat + eid), cid, eid);
               if (right_inbound)
                 ReduceOp::Call(&accum_1, &argu_1, &arge_1,
                   BinaryOp::Call(ufeat + offset + 32, efeat + eid), cid, eid);
             } else {
-              if (left_inbound)
-                ReduceOp::Call(&accum_0, &argu_0, &arge_0,
-                  ufeat[offset], fid, eid);
+              ReduceOp::Call(&accum_0, &argu_0, &arge_0,
+                ufeat[offset], fid, eid);
               if (right_inbound)
                 ReduceOp::Call(&accum_1, &argu_1, &arge_1,
                   ufeat[offset + 32], cid, eid);
@@ -128,16 +125,14 @@ __global__ void GESpMMKernel(
             const Idx cid = __ldg(indices + eid); 
             const Idx offset = feat_len * cid + fid;
             if (BinaryOp::use_rhs) {
-              if (left_inbound)
-                ReduceOp::Call(&accum_0, &argu_0, &arge_0,
-                  BinaryOp::Call(ufeat + offset, efeat + eid), cid, eid);
+              ReduceOp::Call(&accum_0, &argu_0, &arge_0,
+                BinaryOp::Call(ufeat + offset, efeat + eid), cid, eid);
               if (right_inbound)
                 ReduceOp::Call(&accum_1, &argu_1, &arge_1,
                   BinaryOp::Call(ufeat + offset + 32, efeat + eid), cid, eid);
             } else {
-              if (left_inbound)
-                ReduceOp::Call(&accum_0, &argu_0, &arge_0,
-                  ufeat[offset], fid, eid);
+              ReduceOp::Call(&accum_0, &argu_0, &arge_0,
+                ufeat[offset], fid, eid);
               if (right_inbound)
                 ReduceOp::Call(&accum_1, &argu_1, &arge_1,
                   ufeat[offset + 32], cid, eid);
@@ -145,13 +140,11 @@ __global__ void GESpMMKernel(
           }
         }
 
-        if (left_inbound) {
-          out[feat_len * rid + fid] = accum_0;
-          if (ReduceOp::require_arg && BinaryOp::use_rhs)
-            arg_u[feat_len * rid + fid] = argu_0;
-          if (ReduceOp::require_arg && BinaryOp::use_rhs)
-            arg_e[feat_len * rid + fid] = arge_0;
-	}
+        out[feat_len * rid + fid] = accum_0;
+        if (ReduceOp::require_arg && BinaryOp::use_rhs)
+          arg_u[feat_len * rid + fid] = argu_0;
+        if (ReduceOp::require_arg && BinaryOp::use_rhs)
+          arg_e[feat_len * rid + fid] = arge_0;
 
         if (right_inbound) {
           out[feat_len * rid + fid + 32] = accum_1;

--- a/src/array/cuda/ge_spmm.cuh
+++ b/src/array/cuda/ge_spmm.cuh
@@ -19,11 +19,13 @@ namespace aten {
 namespace cuda {
 
 /*! 
- * \brief: TODO(zihao)
+ * \brief CUDA kernel of GE-SpMM on Csr.
+ * \note GE-SpMM: https://arxiv.org/pdf/2007.03179.pdf
+ *       The grid dimension x and y are reordered for better performance.
  */
 template <typename Idx, typename DType,
           typename BinaryOp, typename ReduceOp>
-__global__ void GESpMMSumKernel(
+__global__ void GESpMMKernel(
     const DType* __restrict__ ufeat,
     const DType* __restrict__ efeat,
     DType* __restrict__ out,
@@ -33,34 +35,54 @@ __global__ void GESpMMSumKernel(
     const Idx* __restrict__ indices,
     const int64_t num_rows, const int64_t num_cols,
     const int64_t feat_len) {
-  const Idx rid = blockIdx.x * blockDim.y + threadIdx.y;
-  const Idx tx = threadIdx.x;
+  const Idx rid = blockIdx.y * blockDim.y + threadIdx.y;  // over vertices dimension
+  const Idx fid = (blockIdx.x * 64) + threadIdx.x;        // over feature dimension
 
-  if (rid < num_rows) {
+  if (rid < num_rows && fid < feat_len) {
     const Idx low = __ldg(indptr + rid), high = __ldg(indptr + rid + 1);
-    Idx fid = (blockIdx.y * 64) + tx;  // iterate over feature dimension
     DType accum_0 = ReduceOp::zero,
           accum_1 = ReduceOp::zero;
     Idx argu_0 = 0, arge_0 = 0,
         argu_1 = 0, arge_1 = 0;
 
-    if (blockIdx.y != gridDim.y - 1) {
+    if (blockIdx.x != gridDim.x - 1) {
       for (Idx left = low; left < high; left += 32) {
-        for (Idx i = 0; i < 32 && left + i < high; ++i) {
-          const Idx eid = left + i; 
-          const Idx cid = __ldg(indices + eid);
-          const Idx offset = feat_len * cid + fid;
-          if (BinaryOp::use_rhs) {
-            const DType weight = __ldg(efeat + eid);
-            ReduceOp::Call(&accum_0, &argu_0, &arge_0,
-              BinaryOp::Call(ufeat + offset, &weight), cid, eid);
-            ReduceOp::Call(&accum_1, &argu_1, &arge_1,
-              BinaryOp::Call(ufeat + offset + 32, &weight), cid, eid);
-          } else {
-            ReduceOp::Call(&accum_0, &argu_0, &arge_0,
-              ufeat[offset], fid, eid);
-            ReduceOp::Call(&accum_1, &argu_1, &arge_1,
-              ufeat[offset + 32], cid, eid);
+        if (left + 32 < high) {
+#pragma unroll
+          for (Idx i = 0; i < 32; ++i) {
+            const Idx eid = left + i; 
+            const Idx cid = __ldg(indices + eid);
+            const Idx offset = feat_len * cid + fid;
+            if (BinaryOp::use_rhs) {
+              const DType weight = efeat[eid];
+              ReduceOp::Call(&accum_0, &argu_0, &arge_0,
+                BinaryOp::Call(ufeat + offset, &weight), cid, eid);
+              ReduceOp::Call(&accum_1, &argu_1, &arge_1,
+                BinaryOp::Call(ufeat + offset + 32, &weight), cid, eid);
+            } else {
+              ReduceOp::Call(&accum_0, &argu_0, &arge_0,
+                ufeat[offset], fid, eid);
+              ReduceOp::Call(&accum_1, &argu_1, &arge_1,
+                ufeat[offset + 32], cid, eid);
+            }
+          }
+        } else {
+          for (Idx i = 0; left + i < high; ++i) {
+            const Idx eid = left + i; 
+            const Idx cid = __ldg(indices + eid);
+            const Idx offset = feat_len * cid + fid;
+            if (BinaryOp::use_rhs) {
+              const DType weight = efeat[eid];
+              ReduceOp::Call(&accum_0, &argu_0, &arge_0,
+                BinaryOp::Call(ufeat + offset, &weight), cid, eid);
+              ReduceOp::Call(&accum_1, &argu_1, &arge_1,
+                BinaryOp::Call(ufeat + offset + 32, &weight), cid, eid);
+            } else {
+              ReduceOp::Call(&accum_0, &argu_0, &arge_0,
+                ufeat[offset], fid, eid);
+              ReduceOp::Call(&accum_1, &argu_1, &arge_1,
+                ufeat[offset + 32], cid, eid);
+            }
           }
         }
 
@@ -77,38 +99,56 @@ __global__ void GESpMMSumKernel(
           arg_e[feat_len * rid + fid + 32] = arge_1; 
       }
     } else {
-      bool left_inbound = fid < feat_len,
-           right_inbound = fid + 32 < feat_len;
+      bool right_inbound = fid + 32 < feat_len;
       for (int left = low; left < high; left += 32) {
-        for (int i = 0; i < 32 && left + i < high; ++i) {
-          const Idx eid = left + i; 
-          const Idx cid = __ldg(indices + eid); 
-          const Idx offset = feat_len * cid + fid;
-          if (BinaryOp::use_rhs) {
-            const DType weight = __ldg(efeat + eid);
-            if (left_inbound)
+        if (left + 32 < high) {
+#pragma unroll
+          for (int i = 0; i < 32; ++i) {
+            const Idx eid = left + i; 
+            const Idx cid = __ldg(indices + eid); 
+            const Idx offset = feat_len * cid + fid;
+            if (BinaryOp::use_rhs) {
+              const DType weight = efeat[eid];
               ReduceOp::Call(&accum_0, &argu_0, &arge_0,
                 BinaryOp::Call(ufeat + offset, &weight), cid, eid);
-            if (right_inbound)
-              ReduceOp::Call(&accum_1, &argu_1, &arge_1,
-                BinaryOp::Call(ufeat + offset + 32, &weight), cid, eid);
-          } else {
-            if (left_inbound)
+              if (right_inbound)
+                ReduceOp::Call(&accum_1, &argu_1, &arge_1,
+                  BinaryOp::Call(ufeat + offset + 32, &weight), cid, eid);
+            } else {
               ReduceOp::Call(&accum_0, &argu_0, &arge_0,
                 ufeat[offset], fid, eid);
-            if (right_inbound)
-              ReduceOp::Call(&accum_1, &argu_1, &arge_1,
-                ufeat[offset + 32], cid, eid);
+              if (right_inbound)
+                ReduceOp::Call(&accum_1, &argu_1, &arge_1,
+                  ufeat[offset + 32], cid, eid);
+            }
+          }
+        } else {
+          for (int i = 0; i + left < high; ++i) {
+            const Idx eid = left + i; 
+            const Idx cid = __ldg(indices + eid); 
+            const Idx offset = feat_len * cid + fid;
+            if (BinaryOp::use_rhs) {
+              const DType weight = efeat[eid];
+              ReduceOp::Call(&accum_0, &argu_0, &arge_0,
+                BinaryOp::Call(ufeat + offset, &weight), cid, eid);
+              if (right_inbound)
+                ReduceOp::Call(&accum_1, &argu_1, &arge_1,
+                  BinaryOp::Call(ufeat + offset + 32, &weight), cid, eid);
+            } else {
+              ReduceOp::Call(&accum_0, &argu_0, &arge_0,
+                ufeat[offset], fid, eid);
+              if (right_inbound)
+                ReduceOp::Call(&accum_1, &argu_1, &arge_1,
+                  ufeat[offset + 32], cid, eid);
+            }
           }
         }
 
-        if (left_inbound) {
-          out[feat_len * rid + fid] = accum_0;
-          if (ReduceOp::require_arg && BinaryOp::use_lhs)
-            arg_u[feat_len * rid + fid] = argu_0;
-          if (ReduceOp::require_arg && BinaryOp::use_rhs)
-            arg_e[feat_len * rid + fid] = arge_0;
-        }
+        out[feat_len * rid + fid] = accum_0;
+        if (ReduceOp::require_arg && BinaryOp::use_lhs)
+          arg_u[feat_len * rid + fid] = argu_0;
+        if (ReduceOp::require_arg && BinaryOp::use_rhs)
+          arg_e[feat_len * rid + fid] = arge_0;
 
         if (right_inbound) {
           out[feat_len * rid + fid + 32] = accum_1;
@@ -140,14 +180,14 @@ void GESpMMCsr(
   auto* thr_entry = runtime::CUDAThreadEntry::ThreadLocal();
   
   const int ntx = 32;
-  const int nty = 16;
-  const int nby = (feat_len + (ntx * 2) - 1) / (ntx * 2);
-  const int nbx = (csr.num_rows + nty - 1) / nty;
+  const int nty = 32;
+  const int nbx = (feat_len + (ntx * 2) - 1) / (ntx * 2);
+  const int nby = (csr.num_rows + nty - 1) / nty;
   const dim3 nblks(nbx, nby);
   const dim3 nthrs(ntx, nty);
   const int sh_mem_size = 0;
 
-  CUDA_KERNEL_CALL((GESpMMSumKernel<Idx, DType, BinaryOp, ReduceOp>),
+  CUDA_KERNEL_CALL((GESpMMKernel<Idx, DType, BinaryOp, ReduceOp>),
       nblks, nthrs, sh_mem_size, thr_entry->stream,
       ufeat_data, efeat_data, out_data, argu_data, arge_data,
       indptr, indices,

--- a/src/array/cuda/ge_spmm.cuh
+++ b/src/array/cuda/ge_spmm.cuh
@@ -53,7 +53,7 @@ __global__ void GESpMMKernel(
             const Idx eid = left + i; 
             const Idx cid = __ldg(indices + eid);
             const Idx offset = feat_len * cid + fid;
-            if (BinaryOp::use_rhs) {
+            if (BinaryOp == CopyLhs) {
               ReduceOp::Call(&accum_0, &argu_0, &arge_0,
                 BinaryOp::Call(ufeat + offset, efeat + eid), cid, eid);
               ReduceOp::Call(&accum_1, &argu_1, &arge_1,
@@ -70,7 +70,7 @@ __global__ void GESpMMKernel(
             const Idx eid = left + i; 
             const Idx cid = __ldg(indices + eid);
             const Idx offset = feat_len * cid + fid;
-            if (BinaryOp::use_rhs) {
+            if (BinaryOp == CopyLhs) {
               ReduceOp::Call(&accum_0, &argu_0, &arge_0,
                 BinaryOp::Call(ufeat + offset, efeat + eid), cid, eid);
               ReduceOp::Call(&accum_1, &argu_1, &arge_1,
@@ -106,7 +106,7 @@ __global__ void GESpMMKernel(
             const Idx eid = left + i; 
             const Idx cid = __ldg(indices + eid); 
             const Idx offset = feat_len * cid + fid;
-            if (BinaryOp::use_rhs) {
+            if (BinaryOp == CopyLhs) {
               if (left_inbound)
                 ReduceOp::Call(&accum_0, &argu_0, &arge_0,
                   BinaryOp::Call(ufeat + offset, efeat + eid), cid, eid);
@@ -127,7 +127,7 @@ __global__ void GESpMMKernel(
             const Idx eid = left + i; 
             const Idx cid = __ldg(indices + eid); 
             const Idx offset = feat_len * cid + fid;
-            if (BinaryOp::use_rhs) {
+            if (BinaryOp == CopyLhs) {
               if (left_inbound)
                 ReduceOp::Call(&accum_0, &argu_0, &arge_0,
                   BinaryOp::Call(ufeat + offset, efeat + eid), cid, eid);

--- a/src/array/cuda/ge_spmm.cuh
+++ b/src/array/cuda/ge_spmm.cuh
@@ -116,7 +116,7 @@ __global__ void GESpMMKernel(
 }
 
 template <typename Idx, typename DType,
-          typename BinaryOp, typename ReduceOp>
+          typename BinaryOp>
 void GESpMMCsr(
     const CSRMatrix& csr,
     NDArray ufeat, NDArray efeat,
@@ -137,7 +137,7 @@ void GESpMMCsr(
   const dim3 nthrs(ntx, nty);
   const int sh_mem_size = 0;
 
-  CUDA_KERNEL_CALL((GESpMMKernel<Idx, DType, BinaryOp, ReduceOp>),
+  CUDA_KERNEL_CALL((GESpMMKernel<Idx, DType, BinaryOp>),
       nblks, nthrs, sh_mem_size, thr_entry->stream,
       ufeat_data, efeat_data, out_data,
       indptr, indices,

--- a/src/array/cuda/ge_spmm.cuh
+++ b/src/array/cuda/ge_spmm.cuh
@@ -22,16 +22,61 @@ namespace cuda {
  * \brief: TODO(zihao)
  */
 template <typename Idx, typename DType,
-          typename BinaryOp, typename ReduceOp>
-__global__ void GESpMMCsrKernel(
+          typename BinaryOp, typename ReduceOp,
+	  bool UseEdgeFeat = false>
+__global__ void GESpMMSumKernel(
     const DType* __restrict__ ufeat,
     const DType* __restrict__ efeat,
     DType* __restrict__ out,
-    Idx* __restrict__ arg_u,
-    Idx* __restrict__ arg_e,
-    int64_t N, int64_t M, int64_t E,
+    const Idx* __restrict__ indptr,
+    const Idx* __restrict__ indices,
+    int64_t num_rows, int64_t num_cols, int64_t nnz,
     int64_t feat_len) {
-  // TODO(zihao)
+  extern __shared__ DType array[];
+  Idx* col = (Idx*)array;
+  DType* val = array + 32 * sizeof(Idx);
+  int sm_offset = 32 * threadIdx.y;
+
+  int ty = blockIdx.y * blockDim.y + threadIdx.y;  // iterate over destination nodes
+  const Idx stride_x = blockDim.x * gridDim.x * 64;
+  const Idx stride_x = blockDim.y * gridDim.y;
+  while (ty < num_rows) {
+    const Idx rid = ty;
+    const Idx low = indptr[ty], high = indptr[ty + 1];
+    const Idx tx = threadIdx.x;
+    int cid = (blockIdx.x << 6) + tx;  // iterate over feature dimension
+    while (cid < feat_dim) {
+      DType accum_0 = ReduceOp::zero,
+            accum_1 = ReduceOp::zero;
+      for (int left = low; left < high; left += 32) {
+        col[sm_offset + tx] = indices[low + tx]; 
+	if (UseEdgeFeat)
+	  val[sm_offset + tx] = efeat[low + tx];
+        __syncwarp();
+
+#pragma unroll
+        for (int i = 0; i < 32 && left + i < high; ++i) {
+          const Idx offset = feat_len * col[sm_offset + i] + cid;
+	  if (UseEdgeFeat) {
+	    const DType weight = val[sm_offset + i];
+	    accum_0 += ufeat[offset] * weight;
+	    if (cid + 32 < feat_len)
+	      accum_1 += ufeat[offset + 32] * weight;
+	  } else {
+	    accum_0 += ufeat[offset];
+	    if (cid + 32 < feat_len)
+	      accum_1 += ufeat[offset + 32];
+	  }
+        }
+        __syncwarp();
+      } 
+      out[feat_len * rid + cid] = accum_0;
+      if (cid + 32 < feat_len)
+        out[feat_len * rid + cid + 32] = accum_1;
+      cid += stride_x;
+    }
+    ty += stride_y;
+  }
 }
 
 

--- a/src/array/cuda/spmm.cu
+++ b/src/array/cuda/spmm.cu
@@ -252,6 +252,7 @@ void SpMMCsr(const std::string& op, const std::string& reduce,
           nullptr,
           static_cast<DType*>(out->data),
           x_length);
+      return ;
     } else if (sizeof(IdType) == 4 && op == "mul" && is_scalar_efeat) {
       int64_t x_length = 1;
       for (int i = 1; i < ufeat->ndim; ++i)
@@ -264,8 +265,8 @@ void SpMMCsr(const std::string& op, const std::string& reduce,
           static_cast<DType*>(efeat->data),
           static_cast<DType*>(out->data),
           x_length);
+      return ;
     }
-    return ;
   }
 
   if ((op == "copy_lhs" || is_scalar_efeat) && feat_len > 64) {  // ge-spmm
@@ -276,18 +277,20 @@ void SpMMCsr(const std::string& op, const std::string& reduce,
         cuda::GESpMMCsr<IdType, DType, Op, cuda::reduce::Sum<IdType, DType> >(
           csr, ufeat, efeat, out, NullArray(), NullArray(), feat_len);
       });
+      return ;
     } else if (reduce == "max" && IsNullArray(csr.data)) {
       SWITCH_OP(op, Op, {
         cuda::GESpMMCsr<IdType, DType, Op, cuda::reduce::Max<IdType, DType> >(
           csr, ufeat, efeat, out, out_aux[0], out_aux[1], feat_len);
       });
+      return ;
     } else if (reduce == "min" && IsNullArray(csr.data)) {
       SWITCH_OP(op, Op, {
         cuda::GESpMMCsr<IdType, DType, Op, cuda::reduce::Min<IdType, DType> >(
           csr, ufeat, efeat, out, out_aux[0], out_aux[1], feat_len);
       });
+      return ;
     }
-    return ;
   }
 
   if (reduce == "sum") {  // general kernel

--- a/src/array/cuda/spmm.cu
+++ b/src/array/cuda/spmm.cu
@@ -280,12 +280,12 @@ void SpMMCsr(const std::string& op, const std::string& reduce,
     } else if (reduce == "max") {
       SWITCH_OP(op, Op, {
         cuda::GESpMMCsr<IdType, DType, Op, cuda::reduce::Max<IdType, DType> >(
-          csr, ufeat, efeat, out, out_aux[0], out_aux[1]);
+          csr, ufeat, efeat, out, out_aux[0], out_aux[1], feat_len);
       });
     } else if (reduce == "min") {
       SWITCH_OP(op, Op, {
         cuda::GESpMMCsr<IdType, DType, Op, cuda::reduce::Min<IdType, DType> >(
-          csr, ufeat, efeat, out, out_aux[0], out_aux[1]);
+          csr, ufeat, efeat, out, out_aux[0], out_aux[1], feat_len);
       });
     } else {
       LOG(FATAL) << "Not implemented";

--- a/src/array/cuda/spmm.cu
+++ b/src/array/cuda/spmm.cu
@@ -241,7 +241,7 @@ void SpMMCsr(const std::string& op, const std::string& reduce,
              std::vector<NDArray> out_aux) {
   int64_t feat_len = bcast.out_len;
   bool is_scalar_efeat = efeat.NumElements() == csr.indices->shape[0];
-  if (reduce == "sum" && feat_len <= 128) {  // cusparse
+  if (reduce == "sum" && feat_len <= 64) {  // cusparse
     if (sizeof(IdType) == 4 && op == "copy_lhs") {
       int64_t x_length = 1;
       for (int i = 1; i < ufeat->ndim; ++i)
@@ -268,9 +268,9 @@ void SpMMCsr(const std::string& op, const std::string& reduce,
     return ;
   }
 
-  if ((op == "copy_lhs" || is_scalar_efeat) && feat_len > 128) {  // ge-spmm
+  if ((op == "copy_lhs" || is_scalar_efeat) && feat_len > 64) {  // ge-spmm
     if (reduce == "sum") {
-      if (op != "copy_lhs" && !IsNullArray(csr.data))
+      if (op != "copy_lhs" && !IsNullArray(csr.data))  // reorder edge data
         efeat = IndexSelect(efeat, csr.data);
       SWITCH_OP(op, Op, {
         cuda::GESpMMCsr<IdType, DType, Op, cuda::reduce::Sum<IdType, DType> >(

--- a/src/array/cuda/spmm.cu
+++ b/src/array/cuda/spmm.cu
@@ -270,7 +270,7 @@ void SpMMCsr(const std::string& op, const std::string& reduce,
 
   if ((op == "copy_lhs" || is_scalar_efeat) && feat_len > 128) {  // ge-spmm
     if (reduce == "sum") {
-      if (op != "copy_lhs" && IsNullArray(csr.data))
+      if (op != "copy_lhs" && !IsNullArray(csr.data))
         efeat = IndexSelect(efeat, csr.data);
       SWITCH_OP(op, Op, {
         cuda::GESpMMCsr<IdType, DType, Op, cuda::reduce::Sum<IdType, DType> >(

--- a/src/array/cuda/spmm.cuh
+++ b/src/array/cuda/spmm.cuh
@@ -150,7 +150,7 @@ __global__ void SpMMCsrKernel(
   const Idx* __restrict__ indptr,
   const Idx* __restrict__ indices,
   const Idx* __restrict__ edge_map,
-  int64_t num_rows, int64_t num_cols, int64_t nnz,
+  int64_t num_rows, int64_t num_cols,
   const int64_t* __restrict__ ubcast_off,
   const int64_t* __restrict__ ebcast_off,
   int64_t ufeat_len, int64_t efeat_len, int64_t out_len) {
@@ -306,7 +306,7 @@ void SpMMCsr(
         nblks, nthrs, 0, thr_entry->stream,
         ufeat_data, efeat_data, out_data, argu_data, arge_data,
         indptr, indices, edge_map,
-        csr.num_rows, csr.num_cols, efeat->shape[0],
+        csr.num_rows, csr.num_cols,
         ubcast_off, ebcast_off,
         lhs_len, rhs_len, len)
   });


### PR DESCRIPTION
## Description
GE-SpMM is a SC2020 paper targets improving the performance of SpMM when dealing with scalar shape edge features.
The performance of GE-SpMM is better than cusparse in some settings. This PR implements GE-SpMM in DGL.

## TODO
* [x] Our profiling result suggests GE-SpMM's performance is not as good as cusparse when feature size is small (<=64) in ogbn-arxiv, DGL need to switch between cusparse's implementation and GE-SpMM for better performance.

## Checklist
Please feel free to remove inapplicable items for your PR.
- [x] The PR title starts with [$CATEGORY] (such as [NN], [Model], [Doc], [Feature]])
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage
- [x] Code is well-documented
- [x] To the my best knowledge, examples are either not affected by this change,
      or have been fixed to be compatible with this change
- [x] Related issue is referred in this PR
