### PR TITLE
[Tutorial] Fix tutorial - blitz 4 link prediction

### DIFF
--- a/tutorials/blitz/4_link_predict.py
+++ b/tutorials/blitz/4_link_predict.py
@@ -97,7 +97,7 @@ adj = sp.coo_matrix((np.ones(len(u)), (u.numpy(), v.numpy())))
 adj_neg = 1 - adj.todense() - np.eye(g.number_of_nodes())
 neg_u, neg_v = np.where(adj_neg != 0)
 
-neg_eids = np.random.choice(len(neg_u), g.number_of_edges() // 2)
+neg_eids = np.random.choice(len(neg_u), g.number_of_edges())
 test_neg_u, test_neg_v = neg_u[neg_eids[:test_size]], neg_v[neg_eids[:test_size]]
 train_neg_u, train_neg_v = neg_u[neg_eids[test_size:]], neg_v[neg_eids[test_size:]]
 


### PR DESCRIPTION
The number of edges should be same as posive eids.

## Description
<!-- Brief description. Refer to the related issues if existed.
It'll be great if relevant reviewers can be assigned as well.-->

## Checklist
Please feel free to remove inapplicable items for your PR.
- [x] The PR title starts with [$CATEGORY] (such as [NN], [Model], [Doc], [Feature]])
- [x] Changes are complete (i.e. I finished coding on this PR)
- [ ] All changes have test coverage
- [ ] Code is well-documented
- [ ] To the my best knowledge, examples are either not affected by this change,
      or have been fixed to be compatible with this change
- [ ] Related issue is referred in this PR
- [ ] If the PR is for a new model/paper, I've updated the example index [here](../examples/README.md).

## Changes
<!-- You could use following template
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)
-->
- [x] Fix the code in link prediction tutorial.
  With the description above, the number of negative edges should be the same as the number of positive edges.
 Check live tutorial here: [Prepare training and testing sets](https://docs.dgl.ai/tutorials/blitz/4_link_predict.html#prepare-training-and-testing-sets)
