### PR TITLE
[Distributed] Automatically setting the number of OMP threads for trainers

### DIFF
--- a/tools/launch.py
+++ b/tools/launch.py
@@ -145,7 +145,7 @@ def main():
     if args.num_omp_threads is None:
         # Here we assume all machines have the same number of CPU cores as the machine
         # where the launch script runs.
-        args.num_omp_threads = multiprocessing.cpu_count() // 2 // args.num_trainers
+        args.num_omp_threads = max(multiprocessing.cpu_count() // 2 // args.num_trainers, 1)
         print('The number of OMP threads per trainer is set to', args.num_omp_threads)
 
     udf_command = str(udf_command[0])

--- a/tools/launch.py
+++ b/tools/launch.py
@@ -143,6 +143,8 @@ def main():
     assert args.ip_config is not None, \
             'A user has to specify an IP configuration file with --ip_config.'
     if args.num_omp_threads is None:
+        # Here we assume all machines have the same number of CPU cores as the machine
+        # where the launch script runs.
         args.num_omp_threads = multiprocessing.cpu_count() // 2 // args.num_trainers
         print('The number of OMP threads per trainer is set to', args.num_omp_threads)
 

--- a/tools/launch.py
+++ b/tools/launch.py
@@ -8,6 +8,7 @@ import signal
 import logging
 import time
 import json
+import multiprocessing
 from threading import Thread
 
 DEFAULT_PORT = 30050
@@ -77,6 +78,8 @@ def submit_jobs(args, udf_command):
     client_cmd = client_cmd + ' ' + 'DGL_NUM_SERVER=' + str(args.num_servers)
     if os.environ.get('OMP_NUM_THREADS') is not None:
         client_cmd = client_cmd + ' ' + 'OMP_NUM_THREADS=' + os.environ.get('OMP_NUM_THREADS')
+    else:
+        client_cmd = client_cmd + ' ' + 'OMP_NUM_THREADS=' + str(args.num_omp_threads)
     if os.environ.get('PYTHONPATH') is not None:
         client_cmd = client_cmd + ' ' + 'PYTHONPATH=' + os.environ.get('PYTHONPATH')
 
@@ -111,6 +114,8 @@ def main():
                         the contents of current directory will be rsyncd')
     parser.add_argument('--num_trainers', type=int,
                         help='The number of trainer processes per machine')
+    parser.add_argument('--num_omp_threads', type=int,
+                        help='The number of OMP threads per trainer')
     parser.add_argument('--num_samplers', type=int, default=0,
                         help='The number of sampler processes per trainer process')
     parser.add_argument('--num_servers', type=int,
@@ -137,6 +142,10 @@ def main():
             'A user has to specify a partition configuration file with --part_config.'
     assert args.ip_config is not None, \
             'A user has to specify an IP configuration file with --ip_config.'
+    if args.num_omp_threads is None:
+        args.num_omp_threads = multiprocessing.cpu_count() // 2 // args.num_trainers
+        print('The number of OMP threads per trainer is set to', args.num_omp_threads)
+
     udf_command = str(udf_command[0])
     if 'python' not in udf_command:
         raise RuntimeError("DGL launching script can only support Python executable file.")


### PR DESCRIPTION
## Description
When running more than one trainer in a machine, the number of OMP thread will be set to 1 by default. This makes CPU training very slow. This PR adds an argument to the launch script to customize the number of OMP threads in trainers.

## Checklist
Please feel free to remove inapplicable items for your PR.
- [ ] The PR title starts with [$CATEGORY] (such as [NN], [Model], [Doc], [Feature]])
- [ ] Changes are complete (i.e. I finished coding on this PR)
- [ ] All changes have test coverage
- [ ] Code is well-documented
- [ ] To the my best knowledge, examples are either not affected by this change,
      or have been fixed to be compatible with this change
- [ ] Related issue is referred in this PR
- [ ] If the PR is for a new model/paper, I've updated the example index [here](../examples/README.md).

## Changes
<!-- You could use following template
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)
-->
