### PR TITLE
[Doc] fix docserver build for tutorials

### DIFF
--- a/docs/Makefile
+++ b/docs/Makefile
@@ -29,12 +29,20 @@ pytorch:
 	@echo "##################################################################"
 	@DGLBACKEND=pytorch DGL_LOADALL=true $(SPHINXBUILD) -M html "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O) 
 
+tensorflow:
+	@echo "##################################################################"
+	@echo "#                                                                #"
+	@echo "#                Step 3: Building Tensorflow tutorials           #"
+	@echo "#                                                                #"
+	@echo "##################################################################"
+	@DGLBACKEND=tensorflow DGL_LOADALL=true $(SPHINXBUILD) -M html "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O) 
+
 html-noexec:
 	DGL_LOADALL=true $(SPHINXBUILD) -D plot_gallery=0 -b html "$(SOURCEDIR)" "$(BUILDDIR)/html" 
 	@echo
 	@echo "Build finished. The HTML pages are in $(BUILDDIR)/html."
 
-html: Makefile mxnet pytorch
+html: Makefile mxnet pytorch tensorflow
 
 # Catch-all target: route all unknown targets to Sphinx using the new
 # "make mode" option.  $(O) is meant as a shortcut for $(SPHINXOPTS).

--- a/new-tutorial/1_introduction.py
+++ b/new-tutorial/1_introduction.py
@@ -192,10 +192,12 @@ train(g, model)
 # Training on GPU requires to put both the model and the graph onto GPU
 # with the ``to`` method, similar to what you will do in PyTorch.
 # 
-
-g = g.to('cuda')
-model = GCN(g.ndata['feat'].shape[1], 16, dataset.num_classes).to('cuda')
-train(g, model)
+# .. code:: python
+#
+#    g = g.to('cuda')
+#    model = GCN(g.ndata['feat'].shape[1], 16, dataset.num_classes).to('cuda')
+#    train(g, model)
+#
 
 
 ######################################################################

--- a/python/dgl/nn/__init__.py
+++ b/python/dgl/nn/__init__.py
@@ -25,12 +25,4 @@ def _load_backend(mod_name):
     for api, obj in mod.__dict__.items():
         setattr(thismod, api, obj)
 
-
-LOAD_ALL = os.getenv("DGL_LOADALL", "False")
-
-if LOAD_ALL.lower() != "false":
-    from .mxnet import *
-    from .pytorch import *
-    from .tensorflow import *
-else:
-    _load_backend(backend_name)
+_load_backend(backend_name)


### PR DESCRIPTION
This PR fixes docserver crashes when importing `dgl.nn` on the docserver with PyTorch backend imports Tensorflow NN modules instead.

@jermainewang Our current doc server resides on a CPU machine so running sphinx gallery with GPU code will crash.  Should we upgrade that to a GPU machine?  If so, what about multi-GPU sphinx gallery examples in the future?