### PR TITLE
[Performance][Memory] When cuda11.2 is detected, use cudaMallocAsync/cudaFreeAsync

### DIFF
--- a/include/dgl/runtime/device_api.h
+++ b/include/dgl/runtime/device_api.h
@@ -125,6 +125,14 @@ class DeviceAPI {
    * \param stream The stream to be set.
    */
   virtual void SetStream(DGLContext ctx, DGLStreamHandle stream) {}
+  /**
+   * \brief Get the underlying stream.
+   *
+   * \param ctx The context to get the stream of.
+   *
+   * \return The stream.
+   */
+  virtual DGLStreamHandle GetStream(DGLContext ctx) = 0;
   /*!
    * \brief Synchronize 2 streams of execution.
    *

--- a/src/runtime/cpu_device_api.cc
+++ b/src/runtime/cpu_device_api.cc
@@ -63,6 +63,10 @@ class CPUDeviceAPI final : public DeviceAPI {
   void StreamSync(DGLContext ctx, DGLStreamHandle stream) final {
   }
 
+  DGLStreamHandle GetStream(DGLContext ctx) final {
+    return nullptr;
+  }
+
   void* AllocWorkspace(DGLContext ctx, size_t size, DGLType type_hint) final;
   void FreeWorkspace(DGLContext ctx, void* data) final;
 

--- a/src/runtime/cuda/cuda_device_api.cc
+++ b/src/runtime/cuda/cuda_device_api.cc
@@ -94,13 +94,13 @@ class CUDADeviceAPI final : public DeviceAPI {
     CHECK_EQ(256 % alignment, 0U)
         << "CUDA space is aligned at 256 bytes";
     void *ret;
-    CUDA_CALL(cudaMalloc(&ret, nbytes));
+    CUDA_CALL(cudaMallocAsync(&ret, nbytes, static_cast<cudaStream_t>(GetStream(ctx))));
     return ret;
   }
 
   void FreeDataSpace(DGLContext ctx, void* ptr) final {
     CUDA_CALL(cudaSetDevice(ctx.device_id));
-    CUDA_CALL(cudaFree(ptr));
+    CUDA_CALL(cudaFreeAsync(ptr, static_cast<cudaStream_t>(GetStream(ctx))));
   }
 
   void CopyDataFromTo(const void* from,
@@ -166,8 +166,15 @@ class CUDADeviceAPI final : public DeviceAPI {
   }
 
   void SetStream(DGLContext ctx, DGLStreamHandle stream) final {
+    // sync the new and old stream to ensure we don't cause a race condition
+    SyncStreamFromTo(ctx, GetStream(ctx), stream);
+
     CUDAThreadEntry::ThreadLocal()
         ->stream = static_cast<cudaStream_t>(stream);
+  }
+
+  DGLStreamHandle GetStream(DGLContext ctx) final {
+    return CUDAThreadEntry::ThreadLocal()->stream;
   }
 
   void* AllocWorkspace(DGLContext ctx, size_t size, DGLType type_hint) final {
@@ -190,10 +197,10 @@ class CUDADeviceAPI final : public DeviceAPI {
                       size_t size,
                       cudaMemcpyKind kind,
                       cudaStream_t stream) {
-    if (stream != 0) {
-      CUDA_CALL(cudaMemcpyAsync(to, from, size, kind, stream));
-    } else {
-      CUDA_CALL(cudaMemcpy(to, from, size, kind));
+    CUDA_CALL(cudaMemcpyAsync(to, from, size, kind, stream));
+    if (kind == cudaMemcpyDeviceToHost) {
+      // sync before we try to access it from the host
+      CUDA_CALL(cudaStreamSynchronize(stream));
     }
   }
 };


### PR DESCRIPTION
## Description
This enables use of the new `cudaMallocAsync` and `cudaFreeAsync` functions in CUDA 11.2:
https://docs.nvidia.com/cuda/cuda-runtime-api/group__CUDART__HIGHLEVEL.html#group__CUDART__HIGHLEVEL_1ga31efcffc48981621feddd98d71a0feb

This accomplishes essentially what #2328 provided, but is backend agnostic, and does not require linking against external frameworks.

## Checklist
Please feel free to remove inapplicable items for your PR.
- [x] The PR title starts with [$CATEGORY] (such as [NN], [Model], [Doc], [Feature]])
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage
- [x] Code is well-documented
- [x] To the my best knowledge, examples are either not affected by this change,
      or have been fixed to be compatible with this change


## Changes

Adds `GetStream()` to the `DeviceAPI`.

When `DeviceAPI::SetStream()` is called, the previous stream is synchronized with, to ensure no race condition is created between works scheduled before the call, and work scheduled after the call.

Makes `cudaMemcpy` invocations asynchronous, unless they are `DeviceToHost`. This is because any device-side accesses to the copied memory will be on the associated stream (default or not), and thus will wait for it to complete, while the CPU can move on to schedule more work.

Replaces calls to `cudaMalloc` and `cudaFree` with `cudaMallocAsync` and `cudaFreeAsync`, when the cuda version >= 11.2.
