### PR TITLE
[performance] Optimize the association order of AXW in GraphSAGE.

### DIFF
--- a/README.md
+++ b/README.md
@@ -289,6 +289,14 @@ We are currently in Beta stage.  More features and improvements are coming.
 
 1. [**Adaptive Layout Decomposition with Graph Embedding Neural Networks**](http://www.cse.cuhk.edu.hk/~byu/papers/C98-DAC2020-MPL-Selector.pdf), *Wei Li, Jialu Xia, Yuzhe Ma, Jialu Li, Yibo Lin, Bei Yu*, DAC'20
 
+1. [**Transfer Learning with Graph Neural Networks for Optoelectronic Properties of Conjugated Oligomers**](https://aip.scitation.org/doi/10.1063/5.0037863), J. Chem. Phys. 154, *Chee-Kong Lee, Chengqiang Lu, Yue Yu, Qiming Sun, Chang-Yu Hsieh, Shengyu Zhang, Qi Liu, and  Liang Shi*
+
+1. [**Jet tagging in the Lund plane with graph networks**](https://link.springer.com/article/10.1007/JHEP03(2021)052), Journal of High Energy Physics 2021, *Frédéric A. Dreyer and Huilin Qu* 
+
+1. [**Global Attention Improves Graph Networks Generalization**](https://arxiv.org/abs/2006.07846), *Omri Puny, Heli Ben-Hamu, and Yaron Lipman*
+
+1. [**Learning over Families of Sets -- Hypergraph Representation Learning for Higher Order Tasks**](https://arxiv.org/abs/2101.07773), SDM 2021, *Balasubramaniam Srinivasan, Da Zheng, and George Karypis*
+
 </details>
 
 ## Installation

--- a/python/dgl/nn/pytorch/conv/sageconv.py
+++ b/python/dgl/nn/pytorch/conv/sageconv.py
@@ -208,7 +208,7 @@ class SAGEConv(nn.Module):
 
             # Determine whether to apply linear transformation before message passing A(XW)
             lin_before_mp = self._in_src_feats > self._out_feats
-            
+
             # Message Passing
             if self._aggre_type == 'mean':
                 graph.srcdata['h'] = self.fc_neigh(feat_src) if lin_before_mp else feat_src
@@ -241,12 +241,12 @@ class SAGEConv(nn.Module):
             if self._aggre_type == 'gcn':
                 rst = h_neigh
             else:
-                rst = self.fc_self(h_self) + h_neigh 
+                rst = self.fc_self(h_self) + h_neigh
 
             # bias term
             if self.bias is not None:
                 rst = rst + self.bias
-            
+
             # activation
             if self.activation is not None:
                 rst = self.activation(rst)

--- a/python/dgl/nn/pytorch/conv/sageconv.py
+++ b/python/dgl/nn/pytorch/conv/sageconv.py
@@ -219,7 +219,10 @@ class SAGEConv(nn.Module):
             elif self._aggre_type == 'gcn':
                 check_eq_shape(feat)
                 graph.srcdata['h'] = self.fc_neigh(feat_src) if lin_before_mp else feat_src
-                graph.dstdata['h'] = graph.srcdata['h']     # same as above if homogeneous
+                if isinstance(feat, tuple):  # heterogeneous
+                    graph.dstdata['h'] = self.fc_neigh(feat_dst) if lin_before_mp else feat_dst
+                else:
+                    graph.dstdata['h'] = graph.srcdata['h']
                 graph.update_all(msg_fn, fn.sum('m', 'neigh'))
                 # divide in_degrees
                 degs = graph.in_degrees().to(feat_dst)

--- a/python/dgl/nn/pytorch/conv/sageconv.py
+++ b/python/dgl/nn/pytorch/conv/sageconv.py
@@ -151,12 +151,14 @@ class SAGEConv(nn.Module):
     def _compatibility_check(self):
         """Address the backward compatibility issue brought by #2747"""
         if not hasattr(self, 'bias'):
-            dgl_warning("You are loading a GraphSAGE model trained from a old version of DGL, whose "
-                        "parameters may not compatible with latest version of DGL.")
+            dgl_warning("You are loading a GraphSAGE model trained from a old version of DGL, "
+                        "whose parameters may not compatible with latest version of DGL.")
             bias = self.fc_neigh.bias
+            self.fc_neigh.bias = None
             if hasattr(self, 'fc_self'):
                 if bias is not None:
                     bias = bias + self.fc_self.bias
+                    self.fc_self.bias = None
             self.bias = bias
 
     def _lstm_reducer(self, nodes):

--- a/python/dgl/nn/pytorch/conv/sageconv.py
+++ b/python/dgl/nn/pytorch/conv/sageconv.py
@@ -152,7 +152,7 @@ class SAGEConv(nn.Module):
         """Address the backward compatibility issue brought by #2747"""
         if not hasattr(self, 'bias'):
             dgl_warning("You are loading a GraphSAGE model trained from a old version of DGL, "
-                        "whose parameters may not compatible with latest version of DGL.")
+                        "DGL automatically convert it to be compatible with latest version.")
             bias = self.fc_neigh.bias
             self.fc_neigh.bias = None
             if hasattr(self, 'fc_self'):

--- a/tests/pytorch/test_nn.py
+++ b/tests/pytorch/test_nn.py
@@ -762,7 +762,7 @@ def test_dense_sage_conv(g, idtype, out_dim):
     sage = nn.SAGEConv(5, out_dim, 'gcn')
     dense_sage = nn.DenseSAGEConv(5, out_dim)
     dense_sage.fc.weight.data = sage.fc_neigh.weight.data
-    dense_sage.fc.bias.data = sage.fc_neigh.bias.data
+    dense_sage.fc.bias.data = sage.bias.data
     if len(g.ntypes) == 2:
         feat = (
             F.randn((g.number_of_src_nodes(), 5)),


### PR DESCRIPTION
## Description
Use A(XW) instead of (AX)W when output feature dimensionality is greater than input feature dimensionality. This optimization was used in our GraphConv module but not in SAGEConv module: https://discuss.dgl.ai/t/gpu-kernels-while-running-graphsage-model/1449/4 .

@mufeili , @BarclayII please verify if it's equivalent to the original implementation.

## Checklist
Please feel free to remove inapplicable items for your PR.
- [x] The PR title starts with [$CATEGORY] (such as [NN], [Model], [Doc], [Feature]])
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage
- [x] Code is well-documented
- [x] To the my best knowledge, examples are either not affected by this change,
      or have been fixed to be compatible with this change
- [x] Related issue is referred in this PR
- [x] If the PR is for a new model/paper, I've updated the example index [here](../examples/README.md).