### PR TITLE
[Bug] Multiple fixes for CUDA 11 support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -46,8 +46,8 @@ if(USE_CUDA)
     #   is fixed by https://github.com/NVIDIA/cub/commit/9143e47e048641aa0e6ddfd645bcd54ff1059939
     #   in 11.1.
     message(STATUS "Detected CUDA of version ${CUDA_VERSION}. Use external CUB/Thrust library.")
-    list(INSERT CUDA_INCLUDE_DIRS 0 "${CMAKE_SOURCE_DIR}/third_party/thrust")
-    list(INSERT CUDA_INCLUDE_DIRS 0 "${CMAKE_SOURCE_DIR}/third_party/cub")
+    cuda_include_directories(BEFORE "${CMAKE_SOURCE_DIR}/third_party/thrust")
+    cuda_include_directories(BEFORE "${CMAKE_SOURCE_DIR}/third_party/cub")
   endif()
 endif(USE_CUDA)
 
@@ -92,6 +92,7 @@ else(MSVC)
   check_cxx_compiler_flag("-std=c++14"    SUPPORT_CXX14)
   set(CMAKE_C_FLAGS "-O2 -Wall -fPIC ${CMAKE_C_FLAGS}")
   set(CMAKE_CXX_FLAGS "-O2 -Wall -fPIC -std=c++14 ${CMAKE_CXX_FLAGS}")
+  set(CMAKE_SHARED_LINKER_FLAGS "-Wl,--warn-common ${CMAKE_SHARED_LINKER_FLAGS}")
 endif(MSVC)
 
 if(USE_OPENMP)

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -30,6 +30,7 @@ def unpack_lib(name, libs) {
 def build_dgl_linux(dev) {
   init_git()
   sh "bash tests/scripts/build_dgl.sh ${dev}"
+  sh "ls -lh /usr/lib/x86_64-linux-gnu/"
   pack_lib("dgl-${dev}-linux", dgl_linux_libs)
 }
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -140,7 +140,6 @@ pipeline {
             docker {
               label "linux-c52x-node"
               image "dgllib/dgl-ci-gpu:conda"
-              args "--runtime nvidia"
               args "-u root"
               alwaysPull true
             }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -139,6 +139,7 @@ pipeline {
             docker {
               label "linux-c52x-node"
               image "dgllib/dgl-ci-gpu:conda"
+              args "--runtime nvidia"
               args "-u root"
               alwaysPull true
             }

--- a/cmake/modules/CUDA.cmake
+++ b/cmake/modules/CUDA.cmake
@@ -253,8 +253,9 @@ macro(dgl_config_cuda out_variable)
   list(APPEND CMAKE_CUDA_FLAGS "${NVCC_FLAGS_EXTRA}")
 
   list(APPEND DGL_LINKER_LIBS
-    ${CUDA_CUDA_LIBRARY} ${CUDA_CUDART_LIBRARY}
-    ${CUDA_CUBLAS_LIBRARIES} ${CUDA_cusparse_LIBRARY})
+    ${CUDA_CUDART_LIBRARY}
+    ${CUDA_CUBLAS_LIBRARIES}
+    ${CUDA_cusparse_LIBRARY})
 
   set(${out_variable} ${DGL_CUDA_SRC})
 endmacro()

--- a/cmake/util/FindCUDA.cmake
+++ b/cmake/util/FindCUDA.cmake
@@ -41,20 +41,6 @@ macro(find_cuda use_cuda)
         ${CUDA_TOOLKIT_ROOT_DIR}/lib/x64
         ${CUDA_TOOLKIT_ROOT_DIR}/lib/Win32)
     else(MSVC)
-      find_library(_CUDA_CUDA_LIBRARY cuda
-        PATHS ${CUDA_TOOLKIT_ROOT_DIR}
-        PATH_SUFFIXES lib lib64 targets/x86_64-linux/lib targets/x86_64-linux/lib/stubs lib64/stubs
-        NO_DEFAULT_PATH)
-      if(_CUDA_CUDA_LIBRARY)
-        set(CUDA_CUDA_LIBRARY ${_CUDA_CUDA_LIBRARY})
-      endif()
-      find_library(CUDA_NVRTC_LIBRARY nvrtc
-        PATHS ${CUDA_TOOLKIT_ROOT_DIR}
-        PATH_SUFFIXES lib lib64 targets/x86_64-linux/lib targets/x86_64-linux/lib/stubs lib64/stubs lib/x86_64-linux-gnu
-        NO_DEFAULT_PATH)
-      #find_library(CUDA_CUDNN_LIBRARY cudnn
-      #  ${CUDA_TOOLKIT_ROOT_DIR}/lib64
-      #  ${CUDA_TOOLKIT_ROOT_DIR}/lib)
       find_library(CUDA_CUBLAS_LIBRARY cublas
         ${CUDA_TOOLKIT_ROOT_DIR}/lib64
         ${CUDA_TOOLKIT_ROOT_DIR}/lib)

--- a/cmake/util/FindCUDA.cmake
+++ b/cmake/util/FindCUDA.cmake
@@ -41,14 +41,10 @@ macro(find_cuda use_cuda)
         ${CUDA_TOOLKIT_ROOT_DIR}/lib/x64
         ${CUDA_TOOLKIT_ROOT_DIR}/lib/Win32)
     else(MSVC)
