### PR TITLE
[hotfix] Disable gespmm because of performance degredation in g3 instance.

### DIFF
--- a/src/array/cuda/spmm.cu
+++ b/src/array/cuda/spmm.cu
@@ -244,14 +244,7 @@ void SpMMCsr(const std::string& op, const std::string& reduce,
   bool use_efeat = op != "copy_lhs";
 
   if (reduce == "sum") {
-    if ((!use_efeat || is_scalar_efeat) && feat_len > 64) {  // ge-spmm
-      if (use_efeat && !IsNullArray(csr.data))  // reorder edge data
-        efeat = IndexSelect(efeat, csr.data);
-      SWITCH_OP(op, Op, {
-        cuda::GESpMMCsr<IdType, DType, Op>(
-          csr, ufeat, efeat, out, feat_len);
-      });
-    } else if (sizeof(IdType) == 4 && op == "copy_lhs") {  // cusparse
+    if (sizeof(IdType) == 4 && op == "copy_lhs") {  // cusparse
       int64_t x_length = 1;
       for (int i = 1; i < ufeat->ndim; ++i)
         x_length *= ufeat->shape[i];


### PR DESCRIPTION
## Description
On g3 instance the performance of gespmm is 2x slower than cusparse.

## Checklist
Please feel free to remove inapplicable items for your PR.
- [x] The PR title starts with [$CATEGORY] (such as [NN], [Model], [Doc], [Feature]])
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage
- [x] Code is well-documented
- [x] To the my best knowledge, examples are either not affected by this change,
      or have been fixed to be compatible with this change
- [x] Related issue is referred in this PR

