### PR TITLE
[Distributed] Cleanup the process pool correctly when the process exits.

### DIFF
--- a/python/dgl/distributed/dist_dataloader.py
+++ b/python/dgl/distributed/dist_dataloader.py
@@ -148,6 +148,9 @@ class DistDataLoader:
                 res.get()
 
     def __del__(self):
+        # When the process exits, the process pool may have been closed. We should try
+        # and get the process pool again and see if we need to clean up the process pool.
+        self.pool, self.num_workers = get_sampler_pool()
         if self.pool is not None:
             results = []
             for _ in range(self.num_workers):


### PR DESCRIPTION
## Description
When a process exits, the sampler process pool will be closed. When we delete the data loader, we should double-check if the process pool has been closed or not.

## Checklist
Please feel free to remove inapplicable items for your PR.
- [ ] The PR title starts with [$CATEGORY] (such as [NN], [Model], [Doc], [Feature]])
- [ ] Changes are complete (i.e. I finished coding on this PR)
- [ ] All changes have test coverage
- [ ] Code is well-documented
- [ ] To the my best knowledge, examples are either not affected by this change,
      or have been fixed to be compatible with this change
- [ ] Related issue is referred in this PR
- [ ] If the PR is for a new model/paper, I've updated the example index [here](../examples/README.md).

## Changes
<!-- You could use following template
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)
-->
