### PR TITLE
[hotfix] Enable AVX opt by default.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,7 +24,7 @@ endif()
 # Alernatively, use cmake -DOPTION=VALUE through command-line.
 dgl_option(USE_CUDA "Build with CUDA" OFF)
 dgl_option(USE_OPENMP "Build with OpenMP" ON)
-dgl_option(USE_AVX "Build with AVX optimization" OFF)
+dgl_option(USE_AVX "Build with AVX optimization" ON)
 dgl_option(BUILD_CPP_TEST "Build cpp unittest executables" OFF)
 dgl_option(LIBCXX_ENABLE_PARALLEL_ALGORITHMS "Enable the parallel algorithms library. This requires the PSTL to be available." OFF)
 dgl_option(USE_S3 "Build with S3 support" OFF)

--- a/cmake/config.cmake
+++ b/cmake/config.cmake
@@ -41,4 +41,4 @@ set(BUILD_CPP_TEST OFF)
 set(USE_OPENMP ON)
 
 # Whether to enable Intel's avx optimized kernel
-set(USE_AVX OFF)
+set(USE_AVX ON)


### PR DESCRIPTION
## Description
Set the `USE_AVX` flag's default value to `ON`.

## Checklist
Please feel free to remove inapplicable items for your PR.
- [x] The PR title starts with [$CATEGORY] (such as [NN], [Model], [Doc], [Feature]])
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage
- [x] Code is well-documented
- [x] To the my best knowledge, examples are either not affected by this change,
      or have been fixed to be compatible with this change
- [x] Related issue is referred in this PR
