### PR TITLE
[Examples] Fix a bug in the training iterator of GraphWriter

### DIFF
--- a/examples/pytorch/graphwriter/utlis.py
+++ b/examples/pytorch/graphwriter/utlis.py
@@ -227,6 +227,8 @@ class BucketSampler(torch.utils.data.Sampler):
         random.shuffle(datas)
         idxs = sum(datas, [])
         batch = []
+        
+        lens = torch.Tensor([len(x) for x in self.data_source])
         for idx in idxs:
             batch.append(idx)
             mlen = max([0]+[lens[x] for x in batch])


### PR DESCRIPTION

## Description
In the bucket sampler, the length array should be recovered after random picking samples. The previous implementation uses the permuted length array, so its value is wrong. 

## Checklist
Please feel free to remove inapplicable items for your PR.
- [x] The PR title starts with [$CATEGORY] (such as [NN], [Model], [Doc], [Feature]])
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage
- [x] Code is well-documented
- [x] To the my best knowledge, examples are either not affected by this change,
      or have been fixed to be compatible with this change
- [ ] Related issue is referred in this PR

## Changes
[Examples] Fix a bug in the Bucket Sampler class of GraphWriter Example
