### PR TITLE
docs: fix simple typo, tranfer -> transfer

### DIFF
--- a/python/dgl/dataloading/async_transferer.py
+++ b/python/dgl/dataloading/async_transferer.py
@@ -13,7 +13,7 @@ class Transfer(object):
         Parameters
         ----------
         transfer_id : int
-            The id of the asynchronous tranfer.
+            The id of the asynchronous transfer.
         handle : DGLAsyncTransferer
             The handle of the DGLAsyncTransferer object that initiated the
             transfer.


### PR DESCRIPTION
There is a small typo in python/dgl/dataloading/async_transferer.py.

Should read `transfer` rather than `tranfer`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md