### PR TITLE
Bug fix for RGCN Link Prediction Example Exceeding Specified Epochs

### DIFF
--- a/examples/pytorch/rgcn/link_predict.py
+++ b/examples/pytorch/rgcn/link_predict.py
@@ -191,13 +191,14 @@ def main(args):
                                  valid_data, test_data, hits=[1, 3, 10], eval_bz=args.eval_batch_size,
                                  eval_p=args.eval_protocol)
             # save best model
-            if mrr < best_mrr:
-                if epoch >= args.n_epochs:
-                    break
-            else:
+            if best_mrr < mrr:
                 best_mrr = mrr
                 torch.save({'state_dict': model.state_dict(), 'epoch': epoch},
-                           model_state_file)
+                        model_state_file)
+            
+            if epoch >= args.n_epochs:
+                break
+            
             if use_cuda:
                 model.cuda()
 

--- a/examples/pytorch/rgcn/link_predict.py
+++ b/examples/pytorch/rgcn/link_predict.py
@@ -193,8 +193,7 @@ def main(args):
             # save best model
             if best_mrr < mrr:
                 best_mrr = mrr
-                torch.save({'state_dict': model.state_dict(), 'epoch': epoch},
-                        model_state_file)
+                torch.save({'state_dict': model.state_dict(), 'epoch': epoch}, model_state_file)
             
             if epoch >= args.n_epochs:
                 break


### PR DESCRIPTION
## Description

When running RGCN link prediction example, sometimes specified  number of epochs is exceeded.  
Issue reference: [https://github.com/dmlc/dgl/issues/2752](url)

## Checklist
- [x] Changes are complete 
- [ ] All changes have test coverage
- [x] To the my best knowledge, examples are either not affected by this change,
      or have been fixed to be compatible with this change
- [x] Related issue is referred in this PR


## Changes
Moved indentation of the conditional `break` statement left, so it no longer needs to satisfy the condition `if mrr < best_mrr` in order to break out of the training/evaluation loop.
