### PR TITLE
[Performance] Allow DataLoaders to return indices of the seed array

### DIFF
--- a/python/dgl/dataloading/dataloader.py
+++ b/python/dgl/dataloading/dataloader.py
@@ -364,8 +364,10 @@ class NodeCollator(Collator):
         ----------
         items : list[int] or list[tuple[str, int]]
             Either a list of node IDs (for homogeneous graphs), or a list of node type-ID
-            pairs (for heterogeneous graphs).  If ``return_indices`` is True, represents
-            the indices to the seed node array(s) instead.
+            pairs (for heterogeneous graphs).
+
+            If ``return_indices`` is True, represents the indices to the seed node
+            array(s) instead.
 
         Returns
         -------
@@ -711,8 +713,8 @@ class EdgeCollator(Collator):
         items : list[int] or list[tuple[str, int]]
             Either a list of edge IDs (for homogeneous graphs), or a list of edge type-ID
             pairs (for heterogeneous graphs).
-            
-            If ``return_indices`` is True, represents the indices to the seed node
+
+            If ``return_indices`` is True, represents the indices to the seed edge
             array(s) instead.
 
         Returns

--- a/python/dgl/dataloading/dataloader.py
+++ b/python/dgl/dataloading/dataloader.py
@@ -323,12 +323,13 @@ class NodeCollator(Collator):
 
         if isinstance(nids, Mapping):
             self.nids = utils.prepare_tensor_dict(g, nids, 'nids')
-            dataset = {k: F.arange(0, len(v), F.dtype(v), F.ctx(v))
+            dataset = {k: F.arange(0, len(v), F.dtype(v), F.context(v))
                        for k, v in self.nids.items()} if return_indices else self.nids
             self._dataset = utils.FlattenedDict(dataset)
         else:
             self.nids = utils.prepare_tensor(g, nids, 'nids')
-            self._dataset = F.arange(0, len(v), F.dtype(v), F.ctx(v)) if return_indices else nids
+            self._dataset = F.arange(0, len(nids), F.dtype(nids), F.context(nids)) \
+                            if return_indices else nids
 
     @property
     def dataset(self):
@@ -581,12 +582,13 @@ class EdgeCollator(Collator):
 
         if isinstance(eids, Mapping):
             self.eids = utils.prepare_tensor_dict(g, eids, 'eids')
-            dataset = {k: F.arange(0, len(v), F.dtype(v), F.ctx(v))
+            dataset = {k: F.arange(0, len(v), F.dtype(v), F.context(v))
                        for k, v in self.eids.items()} if return_indices else self.eids
             self._dataset = utils.FlattenedDict(dataset)
         else:
             self.eids = utils.prepare_tensor(g, eids, 'eids')
-            self._dataset = F.arange(0, len(v), F.dtype(v), F.ctx(v)) if return_indices else eids
+            self._dataset = F.arange(0, len(eids), F.dtype(eids), F.context(eids)) \
+                            if return_indices else eids
 
     @property
     def dataset(self):

--- a/python/dgl/dataloading/dataloader.py
+++ b/python/dgl/dataloading/dataloader.py
@@ -364,7 +364,8 @@ class NodeCollator(Collator):
         ----------
         items : list[int] or list[tuple[str, int]]
             Either a list of node IDs (for homogeneous graphs), or a list of node type-ID
-            pairs (for heterogeneous graphs).
+            pairs (for heterogeneous graphs).  If ``return_indices`` is True, represents
+            the indices to the seed node array(s) instead.
 
         Returns
         -------
@@ -378,7 +379,7 @@ class NodeCollator(Collator):
 
             If the original graph has multiple node types, return a dictionary of
             node type names and node ID tensors.  Otherwise, return a single tensor.
-        items : Tensor or dict[ntype, Tensor], optional
+        indices : Tensor or dict[ntype, Tensor], optional
             The indices of the sampled nodes in the ``nids`` member.
 
             Only returned if ``return_indices`` is True.
@@ -486,7 +487,7 @@ class EdgeCollator(Collator):
         A set of builtin negative samplers are provided in
         :ref:`the negative sampling module <api-dataloading-negative-sampling>`.
     return_eids : bool, default False
-        Whether to additionally return the indices of the input ``nids`` array sampled in the
+        Whether to additionally return the indices of the input ``eids`` array sampled in the
         minibatch.
 
     Examples
@@ -710,6 +711,9 @@ class EdgeCollator(Collator):
         items : list[int] or list[tuple[str, int]]
             Either a list of edge IDs (for homogeneous graphs), or a list of edge type-ID
             pairs (for heterogeneous graphs).
+            
+            If ``return_indices`` is True, represents the indices to the seed node
+            array(s) instead.
 
         Returns
         -------

--- a/python/dgl/distributed/dist_graph.py
+++ b/python/dgl/distributed/dist_graph.py
@@ -343,7 +343,7 @@ class DistGraph:
     The example shows the creation of ``DistGraph`` in the standalone mode.
 
     >>> dgl.distributed.partition_graph(g, 'graph_name', 1, num_hops=1, part_method='metis',
-                                        out_path='output/', reshuffle=True)
+    ...                                 out_path='output/', reshuffle=True)
     >>> g = dgl.distributed.DistGraph('graph_name', part_config='output/graph_name.json')
 
     The example shows the creation of ``DistGraph`` in the distributed mode.
@@ -357,7 +357,7 @@ class DistGraph:
     ...     frontier = dgl.distributed.sample_neighbors(g, seeds, 10)
     ...     return dgl.to_block(frontier, seeds)
     >>> dataloader = dgl.distributed.DistDataLoader(dataset=nodes, batch_size=1000,
-                                                    collate_fn=sample, shuffle=True)
+    ...                                             collate_fn=sample, shuffle=True)
     >>> for block in dataloader:
     ...     feat = g.ndata['features'][block.srcdata[dgl.NID]]
     ...     labels = g.ndata['labels'][block.dstdata[dgl.NID]]
