### PR TITLE
[Doc] Some functions used in the tutorial are deprecated

### DIFF
--- a/tutorials/basics/3_pagerank.py.bak
+++ b/tutorials/basics/3_pagerank.py.bak
@@ -96,8 +96,6 @@ def pagerank_reduce_func(nodes):
 #
 # .. image:: https://i.imgur.com/kIMiuFb.png
 #
-# Register the message function and reduce function, which will be called
-# later by DGL.
 
 ###############################################################################
 # The algorithm is straightforward. Here is the code for one

--- a/tutorials/basics/3_pagerank.py.bak
+++ b/tutorials/basics/3_pagerank.py.bak
@@ -99,10 +99,6 @@ def pagerank_reduce_func(nodes):
 # Register the message function and reduce function, which will be called
 # later by DGL.
 
-g.register_message_func(pagerank_message_func)
-g.register_reduce_func(pagerank_reduce_func)
-
-
 ###############################################################################
 # The algorithm is straightforward. Here is the code for one
 # PageRank iteration.
@@ -110,10 +106,10 @@ g.register_reduce_func(pagerank_reduce_func)
 def pagerank_naive(g):
     # Phase #1: send out messages along all edges.
     for u, v in zip(*g.edges()):
-        g.send((u, v))
+        g.send((u, v), pagerank_message_func)
     # Phase #2: receive messages to compute new PageRank values.
     for v in g.nodes():
-        g.recv(v)
+        g.recv(v, pagerank_reduce_func)
 
 
 ###############################################################################
@@ -125,8 +121,8 @@ def pagerank_naive(g):
 # on multiple nodes and edges at one time.
 
 def pagerank_batch(g):
-    g.send(g.edges())
-    g.recv(g.nodes())
+    g.send(g.edges(), pagerank_message_func)
+    g.recv(g.nodes(), pagerank_reduce_func)
 
 
 ###############################################################################


### PR DESCRIPTION
I'm receiving register_message_func and register_reduce_func are deprecated error. I have updated the code such that message and reduce functions are passed to g.send and g.recv

## Description
<!-- Brief description. Refer to the related issues if existed.
It'll be great if relevant reviewers can be assigned as well.-->

## Checklist
Please feel free to remove inapplicable items for your PR.
- [x] The PR title starts with [$CATEGORY] (such as [NN], [Model], [Doc], [Feature]])
- [x] Changes are complete (i.e. I finished coding on this PR)
- [ ] All changes have test coverage
- [x] Code is well-documented
- [ ] To the my best knowledge, examples are either not affected by this change,
      or have been fixed to be compatible with this change
- [x] Related issue is referred in this PR

## Changes
<!-- You could use following template
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)
-->
