### PR TITLE
[Benchmark] Fix for the model_speed benchmarks results stability

### DIFF
--- a/benchmarks/benchmarks/model_speed/bench_gat.py
+++ b/benchmarks/benchmarks/model_speed/bench_gat.py
@@ -122,10 +122,4 @@ def track_time(data):
         epoch_times >= low_boundary) & (epoch_times <= high_boundary)]
     avg_valid_epoch_time = np.mean(valid_epoch_times)
 
-    # TODO: delete logging for final version
-    print(f'Number of epoch times: {len(epoch_times)}')
-    print(f'Number of valid epoch times: {len(valid_epoch_times)}')
-    print(f'Avg epoch times: {avg_epoch_time}')
-    print(f'Avg valid epoch times: {avg_valid_epoch_time}')
-
     return avg_valid_epoch_time

--- a/benchmarks/benchmarks/model_speed/bench_gat.py
+++ b/benchmarks/benchmarks/model_speed/bench_gat.py
@@ -1,11 +1,14 @@
 import time
+
 import dgl
-from dgl.nn.pytorch import GATConv
+import numpy as np
 import torch
 import torch.nn as nn
 import torch.nn.functional as F
+from dgl.nn.pytorch import GATConv
 
 from .. import utils
+
 
 class GAT(nn.Module):
     def __init__(self,
@@ -46,14 +49,17 @@ class GAT(nn.Module):
         logits = self.gat_layers[-1](g, h).mean(1)
         return logits
 
+
 @utils.benchmark('time')
 @utils.parametrize('data', ['cora', 'pubmed'])
 def track_time(data):
-    data = utils.process_data(data)
+    dataset = utils.process_data(data)
     device = utils.get_bench_device()
-    num_epochs = 200
 
-    g = data[0].to(device)
+    g = dataset[0].to(device)
+
+    num_runs = 3
+    num_epochs = 200
 
     features = g.ndata['feat']
     labels = g.ndata['label']
@@ -62,40 +68,64 @@ def track_time(data):
     test_mask = g.ndata['test_mask']
 
     in_feats = features.shape[1]
-    n_classes = data.num_classes
+    n_classes = dataset.num_classes
 
     g = dgl.remove_self_loop(g)
     g = dgl.add_self_loop(g)
 
-    # create model
-    model = GAT(1, in_feats, 8, n_classes, [8, 1], F.elu,
-                0.6, 0.6, 0.2, False)
-    loss_fcn = torch.nn.CrossEntropyLoss()
+    epoch_times = []
 
-    model = model.to(device)
-    model.train()
+    for run in range(num_runs):
+        # create model
+        model = GAT(1, in_feats, 8, n_classes, [8, 1], F.elu,
+                    0.6, 0.6, 0.2, False)
+        loss_fcn = torch.nn.CrossEntropyLoss()
 
-    # optimizer
-    optimizer = torch.optim.Adam(model.parameters(),
-                                 lr=1e-2,
-                                 weight_decay=5e-4)
+        model = model.to(device)
+        model.train()
 
-    # dry run
-    for epoch in range(10):
-        logits = model(g, features)
-        loss = loss_fcn(logits[train_mask], labels[train_mask])
-        optimizer.zero_grad()
-        loss.backward()
-        optimizer.step()
+        # optimizer
+        optimizer = torch.optim.Adam(model.parameters(),
+                                     lr=1e-2,
+                                     weight_decay=5e-4)
 
-    # timing
-    t0 = time.time()
-    for epoch in range(num_epochs):
-        logits = model(g, features)
-        loss = loss_fcn(logits[train_mask], labels[train_mask])
-        optimizer.zero_grad()
-        loss.backward()
-        optimizer.step()
-    t1 = time.time()
+        # dry run
+        for epoch in range(10):
+            logits = model(g, features)
+            loss = loss_fcn(logits[train_mask], labels[train_mask])
+            optimizer.zero_grad()
+            loss.backward()
+            optimizer.step()
 
-    return (t1 - t0) / num_epochs
+        # timing
+        for epoch in range(num_epochs):
+            t0 = time.time()
+
+            logits = model(g, features)
+            loss = loss_fcn(logits[train_mask], labels[train_mask])
+            optimizer.zero_grad()
+            loss.backward()
+            optimizer.step()
+
+            t1 = time.time()
+
+            epoch_times.append(t1 - t0)
+
+    avg_epoch_time = np.mean(epoch_times)
+    std_epoch_time = np.std(epoch_times)
+
+    std_const = 1.5
+    low_boundary = avg_epoch_time - std_epoch_time * std_const
+    high_boundary = avg_epoch_time + std_epoch_time * std_const
+
+    valid_epoch_times = np.array(epoch_times)[(
+        epoch_times >= low_boundary) & (epoch_times <= high_boundary)]
+    avg_valid_epoch_time = np.mean(valid_epoch_times)
+
+    # TODO: delete logging for final version
+    print(f'Number of epoch times: {len(epoch_times)}')
+    print(f'Number of valid epoch times: {len(valid_epoch_times)}')
+    print(f'Avg epoch times: {avg_epoch_time}')
+    print(f'Avg valid epoch times: {avg_valid_epoch_time}')
+
+    return avg_valid_epoch_time

--- a/benchmarks/benchmarks/model_speed/bench_gat_ns.py
+++ b/benchmarks/benchmarks/model_speed/bench_gat_ns.py
@@ -1,15 +1,12 @@
 import time
-import traceback
 
 import dgl
 import dgl.nn.pytorch as dglnn
 import numpy as np
 import torch as th
-import torch.multiprocessing as mp
 import torch.nn as nn
 import torch.nn.functional as F
 import torch.optim as optim
-from torch.utils.data import DataLoader
 
 from .. import utils
 
@@ -177,11 +174,5 @@ def track_time(data):
     valid_epoch_times = np.array(epoch_times)[(
         epoch_times >= low_boundary) & (epoch_times <= high_boundary)]
     avg_valid_epoch_time = np.mean(valid_epoch_times)
-
-    # TODO: delete logging for final version
-    print(f'Number of epoch times: {len(epoch_times)}')
-    print(f'Number of valid epoch times: {len(valid_epoch_times)}')
-    print(f'Avg epoch times: {avg_epoch_time}')
-    print(f'Avg valid epoch times: {avg_valid_epoch_time}')
 
     return avg_valid_epoch_time

--- a/benchmarks/benchmarks/model_speed/bench_gcn_udf.py
+++ b/benchmarks/benchmarks/model_speed/bench_gcn_udf.py
@@ -149,10 +149,4 @@ def track_time(data):
         epoch_times >= low_boundary) & (epoch_times <= high_boundary)]
     avg_valid_epoch_time = np.mean(valid_epoch_times)
 
