### PR TITLE
[Performance] Prefer parallelized conversion to CSC from COO instead of transposing CSR

### DIFF
--- a/python/dgl/convert.py
+++ b/python/dgl/convert.py
@@ -158,7 +158,7 @@ def graph(data,
                            ' but got {} and {}.'.format(num_nodes, max(urange, vrange) - 1))
         urange, vrange = num_nodes, num_nodes
 
-    g = create_from_edges(u, v, '_N', '_E', '_N', urange, vrange)
+    g = create_from_edges(u, v, '_N', '_E', '_N', urange, vrange, validate=False)
 
     return g.to(device)
 

--- a/src/graph/unit_graph.cc
+++ b/src/graph/unit_graph.cc
@@ -1310,6 +1310,8 @@ UnitGraph::CSRPtr UnitGraph::GetInCSR(bool inplace) const {
       LOG(FATAL) << "The graph have restricted sparse format " <<
         CodeToStr(formats_) << ", cannot create CSC matrix.";
   CSRPtr ret = in_csr_;
+  // Prefers converting from COO since it is parallelized.
+  // TODO(BarclayII): need benchmarking.
   if (!in_csr_->defined()) {
     if (coo_->defined()) {
       const auto& newadj = aten::COOToCSR(
@@ -1339,6 +1341,8 @@ UnitGraph::CSRPtr UnitGraph::GetOutCSR(bool inplace) const {
       LOG(FATAL) << "The graph have restricted sparse format " <<
         CodeToStr(formats_) << ", cannot create CSR matrix.";
   CSRPtr ret = out_csr_;
+  // Prefers converting from COO since it is parallelized.
+  // TODO(BarclayII): need benchmarking.
   if (!out_csr_->defined()) {
     if (coo_->defined()) {
       const auto& newadj = aten::COOToCSR(coo_->adj());

--- a/src/graph/unit_graph.cc
+++ b/src/graph/unit_graph.cc
@@ -1311,17 +1311,17 @@ UnitGraph::CSRPtr UnitGraph::GetInCSR(bool inplace) const {
         CodeToStr(formats_) << ", cannot create CSC matrix.";
   CSRPtr ret = in_csr_;
   if (!in_csr_->defined()) {
-    if (out_csr_->defined()) {
-      const auto& newadj = aten::CSRTranspose(out_csr_->adj());
+    if (coo_->defined()) {
+      const auto& newadj = aten::COOToCSR(
+            aten::COOTranspose(coo_->adj()));
 
       if (inplace)
         *(const_cast<UnitGraph*>(this)->in_csr_) = CSR(meta_graph(), newadj);
       else
         ret = std::make_shared<CSR>(meta_graph(), newadj);
     } else {
-      CHECK(coo_->defined()) << "None of CSR, COO exist";
-      const auto& newadj = aten::COOToCSR(
-            aten::COOTranspose(coo_->adj()));
+      CHECK(out_csr_->defined()) << "None of CSR, COO exist";
+      const auto& newadj = aten::CSRTranspose(out_csr_->adj());
 
       if (inplace)
         *(const_cast<UnitGraph*>(this)->in_csr_) = CSR(meta_graph(), newadj);
@@ -1340,16 +1340,16 @@ UnitGraph::CSRPtr UnitGraph::GetOutCSR(bool inplace) const {
         CodeToStr(formats_) << ", cannot create CSR matrix.";
   CSRPtr ret = out_csr_;
   if (!out_csr_->defined()) {
-    if (in_csr_->defined()) {
-      const auto& newadj = aten::CSRTranspose(in_csr_->adj());
+    if (coo_->defined()) {
+      const auto& newadj = aten::COOToCSR(coo_->adj());
 
       if (inplace)
         *(const_cast<UnitGraph*>(this)->out_csr_) = CSR(meta_graph(), newadj);
       else
         ret = std::make_shared<CSR>(meta_graph(), newadj);
     } else {
-      CHECK(coo_->defined()) << "None of CSR, COO exist";
-      const auto& newadj = aten::COOToCSR(coo_->adj());
+      CHECK(in_csr_->defined()) << "None of CSR, COO exist";
+      const auto& newadj = aten::CSRTranspose(in_csr_->adj());
 
       if (inplace)
         *(const_cast<UnitGraph*>(this)->out_csr_) = CSR(meta_graph(), newadj);


### PR DESCRIPTION
This makes `g.create_formats_()` significantly faster for large graphs such as OGB-MAG240M.