### PR TITLE
[Build] fix build problems

### DIFF
--- a/src/array/cpu/spmat_op_impl_coo.cc
+++ b/src/array/cpu/spmat_op_impl_coo.cc
@@ -3,7 +3,7 @@
  * \file array/cpu/spmat_op_impl.cc
  * \brief CPU implementation of COO sparse matrix operators
  */
-#include <omp.h>
+#include <dmlc/omp.h>
 #include <vector>
 #include <unordered_set>
 #include <unordered_map>

--- a/src/runtime/cuda/cuda_common.h
+++ b/src/runtime/cuda/cuda_common.h
@@ -93,6 +93,7 @@ struct cuda_dtype<double> {
   static constexpr cudaDataType_t value = CUDA_R_64F;
 };
 
+#if CUDART_VERSION >= 11000
 /*
  * \brief Cast index data type to cusparseIndexType_t.
  */
@@ -110,6 +111,7 @@ template <>
 struct cusparse_idtype<int64_t> {
   static constexpr cusparseIndexType_t value = CUSPARSE_INDEX_64I;
 };
+#endif
 
 /*! \brief Thread local workspace */
 class CUDAThreadEntry {


### PR DESCRIPTION
## Description
* CUDA 9.2 fails building due to unintentional usage of `cusparseIndexType_t`.
* Mac fails building due to inclusion of `<omp.h>`.