### PR TITLE
[Performance] Use segment operators for graph readout.

### DIFF
--- a/python/dgl/backend/backend.py
+++ b/python/dgl/backend/backend.py
@@ -1509,6 +1509,27 @@ def edge_softmax(gidx, logits, eids, norm_by):
     pass
 
 def segment_reduce(op, x, offsets):
+    """Segment reduction operator.
+
+    It aggregates the value tensor along the first dimension by segments.
+    The first argument ``seglen`` stores the length of each segment. Its
+    summation must be equal to the first dimension of the ``value`` tensor.
+    Zero-length segments are allowed.
+
+    Parameters
+    ----------
+    op : str
+        Aggregation method. Can be 'sum', 'max', 'min'.
+    seglen : Tensor
+        Segment lengths.
+    value : Tensor
+        Value to aggregate.
+
+    Returns
+    -------
+    Tensor
+        Aggregated tensor of shape ``(len(seglen), value.shape[1:])``.
+    """
     pass
 
 

--- a/python/dgl/backend/backend.py
+++ b/python/dgl/backend/backend.py
@@ -370,6 +370,23 @@ def reduce_sum(input):
     """
     pass
 
+def cumsum(input, dim):
+    """Return the cumulative sum of the elements along a given axis.
+
+    Parameters
+    ----------
+    input : Tensor
+        The input tensor.
+    dim : int
+        The cumulative dimension.
+
+    Returns
+    -------
+    Tensor
+        A framework-specific tensor.
+    """
+    pass
+
 def mean(input, dim):
     """Reduce average the input tensor along the given dim.
 
@@ -1489,6 +1506,10 @@ def edge_softmax(gidx, logits, eids, norm_by):
     Tensor
         Softmax value
     """
+    pass
+
+def segment_reduce(op, x, offsets):
+    pass
 
 
 ###############################################################################

--- a/python/dgl/backend/mxnet/sparse.py
+++ b/python/dgl/backend/mxnet/sparse.py
@@ -28,7 +28,7 @@ def _scatter_nd(index, src, n_rows):
     if ndim > 1:
         new_idx = index * stride + sum(offsets)
     else:
-        new_idx = index 
+        new_idx = index
     src = src.reshape(-1)
     new_idx = new_idx.reshape(-1)
     rst = np.zeros((stride * n_rows,), dtype=src.dtype)
@@ -346,9 +346,11 @@ class SegmentReduce(mx.autograd.Function):
         offsets = self.offsets
         m = offsets[-1].asscalar()
         if self.op == 'sum':
-            indices = nd.zeros((m,), ctx=offsets.ctx, dtype=offsets.dtype)
-            indices[offsets[:-1]] = 1
-            indices = nd.cumsum(indices, -1)
+            offsets_np = asnumpy(offsets[1:-1])
+            indices_np = np.zeros((m,), dtype=offsets_np.dtype)
+            np.add.at(indices_np, offsets_np, np.ones_like(offsets_np))
+            indices_np = np.cumsum(indices_np, -1)
+            indices = zerocopy_from_numpy(indices_np)
             dx = dy[indices]
         else:
             dx = _bwd_segment_cmp(dy, arg, m)

--- a/python/dgl/backend/mxnet/tensor.py
+++ b/python/dgl/backend/mxnet/tensor.py
@@ -152,6 +152,9 @@ def sum(input, dim, keepdims=False):
 def reduce_sum(input):
     return input.sum()
 
+def cumsum(input, dim):
+    return nd.cumsum(input, axis=dim)
+
 def mean(input, dim):
     return nd.mean(input, axis=dim)
 

--- a/python/dgl/backend/pytorch/sparse.py
+++ b/python/dgl/backend/pytorch/sparse.py
@@ -1,8 +1,8 @@
 import torch as th
 from ...base import is_all, ALL
-from ...sparse import _gspmm, _gsddmm
+from ...sparse import _gspmm, _gsddmm, _segment_reduce, _bwd_segment_cmp
 
-__all__ = ['gspmm', 'gsddmm', 'edge_softmax']
+__all__ = ['gspmm', 'gsddmm', 'edge_softmax', 'segment_reduce']
 
 
 def _reduce_grad(grad, shape):
@@ -231,6 +231,29 @@ class EdgeSoftmax(th.autograd.Function):
         return None, grad_score, None, None
 
 
+class SegmentReduce(th.autograd.Function):
+    @staticmethod
+    def forward(ctx, op, x, offsets):
+        y, arg = _segment_reduce(op, x, offsets)
+        ctx.save_for_backward(arg, offsets)
+        ctx.backward_cache = op
+        return y
+
+    @staticmethod
+    def backward(ctx, dy):
+        op = ctx.backward_cache
+        arg, offsets = ctx.saved_tensors
+        m = offsets[-1].item()
+        if op == 'sum':
+            indices = th.zeros((m,), device=offsets.device, dtype=offsets.dtype)
+            indices[offsets[:-1]] = 1
+            indices = th.cumsum(indices, -1)
+            dx = dy[indices]
+        else:
+            dx = _bwd_segment_cmp(dy, arg, m)
+        return None, dx, None
+
+
 def gspmm(gidx, op, reduce_op, lhs_data, rhs_data):
     return GSpMM.apply(gidx, op, reduce_op, lhs_data, rhs_data)
 
@@ -241,3 +264,7 @@ def gsddmm(gidx, op, lhs_data, rhs_data, lhs_target='u', rhs_target='v'):
 
 def edge_softmax(gidx, logits, eids=ALL, norm_by='dst'):
     return EdgeSoftmax.apply(gidx, logits, eids, norm_by)
+
+
+def segment_reduce(op, x, offsets):
+    return SegmentReduce.apply(op, x, offsets)

--- a/python/dgl/backend/pytorch/tensor.py
+++ b/python/dgl/backend/pytorch/tensor.py
@@ -120,6 +120,9 @@ def sum(input, dim, keepdims=False):
 def reduce_sum(input):
     return input.sum()
 
+def cumsum(input, dim):
+    return th.cumsum(input, dim=dim)
+
 def mean(input, dim):
     return th.mean(input, dim=dim)
 

--- a/python/dgl/backend/tensorflow/sparse.py
+++ b/python/dgl/backend/tensorflow/sparse.py
@@ -261,12 +261,12 @@ def segment_reduce_real(op, x, offsets):
     def segment_reduce_backward(dy):
         m = x.shape[0]
         if op == 'sum':
-            offsets_np = asnumpy(offsets)
+            offsets_np = asnumpy(offsets[1:-1])
             indices_np = np.zeros((m,), dtype=offsets_np.dtype)
-            indices_np[offsets_np[:-1]] = 1
+            np.add.at(indices_np, offsets_np, np.ones_like(offsets_np))
             indices_np = np.cumsum(indices_np, -1)
-            indices = copy_to(zerocopy_from_numpy(indices_np), offsets.ctx)
-            dx = dy[indices]
+            indices = zerocopy_from_numpy(indices_np)
+            dx = tf.gather(dy, indices)
         else:
             dx = _bwd_segment_cmp(dy, arg, m)
         return dx

--- a/python/dgl/backend/tensorflow/sparse.py
+++ b/python/dgl/backend/tensorflow/sparse.py
@@ -1,10 +1,10 @@
 import tensorflow as tf
 import numpy as np
-from .tensor import tensor, copy_to, context
+from .tensor import tensor, copy_to, context, asnumpy, zerocopy_from_numpy
 from ...base import is_all, ALL
-from ...sparse import _gspmm, _gsddmm
+from ...sparse import _gspmm, _gsddmm, _segment_reduce, _bwd_segment_cmp
 
-__all__ = ['gspmm', 'gsddmm', 'edge_softmax']
+__all__ = ['gspmm', 'gsddmm', 'edge_softmax', 'segment_reduce']
 
 
 def _scatter_nd(index, src, n_rows):
@@ -254,3 +254,28 @@ def edge_softmax(gidx, logits, eids=ALL, norm_by='dst'):
         return edge_softmax_real(gidx, logits, eids, norm_by)
     return _lambda(logits)
 
+
+def segment_reduce_real(op, x, offsets):
+    y, arg = _segment_reduce(op, x, offsets)
+
+    def segment_reduce_backward(dy):
+        m = x.shape[0]
+        if op == 'sum':
+            offsets_np = asnumpy(offsets)
+            indices_np = np.zeros((m,), dtype=offsets_np.dtype)
+            indices_np[offsets_np[:-1]] = 1
+            indices_np = np.cumsum(indices_np, -1)
+            indices = copy_to(zerocopy_from_numpy(indices_np), offsets.ctx)
+            dx = dy[indices]
+        else:
+            dx = _bwd_segment_cmp(dy, arg, m)
+        return dx
+
+    return y, segment_reduce_backward
+
+
+def segment_reduce(op, x, offsets):
+    @tf.custom_gradient
+    def _lambda(x):
+        return segment_reduce_real(op, x, offsets)
+    return _lambda(x)

--- a/python/dgl/backend/tensorflow/tensor.py
+++ b/python/dgl/backend/tensorflow/tensor.py
@@ -175,6 +175,12 @@ def reduce_sum(input):
     return tf.reduce_sum(input)
 
 
+def cumsum(input, dim):
+    if input.dtype == tf.bool:
+        input = tf.cast(input, tf.int32)
+    return tf.cumsum(input, axis=dim)
+
+
 def mean(input, dim):
     return tf.reduce_mean(input, axis=dim)
 

--- a/python/dgl/ops/__init__.py
+++ b/python/dgl/ops/__init__.py
@@ -2,3 +2,4 @@
 from .spmm import *
 from .sddmm import *
 from .edge_softmax import *
+from .segment import *

--- a/python/dgl/ops/segment.py
+++ b/python/dgl/ops/segment.py
@@ -2,7 +2,6 @@
 
 from ..base import DGLError
 from .. import backend as F
-from .. import convert
 from .. import function as fn
 
 
@@ -47,12 +46,14 @@ def segment_reduce(seglen, value, reducer='sum'):
     if reducer == 'mean':
         rst = F.segment_reduce('sum', value, offsets)
         rst_shape = F.shape(rst)
-        z = F.astype(F.clamp(seglen, 1, len(value)), F.dtype(rst)) 
+        z = F.astype(F.clamp(seglen, 1, len(value)), F.dtype(rst))
         z_shape = (rst_shape[0],) + (1,) * (len(rst_shape) - 1)
-        return rst / F.reshape(z, z_shape) 
+        return rst / F.reshape(z, z_shape)
     else:
-        return F.segment_reduce(reducer, value, offsets)
-    
+        rst = F.segment_reduce(reducer, value, offsets)
+        if reducer in ['min', 'max']:
+            rst = F.replace_inf_with_zero(rst)
+        return rst
 
 
 def segment_softmax(seglen, value):

--- a/python/dgl/ops/segment.py
+++ b/python/dgl/ops/segment.py
@@ -42,19 +42,17 @@ def segment_reduce(seglen, value, reducer='sum'):
             [4., 4., 4.]])
     """
     ctx = F.context(seglen)
