### PR TITLE
[Performance] Don't create extra formats in dataloader

### DIFF
--- a/python/dgl/dataloading/dataloader.py
+++ b/python/dgl/dataloading/dataloader.py
@@ -251,8 +251,6 @@ class BlockSampler(object):
 
             seed_nodes = {ntype: block.srcnodes[ntype].data[NID] for ntype in block.srctypes}
 
-            # Pre-generate CSR format so that it can be used in training directly
-            block.create_formats_()
             blocks.insert(0, block)
         return blocks
 


### PR DESCRIPTION
## Description
This removes creating CSC and CSR matrices in the NodeDataloader. This essentially transfers work from the worker processes, to the training process, which helps to alleviate bottlenecks occurring in mini-batch generation. When training is done on the GPU, this avoids transferring 2 of the 3 copies of the graph to the GPU, in addition to shifting more work to the GPU.

When combined with #2391, this can lead to a larger performance improvement.

## Checklist
Please feel free to remove inapplicable items for your PR.
- [x] The PR title starts with [$CATEGORY] (such as [NN], [Model], [Doc], [Feature]])
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage
- [x] Code is well-documented
- [x] To the my best knowledge, examples are either not affected by this change,
      or have been fixed to be compatible with this change
- [x] Related issue is referred in this PR



