### PR TITLE
[hotfix] Make USE_AVX a flag in cmake to avoid compilation error for arm user

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,6 +24,7 @@ endif()
 # Alernatively, use cmake -DOPTION=VALUE through command-line.
 dgl_option(USE_CUDA "Build with CUDA" OFF)
 dgl_option(USE_OPENMP "Build with OpenMP" ON)
+dgl_option(USE_AVX "Build with AVX optimization" OFF)
 dgl_option(BUILD_CPP_TEST "Build cpp unittest executables" OFF)
 dgl_option(LIBCXX_ENABLE_PARALLEL_ALGORITHMS "Enable the parallel algorithms library. This requires the PSTL to be available." OFF)
 dgl_option(USE_S3 "Build with S3 support" OFF)
@@ -107,6 +108,10 @@ if(USE_OPENMP)
     set(CMAKE_CXX_FLAGS "${OpenMP_CXX_FLAGS} ${CMAKE_CXX_FLAGS}")
   endif(OPENMP_FOUND)
 endif(USE_OPENMP)
+
+if(USE_AVX)
+  add_compile_definitions(WITH_AVX)
+endif(USE_AVX)
 
 # To compile METIS correct for DGL.
 if(MSVC)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -110,7 +110,7 @@ if(USE_OPENMP)
 endif(USE_OPENMP)
 
 if(USE_AVX)
-  add_compile_definitions(WITH_AVX)
+  add_compile_definitions(USE_AVX)
 endif(USE_AVX)
 
 # To compile METIS correct for DGL.

--- a/cmake/config.cmake
+++ b/cmake/config.cmake
@@ -39,3 +39,6 @@ set(BUILD_CPP_TEST OFF)
 
 # Whether to enable OpenMP
 set(USE_OPENMP ON)
+
+# Whether to enable Intel's avx optimized kernel
+set(USE_AVX OFF)

--- a/src/array/cpu/spmm.h
+++ b/src/array/cpu/spmm.h
@@ -13,10 +13,10 @@
 #include <memory>
 #include "spmm_binary_ops.h"
 #if !defined(_WIN32)
-#ifdef WITH_AVX
+#ifdef USE_AVX
 #include "intel/cpu_support.h"
-#endif
-#endif
+#endif  // USE_AVX
+#endif  // _WIN32
 namespace dgl {
 namespace aten {
 namespace cpu {
@@ -43,7 +43,7 @@ void SpMMSumCsr(const BcastOff& bcast, const CSRMatrix& csr, NDArray ufeat,
   int64_t dim = bcast.out_len, lhs_dim = bcast.lhs_len, rhs_dim = bcast.rhs_len;
   DType* O = out.Ptr<DType>();
 #if !defined(_WIN32)
-#ifdef WITH_AVX
+#ifdef USE_AVX
   typedef dgl::ElemWiseAddUpdate<Op> ElemWiseUpd;
   /* Prepare an assembler kernel */
   static std::unique_ptr<ElemWiseUpd> asm_kernel_ptr(
@@ -65,8 +65,8 @@ void SpMMSumCsr(const BcastOff& bcast, const CSRMatrix& csr, NDArray ufeat,
       }
     }
   } else {
-#endif
-#endif
+#endif  // USE_AVX
+#endif  // _WIN32
 
 #pragma omp parallel for
     for (IdType rid = 0; rid < csr.num_rows; ++rid) {
@@ -88,10 +88,10 @@ void SpMMSumCsr(const BcastOff& bcast, const CSRMatrix& csr, NDArray ufeat,
       }
     }
 #if !defined(_WIN32)
-#ifdef WITH_AVX
+#ifdef USE_AVX
   }
-#endif
-#endif
+#endif  // USE_AVX
+#endif  // _WIN32
 }
 
 /*!

--- a/src/array/cpu/spmm.h
+++ b/src/array/cpu/spmm.h
@@ -13,7 +13,9 @@
 #include <memory>
 #include "spmm_binary_ops.h"
 #if !defined(_WIN32)
+#ifdef WITH_AVX
 #include "intel/cpu_support.h"
+#endif
 #endif
 namespace dgl {
 namespace aten {
@@ -41,6 +43,7 @@ void SpMMSumCsr(const BcastOff& bcast, const CSRMatrix& csr, NDArray ufeat,
   int64_t dim = bcast.out_len, lhs_dim = bcast.lhs_len, rhs_dim = bcast.rhs_len;
   DType* O = out.Ptr<DType>();
 #if !defined(_WIN32)
+#ifdef WITH_AVX
   typedef dgl::ElemWiseAddUpdate<Op> ElemWiseUpd;
   /* Prepare an assembler kernel */
   static std::unique_ptr<ElemWiseUpd> asm_kernel_ptr(
@@ -63,6 +66,7 @@ void SpMMSumCsr(const BcastOff& bcast, const CSRMatrix& csr, NDArray ufeat,
     }
   } else {
 #endif
+#endif
 
 #pragma omp parallel for
     for (IdType rid = 0; rid < csr.num_rows; ++rid) {
@@ -84,7 +88,9 @@ void SpMMSumCsr(const BcastOff& bcast, const CSRMatrix& csr, NDArray ufeat,
       }
     }
 #if !defined(_WIN32)
+#ifdef WITH_AVX
   }
+#endif
 #endif
 }
 

--- a/tests/cpp/test_spmm.cc
+++ b/tests/cpp/test_spmm.cc
@@ -1,4 +1,5 @@
 #if !defined(_WIN32)
+#ifdef WITH_AVX
 #include <../../src/array/cpu/spmm.h>
 #include <dgl/array.h>
 #include <gtest/gtest.h>
@@ -313,4 +314,5 @@ TEST(SpmmTest, TestSpmmDiv) {
   _TestSpmmDiv<float>();
   _TestSpmmDiv<double>();
 }
+#endif
 #endif

--- a/tests/cpp/test_spmm.cc
+++ b/tests/cpp/test_spmm.cc
@@ -1,5 +1,5 @@
 #if !defined(_WIN32)
-#ifdef WITH_AVX
+#ifdef USE_AVX
 #include <../../src/array/cpu/spmm.h>
 #include <dgl/array.h>
 #include <gtest/gtest.h>
@@ -314,5 +314,5 @@ TEST(SpmmTest, TestSpmmDiv) {
   _TestSpmmDiv<float>();
   _TestSpmmDiv<double>();
 }
-#endif
-#endif
+#endif  // USE_AVX
+#endif  // _WIN32


### PR DESCRIPTION
## Description
To fix #2424 .

## Checklist
Please feel free to remove inapplicable items for your PR.
- [x] The PR title starts with [$CATEGORY] (such as [NN], [Model], [Doc], [Feature]])
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage
- [x] Code is well-documented
- [x] To the my best knowledge, examples are either not affected by this change,
      or have been fixed to be compatible with this change
- [x] Related issue is referred in this PR
