### PR TITLE
Fix sparseadam bug in metapath2vec(pytorch)

### DIFF
--- a/examples/pytorch/metapath2vec/metapath2vec.py
+++ b/examples/pytorch/metapath2vec/metapath2vec.py
@@ -36,7 +36,7 @@ class Metapath2VecTrainer:
 
     def train(self):
 
-        optimizer = optim.SparseAdam(self.skip_gram_model.parameters(), lr=self.initial_lr)
+        optimizer = optim.SparseAdam(list(self.skip_gram_model.parameters()), lr=self.initial_lr)
         scheduler = torch.optim.lr_scheduler.CosineAnnealingLR(optimizer, len(self.dataloader))
 
         for iteration in range(self.iterations):


### PR DESCRIPTION
## Description

<!-- Brief description. Refer to the related issues if existed.
It'll be great if relevant reviewers can be assigned as well.-->
Related issue [#2571](https://github.com/dmlc/dgl/issues/2571)

🐛 Bug

https://github.com/dmlc/dgl/blob/a613ad880690a8b155537117ea038a9de14111ed/examples/pytorch/metapath2vec/metapath2vec.py#L39

I'm using `pytorch=1.7.1` and it occurs:
```shell
Traceback (most recent call last):
  File "metapath2vec.py", line 81, in <module>
    m2v.train()
  File "metapath2vec.py", line 39, in train
    optimizer = optim.SparseAdam(self.skip_gram_model.parameters(), lr=self.initial_lr)
  File "/home/S22/anaconda3/envs/stapy/lib/python3.8/site-packages/torch/optim/sparse_adam.py", line 49, in __init__
    super(SparseAdam, self).__init__(params, defaults)
  File "/home/S22/anaconda3/envs/stapy/lib/python3.8/site-packages/torch/optim/optimizer.py", line 47, in __init__
    raise ValueError("optimizer got an empty parameter list")
ValueError: optimizer got an empty parameter list
```

It seems that there is a bug in `Sparseadam` in PyTorch, and it can be temporarily fixed by:
```python
optimizer = optim.SparseAdam(list(self.skip_gram_model.parameters()), lr=self.initial_lr)
```


