### PR TITLE
[Doc] Clarify 'orig_id' and `dgl.NID` in distributed training

### DIFF
--- a/docs/source/guide/distributed-preprocessing.rst
+++ b/docs/source/guide/distributed-preprocessing.rst
@@ -22,9 +22,11 @@ in a format that is easy to load during the training.
 
 By default, the partition API assigns new IDs to the nodes and edges in the input graph to help locate
 nodes/edges during distributed training/inference. After assigning IDs, the partition API shuffles
-all node data and edge data accordingly. During the training, users just use the new node/edge IDs.
-However, the original IDs are still accessible through ``g.ndata['orig_id']`` and ``g.edata['orig_id']``,
-where ``g`` is a DistGraph object (see the section of DistGraph).
+all node data and edge data accordingly. After generating partitioned subgraphs, each subgraph is stored
+as a ``DGLGraph`` object. The original node/edge IDs before reshuffling are stored in the field of
+'orig_id' in the node/edge data of the subgraphs. The node data `dgl.NID` and the edge data `dgl.EID`
+of the subgraphs store new node/edge IDs of the full graph after nodes/edges reshuffle.
+During the training, users just use the new node/edge IDs.
 
 The partitioned results are stored in multiple files in the output directory. It always contains
 a JSON file called xxx.json, where xxx is the graph name provided to the partition API. The JSON file


### PR DESCRIPTION
## Description
Fix an error in the doc that explains the original node/edge IDs and clarify the explanation of 'orig_id' and `dgl.NID`

## Checklist
Please feel free to remove inapplicable items for your PR.
- [ ] The PR title starts with [$CATEGORY] (such as [NN], [Model], [Doc], [Feature]])
- [ ] Changes are complete (i.e. I finished coding on this PR)
- [ ] All changes have test coverage
- [ ] Code is well-documented
- [ ] To the my best knowledge, examples are either not affected by this change,
      or have been fixed to be compatible with this change
- [ ] Related issue is referred in this PR
- [ ] If the PR is for a new model/paper, I've updated the example index [here](../examples/README.md).

## Changes
<!-- You could use following template
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)
-->