-    # TODO: delete logging for final version
-    print(f'Number of epoch times: {len(epoch_times)}')
-    print(f'Number of valid epoch times: {len(valid_epoch_times)}')
-    print(f'Avg epoch times: {avg_epoch_time}')
-    print(f'Avg valid epoch times: {avg_valid_epoch_time}')
-
     return avg_valid_epoch_time

--- a/benchmarks/benchmarks/model_speed/bench_pinsage.py
+++ b/benchmarks/benchmarks/model_speed/bench_pinsage.py
@@ -480,10 +480,4 @@ def track_time(data):
         epoch_times >= low_boundary) & (epoch_times <= high_boundary)]
     avg_valid_epoch_time = np.mean(valid_epoch_times)
 
-    # TODO: delete logging for final version
-    print(f'Number of epoch times: {len(epoch_times)}')
-    print(f'Number of valid epoch times: {len(valid_epoch_times)}')
-    print(f'Avg epoch times: {avg_epoch_time}')
-    print(f'Avg valid epoch times: {avg_valid_epoch_time}')
-
     return avg_valid_epoch_time

--- a/benchmarks/benchmarks/model_speed/bench_rgcn.py
+++ b/benchmarks/benchmarks/model_speed/bench_rgcn.py
@@ -160,10 +160,4 @@ def track_time(data, lowmem, use_type_count):
         epoch_times >= low_boundary) & (epoch_times <= high_boundary)]
     avg_valid_epoch_time = np.mean(valid_epoch_times)
 
-    # TODO: delete logging for final version
-    print(f'Number of epoch times: {len(epoch_times)}')
-    print(f'Number of valid epoch times: {len(valid_epoch_times)}')
-    print(f'Avg epoch times: {avg_epoch_time}')
-    print(f'Avg valid epoch times: {avg_valid_epoch_time}')
-
     return avg_valid_epoch_time

