### PR TITLE
[Performance][Hotfix] Disable openmp in arithmetic operation

### DIFF
--- a/src/array/cpu/array_op_impl.cc
+++ b/src/array/cpu/array_op_impl.cc
@@ -48,8 +48,9 @@ IdArray BinaryElewise(IdArray lhs, IdArray rhs) {
   const IdType* lhs_data = static_cast<IdType*>(lhs->data);
   const IdType* rhs_data = static_cast<IdType*>(rhs->data);
   IdType* ret_data = static_cast<IdType*>(ret->data);
-  // TODO(minjie): we should split the loop into segments for better cache locality.
-#pragma omp parallel for
+  // TODO(BarclayII): this usually incurs lots of overhead in thread spawning, scheduling,
+  // etc., especially since the workload is very light.
+//#pragma omp parallel for
   for (int64_t i = 0; i < lhs->shape[0]; ++i) {
     ret_data[i] = Op::Call(lhs_data[i], rhs_data[i]);
   }
@@ -84,8 +85,9 @@ IdArray BinaryElewise(IdArray lhs, IdType rhs) {
   IdArray ret = NewIdArray(lhs->shape[0], lhs->ctx, lhs->dtype.bits);
   const IdType* lhs_data = static_cast<IdType*>(lhs->data);
   IdType* ret_data = static_cast<IdType*>(ret->data);
-  // TODO(minjie): we should split the loop into segments for better cache locality.
-#pragma omp parallel for
+  // TODO(BarclayII): this usually incurs lots of overhead in thread spawning, scheduling,
+  // etc., especially since the workload is very light.
+//#pragma omp parallel for
   for (int64_t i = 0; i < lhs->shape[0]; ++i) {
     ret_data[i] = Op::Call(lhs_data[i], rhs);
   }
@@ -120,8 +122,9 @@ IdArray BinaryElewise(IdType lhs, IdArray rhs) {
   IdArray ret = NewIdArray(rhs->shape[0], rhs->ctx, rhs->dtype.bits);
   const IdType* rhs_data = static_cast<IdType*>(rhs->data);
   IdType* ret_data = static_cast<IdType*>(ret->data);
-  // TODO(minjie): we should split the loop into segments for better cache locality.
-#pragma omp parallel for
+  // TODO(BarclayII): this usually incurs lots of overhead in thread spawning, scheduling,
+  // etc., especially since the workload is very light.
+//#pragma omp parallel for
   for (int64_t i = 0; i < rhs->shape[0]; ++i) {
     ret_data[i] = Op::Call(lhs, rhs_data[i]);
   }
@@ -156,8 +159,9 @@ IdArray UnaryElewise(IdArray lhs) {
   IdArray ret = NewIdArray(lhs->shape[0], lhs->ctx, lhs->dtype.bits);
   const IdType* lhs_data = static_cast<IdType*>(lhs->data);
   IdType* ret_data = static_cast<IdType*>(ret->data);
-  // TODO(minjie): we should split the loop into segments for better cache locality.
-#pragma omp parallel for
+  // TODO(BarclayII): this usually incurs lots of overhead in thread spawning, scheduling,
+  // etc., especially since the workload is very light.
+//#pragma omp parallel for
   for (int64_t i = 0; i < lhs->shape[0]; ++i) {
     ret_data[i] = Op::Call(lhs_data[i]);
   }

--- a/src/array/cpu/array_op_impl.cc
+++ b/src/array/cpu/array_op_impl.cc
@@ -49,7 +49,7 @@ IdArray BinaryElewise(IdArray lhs, IdArray rhs) {
   const IdType* rhs_data = static_cast<IdType*>(rhs->data);
   IdType* ret_data = static_cast<IdType*>(ret->data);
   // TODO(BarclayII): this usually incurs lots of overhead in thread spawning, scheduling,
-  // etc., especially since the workload is very light.
+  // etc., especially since the workload is very light.  Need to replace with parallel_for.
 // #pragma omp parallel for
   for (int64_t i = 0; i < lhs->shape[0]; ++i) {
     ret_data[i] = Op::Call(lhs_data[i], rhs_data[i]);
@@ -86,7 +86,7 @@ IdArray BinaryElewise(IdArray lhs, IdType rhs) {
   const IdType* lhs_data = static_cast<IdType*>(lhs->data);
   IdType* ret_data = static_cast<IdType*>(ret->data);
   // TODO(BarclayII): this usually incurs lots of overhead in thread spawning, scheduling,
-  // etc., especially since the workload is very light.
+  // etc., especially since the workload is very light.  Need to replace with parallel_for.
 // #pragma omp parallel for
   for (int64_t i = 0; i < lhs->shape[0]; ++i) {
     ret_data[i] = Op::Call(lhs_data[i], rhs);
@@ -123,7 +123,7 @@ IdArray BinaryElewise(IdType lhs, IdArray rhs) {
   const IdType* rhs_data = static_cast<IdType*>(rhs->data);
   IdType* ret_data = static_cast<IdType*>(ret->data);
   // TODO(BarclayII): this usually incurs lots of overhead in thread spawning, scheduling,
-  // etc., especially since the workload is very light.
+  // etc., especially since the workload is very light.  Need to replace with parallel_for.
 // #pragma omp parallel for
   for (int64_t i = 0; i < rhs->shape[0]; ++i) {
     ret_data[i] = Op::Call(lhs, rhs_data[i]);
@@ -160,7 +160,7 @@ IdArray UnaryElewise(IdArray lhs) {
   const IdType* lhs_data = static_cast<IdType*>(lhs->data);
   IdType* ret_data = static_cast<IdType*>(ret->data);
   // TODO(BarclayII): this usually incurs lots of overhead in thread spawning, scheduling,
-  // etc., especially since the workload is very light.
+  // etc., especially since the workload is very light.  Need to replace with parallel_for.
 // #pragma omp parallel for
   for (int64_t i = 0; i < lhs->shape[0]; ++i) {
     ret_data[i] = Op::Call(lhs_data[i]);

--- a/src/array/cpu/array_op_impl.cc
+++ b/src/array/cpu/array_op_impl.cc
@@ -50,7 +50,7 @@ IdArray BinaryElewise(IdArray lhs, IdArray rhs) {
   IdType* ret_data = static_cast<IdType*>(ret->data);
   // TODO(BarclayII): this usually incurs lots of overhead in thread spawning, scheduling,
   // etc., especially since the workload is very light.
-//#pragma omp parallel for
+// #pragma omp parallel for
   for (int64_t i = 0; i < lhs->shape[0]; ++i) {
     ret_data[i] = Op::Call(lhs_data[i], rhs_data[i]);
   }
@@ -87,7 +87,7 @@ IdArray BinaryElewise(IdArray lhs, IdType rhs) {
   IdType* ret_data = static_cast<IdType*>(ret->data);
   // TODO(BarclayII): this usually incurs lots of overhead in thread spawning, scheduling,
   // etc., especially since the workload is very light.
-//#pragma omp parallel for
+// #pragma omp parallel for
   for (int64_t i = 0; i < lhs->shape[0]; ++i) {
     ret_data[i] = Op::Call(lhs_data[i], rhs);
   }
@@ -124,7 +124,7 @@ IdArray BinaryElewise(IdType lhs, IdArray rhs) {
   IdType* ret_data = static_cast<IdType*>(ret->data);
   // TODO(BarclayII): this usually incurs lots of overhead in thread spawning, scheduling,
   // etc., especially since the workload is very light.
-//#pragma omp parallel for
+// #pragma omp parallel for
   for (int64_t i = 0; i < rhs->shape[0]; ++i) {
     ret_data[i] = Op::Call(lhs, rhs_data[i]);
   }
@@ -161,7 +161,7 @@ IdArray UnaryElewise(IdArray lhs) {
   IdType* ret_data = static_cast<IdType*>(ret->data);
   // TODO(BarclayII): this usually incurs lots of overhead in thread spawning, scheduling,
   // etc., especially since the workload is very light.
-//#pragma omp parallel for
+// #pragma omp parallel for
   for (int64_t i = 0; i < lhs->shape[0]; ++i) {
     ret_data[i] = Op::Call(lhs_data[i]);
   }


### PR DESCRIPTION
## Description
Currently we parallelize DGL's arithmetic operations using OpenMP.  However the workload size of those operations are usually very light:
* For Benchmarking GNNs, the workload size is around 10k for SBM-PATTERN 100k experiments, and less than 100 for ZINC 100k experiments.
* For OGB products, the workload size is usually 1.

Using OpenMP to parallelize these operations will incur lots of overhead in thread spawning and scheduling, which is the main reason why Benchmarking GNNs experiments slowed down in 0.5+, especially in parallel experiments.

Here is the comparison of training time (seconds per epoch) on a g3.16x AWS instance between removing and keeping the OpenMP routines in Benchmarking GNNs experiments and OGB experiments:

```
		0.4.2	0.5.3	0.5.3 No OMP
ZINC
GCN		2.1130	2.4221	2.1997
GAT		3.3316	3.2240	2.9484
SAGE		2.3838	2.4674	2.2154
GIN		3.0113	3.2034	3.0296
GGCN		4.1356	6.2027	4.2853
MoNet		2.9530	3.0451	2.8517

SBM
GCN		29.5327	18.6368	16.6338
GAT		84.6075	33.3924	23.4785
SAGE		38.2151	17.8404	14.2021
GIN		32.2307	25.8041	19.7009
GGCN		207.929	177.431	175.144
MoNet		110.498	32.5692	31.5179

OGB-Products
SAGE (4 workers)	37.6392	40.5491
GAT (4 workers)		216.969	198.433
SAGE (0 workers)	56.5372	59.1538
GAT (0 workers)		131.085	117.392

OGB-Arxiv
GCN			0.8707	0.9196
```

Later on, we should replace all OpenMP parallel loops with PyTorch's `parallel_for` construct as mentioned in #2408 .