### PR TITLE
[Example] remove unused and undefined function for running an example

### DIFF
--- a/examples/pytorch/seal/sampler.py
+++ b/examples/pytorch/seal/sampler.py
@@ -7,7 +7,7 @@ from torch.utils.data import DataLoader, Dataset
 from dgl import DGLGraph, NID
 from dgl.dataloading.negative_sampler import Uniform
 from dgl import add_self_loop
-from utils import drnl_node_labeling, coalesce_graph
+from utils import drnl_node_labeling
 
 
 class GraphDataSet(Dataset):


### PR DESCRIPTION
## Description
Function coalesce_graph is undefined and unused.
So It occurs an error while running an example.

## Checklist
Please feel free to remove inapplicable items for your PR.
- [x ] The PR title starts with [$CATEGORY] (such as [NN], [Model], [Doc], [Feature]])
- [ ] Changes are complete (i.e. I finished coding on this PR)
- [ ] All changes have test coverage
- [ ] Code is well-documented
- [ ] To the my best knowledge, examples are either not affected by this change,
      or have been fixed to be compatible with this change
- [ ] Related issue is referred in this PR
- [ ] If the PR is for a new model/paper, I've updated the example index [here](../examples/README.md).

## Changes
<!-- You could use following template
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)
-->
