### PR TITLE
[Rpc] change msg_seq from int to int_64

### DIFF
--- a/src/rpc/rpc.cc
+++ b/src/rpc/rpc.cc
@@ -380,7 +380,7 @@ DGL_REGISTER_GLOBAL("distributed.rpc._CAPI_DGLRPCFastPull")
   int group_count = args[3];
   int client_id = args[4];
   int service_id = args[5];
-  int msg_seq = args[6];
+  int64_t msg_seq = args[6];
   std::string pickle_data = args[7];
   NDArray ID = args[8];
   NDArray part_id = args[9];


### PR DESCRIPTION
## Description

change msg_seq from int to int_64 to avoid potential bugs.

## Checklist
Please feel free to remove inapplicable items for your PR.
- [ ] The PR title starts with [$CATEGORY] (such as [NN], [Model], [Doc], [Feature]])
- [ ] Changes are complete (i.e. I finished coding on this PR)
- [ ] All changes have test coverage
- [ ] Code is well-documented
- [ ] To the my best knowledge, examples are either not affected by this change,
      or have been fixed to be compatible with this change
- [ ] Related issue is referred in this PR

## Changes
<!-- You could use following template
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)
-->