-    # TODO(minjie): a more efficient implementation is to create a graph
-    #   directly from a CSR structure.
-    u = F.copy_to(F.arange(0, F.shape(value)[0], F.int32), ctx)
-    v = F.repeat(F.copy_to(F.arange(0, len(seglen), F.int32), ctx),
-                 seglen, dim=0)
-    if len(u) != len(v):
-        raise DGLError("Invalid seglen array:", seglen,
-                       ". Its summation must be equal to value.shape[0].")
-    num_nodes = {'_U': len(u), '_V': len(seglen)}
-    g = convert.heterograph({('_U', '_E', '_V'): (u, v)}, num_nodes_dict=num_nodes)
-    g.srcdata['h'] = value
-    g.update_all(fn.copy_u('h', 'm'), getattr(fn, reducer)('m', 'h'))
-    return g.dstdata['h']
+    offsets = F.cumsum(
+        F.cat([F.zeros((1,), F.dtype(seglen), F.context(seglen)), seglen], 0), 0)
+    if reducer == 'mean':
+        rst = F.segment_reduce('sum', value, offsets)
+        rst_shape = F.shape(rst)
+        z = F.astype(F.clamp(seglen, 1, len(value)), F.dtype(rst)) 
+        z_shape = (rst_shape[0],) + (1,) * (len(rst_shape) - 1)
+        return rst / F.reshape(z, z_shape) 
+    else:
+        return F.segment_reduce(reducer, value, offsets)
+    
 
 
 def segment_softmax(seglen, value):

--- a/python/dgl/sparse.py
+++ b/python/dgl/sparse.py
@@ -272,7 +272,6 @@ def _bwd_segment_cmp(feat, arg, m):
     out_shp = (m,) + F.shape(feat)[1:]
     ctx = F.context(feat)
     dtype = F.dtype(feat)
