### PR TITLE
[WIP] Report an error if shared-memory file exists.

### DIFF
--- a/src/runtime/shared_mem.cc
+++ b/src/runtime/shared_mem.cc
@@ -45,7 +45,7 @@ void *SharedMemory::CreateNew(size_t size) {
 #ifndef _WIN32
   this->own = true;
 
-  int flag = O_RDWR|O_CREAT;
+  int flag = O_RDWR|O_CREAT|O_EXCL;
   fd = shm_open(name.c_str(), flag, S_IRUSR | S_IWUSR);
   CHECK_NE(fd, -1) << "fail to open " << name << ": " << strerror(errno);
   auto res = ftruncate(fd, size);


### PR DESCRIPTION
## Description
DGL uses named shared memory. The shared memory is identified by a file name. When creating shared memory, it should report error if the file already exists.

## Checklist
Please feel free to remove inapplicable items for your PR.
- [ ] The PR title starts with [$CATEGORY] (such as [NN], [Model], [Doc], [Feature]])
- [ ] Changes are complete (i.e. I finished coding on this PR)
- [ ] All changes have test coverage
- [ ] Code is well-documented
- [ ] To the my best knowledge, examples are either not affected by this change,
      or have been fixed to be compatible with this change
- [ ] Related issue is referred in this PR

## Changes
<!-- You could use following template
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)
-->