@@ -492,6 +492,7 @@ class DistGraph:
         long
         int
         """
+        # TODO(da?): describe when self._g is None and idtype shouldn't be called.
         return self._g.idtype
 
     @property
@@ -513,6 +514,7 @@ class DistGraph:
         -------
         Device context object
         """
+        # TODO(da?): describe when self._g is None and device shouldn't be called.
         return self._g.device
 
     @property
@@ -788,7 +790,7 @@ def _split_even(partition_book, rank, elements):
     # here we divide the element list as evenly as possible. If we use range partitioning,
     # the split results also respect the data locality. Range partitioning is the default
     # strategy.
-    # TODO(zhegnda) we need another way to divide the list for other partitioning strategy.
+    # TODO(zhengda) we need another way to divide the list for other partitioning strategy.
 
     # compute the offset of each split and ensure that the difference of each partition size
     # is 1.


### PR DESCRIPTION
## Description
As requested in #2461 .

For semi-supervised learning with very few labels, creating a label tensor with the same size as the number of nodes wastes memory.  This change introduces the optional argument `return_indices` that allows the DataLoader to additionally return the indices of seed nodes/edges sampled in the minibatch.

### Example 1

```python
g = dgl.rand_graph(100, 1000)
sampler = dgl.dataloading.MultiLayerNeighborSampler([4])
dl = dgl.dataloading.NodeDataLoader(
    g, torch.arange(0, 100, 5), sampler, batch_size=5, return_indices=True, shuffle=True)
next(iter(dl))
```
Output:
```
(tensor([15, 20,  0, 95, 35,  8, 78, 99, 73, 97,  6, 40,  2, 14, 92, 54, 16, 23,
         30, 71, 50, 94, 93]),
 tensor([15, 20,  0, 95, 35]),
 tensor([ 3,  4,  0, 19,  7]),
 [Block(num_src_nodes=23, num_dst_nodes=5, num_edges=20)])
```
### Example 2
```python
dl = dgl.dataloading.EdgeDataLoader(
    g, torch.arange(0, 1000, 5), sampler, batch_size=5, return_indices=True, shuffle=True,
    negative_sampler=dgl.dataloading.negative_sampler.Uniform(2))
result = next(iter(dl))
result, result[1].edata[dgl.EID]
```
Output:
```
((tensor([ 3, 86, 57, 21, 31, 90,  7, 92, 29, 13, 95, 99, 84, 54,  2, 98, 79, 60,
           8, 69, 41, 24,  5, 33, 16, 65, 63, 45, 71, 39, 97, 82, 42, 35, 73, 18,
          49, 44, 40, 74, 37, 23, 30, 75, 36,  6, 20, 51, 15, 47, 78]),
  Graph(num_nodes=14, num_edges=5,
        ndata_schemes={'_ID': Scheme(shape=(), dtype=torch.int64)}
        edata_schemes={'_ID': Scheme(shape=(), dtype=torch.int64)}),
  Graph(num_nodes=14, num_edges=10,
        ndata_schemes={'_ID': Scheme(shape=(), dtype=torch.int64)}
        edata_schemes={}),
  tensor([ 78,  15,  16,  25, 181]),
  [Block(num_src_nodes=51, num_dst_nodes=14, num_edges=56)]),
 tensor([390,  75,  80, 125, 905]))
```

## Checklist
Please feel free to remove inapplicable items for your PR.
- [x] The PR title starts with [$CATEGORY] (such as [NN], [Model], [Doc], [Feature]])
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage
- [x] Code is well-documented
- [x] To the my best knowledge, examples are either not affected by this change,
      or have been fixed to be compatible with this change