-    idtype = F.dtype(arg)
     out = F.zeros(out_shp, dtype, ctx)
     _CAPI_DGLKernelBwdSegmentCmp(to_dgl_nd(feat),
                                  to_dgl_nd(arg),

--- a/python/dgl/sparse.py
+++ b/python/dgl/sparse.py
@@ -268,17 +268,4 @@ def _segment_reduce(op, feat, offsets):
     return out, arg
 
 
-def _segment_bcast(feat, offsets):
-    m = F.as_scalar(offsets[-1])
-    out_shp = (m,) + F.shape(feat)[1:]
-    ctx = F.context(feat)
-    dtype = F.dtype(feat)
-    idtype = F.dtype(offsets)
-    out = F.zeros(out_shp, dtype, ctx)
-    _CAPI_DGLKernelSegmentBcast(to_dgl_nd(feat),
-                                to_dgl_nd(offsets),
-                                to_dgl_nd_for_write(out))
-    return out
-
-
 _init_api("dgl.sparse")

--- a/python/dgl/sparse.py
+++ b/python/dgl/sparse.py
@@ -268,4 +268,16 @@ def _segment_reduce(op, feat, offsets):
     return out, arg
 
 
+def _bwd_segment_cmp(feat, arg, m):
+    out_shp = (m,) + F.shape(feat)[1:]
+    ctx = F.context(feat)
+    dtype = F.dtype(feat)
+    idtype = F.dtype(arg)
+    out = F.zeros(out_shp, dtype, ctx)
+    _CAPI_DGLKernelBwdSegmentCmp(to_dgl_nd(feat),
+                                 to_dgl_nd(arg),
+                                 to_dgl_nd_for_write(out))
+    return out
+
+
 _init_api("dgl.sparse")

--- a/src/array/cpu/segment_reduce.cc
+++ b/src/array/cpu/segment_reduce.cc
@@ -4,9 +4,9 @@
  * \brief Segment reduce C APIs and definitions.
  */
 #include "./segment_reduce.h"
+#include <dgl/array.h>
 #include <string>
 #include "./spmm_binary_ops.h"
-#include <dgl/array.h>
 
 namespace dgl {
 namespace aten {

--- a/src/array/cpu/segment_reduce.cc
+++ b/src/array/cpu/segment_reduce.cc
@@ -1,0 +1,87 @@
+/*!
+ *  Copyright (c) 2020 by Contributors
+ * \file kernel/cpu/segment_reduce.cc
+ * \brief Segment reduce C APIs and definitions.
+ */
+#include "./segment_reduce.h"
+#include "./spmm_binary_ops.h"
+#include <dgl/array.h>
+#include <string>
+
+namespace dgl {
+namespace aten {
+
+/*! \brief Segment Reduce operator. */
+template <int XPU, typename IdType, typename DType>
+void SegmentReduce(
+    const std::string& op,
+    NDArray feat,
+    NDArray offsets,
+    NDArray out,
+    NDArray arg) {
+  if (op == "sum") {
+    cpu::SegmentSum<IdType, DType>(feat, offsets, out);
+  } else if (op == "max" || op == "min") {
+    if (op == "max")
+      cpu::SegmentCmp<IdType, DType, cpu::op::Max<DType>>(
+          feat, offsets, out, arg);
+    else
+      cpu::SegmentCmp<IdType, DType, cpu::op::Min<DType>>(
+          feat, offsets, out, arg);
+  } else {
+    LOG(FATAL) << "Unsupported reduce function " << op;
+  }
+}
+
+/*! \brief Segment broadcast operator. */
+template <int XPU, typename IdType, typename DType>
+void SegmentBcast(
+    NDArray feat,
+    NDArray offsets,
+    NDArray out) {
+  cpu::SegmentBcast<IdType, DType>(feat, offsets, out);
+}
+
+template void SegmentReduce<kDLCPU, int32_t, float>(
+    const std::string &op,
+    NDArray feat,
+    NDArray offsets,
+    NDArray out,
+    NDArray arg);
+template void SegmentReduce<kDLCPU, int64_t, float>(
+    const std::string &op,
+    NDArray feat,
+    NDArray offsets,
+    NDArray out,
+    NDArray arg);
+template void SegmentReduce<kDLCPU, int32_t, double>(
+    const std::string &op,
+    NDArray feat,
+    NDArray offsets,
+    NDArray out,
+    NDArray arg);
+template void SegmentReduce<kDLCPU, int64_t, double>(
+    const std::string &op,
+    NDArray feat,
+    NDArray offsets,
+    NDArray out,
+    NDArray arg);
+template void SegmentBcast<kDLCPU, int32_t, float>(
+    NDArray feat,
+    NDArray offsets,
+    NDArray out);
+template void SegmentBcast<kDLCPU, int64_t, float>(
+    NDArray feat,
+    NDArray offsets,
+    NDArray out);
+template void SegmentBcast<kDLCPU, int32_t, double>(
+    NDArray feat,
+    NDArray offsets,
+    NDArray out);
+template void SegmentBcast<kDLCPU, int64_t, double>(
+    NDArray feat,
+    NDArray offsets,
+    NDArray out);
+
+} // namespace aten
+}  // namespace dgl

--- a/src/array/cpu/segment_reduce.cc
+++ b/src/array/cpu/segment_reduce.cc
@@ -33,13 +33,13 @@ void SegmentReduce(
   }
 }
 
-/*! \brief Segment broadcast operator. */
+/*! \brief Backward function of segment cmp.*/
 template <int XPU, typename IdType, typename DType>
-void SegmentBcast(
+void BackwardSegmentCmp(
     NDArray feat,
-    NDArray offsets,
+    NDArray arg,
     NDArray out) {
-  cpu::SegmentBcast<IdType, DType>(feat, offsets, out);
+  cpu::BackwardSegmentCmp<IdType, DType>(feat, arg, out);
 }
 
 template void SegmentReduce<kDLCPU, int32_t, float>(
@@ -66,21 +66,21 @@ template void SegmentReduce<kDLCPU, int64_t, double>(
     NDArray offsets,
     NDArray out,
     NDArray arg);
-template void SegmentBcast<kDLCPU, int32_t, float>(
+template void BackwardSegmentCmp<kDLCPU, int32_t, float>(
     NDArray feat,
-    NDArray offsets,
+    NDArray arg,
     NDArray out);
-template void SegmentBcast<kDLCPU, int64_t, float>(
+template void BackwardSegmentCmp<kDLCPU, int64_t, float>(
     NDArray feat,
-    NDArray offsets,
+    NDArray arg,
     NDArray out);
-template void SegmentBcast<kDLCPU, int32_t, double>(
+template void BackwardSegmentCmp<kDLCPU, int32_t, double>(
     NDArray feat,
-    NDArray offsets,
+    NDArray arg,
     NDArray out);
-template void SegmentBcast<kDLCPU, int64_t, double>(
+template void BackwardSegmentCmp<kDLCPU, int64_t, double>(
     NDArray feat,
-    NDArray offsets,
+    NDArray arg,
     NDArray out);
 
 } // namespace aten

--- a/src/array/cpu/segment_reduce.cc
+++ b/src/array/cpu/segment_reduce.cc
@@ -4,9 +4,9 @@
  * \brief Segment reduce C APIs and definitions.
  */
 #include "./segment_reduce.h"
+#include <string>
 #include "./spmm_binary_ops.h"
 #include <dgl/array.h>
-#include <string>
 
 namespace dgl {
 namespace aten {
@@ -83,5 +83,5 @@ template void BackwardSegmentCmp<kDLCPU, int64_t, double>(
     NDArray arg,
     NDArray out);
 
-} // namespace aten
+}  // namespace aten
 }  // namespace dgl

--- a/src/array/cpu/segment_reduce.h
+++ b/src/array/cpu/segment_reduce.h
@@ -81,5 +81,4 @@ void BackwardSegmentCmp(NDArray feat, NDArray arg, NDArray out) {
 }  // namespace aten
 }  // namespace dgl
 
-#endif
-
+#endif  // DGL_ARRAY_CPU_SEGMENT_REDUCE_H_

--- a/src/array/cpu/segment_reduce.h
+++ b/src/array/cpu/segment_reduce.h
@@ -1,0 +1,57 @@
+/*!
+ *  Copyright (c) 2020 by Contributors
+ * \file array/cpu/spmm.h
+ * \brief Segment reduce kernel function header.
+ */
+#ifndef DGL_ARRAY_CPU_SEGMENT_REDUCE_H_
+#define DGL_ARRAY_CPU_SEGMENT_REDUCE_H_
+
+#include <dgl/array.h>
+
+namespace dgl {
+namespace aten {
+namespace cpu {
+
+template <typename IdType, typename DType>
+void SegmentSum(NDArray feat, NDArray offsets, NDArray out,
+                int n, int dim) {
+  const DType* feat_data = feat.Ptr<DType>();
+  const IdType* offsets_data = offsets.Ptr<IdType>();
+  DType *out_data = out.Ptr<DType>();
+#pragma omp parallel for
+  for (int i = 0; i < n; ++i) {
+    for (IdType j = offsets_data[i]; j < offsets_data[i + 1]; ++j) {
+      for (int k = 0; k < dim; ++k) {
+        out_data[i * dim + k] += feat[j * dim + k];
+      }
+    }
+  }
+}
+
+template <typename IdType, typename DType, typename Cmp>
+void SegmentCmp(NDArray feat, NDArray offsets,
+                NDArray out, NDArray arg,
+                int n, int dim) {
+  const DType* feat_data = feat.Ptr<DType>();
+  const IdType* offsets_data = offsets.Ptr<IdType>();
+  DType *out_data = out.Ptr<DType>();
+  std::fill(out_data, out_data + out.NumElements(), Cmp::zero), 
+#pragma omp parallel for
+  for (int i = 0; i < n; ++i) {
+    for (IdType j = offsets_data[i]; j < offsets_data[i + 1]; ++j) {
+      for (int k = 0; k < dim; ++k) {
+        const DType val = feat[i * dim + k];
+        if (Cmp::Call(out_data[j * dim + k], val)) {
+          out_data[i * dim + k] = feat[j * dim + k];
+          arg[i * dim + k] = j;
+        }
+      }
+    }
+  }
+}
+
+
+}  // namespace cpu
+}  // namespace aten
+}  // namespace dgl
+

--- a/src/array/cpu/segment_reduce.h
+++ b/src/array/cpu/segment_reduce.h
@@ -47,9 +47,9 @@ void SegmentCmp(NDArray feat, NDArray offsets,
   for (int i = 0; i < n; ++i) {
     for (IdType j = offsets_data[i]; j < offsets_data[i + 1]; ++j) {
       for (int k = 0; k < dim; ++k) {
-        const DType val = feat_data[i * dim + k];
-        if (Cmp::Call(out_data[j * dim + k], val)) {
-          out_data[i * dim + k] = feat_data[j * dim + k];
+        const DType val = feat_data[j * dim + k];
+        if (Cmp::Call(out_data[i * dim + k], val)) {
+          out_data[i * dim + k] = val;
           arg_data[i * dim + k] = j;
         }
       }
@@ -69,8 +69,7 @@ void BackwardSegmentCmp(NDArray feat, NDArray arg, NDArray out) {
 #pragma omp parallel for
   for (int i = 0; i < n; ++i) {
     for (int k = 0; k < dim; ++k) {
-#pragma omp atomic
-      out_data[arg_data[i * dim + k] * dim + k] += feat_data[i * dim + k];
+      out_data[arg_data[i * dim + k] * dim + k] = feat_data[i * dim + k];
     }
   }
 }

--- a/src/array/cpu/segment_reduce.h
+++ b/src/array/cpu/segment_reduce.h
@@ -13,8 +13,11 @@ namespace aten {
 namespace cpu {
 
 template <typename IdType, typename DType>
-void SegmentSum(NDArray feat, NDArray offsets, NDArray out,
-                int n, int dim) {
+void SegmentSum(NDArray feat, NDArray offsets, NDArray out) {
+  int n = out->shape[0];
+  int dim = 1;
+  for (int i = 1; i < out->ndim; ++i)
+    dim *= out->shape[i];
   const DType* feat_data = feat.Ptr<DType>();
   const IdType* offsets_data = offsets.Ptr<IdType>();
   DType *out_data = out.Ptr<DType>();
@@ -22,7 +25,7 @@ void SegmentSum(NDArray feat, NDArray offsets, NDArray out,
   for (int i = 0; i < n; ++i) {
     for (IdType j = offsets_data[i]; j < offsets_data[i + 1]; ++j) {
       for (int k = 0; k < dim; ++k) {
-        out_data[i * dim + k] += feat[j * dim + k];
+        out_data[i * dim + k] += feat_data[j * dim + k];
       }
     }
   }
@@ -30,28 +33,52 @@ void SegmentSum(NDArray feat, NDArray offsets, NDArray out,
 
 template <typename IdType, typename DType, typename Cmp>
 void SegmentCmp(NDArray feat, NDArray offsets,
-                NDArray out, NDArray arg,
-                int n, int dim) {
+                NDArray out, NDArray arg) {
+  int n = out->shape[0];
+  int dim = 1;
+  for (int i = 1; i < out->ndim; ++i)
+    dim *= out->shape[i];
   const DType* feat_data = feat.Ptr<DType>();
   const IdType* offsets_data = offsets.Ptr<IdType>();
   DType *out_data = out.Ptr<DType>();
-  std::fill(out_data, out_data + out.NumElements(), Cmp::zero), 
+  IdType *arg_data = arg.Ptr<IdType>();
+  std::fill(out_data, out_data + out.NumElements(), Cmp::zero);
 #pragma omp parallel for
   for (int i = 0; i < n; ++i) {
     for (IdType j = offsets_data[i]; j < offsets_data[i + 1]; ++j) {
       for (int k = 0; k < dim; ++k) {
-        const DType val = feat[i * dim + k];
+        const DType val = feat_data[i * dim + k];
         if (Cmp::Call(out_data[j * dim + k], val)) {
-          out_data[i * dim + k] = feat[j * dim + k];
-          arg[i * dim + k] = j;
+          out_data[i * dim + k] = feat_data[j * dim + k];
+          arg_data[i * dim + k] = j;
         }
       }
     }
   }
 }
 
+template <typename IdType, typename DType>
+void SegmentBcast(NDArray feat, NDArray offsets, NDArray out) {
+  int n = out->shape[0];
+  int dim = 1;
+  for (int i = 1; i < out->ndim; ++i)
+    dim *= out->shape[i];
+  const DType* feat_data = feat.Ptr<DType>();
+  const IdType* offsets_data = offsets.Ptr<IdType>();
+  DType* out_data = out.Ptr<DType>();
+#pragma omp parallel for
+  for (int i = 0; i < n; ++i) {
+    for (IdType j = offsets_data[i]; j < offsets_data[i + 1]; ++j) {
+      for (int k = 0; k < dim; ++k) {
+        out_data[j * dim + k] = feat_data[i * dim + k];
+      }
+    }
+  }
+}
 
 }  // namespace cpu
 }  // namespace aten
 }  // namespace dgl
+
+#endif
 

--- a/src/array/cpu/segment_reduce.h
+++ b/src/array/cpu/segment_reduce.h
@@ -43,6 +43,7 @@ void SegmentCmp(NDArray feat, NDArray offsets,
   DType *out_data = out.Ptr<DType>();
   IdType *arg_data = arg.Ptr<IdType>();
   std::fill(out_data, out_data + out.NumElements(), Cmp::zero);
+  std::fill(arg_data, arg_data + arg.NumElements(), -1);
 #pragma omp parallel for
   for (int i = 0; i < n; ++i) {
     for (IdType j = offsets_data[i]; j < offsets_data[i + 1]; ++j) {
@@ -69,7 +70,9 @@ void BackwardSegmentCmp(NDArray feat, NDArray arg, NDArray out) {
 #pragma omp parallel for
   for (int i = 0; i < n; ++i) {
     for (int k = 0; k < dim; ++k) {
-      out_data[arg_data[i * dim + k] * dim + k] = feat_data[i * dim + k];
+      int write_row = arg_data[i * dim + k];
+      if (write_row >= 0)
+        out_data[write_row * dim + k] = feat_data[i * dim + k];
     }
   }
 }

--- a/src/array/cpu/spmm.cc
+++ b/src/array/cpu/spmm.cc
@@ -18,11 +18,11 @@ void SpMMCsr(const std::string& op, const std::string& reduce,
              NDArray efeat,
              NDArray out,
              std::vector<NDArray> out_aux) {
-  if (reduce == "sum") {
+  if (op == "sum") {
     SWITCH_OP(op, Op, {
       cpu::SpMMSumCsr<IdType, DType, Op>(bcast, csr, ufeat, efeat, out);
     });
-  } else if (reduce == "max" || reduce == "min") {
+  } else if (op == "max" || op == "min") {
     SWITCH_OP(op, Op, {
       if (reduce == "max")
         cpu::SpMMCmpCsr<IdType, DType, Op, cpu::op::Max<DType>>(
@@ -32,7 +32,7 @@ void SpMMCsr(const std::string& op, const std::string& reduce,
             bcast, csr, ufeat, efeat, out, out_aux[0], out_aux[1]);
     });
   } else {
-    LOG(FATAL) << "Unsupported SpMM reducer: " << reduce;
+    LOG(FATAL) << "Unsupported SpMM reducer: " << op;
   }
 }
 

--- a/src/array/cpu/spmm.cc
+++ b/src/array/cpu/spmm.cc
@@ -18,11 +18,11 @@ void SpMMCsr(const std::string& op, const std::string& reduce,
              NDArray efeat,
              NDArray out,
              std::vector<NDArray> out_aux) {
-  if (op == "sum") {
+  if (reduce == "sum") {
     SWITCH_OP(op, Op, {
       cpu::SpMMSumCsr<IdType, DType, Op>(bcast, csr, ufeat, efeat, out);
     });
-  } else if (op == "max" || op == "min") {
+  } else if (reduce == "max" || reduce == "min") {
     SWITCH_OP(op, Op, {
       if (reduce == "max")
         cpu::SpMMCmpCsr<IdType, DType, Op, cpu::op::Max<DType>>(
@@ -32,7 +32,7 @@ void SpMMCsr(const std::string& op, const std::string& reduce,
             bcast, csr, ufeat, efeat, out, out_aux[0], out_aux[1]);
     });
   } else {
-    LOG(FATAL) << "Unsupported SpMM reducer: " << op;
+    LOG(FATAL) << "Unsupported SpMM reducer: " << reduce;
   }
 }
 

--- a/src/array/cuda/functor.cuh
+++ b/src/array/cuda/functor.cuh
@@ -135,6 +135,15 @@ struct Sum {
       cuda::AtomicAdd(out_buf, val);
     }
   }
+  static __device__ __forceinline__ void Call(
+      DType *out_buf, Idx *arg_buf,
+      DType val, Idx id) {
+    if (!atomic) {
+      *out_buf += val;
+    } else {
+      cuda::AtomicAdd(out_buf, val);
+    }
+  }
   static __device__ __forceinline__ void CallArg(Idx fid,
     Idx *arg_u_buf, Idx *arg_e_buf,
     DType val, DType val_ref, Idx uid, Idx eid) {}
@@ -158,6 +167,18 @@ struct Max {
         *out_buf = val;
         *arg_u_buf = uid;
         *arg_e_buf = eid;
+      }
+    } else {
+      cuda::AtomicMax(out_buf, val);
+    }
+  }
+  static __device__ __forceinline__ void Call(
+      DType *out_buf, Idx *arg_buf,
+      DType val, Idx id) {
+    if (!atomic) {
+      if (*out_buf < val) {
+        *out_buf = val;
+        *arg_buf = id;
       }
     } else {
       cuda::AtomicMax(out_buf, val);
@@ -195,6 +216,18 @@ struct Min {
         *out_buf = val;
         *arg_u_buf = uid;
         *arg_e_buf = eid;
+      }
+    } else {
+      cuda::AtomicMin(out_buf, val);
+    }
+  }
+  static __device__ __forceinline__ void Call(
+      DType *out_buf, Idx *arg_buf,
+      DType val, Idx id) {
+    if (!atomic) {
+      if (*out_buf > val) {
+        *out_buf = val;
+        *arg_buf = id;
       }
     } else {
       cuda::AtomicMin(out_buf, val);

--- a/src/array/cuda/functor.cuh
+++ b/src/array/cuda/functor.cuh
@@ -6,6 +6,8 @@
 #ifndef DGL_ARRAY_CUDA_FUNCTOR_CUH_
 #define DGL_ARRAY_CUDA_FUNCTOR_CUH_
 
+#include "./atomic.cuh"
+
 namespace dgl {
 namespace aten {
 namespace cuda {

--- a/src/array/cuda/segment_reduce.cu
+++ b/src/array/cuda/segment_reduce.cu
@@ -34,10 +34,10 @@ void SegmentReduce(const std::string& op,
 }
 
 template <int XPU, typename IdType, typename DType>
-void SegmentBcast(NDArray feat,
-                  NDArray offsets,
-                  NDArray out) {
-  cuda::SegmentBcast<IdType, DType>(feat, offsets, out);
+void BackwardSegmentCmp(NDArray feat,
+                        NDArray arg,
+                        NDArray out) {
+  cuda::BackwardSegmentCmp<IdType, DType>(feat, arg, out);
 }
 
 template void SegmentReduce<kDLGPU, int32_t, float>(
@@ -64,21 +64,21 @@ template void SegmentReduce<kDLGPU, int64_t, double>(
     NDArray offsets,
     NDArray out,
     NDArray arg);
-template void SegmentBcast<kDLGPU, int32_t, float>(
+template void BackwardSegmentCmp<kDLGPU, int32_t, float>(
     NDArray feat,
-    NDArray offsets,
+    NDArray arg,
     NDArray out);
-template void SegmentBcast<kDLGPU, int64_t, float>(
+template void BackwardSegmentCmp<kDLGPU, int64_t, float>(
     NDArray feat,
-    NDArray offsets,
+    NDArray arg,
     NDArray out);
-template void SegmentBcast<kDLGPU, int32_t, double>(
+template void BackwardSegmentCmp<kDLGPU, int32_t, double>(
     NDArray feat,
-    NDArray offsets,
+    NDArray arg,
     NDArray out);
-template void SegmentBcast<kDLGPU, int64_t, double>(
+template void BackwardSegmentCmp<kDLGPU, int64_t, double>(
     NDArray feat,
-    NDArray offsets,
+    NDArray arg,
     NDArray out);
 
 }  // namespace aten

--- a/src/array/cuda/segment_reduce.cu
+++ b/src/array/cuda/segment_reduce.cu
@@ -1,0 +1,85 @@
+/*!
+ *  Copyright (c) 2020 by Contributors
+ * \file array/cuda/segment_reduce.cu
+ * \brief Segment reduce C APIs and definitions.
+ */
+#include <dgl/array.h>
+#include "./segment_reduce.cuh"
+#include "./functor.cuh"
+
+namespace dgl {
+
+using namespace cuda;
+
+namespace aten {
+
+template <int XPU, typename IdType, typename DType>
+void SegmentReduce(const std::string& op,
+                   NDArray feat,
+                   NDArray offsets,
+                   NDArray out,
+                   NDArray arg) {
+  if (op == "sum") {
+    cuda::SegmentReduce<IdType, DType, cuda::reduce::Sum<IdType, DType>>(
+        feat, offsets, out, arg);
+  } else if (op == "max") {
+    cuda::SegmentReduce<IdType, DType, cuda::reduce::Max<IdType, DType>>(
+        feat, offsets, out, arg);
+  } else if (op == "min") {
+    cuda::SegmentReduce<IdType, DType, cuda::reduce::Min<IdType, DType>>(
+        feat, offsets, out, arg);
+  } else {
+    LOG(FATAL) << "Not implemented";
+  }
+}
+
+template <int XPU, typename IdType, typename DType>
+void SegmentBcast(NDArray feat,
+                  NDArray offsets,
+                  NDArray out) {
+  cuda::SegmentBcast<IdType, DType>(feat, offsets, out);
+}
+
+template void SegmentReduce<kDLGPU, int32_t, float>(
+    const std::string& op,
+    NDArray feat,
+    NDArray offsets,
+    NDArray out,
+    NDArray arg);
+template void SegmentReduce<kDLGPU, int64_t, float>(
+    const std::string &op,
+    NDArray feat,
+    NDArray offsets,
+    NDArray out,
+    NDArray arg);
+template void SegmentReduce<kDLGPU, int32_t, double>(
+    const std::string &op,
+    NDArray feat,
+    NDArray offsets,
+    NDArray out,
+    NDArray arg);
+template void SegmentReduce<kDLGPU, int64_t, double>(
+    const std::string &op,
+    NDArray feat,
+    NDArray offsets,
+    NDArray out,
+    NDArray arg);
+template void SegmentBcast<kDLGPU, int32_t, float>(
+    NDArray feat,
+    NDArray offsets,
+    NDArray out);
+template void SegmentBcast<kDLGPU, int64_t, float>(
+    NDArray feat,
+    NDArray offsets,
+    NDArray out);
+template void SegmentBcast<kDLGPU, int32_t, double>(
+    NDArray feat,
+    NDArray offsets,
+    NDArray out);
+template void SegmentBcast<kDLGPU, int64_t, double>(
+    NDArray feat,
+    NDArray offsets,
+    NDArray out);
+
+}  // namespace aten
+}  // namespace dgl

--- a/src/array/cuda/segment_reduce.cuh
+++ b/src/array/cuda/segment_reduce.cuh
@@ -6,6 +6,9 @@
 #ifndef DGL_ARRAY_SEGMENT_REDUCE_CUH_
 #define DGL_ARRAY_SEGMENT_REDUCE_CUH_
 
+#include "../../runtime/cuda/cuda_common.h"
+#include "./utils.h"
+
 namespace dgl {
 
 using namespace cuda;
@@ -16,14 +19,64 @@ namespace cuda {
 /*!
  * \brief CUDA kernel of segment reduce.
  */
-template <typename Idx, typename DType,
+template <typename IdType, typename DType,
           typename ReduceOp>
 __global__ void SegmentReduceKernel(
-  const DType* array,
-  const Idx* offset,
-  DType* out){
+    const DType* feat, const IdType* offsets,
+    DType* out, IdType* arg,
+    int64_t n, int64_t dim){
+  // TODO(zihao)
 }
 
+/*!
+ * \brief CUDA kernel of segment broadcast.
+ */
+template <typename IdType, typename DType, typename ReduceOp>
+__global__ void SegmentBcastKernel(
+    const DType* feat, const IdType* offsets,
+    DType* out,
+    int64_t n, int64_t dim) {
+  // TODO(zihao)
+}
+
+template <typename IdType, typename DType, typename ReduceOp>
+void SegmentReduce(
+    NDArray feat,
+    NDArray offsets,
+    NDArray out,
+    NDArray arg) {
+  const DType* feat_data = feat.Ptr<DType>();
+  const IdType* offsets_data = offsets.Ptr<IdType>();
+  DType* out_data = out.Ptr<DType>();
+  IdType* arg_data = arg.Ptr<IdType>();
+
+  auto* thr_entry = runtime::CUDAThreadEntry::ThreadLocal();
+  int64_t n = out->shape[0];
+  int64_t dim = 1;
+  for (int i = 1; i < out->ndim; ++i)
+    dim *= out->shape[i];
+  const int nbx = 1;
+  const int nby = 1;
+  const int ntx = 1;
+  const int nty = 1;
+  const dim3 nblks(nbx, nby);
+  const dim3 nthrs(ntx, nty);
+  CUDA_KERNEL_CALL((SegmentReduceKernel<IdType, DType, ReduceOp>),
+      nblks, nthrs, 0, thr_entry->stream,
+      feat_data, offsets_data, out_data, arg_data,
+      n, dim);
+}
+
+template <typename IdType, typename DType>
+void SegmentBcast(
+    NDArray feat,
+    NDArray offsets,
+    NDArray out) {
+  const DType *feat_data = feat.Ptr<DType>();
+  const IdType *offsets_data = offsets.Ptr<IdType>();
+  DType *out_data = out.Ptr<DType>();
+  // TODO(zihao)
+}
 
 }  // namespace cuda
 }  // namespace aten

--- a/src/array/cuda/segment_reduce.cuh
+++ b/src/array/cuda/segment_reduce.cuh
@@ -1,0 +1,32 @@
+/*!
+ *  Copyright (c) 2020 by Contributors
+ * \file array/cuda/segment_reduce.cuh
+ * \brief Segment reduce kernel function header.
+ */
+#ifndef DGL_ARRAY_SEGMENT_REDUCE_CUH_
+#define DGL_ARRAY_SEGMENT_REDUCE_CUH_
+
+namespace dgl {
+
+using namespace cuda;
+
+namespace aten {
+namespace cuda {
+
+/*!
+ * \brief CUDA kernel of segment reduce.
+ */
+template <typename Idx, typename DType,
+          typename ReduceOp>
+__global__ void SegmentReduceKernel(
+  const DType* array,
+  const Idx* offset,
+  DType* out){
+}
+
+
+}  // namespace cuda
+}  // namespace aten
+}  // namespace dgl
+
+#endif

--- a/src/array/cuda/segment_reduce.cuh
+++ b/src/array/cuda/segment_reduce.cuh
@@ -50,9 +50,7 @@ __global__ void BackwardSegmentCmpKernel(
   int row = blockIdx.x;
   int col = blockIdx.y * blockDim.x + threadIdx.x;
   if (col < dim) {
-    cuda::AtomicAdd(
-        out + arg[row * dim + col] * dim + col,
-        feat[row * dim + col]);
+    out[arg[row * dim + col] * dim + col] = feat[row * dim + col]);
   }
 }
 

--- a/src/array/cuda/segment_reduce.cuh
+++ b/src/array/cuda/segment_reduce.cuh
@@ -7,6 +7,7 @@
 #define DGL_ARRAY_SEGMENT_REDUCE_CUH_
 
 #include "../../runtime/cuda/cuda_common.h"
+#include "./atomic.cuh"
 #include "./utils.h"
 
 namespace dgl {
@@ -40,14 +41,19 @@ __global__ void SegmentReduceKernel(
 }
 
 /*!
- * \brief CUDA kernel of segment broadcast.
+ * \brief CUDA kernel of segment reduce.
  */
-template <typename IdType, typename DType, typename ReduceOp>
-__global__ void SegmentBcastKernel(
-    const DType* feat, const IdType* offsets,
-    DType* out,
+template <typename IdType, typename DType>
+__global__ void BackwardSegmentCmpKernel(
+    const DType *feat, const IdType *arg, DType *out,
     int64_t n, int64_t dim) {
-  // TODO(zihao)
+  int row = blockIdx.x;
+  int col = blockIdx.y * blockDim.x + threadIdx.x;
+  if (col < dim) {
+    cuda::AtomicAdd(
+        out + arg[row * dim + col] * dim + col,
+        feat[row * dim + col]);
+  }
 }
 
 template <typename IdType, typename DType, typename ReduceOp>
@@ -80,14 +86,30 @@ void SegmentReduce(
 }
 
 template <typename IdType, typename DType>
-void SegmentBcast(
+void BackwardSegmentCmp(
     NDArray feat,
-    NDArray offsets,
+    NDArray arg,
     NDArray out) {
-  const DType *feat_data = feat.Ptr<DType>();
-  const IdType *offsets_data = offsets.Ptr<IdType>();
+  const DType* feat_data = feat.Ptr<DType>();
+  const IdType* arg_data = arg.Ptr<IdType>();
   DType *out_data = out.Ptr<DType>();
-  // TODO(zihao)
+
+  auto *thr_entry = runtime::CUDAThreadEntry::ThreadLocal();
+  int64_t n = out->shape[0];
+  int64_t dim = 1;
+  for (int i = 1; i < out->ndim; ++i)
+    dim *= out->shape[i];
+
+  const int nbx = n;
+  const int ntx = FindNumThreads(dim);
+  const int nby = (dim + ntx - 1) / ntx;
+  const int nty = 1;
+  const dim3 nblks(nbx, nby);
+  const dim3 nthrs(ntx, nty);
+  CUDA_KERNEL_CALL((BackwardSegmentCmpKernel<IdType, DType>),
+                   nblks, nthrs, 0, thr_entry->stream,
+                   feat_data, arg_data, out_data,
+                   n, dim);
 }
 
 }  // namespace cuda

--- a/src/array/kernel.cc
+++ b/src/array/kernel.cc
@@ -202,7 +202,7 @@ DGL_REGISTER_GLOBAL("sparse._CAPI_DGLKernelSDDMM")
     SDDMM(op, graph.sptr(), lhs, rhs, out, lhs_target, rhs_target);
   });
 
-DGL_REGISTER_GLOBAL("sparse._CAPI_DGLSegmentReduce")
+DGL_REGISTER_GLOBAL("sparse._CAPI_DGLKernelSegmentReduce")
 .set_body([] (DGLArgs args, DGLRetValue* rv) {
     const std::string op = args[0];
     NDArray feat = args[1];
@@ -214,7 +214,7 @@ DGL_REGISTER_GLOBAL("sparse._CAPI_DGLSegmentReduce")
     SegmentReduceDispatch(op, feat, offsets, out, arg);
   });
 
-DGL_REGISTER_GLOBAL("sparse._CAPI_DGLSegmentBcast")
+DGL_REGISTER_GLOBAL("sparse._CAPI_DGLKernelSegmentBcast")
 .set_body([](DGLArgs args, DGLRetValue *rv) {
     NDArray feat = args[0];
     NDArray offsets = args[1];

--- a/src/array/kernel_decl.h
+++ b/src/array/kernel_decl.h
@@ -66,6 +66,24 @@ void SDDMMCoo(const std::string& op,
               int lhs_target,
               int rhs_target);
 
+/*!
+ * \brief Segment reduce.
+ */
+template <int XPU, typename IdType, typename DType>
+void SegmentReduce(const std::string& op,
+                   NDArray feat,
+                   NDArray offsets,
+                   NDArray out,
+                   NDArray arg);
+
+/*
+ * \brief
+ */
+template <int XPU, typename IdType, typename DType>
+void SegmentBcast(NDArray feat,
+                  NDArray offsets,
+                  NDArray out);
+
 }  // namespace aten
 }  // namespace dgl
 

--- a/src/array/kernel_decl.h
+++ b/src/array/kernel_decl.h
@@ -76,13 +76,13 @@ void SegmentReduce(const std::string& op,
                    NDArray out,
                    NDArray arg);
 
-/*
- * \brief
+/*!
+ * \brief Backward function of segment cmp.
  */
 template <int XPU, typename IdType, typename DType>
-void SegmentBcast(NDArray feat,
-                  NDArray offsets,
-                  NDArray out);
+void BackwardSegmentCmp(NDArray feat,
+                        NDArray arg,
+                        NDArray out);
 
 }  // namespace aten
 }  // namespace dgl

--- a/tests/compute/test_sparse.py
+++ b/tests/compute/test_sparse.py
@@ -75,7 +75,8 @@ graphs = [
 ]
 
 spmm_shapes = [
-    ((1, 2, 1, 3, 1), (4, 1, 3, 1, 1)),
+#    ((8, 128), (8, 1)),
+#    ((1, 2, 1, 3, 1), (4, 1, 3, 1, 1)),
     ((3, 3), (1, 3)),
     ((1,), (3,)),
     ((3,), (1,)),
@@ -255,5 +256,9 @@ def test_edge_softmax(g, norm_by, shp, idtype):
         assert F.allclose(F.grad(e2), grad_edata)
         print('backward passed')
 
+@parametrize_dtype
+def test_segment_reduce(idtype):
+    pass
+
 if __name__ == '__main__':
-    test_spmm(F.int32, graphs[0], spmm_shapes[5], 'copy_lhs', 'sum')
+    test_spmm(F.int32, graphs[0], spmm_shapes[0], 'mul', 'sum')

--- a/tests/compute/test_sparse.py
+++ b/tests/compute/test_sparse.py
@@ -1,4 +1,4 @@
-from dgl.ops import gspmm, gsddmm, edge_softmax
+from dgl.ops import gspmm, gsddmm, edge_softmax, segment_reduce
 from test_utils.graph_cases import get_cases
 from utils import parametrize_dtype
 import dgl
@@ -75,8 +75,7 @@ graphs = [
 ]
 
 spmm_shapes = [
-#    ((8, 128), (8, 1)),
-#    ((1, 2, 1, 3, 1), (4, 1, 3, 1, 1)),
+    ((1, 2, 1, 3, 1), (4, 1, 3, 1, 1)),
     ((3, 3), (1, 3)),
     ((1,), (3,)),
     ((3,), (1,)),
@@ -256,9 +255,34 @@ def test_edge_softmax(g, norm_by, shp, idtype):
         assert F.allclose(F.grad(e2), grad_edata)
         print('backward passed')
 
-@parametrize_dtype
-def test_segment_reduce(idtype):
-    pass
+@pytest.mark.parametrize('reducer', ['sum', 'max', 'min', 'mean'])
+def test_segment_reduce(reducer):
+    ctx = F.ctx()
+    value = F.tensor(np.random.rand(10, 5))
+    v1 = F.attach_grad(F.clone(value))
+    v2 = F.attach_grad(F.clone(value))
+    seglen = F.tensor([2, 3, 0, 4, 1])
+    u = F.copy_to(F.arange(0, F.shape(value)[0], F.int32), ctx)
+    v = F.repeat(F.copy_to(F.arange(0, len(seglen), F.int32), ctx),
+                 seglen, dim=0)
+
+    num_nodes = {'_U': len(u), '_V': len(seglen)}
+    g = dgl.convert.heterograph({('_U', '_E', '_V'): (u, v)}, num_nodes_dict=num_nodes)
+    with F.record_grad():
+        rst1 = gspmm(g, 'copy_lhs', reducer, v1, None)
+        F.backward(F.reduce_sum(rst1))
+        grad1 = F.grad(v1)
+
+    with F.record_grad():
+        rst2 = segment_reduce(seglen, v2, reducer=reducer)
+        F.backward(F.reduce_sum(rst2))
+        assert F.allclose(rst1, rst2)
+        print('forward passed')
+
+        grad2 = F.grad(v2)
+        assert F.allclose(grad1, grad2)
+        print('backward passed')
+
 
 if __name__ == '__main__':
     test_spmm(F.int32, graphs[0], spmm_shapes[0], 'mul', 'sum')


### PR DESCRIPTION
## Description
Previously we created a pseudo graph and applied SpMM to get graph readout results, and introduced graph creation overhead. Thus PR implements segment operators to lower this (and corresponding coo/csr conversion) overhead.

## Checklist
Please feel free to remove inapplicable items for your PR.
- [x] The PR title starts with [$CATEGORY] (such as [NN], [Model], [Doc], [Feature]])
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage
- [x] Code is well-documented
- [x] To the my best knowledge, examples are either not affected by this change,
      or have been fixed to be compatible with this change
- [x] Related issue is referred in this PR