### PR TITLE
[Doc, UG, Tutorial] Misc Fix

### DIFF
--- a/docs/source/guide/training-edge.rst
+++ b/docs/source/guide/training-edge.rst
@@ -3,8 +3,7 @@
 5.2 Edge Classification/Regression
 ---------------------------------------------
 
-Sometimes you wish to predict the attributes on the edges of the graph,
-or even whether an edge exists or not between two given nodes. In that
+Sometimes you wish to predict the attributes on the edges of the graph. In that
 case, you would like to have an *edge classification/regression* model.
 
 Here we generate a random graph for edge prediction as a demonstration.

--- a/python/dgl/convert.py
+++ b/python/dgl/convert.py
@@ -259,6 +259,8 @@ def heterograph(data_dict,
        formats and chooses the most efficient one depending on the computation invoked.
        If memory usage becomes an issue in the case of large graphs, use
        :func:`dgl.DGLGraph.formats` to restrict the allowed formats.
+    4. DGL internally decides a deterministic order for the same set of node types and canonical
+       edge types, which does not necessarily follow the order in :attr:`data_dict`.
 
     Examples
     --------

--- a/tutorials/basics/1_first.py
+++ b/tutorials/basics/1_first.py
@@ -64,7 +64,7 @@ def build_karate_club_graph():
     u = np.concatenate([src, dst])
     v = np.concatenate([dst, src])
     # Construct a DGLGraph
-    return dgl.DGLGraph((u, v))
+    return dgl.graph((u, v))
 
 ###############################################################################
 # Print out the number of nodes and edges in our newly constructed graph:

--- a/tutorials/models/1_gnn/1_gcn.py
+++ b/tutorials/models/1_gnn/1_gcn.py
@@ -49,7 +49,7 @@ import torch.nn as nn
 import torch.nn.functional as F
 from dgl import DGLGraph
 
-gcn_msg = fn.copy_src(src='h', out='m')
+gcn_msg = fn.copy_u(src='h', out='m')
 gcn_reduce = fn.sum(msg='m', out='h')
 
 ###############################################################################

--- a/tutorials/models/1_gnn/1_gcn.py
+++ b/tutorials/models/1_gnn/1_gcn.py
@@ -49,7 +49,7 @@ import torch.nn as nn
 import torch.nn.functional as F
 from dgl import DGLGraph
 
-gcn_msg = fn.copy_u(src='h', out='m')
+gcn_msg = fn.copy_u(u='h', out='m')
 gcn_reduce = fn.sum(msg='m', out='h')
 
 ###############################################################################

--- a/tutorials/models/1_gnn/1_gcn.py
+++ b/tutorials/models/1_gnn/1_gcn.py
@@ -95,15 +95,14 @@ print(net)
 ###############################################################################
 # We load the cora dataset using DGL's built-in data module.
 
-from dgl.data import citation_graph as citegrh
-import networkx as nx
+from dgl.data import CoraGraphDataset
 def load_cora_data():
-    data = citegrh.load_cora()
-    features = th.FloatTensor(data.features)
-    labels = th.LongTensor(data.labels)
-    train_mask = th.BoolTensor(data.train_mask)
-    test_mask = th.BoolTensor(data.test_mask)
-    g = DGLGraph(data.graph)
+    dataset = CoraGraphDataset()
+    g = dataset[0]
+    features = g.ndata['feat']
+    labels = g.ndata['label']
+    train_mask = g.ndata['train_mask']
+    test_mask = g.ndata['test_mask']
     return g, features, labels, train_mask, test_mask
 
 ###############################################################################


### PR DESCRIPTION
## Description
1. The documentation of `heterograph` now mentions that DGL internally decides a deterministic order for node types and canonical edge types, which does not necessarily follow the order in `data_dict` argument. This has been requested by [thread 1555](https://discuss.dgl.ai/t/whta-is-the-order-of-c-etype-in-hetero-graph/1555/3).
2. Replace deprecated APIs (`dgl.DGLGraph`, `dgl.function.copy_u`, `dgl.data.citation_graph.load_cora`) in the tutorial and user guide.
3. The user guide section on edge classification/regression should not mention "or even whether an edge exists or not between two given nodes" as the scenario is for link prediction.

## Checklist
Please feel free to remove inapplicable items for your PR.
- [x] The PR title starts with [$CATEGORY] (such as [NN], [Model], [Doc], [Feature]])
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage
- [x] Code is well-documented
- [x] To the my best knowledge, examples are either not affected by this change,
      or have been fixed to be compatible with this change
- [x] Related issue is referred in this PR