-      # The CI seems to have trouble locating the CUDA library so I'm manually doing that.
-      find_library(_CUDA_CUDA_LIBRARY cuda
+      find_library(CUDA_CUDA_LIBRARY cuda
         PATHS ${CUDA_TOOLKIT_ROOT_DIR}
-        PATH_SUFFIXES lib lib64 targets/x86_64-linux/lib targets/x86_64-linux/lib/stubs lib64/stubs
+        PATH_SUFFIXES lib lib64 targets/x86_64-linux/lib
         NO_DEFAULT_PATH)
-      if(_CUDA_CUDA_LIBRARY)
-        set(CUDA_CUDA_LIBRARY ${_CUDA_CUDA_LIBRARY})
-      endif()
       find_library(CUDA_CUBLAS_LIBRARY cublas
         ${CUDA_TOOLKIT_ROOT_DIR}/lib64
         ${CUDA_TOOLKIT_ROOT_DIR}/lib)

--- a/cmake/util/FindCUDA.cmake
+++ b/cmake/util/FindCUDA.cmake
@@ -41,18 +41,18 @@ macro(find_cuda use_cuda)
         ${CUDA_TOOLKIT_ROOT_DIR}/lib/x64
         ${CUDA_TOOLKIT_ROOT_DIR}/lib/Win32)
     else(MSVC)
-      find_library(CUDA_CUDA_LIBRARY cuda
-        PATHS ${CUDA_TOOLKIT_ROOT_DIR}
-        PATH_SUFFIXES lib lib64 targets/x86_64-linux/lib
-        NO_DEFAULT_PATH)
+      #find_library(CUDA_CUDA_LIBRARY cuda
+      #  PATHS ${CUDA_TOOLKIT_ROOT_DIR}
+      #  PATH_SUFFIXES lib lib64 targets/x86_64-linux/lib
+      #  NO_DEFAULT_PATH)
       find_library(CUDA_CUBLAS_LIBRARY cublas
         ${CUDA_TOOLKIT_ROOT_DIR}/lib64
         ${CUDA_TOOLKIT_ROOT_DIR}/lib)
     endif(MSVC)
     message(STATUS "Found CUDA_TOOLKIT_ROOT_DIR=" ${CUDA_TOOLKIT_ROOT_DIR})
-    message(STATUS "Found CUDA_CUDA_LIBRARY=" ${CUDA_CUDA_LIBRARY})
+    #message(STATUS "Found CUDA_CUDA_LIBRARY=" ${CUDA_CUDA_LIBRARY})
     message(STATUS "Found CUDA_CUDART_LIBRARY=" ${CUDA_CUDART_LIBRARY})
-    message(STATUS "Found CUDA_NVRTC_LIBRARY=" ${CUDA_NVRTC_LIBRARY})
+    #message(STATUS "Found CUDA_NVRTC_LIBRARY=" ${CUDA_NVRTC_LIBRARY})
     #message(STATUS "Found CUDA_CUDNN_LIBRARY=" ${CUDA_CUDNN_LIBRARY})
     message(STATUS "Found CUDA_CUBLAS_LIBRARY=" ${CUDA_CUBLAS_LIBRARY})
   endif(CUDA_FOUND)

--- a/cmake/util/FindCUDA.cmake
+++ b/cmake/util/FindCUDA.cmake
@@ -43,9 +43,9 @@ macro(find_cuda use_cuda)
     else(MSVC)
       # The CI seems to have trouble locating the CUDA library so I'm manually doing that.
       find_library(_CUDA_CUDA_LIBRARY cuda
-                   PATHS ${CUDA_TOOLKIT_ROOT_DIR}
-                   PATH_SUFFIXES lib lib64 targets/x86_64-linux/lib
-                   NO_DEFAULT_PATH)
+        PATHS ${CUDA_TOOLKIT_ROOT_DIR}
+        PATH_SUFFIXES lib lib64 targets/x86_64-linux/lib targets/x86_64-linux/lib/stubs lib64/stubs
+        NO_DEFAULT_PATH)
       if(_CUDA_CUDA_LIBRARY)
         set(CUDA_CUDA_LIBRARY ${_CUDA_CUDA_LIBRARY})
       endif()

