### PR TITLE
[RPC] Make the port reusable after the socket is closed.

### DIFF
--- a/src/rpc/network/tcp_socket.cc
+++ b/src/rpc/network/tcp_socket.cc
@@ -30,6 +30,11 @@ TCPSocket::TCPSocket() {
   if (socket_ < 0) {
     LOG(FATAL) << "Can't create new socket. Errno=" << errno;
   }
+  // This is to make sure the same port can be reused right after the socket is closed.
+  int enable = 1;
+  if (setsockopt(socket_, SOL_SOCKET, SO_REUSEADDR, &enable, sizeof(int)) < 0) {
+    LOG(WARNING) << "cannot make the socket reusable. Errno=" << errno;
+  }
 }
 
 TCPSocket::~TCPSocket() {

--- a/src/rpc/network/tcp_socket.cc
+++ b/src/rpc/network/tcp_socket.cc
@@ -30,11 +30,13 @@ TCPSocket::TCPSocket() {
   if (socket_ < 0) {
     LOG(FATAL) << "Can't create new socket. Errno=" << errno;
   }
+#ifndef _WIN32
   // This is to make sure the same port can be reused right after the socket is closed.
   int enable = 1;
   if (setsockopt(socket_, SOL_SOCKET, SO_REUSEADDR, &enable, sizeof(int)) < 0) {
     LOG(WARNING) << "cannot make the socket reusable. Errno=" << errno;
   }
+#endif  // _WIN32
 }
 
 TCPSocket::~TCPSocket() {


### PR DESCRIPTION
## Description
Currently, when a socket that binds to a port is closed, the socket cannot be reused for a few minutes. This is because the closed socket is in a wait status in the Linux kernel. More details can be found here: https://hea-www.harvard.edu/~fine/Tech/addrinuse.html
The fix is to make the socket reusable after the socket is closed.

## Checklist
Please feel free to remove inapplicable items for your PR.
- [ ] The PR title starts with [$CATEGORY] (such as [NN], [Model], [Doc], [Feature]])
- [ ] Changes are complete (i.e. I finished coding on this PR)
- [ ] All changes have test coverage
- [ ] Code is well-documented
- [ ] To the my best knowledge, examples are either not affected by this change,
      or have been fixed to be compatible with this change
- [ ] Related issue is referred in this PR

## Changes
<!-- You could use following template
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)
-->
