### PR TITLE
[BugFix][Dataloading] Disable AsyncTransferer copying to anywhere but the GPU

### DIFF
--- a/docs/source/api/python/dgl.dataloading.rst
+++ b/docs/source/api/python/dgl.dataloading.rst
@@ -53,7 +53,7 @@ Async Copying to/from GPUs
 --------------------------
 .. currentmodule:: dgl.dataloading
 
-Data can be copied from the CPU to the GPU, or from the GPU to the CPU,
+Data can be copied from the CPU to the GPU
 while the GPU is being used for
 computation, using the :class:`AsyncTransferer`.
 For the transfer to be fully asynchronous, the context the

--- a/python/dgl/dataloading/async_transferer.py
+++ b/python/dgl/dataloading/async_transferer.py
@@ -1,6 +1,5 @@
-""" API for transferring data to/from the GPU over second stream.A """
+"""API for transferring data to the GPU over second stream."""
 
-import dgl
 from .. import backend as F
 from .. import ndarray
 from .. import utils
@@ -37,7 +36,7 @@ class Transfer(object):
 
 
 class AsyncTransferer(object):
-    """ Class for initiating asynchronous copies to/from the GPU on a second
+    """ Class for initiating asynchronous copies to the GPU on a second
     GPU stream.
 
     To initiate a transfer to a GPU:

--- a/python/dgl/dataloading/async_transferer.py
+++ b/python/dgl/dataloading/async_transferer.py
@@ -1,6 +1,6 @@
 """ API for transferring data to/from the GPU over second stream.A """
 
-
+import dgl
 from .. import backend as F
 from .. import ndarray
 from .. import utils
@@ -73,8 +73,7 @@ class AsyncTransferer(object):
         to be asynchronous, the context the AsyncTranserer is created with must
         be a GPU context, and the input tensor must be in pinned memory.
 
-        Currently, transfers from the GPU to the CPU, and CPU to CPU, will
-        be synchronous.
+        Currently, only transfers to the GPU are supported.
 
         Parameters
         ----------
@@ -93,6 +92,9 @@ class AsyncTransferer(object):
             ctx = device
         else:
             ctx = utils.to_dgl_context(device)
+
+        if ctx.device_type != ndarray.DGLContext.STR2MASK["gpu"]:
+            raise ValueError("'device' must be a GPU device.")
 
         tensor = F.zerocopy_to_dgl_ndarray(tensor)
 

--- a/tests/compute/test_async_transferer.py
+++ b/tests/compute/test_async_transferer.py
@@ -16,12 +16,16 @@ def test_async_transferer_to_other():
 def test_async_transferer_from_other():
     other_ones = F.ones([100,75,25], dtype=F.int32, ctx=F.ctx())
     tran = AsyncTransferer(F.ctx())
-    t = tran.async_copy(other_ones, F.cpu())
-    cpu_ones = t.wait()
-
-    assert F.context(cpu_ones) == F.cpu()
-    assert F.array_equal(F.copy_to(other_ones, ctx=F.cpu()), cpu_ones)
-
+    
+    try:
+        t = tran.async_copy(other_ones, F.cpu())
+    except ValueError:
+        # correctly threw an error
+        pass
+    else:
+        # should have thrown an error
+        assert False
+        
 if __name__ == '__main__':
     test_async_transferer_to_other()
     test_async_transferer_from_other()

--- a/tests/compute/test_async_transferer.py
+++ b/tests/compute/test_async_transferer.py
@@ -4,6 +4,8 @@ import backend as F
 
 from dgl.dataloading import AsyncTransferer
 
+@unittest.skipIf(F._default_context_str == 'cpu',
+                 reason="CPU transfer not allowed")
 def test_async_transferer_to_other():
     cpu_ones = F.ones([100,75,25], dtype=F.int32, ctx=F.cpu())
     tran = AsyncTransferer(F.ctx())


### PR DESCRIPTION
## Description
Disable using AsyncTransferer for copying to anywhere but the GPU, to avoid the failing unit. Will diagnose and create new PR re-enabling functionality once issue is identified.

## Checklist
Please feel free to remove inapplicable items for your PR.
- [x] The PR title starts with [$CATEGORY] (such as [NN], [Model], [Doc], [Feature]])
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage
- [x] Code is well-documented
- [x] To the my best knowledge, examples are either not affected by this change,
      or have been fixed to be compatible with this change
- [x] Related issue is referred in this PR

## Changes

Made AsyncTransferer.copy_async() raise a ValueError if the destination context is not the GPU.

Change the unit test to expect an a ValueError when the destination is not a GPU.