--- a/cmake/util/FindCUDA.cmake
+++ b/cmake/util/FindCUDA.cmake
@@ -41,6 +41,17 @@ macro(find_cuda use_cuda)
         ${CUDA_TOOLKIT_ROOT_DIR}/lib/x64
         ${CUDA_TOOLKIT_ROOT_DIR}/lib/Win32)
     else(MSVC)
+      # The CI seems to have trouble locating the CUDA library so I'm manually doing that.
+      string(FIND ${CUDA_CUDA_LIBRARY} "NOTFOUND" CUDA_CUDA_LIBRARY_NOTFOUND)
+      if(${CUDA_CUDA_LIBRARY_NOTFOUND} EQUAL -1)
+        find_library(_CUDA_CUDA_LIBRARY cuda
+                     PATHS ${CUDA_TOOLKIT_ROOT_DIR}
+                     PATH_SUFFIXES lib lib64 targets/x86_64-linux/lib
+                     NO_DEFAULT_PATH)
+        if(_CUDA_CUDA_LIBRARY)
+          set(CUDA_CUDA_LIBRARY ${_CUDA_CUDA_LIBRARY})
+        endif()
+      endif()
       find_library(CUDA_CUBLAS_LIBRARY cublas
         ${CUDA_TOOLKIT_ROOT_DIR}/lib64
         ${CUDA_TOOLKIT_ROOT_DIR}/lib)

--- a/cmake/util/FindCUDA.cmake
+++ b/cmake/util/FindCUDA.cmake
@@ -42,15 +42,12 @@ macro(find_cuda use_cuda)
         ${CUDA_TOOLKIT_ROOT_DIR}/lib/Win32)
     else(MSVC)
       # The CI seems to have trouble locating the CUDA library so I'm manually doing that.
-      string(FIND ${CUDA_CUDA_LIBRARY} "NOTFOUND" CUDA_CUDA_LIBRARY_NOTFOUND)
-      if(${CUDA_CUDA_LIBRARY_NOTFOUND} EQUAL -1)
-        find_library(_CUDA_CUDA_LIBRARY cuda
-                     PATHS ${CUDA_TOOLKIT_ROOT_DIR}
-                     PATH_SUFFIXES lib lib64 targets/x86_64-linux/lib
-                     NO_DEFAULT_PATH)
-        if(_CUDA_CUDA_LIBRARY)
-          set(CUDA_CUDA_LIBRARY ${_CUDA_CUDA_LIBRARY})
-        endif()
+      find_library(_CUDA_CUDA_LIBRARY cuda
+                   PATHS ${CUDA_TOOLKIT_ROOT_DIR}
+                   PATH_SUFFIXES lib lib64 targets/x86_64-linux/lib
+                   NO_DEFAULT_PATH)
+      if(_CUDA_CUDA_LIBRARY)
+        set(CUDA_CUDA_LIBRARY ${_CUDA_CUDA_LIBRARY})
       endif()
       find_library(CUDA_CUBLAS_LIBRARY cublas
         ${CUDA_TOOLKIT_ROOT_DIR}/lib64

--- a/src/array/cpu/array_op_impl.cc
+++ b/src/array/cpu/array_op_impl.cc
@@ -222,26 +222,6 @@ IdArray Relabel_(const std::vector<IdArray>& arrays) {
 template IdArray Relabel_<kDLCPU, int32_t>(const std::vector<IdArray>& arrays);
 template IdArray Relabel_<kDLCPU, int64_t>(const std::vector<IdArray>& arrays);
 
-
-///////////////////////////// NonZero /////////////////////////////
-
-template <DLDeviceType XPU, typename IdType>
-IdArray NonZero(BoolArray bool_arr) {
-  const IdType* bool_data = static_cast<IdType*>(bool_arr->data);
-  CHECK(bool_arr->ndim == 1) << "NonZero only supports 1D array";
-  std::vector<IdType> nonzero_indices;
-  for (int64_t i = 0; i < bool_arr->shape[0]; i++) {
-    if ((bool_data[i]) != 0) {
-      nonzero_indices.push_back(i);
-    }
-  }
-  return VecToIdArray(nonzero_indices, sizeof(IdType) * 8);
-}
-
-// TODO(Allen): Implement GPU version
-template IdArray NonZero<kDLCPU, int32_t>(BoolArray bool_arr);
-template IdArray NonZero<kDLCPU, int64_t>(BoolArray bool_arr);
-
 }  // namespace impl
 }  // namespace aten
 }  // namespace dgl


### PR DESCRIPTION
## Description
This PR makes sure to include CUB/Thrust in our submodules rather than the system ones if CUDA version is no greater than 11.0.  It also removes a redundant NonZero implementation.