--- a/benchmarks/benchmarks/model_speed/bench_rgcn_hetero_ns.py
+++ b/benchmarks/benchmarks/model_speed/bench_rgcn_hetero_ns.py
@@ -360,10 +360,4 @@ def track_time(data):
         epoch_times >= low_boundary) & (epoch_times <= high_boundary)]
     avg_valid_epoch_time = np.mean(valid_epoch_times)
 
-    # TODO: delete logging for final version
-    print(f'Number of epoch times: {len(epoch_times)}')
-    print(f'Number of valid epoch times: {len(valid_epoch_times)}')
-    print(f'Avg epoch times: {avg_epoch_time}')
-    print(f'Avg valid epoch times: {avg_valid_epoch_time}')
-
     return avg_valid_epoch_time

--- a/benchmarks/benchmarks/model_speed/bench_rgcn_homogeneous_ns.py
+++ b/benchmarks/benchmarks/model_speed/bench_rgcn_homogeneous_ns.py
@@ -357,10 +357,4 @@ def track_time(data):
         epoch_times >= low_boundary) & (epoch_times <= high_boundary)]
     avg_valid_epoch_time = np.mean(valid_epoch_times)
 
-    # TODO: delete logging for final version
-    print(f'Number of epoch times: {len(epoch_times)}')
-    print(f'Number of valid epoch times: {len(valid_epoch_times)}')
-    print(f'Avg epoch times: {avg_epoch_time}')
-    print(f'Avg valid epoch times: {avg_valid_epoch_time}')
-
     return avg_valid_epoch_time

--- a/benchmarks/benchmarks/model_speed/bench_sage.py
+++ b/benchmarks/benchmarks/model_speed/bench_sage.py
@@ -114,10 +114,4 @@ def track_time(data):
         epoch_times >= low_boundary) & (epoch_times <= high_boundary)]
     avg_valid_epoch_time = np.mean(valid_epoch_times)
 
-    # TODO: delete logging for final version
-    print(f'Number of epoch times: {len(epoch_times)}')
-    print(f'Number of valid epoch times: {len(valid_epoch_times)}')
-    print(f'Avg epoch times: {avg_epoch_time}')
-    print(f'Avg valid epoch times: {avg_valid_epoch_time}')
-
     return avg_valid_epoch_time

--- a/benchmarks/benchmarks/model_speed/bench_sage_ns.py
+++ b/benchmarks/benchmarks/model_speed/bench_sage_ns.py
@@ -1,14 +1,15 @@
+import time
+
 import dgl
+import dgl.nn.pytorch as dglnn
+import numpy as np
 import torch as th
 import torch.nn as nn
 import torch.nn.functional as F
 import torch.optim as optim
-import torch.multiprocessing as mp
-from torch.utils.data import DataLoader
-import dgl.nn.pytorch as dglnn
-import time
 
 from .. import utils
