### PR TITLE
[Doc] Update deprecated method name in load_graph.py

### DIFF
--- a/examples/pytorch/graphsage/load_graph.py
+++ b/examples/pytorch/graphsage/load_graph.py
@@ -9,7 +9,7 @@ def load_reddit():
     g = data[0]
     g.ndata['features'] = g.ndata['feat']
     g.ndata['labels'] = g.ndata['label']
-    return g, data.num_labels
+    return g, data.num_classes
 
 def load_ogb(name):
     from ogb.nodeproppred import DglNodePropPredDataset


### PR DESCRIPTION

## Description
Method `dataset.num_labels` has been deprecated and replaced by `dataset.num_classes`.  
Updating the method name to avoid runtime warning.

## Checklist
Please feel free to remove inapplicable items for your PR.
- [x] The PR title starts with [$CATEGORY] (such as [NN], [Model], [Doc], [Feature]])
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] To the my best knowledge, examples are either not affected by this change,
      or have been fixed to be compatible with this change


