### PR TITLE
[Doc] "bool" spell error in knowledge_graph.py

### DIFF
--- a/python/dgl/data/knowledge_graph.py
+++ b/python/dgl/data/knowledge_graph.py
@@ -27,7 +27,7 @@ class KnowledgeGraphDataset(DGLBuiltinDataset):
     -----------
     name: str
         Name can be 'FB15k-237', 'FB15k' or 'wn18'.
-    reverse: boo
+    reverse: bool
         Whether add reverse edges. Default: True.
     raw_dir : str
         Raw file directory to download/contains the input data directory.


### PR DESCRIPTION
##  Description
The 'l' in "bool" is lost.

## Checklist
Please feel free to remove inapplicable items for your PR.
- [x] The PR title starts with [$CATEGORY] (such as [NN], [Model], [Doc], [Feature]])
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage
- [x] Code is well-documented
- [x] To the my best knowledge, examples are either not affected by this change,
      or have been fixed to be compatible with this change
- [ ] Related issue is referred in this PR

## Changes
- [x] Changed "boo" to "bool" in python/dgl/data/knowledge_graph.py line 30.
