### PR TITLE
[Bugfix] add default value for BlockSampler

### DIFF
--- a/docs/source/guide/minibatch-custom-sampler.rst
+++ b/docs/source/guide/minibatch-custom-sampler.rst
@@ -361,10 +361,9 @@ nodes with a probability, one can simply define the sampler as follows:
 .. code:: python
 
     class MultiLayerDropoutSampler(dgl.dataloading.BlockSampler):
-        def __init__(self, p, n_layers):
-            super().__init__()
+        def __init__(self, p, num_layers):
+            super().__init__(num_layers)
     
-            self.n_layers = n_layers
             self.p = p
     
         def sample_frontier(self, block_id, g, seed_nodes, *args, **kwargs):
@@ -380,7 +379,7 @@ nodes with a probability, one can simply define the sampler as follows:
             return frontier
     
         def __len__(self):
-            return self.n_layers
+            return self.num_layers
 
 After implementing your sampler, you can create a data loader that takes
 in your sampler and it will keep generating lists of MFGs while
@@ -422,10 +421,9 @@ all edge types, so that it can work on heterogeneous graphs as well.
 .. code:: python
 
     class MultiLayerDropoutSampler(dgl.dataloading.BlockSampler):
-        def __init__(self, p, n_layers):
-            super().__init__()
+        def __init__(self, p, num_layers):
+            super().__init__(num_layers)
     
-            self.n_layers = n_layers
             self.p = p
     
         def sample_frontier(self, block_id, g, seed_nodes, *args, **kwargs):
@@ -445,7 +443,4 @@ all edge types, so that it can work on heterogeneous graphs as well.
             return frontier
     
         def __len__(self):
-            return self.n_layers
-
-
-
+            return self.num_layers

--- a/docs/source/guide_cn/minibatch-custom-sampler.rst
+++ b/docs/source/guide_cn/minibatch-custom-sampler.rst
@@ -308,10 +308,9 @@ DGL确保块的输出节点将始终出现在输入节点中。如下代码所�
 .. code:: python
 
     class MultiLayerDropoutSampler(dgl.dataloading.BlockSampler):
-        def __init__(self, p, n_layers):
-            super().__init__()
-    
-            self.n_layers = n_layers
+        def __init__(self, p, num_layers):
+            super().__init__(num_layers)
+
             self.p = p
     
         def sample_frontier(self, block_id, g, seed_nodes, *args, **kwargs):
@@ -326,7 +325,7 @@ DGL确保块的输出节点将始终出现在输入节点中。如下代码所�
             return frontier
     
         def __len__(self):
-            return self.n_layers
+            return self.num_layers
 
 在实现自定义采样器后，用户可以创建一个数据加载器。这个数据加载器使用用户自定义的采样器，
 并且遍历种子节点生成一系列的块。
@@ -365,10 +364,9 @@ DGL确保块的输出节点将始终出现在输入节点中。如下代码所�
 .. code:: python
 
     class MultiLayerDropoutSampler(dgl.dataloading.BlockSampler):
-        def __init__(self, p, n_layers):
-            super().__init__()
-    
-            self.n_layers = n_layers
+        def __init__(self, p, num_layers):
+            super().__init__(num_layers)
+
             self.p = p
     
         def sample_frontier(self, block_id, g, seed_nodes, *args, **kwargs):
@@ -387,4 +385,5 @@ DGL确保块的输出节点将始终出现在输入节点中。如下代码所�
             return frontier
     
         def __len__(self):
-            return self.n_layers
+            return self.num_layers
+            

--- a/python/dgl/dataloading/dataloader.py
+++ b/python/dgl/dataloading/dataloader.py
@@ -158,7 +158,7 @@ class BlockSampler(object):
     :ref:`User Guide Section 6 <guide-minibatch>` and
     :doc:`Minibatch Training Tutorials <tutorials/large/L0_neighbor_sampling_overview>`.
     """
-    def __init__(self, num_layers, return_eids):
+    def __init__(self, num_layers, return_eids=False):
         self.num_layers = num_layers
         self.return_eids = return_eids
 


### PR DESCRIPTION
## Description
The 'return_eids' of dgl.dataloading.BlockSampler requires a default value. 
Otherwise when following the instructions of  [Chap6.4 of User Guide](https://docs.dgl.ai/en/0.6.x/guide/minibatch-custom-sampler.html#guide-minibatch-customizing-neighborhood-sampler). This error would occor:
 File "/Users/hengruz/opt/anaconda3/lib/python3.8/site-packages/dgl/dataloading/dataloader.py", line 163, in __init__
    self.return_eids = return_eids
NameError: name 'return_eids' is not defined

Also, there is a mior mistake in MultiLayerDropoutSampler class in Chap6.4,  I've fixed it in this PR

## Checklist
Please feel free to remove inapplicable items for your PR.
- [ ] The PR title starts with [$CATEGORY] (such as [NN], [Model], [Doc], [Feature]])
- [ ] Changes are complete (i.e. I finished coding on this PR)
- [ ] All changes have test coverage
- [ ] Code is well-documented
- [ ] To the my best knowledge, examples are either not affected by this change,
      or have been fixed to be compatible with this change
- [ ] Related issue is referred in this PR

## Changes
<!-- You could use following template
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)
-->
