### PR TITLE
[Doc] Fix line reference in graph feature guide

### DIFF
--- a/docs/source/guide/graph-feature.rst
+++ b/docs/source/guide/graph-feature.rst
@@ -45,7 +45,7 @@ Important facts about the :py:attr:`~dgl.DGLGraph.ndata`/:py:attr:`~dgl.DGLGraph
   nodes/edges in the graph.
 - Features of the same name must have the same dimensionality and data type.
 - The feature tensor is in row-major layout -- each row-slice stores the feature of one
-  node or edge (e.g., see lines 10-11 in the above example).
+  node or edge (e.g., see lines 16-19 in the above example).
 
 For weighted graphs, one can store the weights as an edge feature as below.
 


### PR DESCRIPTION
## Description
The basic guide explaining [graph node/edge features](https://docs.dgl.ai/guide/graph-feature.html) mentions feature tensor being in row major layout. The line number in the code now correspond to the text.

## Checklist
Please feel free to remove inapplicable items for your PR.
- [x] The PR title starts with [$CATEGORY] (such as [NN], [Model], [Doc], [Feature]])
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage
- [x] Code is well-documented
- [x] To the my best knowledge, examples are either not affected by this change,
      or have been fixed to be compatible with this change
- [ ] Related issue is referred in this PR

## Changes

- [x] graph-feature guide minor doc fix