+
 
 class SAGE(nn.Module):
     def __init__(self,
@@ -39,6 +40,7 @@ class SAGE(nn.Module):
                 h = self.dropout(h)
         return h
 
+
 def load_subtensor(g, seeds, input_nodes, device):
     """
     Copys features and labels of a set of nodes onto GPU.
@@ -47,22 +49,23 @@ def load_subtensor(g, seeds, input_nodes, device):
     batch_labels = g.ndata['labels'][seeds].to(device)
     return batch_inputs, batch_labels
 
+
 @utils.benchmark('time', 600)
 @utils.parametrize('data', ['reddit', 'ogbn-products'])
 def track_time(data):
-    data = utils.process_data(data)
+    dataset = utils.process_data(data)
     device = utils.get_bench_device()
-    g = data[0]
+    g = dataset[0]
     g.ndata['features'] = g.ndata['feat']
     g.ndata['labels'] = g.ndata['label']
     in_feats = g.ndata['features'].shape[1]
-    n_classes = data.num_classes
+    n_classes = dataset.num_classes
 
     # Create csr/coo/csc formats before launching training processes with multi-gpu.
     # This avoids creating certain formats in each sub-process, which saves momory and CPU.
     g.create_formats_()
 
-    num_epochs = 20
+    num_runs = 3
     num_hidden = 16
     num_layers = 2
     fan_out = '10,25'
@@ -85,52 +88,77 @@ def track_time(data):
         drop_last=False,
         num_workers=num_workers)
 
-    # Define model and optimizer
-    model = SAGE(in_feats, num_hidden, n_classes, num_layers, F.relu, dropout)
-    model = model.to(device)
-    loss_fcn = nn.CrossEntropyLoss()
-    loss_fcn = loss_fcn.to(device)
-    optimizer = optim.Adam(model.parameters(), lr=lr)
+    epoch_times = []
 
-    # dry run
-    for step, (input_nodes, seeds, blocks) in enumerate(dataloader):
-        # Load the input features as well as output labels
-        #batch_inputs, batch_labels = load_subtensor(g, seeds, input_nodes, device)
-        blocks = [block.int().to(device) for block in blocks]
-        batch_inputs = blocks[0].srcdata['features']
-        batch_labels = blocks[-1].dstdata['labels']
+    for run in range(num_runs):
+        # Define model and optimizer
+        model = SAGE(in_feats, num_hidden, n_classes,
+                     num_layers, F.relu, dropout)
+        model = model.to(device)
+        loss_fcn = nn.CrossEntropyLoss()
+        loss_fcn = loss_fcn.to(device)
+        optimizer = optim.Adam(model.parameters(), lr=lr)
 
-        # Compute loss and prediction
-        batch_pred = model(blocks, batch_inputs)
-        loss = loss_fcn(batch_pred, batch_labels)
-        optimizer.zero_grad()
-        loss.backward()
-        optimizer.step()
+        # dry run
+        for step, (input_nodes, seeds, blocks) in enumerate(dataloader):
+            # Load the input features as well as output labels
+            #batch_inputs, batch_labels = load_subtensor(g, seeds, input_nodes, device)
+            blocks = [block.int().to(device) for block in blocks]
+            batch_inputs = blocks[0].srcdata['features']
+            batch_labels = blocks[-1].dstdata['labels']
 
-        if step >= 3:
-            break
+            # Compute loss and prediction
+            batch_pred = model(blocks, batch_inputs)
+            loss = loss_fcn(batch_pred, batch_labels)
+            optimizer.zero_grad()
+            loss.backward()
+            optimizer.step()
 
-    # Training loop
-    avg = 0
-    iter_tput = []
-    t0 = time.time()
-    for step, (input_nodes, seeds, blocks) in enumerate(dataloader):
-        # Load the input features as well as output labels
-        #batch_inputs, batch_labels = load_subtensor(g, seeds, input_nodes, device)
-        blocks = [block.int().to(device) for block in blocks]
-        batch_inputs = blocks[0].srcdata['features']
-        batch_labels = blocks[-1].dstdata['labels']
+            if step >= 4:
+                break
 
-        # Compute loss and prediction
-        batch_pred = model(blocks, batch_inputs)
-        loss = loss_fcn(batch_pred, batch_labels)
-        optimizer.zero_grad()
-        loss.backward()
-        optimizer.step()
+        # Training loop
+        avg = 0
+        iter_tput = []
 
-        if step >= 9:  # time 10 loops
-            break
+        for step, (input_nodes, seeds, blocks) in enumerate(dataloader):
+            t0 = time.time()
 
-    t1 = time.time()
+            # Load the input features as well as output labels
+            #batch_inputs, batch_labels = load_subtensor(g, seeds, input_nodes, device)
+            blocks = [block.int().to(device) for block in blocks]
+            batch_inputs = blocks[0].srcdata['features']
+            batch_labels = blocks[-1].dstdata['labels']
 
-    return (t1 - t0) / (step + 1)
+            # Compute loss and prediction
+            batch_pred = model(blocks, batch_inputs)
+            loss = loss_fcn(batch_pred, batch_labels)
+            optimizer.zero_grad()
+            loss.backward()
+            optimizer.step()
+
+            t1 = time.time()
+
+            epoch_times.append(t1 - t0)
+
+            if step >= 9:  # time 10 loops
+                break
+
+    avg_epoch_time = np.mean(epoch_times)
+    std_epoch_time = np.std(epoch_times)
+
+    std_const = 1.5
+    low_boundary = avg_epoch_time - std_epoch_time * std_const
+    high_boundary = avg_epoch_time + std_epoch_time * std_const
+
+    valid_epoch_times = np.array(epoch_times)[(
+        epoch_times >= low_boundary) & (epoch_times <= high_boundary)]
+    avg_valid_epoch_time = np.mean(valid_epoch_times)
+
+    # TODO: delete logging for final version
+    print(f'Number of epoch times: {len(epoch_times)}')
+    print(f'Number of valid epoch times: {len(valid_epoch_times)}')
+    print(f'Avg epoch times: {avg_epoch_time}')
+    print(f'Avg valid epoch times: {avg_valid_epoch_time}')
+
+    return avg_valid_epoch_time

--- a/benchmarks/benchmarks/model_speed/bench_sage_ns.py
+++ b/benchmarks/benchmarks/model_speed/bench_sage_ns.py
@@ -155,10 +155,4 @@ def track_time(data):
         epoch_times >= low_boundary) & (epoch_times <= high_boundary)]
     avg_valid_epoch_time = np.mean(valid_epoch_times)
 
-    # TODO: delete logging for final version
-    print(f'Number of epoch times: {len(epoch_times)}')
-    print(f'Number of valid epoch times: {len(valid_epoch_times)}')
-    print(f'Avg epoch times: {avg_epoch_time}')
-    print(f'Avg valid epoch times: {avg_valid_epoch_time}')
-
     return avg_valid_epoch_time

--- a/benchmarks/benchmarks/model_speed/bench_sage_unsupervised_ns.py
+++ b/benchmarks/benchmarks/model_speed/bench_sage_unsupervised_ns.py
@@ -206,10 +206,4 @@ def track_time(data, num_negs, batch_size):
         epoch_times >= low_boundary) & (epoch_times <= high_boundary)]
     avg_valid_epoch_time = np.mean(valid_epoch_times)
 
-    # TODO: delete logging for final version
-    print(f'Number of epoch times: {len(epoch_times)}')
-    print(f'Number of valid epoch times: {len(valid_epoch_times)}')
-    print(f'Avg epoch times: {avg_epoch_time}')
-    print(f'Avg valid epoch times: {avg_valid_epoch_time}')
-
     return avg_valid_epoch_time


### PR DESCRIPTION
## Introduction
@jermainewang @yzh119 I noticed that results of current model_speed benchmarks are unstable and not reliable for quick experiments or for the regression tests. For tests of results stability I compared 2 runs of the full test suite run one after another. Reference and tested states were run in separate Docker containers with fresh Conda environment and there were no other workload on the machine.

##  Description
For the present state of the model_speed benchmarks comparing 2 results for the same commit could lead to speedup (`speedup = result_1 / result_2`) ranging from 0.90x to 1.10x in worst case scenario and frequently ranging from 0.95x to 1.05x. This makes performing quick experiments and looking for speedup much more difficult as retests have to be made to confirm the results. Example of results for 1 run (notice gat_ns, pinsage, sage_ns, sage_unsupervised_ns):
| model                | dataset       | lowmem | type_count | n_negs | batch | reference | tested   | speedup |
|----------------------|---------------|--------|------------|--------|-------|-----------|----------|---------|
| gat                  | cora          | NaN    | NaN        | NaN    | NaN   | 0.019394  | 0.01946  | 1.00    |
| gat                  | pubmed        | NaN    | NaN        | NaN    | NaN   | 0.048195  | 0.048511 | 0.99    |
| gat_ns               | ogbn-products | NaN    | NaN        | NaN    | NaN   | 0.489388  | 0.438861 | 1.12    |
| gat_ns               | reddit        | NaN    | NaN        | NaN    | NaN   | 0.482658  | 0.480488 | 1.00    |
| gcn_udf              | cora          | NaN    | NaN        | NaN    | NaN   | 0.084321  | 0.082097 | 1.03    |
| gcn_udf              | pubmed        | NaN    | NaN        | NaN    | NaN   | 0.458868  | 0.456265 | 1.01    |
| pinsage              | nowplaying_rs | NaN    | NaN        | NaN    | NaN   | 0.105034  | 0.118153 | 0.89    |
| rgcn                 | aifb          | FALSE  | FALSE      | NaN    | NaN   | 0.093191  | 0.091667 | 1.02    |
| rgcn                 | aifb          | FALSE  | TRUE       | NaN    | NaN   | 0.098646  | 0.097513 | 1.01    |
| rgcn                 | aifb          | TRUE   | FALSE      | NaN    | NaN   | 0.101717  | 0.102234 | 0.99    |
| rgcn                 | aifb          | TRUE   | TRUE       | NaN    | NaN   | 0.093609  | 0.094805 | 0.99    |
| rgcn_hetero_ns       | am            | NaN    | NaN        | NaN    | NaN   | 1.140415  | 1.113925 | 1.02    |
| rgcn_hetero_ns       | ogbn-mag      | NaN    | NaN        | NaN    | NaN   | 0.348293  | 0.344832 | 1.01    |
| rgcn_homogeneous_ns  | am            | NaN    | NaN        | NaN    | NaN   | 0.981405  | 0.971834 | 1.01    |
| rgcn_homogeneous_ns  | ogbn-mag      | NaN    | NaN        | NaN    | NaN   | 0.903702  | 0.886176 | 1.02    |
| sage                 | cora          | NaN    | NaN        | NaN    | NaN   | 0.0095    | 0.005783 | 1.64    |
| sage                 | pubmed        | NaN    | NaN        | NaN    | NaN   | 0.027908  | 0.028281 | 0.99    |
| sage_ns              | ogbn-products | NaN    | NaN        | NaN    | NaN   | 0.174926  | 0.169676 | 1.03    |
| sage_ns              | reddit        | NaN    | NaN        | NaN    | NaN   | 0.198665  | 0.190097 | 1.05    |
| sage_unsupervised_ns | reddit        | NaN    | NaN        | 2      | 1024  | 1.914852  | 1.894552 | 1.01    |
| sage_unsupervised_ns | reddit        | NaN    | NaN        | 2      | 2048  | 2.012166  | 2.013621 | 1.00    |
| sage_unsupervised_ns | reddit        | NaN    | NaN        | 2      | 8192  | 2.464784  | 2.349167 | 1.05    |
| sage_unsupervised_ns | reddit        | NaN    | NaN        | 32     | 1024  | 1.888076  | 1.889628 | 1.00    |
| sage_unsupervised_ns | reddit        | NaN    | NaN        | 32     | 2048  | 2.054298  | 1.980407 | 1.04    |
| sage_unsupervised_ns | reddit        | NaN    | NaN        | 32     | 8192  | 2.38998   | 2.36327  | 1.01    |
| sage_unsupervised_ns | reddit        | NaN    | NaN        | 8      | 1024  | 1.964114  | 1.895709 | 1.04    |
| sage_unsupervised_ns | reddit        | NaN    | NaN        | 8      | 2048  | 1.994802  | 2.035146 | 0.98    |
| sage_unsupervised_ns | reddit        | NaN    | NaN        | 8      | 8192  | 2.344019  | 2.29978  | 1.02    |

It seems to be easily resolved by running 3-5 runs of test suite and calculating average of results, but it could be problematic for contributors running quick experiments locally without CI system and results parsing module. It is also problematic for the regression tests and usage of ASV library, because ASV is overwriting results for commit instead of calculating average. Another problem is high value of standard deviation which is also problematic for regression tests. Therefore I propose method in which comparison of 2 results of the same commit leads to speedup usually ranging from 0.98x to 1.02x. Example of results for 1 run:
| model                | dataset       | lowmem | type_count | n_negs | batch | reference | tested   | speedup |
|----------------------|---------------|--------|------------|--------|-------|-----------|----------|---------|
| gat                  | cora          | NaN    | NaN        | NaN    | NaN   | 0.02181   | 0.020516 | 1.06    |
| gat                  | pubmed        | NaN    | NaN        | NaN    | NaN   | 0.048706  | 0.048651 | 1.00    |
| gat_ns               | ogbn-products | NaN    | NaN        | NaN    | NaN   | 0.280246  | 0.279388 | 1.00    |
| gat_ns               | reddit        | NaN    | NaN        | NaN    | NaN   | 0.341361  | 0.351791 | 0.97    |
| gcn_udf              | cora          | NaN    | NaN        | NaN    | NaN   | 0.084972  | 0.084527 | 1.01    |
| gcn_udf              | pubmed        | NaN    | NaN        | NaN    | NaN   | 0.456615  | 0.455419 | 1.00    |
| pinsage              | nowplaying_rs | NaN    | NaN        | NaN    | NaN   | 0.051597  | 0.053634 | 0.96    |
| rgcn                 | aifb          | FALSE  | FALSE      | NaN    | NaN   | 0.092925  | 0.092297 | 1.01    |
| rgcn                 | aifb          | FALSE  | TRUE       | NaN    | NaN   | 0.099435  | 0.099132 | 1.00    |
| rgcn                 | aifb          | TRUE   | FALSE      | NaN    | NaN   | 0.101849  | 0.101431 | 1.00    |
| rgcn                 | aifb          | TRUE   | TRUE       | NaN    | NaN   | 0.094622  | 0.094591 | 1.00    |
| rgcn_hetero_ns       | am            | NaN    | NaN        | NaN    | NaN   | 0.222502  | 0.220672 | 1.01    |
| rgcn_hetero_ns       | ogbn-mag      | NaN    | NaN        | NaN    | NaN   | 0.268841  | 0.269997 | 1.00    |
| rgcn_homogeneous_ns  | am            | NaN    | NaN        | NaN    | NaN   | 0.102341  | 0.102837 | 1.00    |
| rgcn_homogeneous_ns  | ogbn-mag      | NaN    | NaN        | NaN    | NaN   | 0.79319   | 0.785675 | 1.01    |
| sage                 | cora          | NaN    | NaN        | NaN    | NaN   | 0.006288  | 0.007278 | 0.86    |
| sage                 | pubmed        | NaN    | NaN        | NaN    | NaN   | 0.028342  | 0.027793 | 1.02    |
| sage_ns              | ogbn-products | NaN    | NaN        | NaN    | NaN   | 0.040347  | 0.040603 | 0.99    |
| sage_ns              | reddit        | NaN    | NaN        | NaN    | NaN   | 0.083302  | 0.081782 | 1.02    |
| sage_unsupervised_ns | reddit        | NaN    | NaN        | 2      | 1024  | 0.147776  | 0.146276 | 1.01    |
| sage_unsupervised_ns | reddit        | NaN    | NaN        | 2      | 2048  | 0.185933  | 0.185865 | 1.00    |
| sage_unsupervised_ns | reddit        | NaN    | NaN        | 2      | 8192  | 0.270673  | 0.269772 | 1.00    |
| sage_unsupervised_ns | reddit        | NaN    | NaN        | 32     | 1024  | 0.147571  | 0.14906  | 0.99    |
| sage_unsupervised_ns | reddit        | NaN    | NaN        | 32     | 2048  | 0.184202  | 0.185694 | 0.99    |
| sage_unsupervised_ns | reddit        | NaN    | NaN        | 32     | 8192  | 0.272361  | 0.278029 | 0.98    |
| sage_unsupervised_ns | reddit        | NaN    | NaN        | 8      | 1024  | 0.147405  | 0.147646 | 1.00    |
| sage_unsupervised_ns | reddit        | NaN    | NaN        | 8      | 2048  | 0.187751  | 0.182919 | 1.03    |
| sage_unsupervised_ns | reddit        | NaN    | NaN        | 8      | 8192  | 0.273749  | 0.274561 | 1.00    |

The new method also makes value of the standard deviation much lower. Results for 20 runs of the same commit for old and new method (`std_new_smaller = std_old / std_new`):
| model                | dataset       | lowmem | type_count | n_negs | batch | std_new_smaller |
|----------------------|---------------|--------|------------|--------|-------|-----------------|
| gat                  | cora          | NaN    | NaN        | NaN    | NaN   | 1.26            |
| gat                  | pubmed        | NaN    | NaN        | NaN    | NaN   | 1.44            |
| gat_ns               | ogbn-products | NaN    | NaN        | NaN    | NaN   | 6.70            |
| gat_ns               | reddit        | NaN    | NaN        | NaN    | NaN   | 2.20            |
| gcn_udf              | cora          | NaN    | NaN        | NaN    | NaN   | 0.60            |
| gcn_udf              | pubmed        | NaN    | NaN        | NaN    | NaN   | 1.39            |
| pinsage              | nowplaying_rs | NaN    | NaN        | NaN    | NaN   | 9.17            |
| rgcn                 | aifb          | FALSE  | FALSE      | NaN    | NaN   | 1.23            |
| rgcn                 | aifb          | FALSE  | TRUE       | NaN    | NaN   | 1.25            |
| rgcn                 | aifb          | TRUE   | FALSE      | NaN    | NaN   | 1.17            |
| rgcn                 | aifb          | TRUE   | TRUE       | NaN    | NaN   | 0.85            |
| rgcn_hetero_ns       | am            | NaN    | NaN        | NaN    | NaN   | 51.63           |
| rgcn_hetero_ns       | ogbn-mag      | NaN    | NaN        | NaN    | NaN   | 1.74            |
| rgcn_homogeneous_ns  | am            | NaN    | NaN        | NaN    | NaN   | 14.57           |
| rgcn_homogeneous_ns  | ogbn-mag      | NaN    | NaN        | NaN    | NaN   | 1.06            |
| sage                 | cora          | NaN    | NaN        | NaN    | NaN   | 2.01            |
| sage                 | pubmed        | NaN    | NaN        | NaN    | NaN   | 0.96            |
| sage_ns              | ogbn-products | NaN    | NaN        | NaN    | NaN   | 6.33            |
| sage_ns              | reddit        | NaN    | NaN        | NaN    | NaN   | 8.22            |
| sage_unsupervised_ns | reddit        | NaN    | NaN        | 2      | 1024  | 30.91           |
| sage_unsupervised_ns | reddit        | NaN    | NaN        | 2      | 2048  | 24.77           |
| sage_unsupervised_ns | reddit        | NaN    | NaN        | 2      | 8192  | 14.11           |
| sage_unsupervised_ns | reddit        | NaN    | NaN        | 32     | 1024  | 19.31           |
| sage_unsupervised_ns | reddit        | NaN    | NaN        | 32     | 2048  | 42.18           |
| sage_unsupervised_ns | reddit        | NaN    | NaN        | 32     | 8192  | 16.30           |
| sage_unsupervised_ns | reddit        | NaN    | NaN        | 8      | 1024  | 38.23           |
| sage_unsupervised_ns | reddit        | NaN    | NaN        | 8      | 2048  | 11.75           |
| sage_unsupervised_ns | reddit        | NaN    | NaN        | 8      | 8192  | 27.23           |

# Summary
New method guarantees more stable and reliable results of performance benchmarks. It is easier to use for contributors who are running benchmarks locally and is available to use with ASV library. Standard deviation is much lower which is useful for regression tests. I also suggest to give up benchmarking on Cora dataset, because epoch time is so small that it is impossible to have stable results even with new method (it leads sometimes to speedup like 1.80x for the same commit comparison). I attach results from 10 tests of old and new method (2 runs of same commit per test): [benchmark_stability.xlsx](https://github.com/dmlc/dgl/files/6207094/benchmark_stability.xlsx)

## Changes
* 3 runs of training inside script
* Validation of results for calculation of the final average `low boundary <= epoch time <= high boundary` (results outside of this range are rejected):
  * `low boundary = average epoch time - (standard deviation * 1.5)`
  * `high boundary = average epoch time + (standard deviation * 1.5)`
* 5 dry epochs (batch steps) instead of 4 for NS training
* Added dry runs for RGCN (full graph)
* Batch size 64 instead of 1024 for RGCN Heterogeneous NS and RGCN Homogeneous NSfor AM dataset. This dataset is small and with batch size of 1024 it records only 1 epoch (batch step) time per run
* Code refactoring like sorting import, deletion of unused imports, unification of naming and structure of code inside the `track_time` function

## Machine Info
* CPU: Intel(R) Xeon(R) Platinum 8260L CPU @ 2.40GHz
* Cores: 48
* RAM: 256 GB
* DGL_CPU_INTEL_KERNEL_ENABLED=1
* OMP_NUM_THREADS=24
* Docker container: [dgl-ci-cpu](https://hub.docker.com/r/dgllib/dgl-ci-cpu)
* Linux distribution: Ubuntu 16.04.6 LTS
* Kernel version: Linux 4.15.0-137-generic
* Python: 3.6
* GPU: None

## Checklist
Please feel free to remove inapplicable items for your PR.
- [x] The PR title starts with [$CATEGORY] (such as [NN], [Model], [Doc], [Feature]])
- [x] Changes are complete (i.e. I finished coding on this PR)
- [ ] All changes have test coverage
- [ ] Code is well-documented
- [x] To the my best knowledge, examples are either not affected by this change,
      or have been fixed to be compatible with this change
- [ ] Related issue is referred in this PR
- [ ] If the PR is for a new model/paper, I've updated the example index [here](../examples/README.md).