### PR TITLE
[Feature] Add max_inf and min_inf reducers that does not replace infinities with zero

### DIFF
--- a/python/dgl/function/reducer.py
+++ b/python/dgl/function/reducer.py
@@ -87,7 +87,7 @@ __all__ = []
 
 def _register_builtin_reduce_func():
     """Register builtin reduce functions"""
-    for reduce_op in ["max", "min", "sum", "mean"]:
+    for reduce_op in ["max", "min", "sum", "mean", "min_inf", "max_inf"]:
         builtin = _gen_reduce_builtin(reduce_op)
         setattr(sys.modules[__name__], reduce_op, builtin)
         __all__.append(reduce_op)


### PR DESCRIPTION
## Description
Currently `min` and `max` reducers automatically replaces infinities with zeros, which makes sense for computations in neural networks.

This PR adds two reducers `max_inf` and `min_inf` that do not replace infinities.  They are useful for e.g. computing differentiable shortest paths with message passing:
```python
while not converged:
    g.update_all(dgl.function.u_add_e('x', 'd', 'm'), dgl.function.min_inf('m', 'x_new'))
    g.ndata['x'] = torch.min(g.ndata['x'], g.ndata['x_new'])
```

This is a draft and only for my own research purpose.  If someone has the same requirement though you can take a look in this PR.

## Checklist
Please feel free to remove inapplicable items for your PR.
- [x] The PR title starts with [$CATEGORY] (such as [NN], [Model], [Doc], [Feature]])
- [ ] Changes are complete (i.e. I finished coding on this PR)
- [ ] All changes have test coverage
- [ ] Code is well-documented
- [ ] To the my best knowledge, examples are either not affected by this change,
      or have been fixed to be compatible with this change
- [ ] Related issue is referred in this PR
- [ ] If the PR is for a new model/paper, I've updated the example index [here](../examples/README.md).
