### PR TITLE
[Distributed] Return the ID mapping in graph partitioning.

### DIFF
--- a/python/dgl/distributed/partition.py
+++ b/python/dgl/distributed/partition.py
@@ -473,7 +473,8 @@ def partition_graph(g, graph_name, num_parts, out_path, num_hops=1, part_method=
             node_parts = random_choice(num_parts, sim_g.number_of_nodes())
         parts, orig_nids, orig_eids = partition_graph_with_halo(sim_g, node_parts, num_hops,
                                                                 reshuffle=reshuffle)
-        if reshuffle and return_mapping and len(g.etypes) > 1:
+        is_hetero = len(g.etypes) > 1 or len(g.ntypes) > 1
+        if reshuffle and return_mapping and is_hetero:
             # Get the type IDs
             orig_ntype = F.gather_row(sim_g.ndata[NTYPE], orig_nids)
             orig_etype = F.gather_row(sim_g.edata[ETYPE], orig_eids)
@@ -484,7 +485,7 @@ def partition_graph(g, graph_name, num_parts, out_path, num_hops=1, part_method=
                     for ntype in g.ntypes}
             orig_eids = {etype: F.boolean_mask(orig_eids, orig_etype == g.get_etype_id(etype)) \
                     for etype in g.etypes}
-        elif not reshuffle and len(g.etypes) == 1 and return_mapping:
+        elif not reshuffle and not is_hetero and return_mapping:
             orig_nids = F.arange(0, sim_g.number_of_nodes())
             orig_eids = F.arange(0, sim_g.number_of_edges())
         elif not reshuffle and return_mapping:

--- a/python/dgl/distributed/partition.py
+++ b/python/dgl/distributed/partition.py
@@ -11,7 +11,6 @@ from ..convert import to_homogeneous
 from ..random import choice as random_choice
 from ..data.utils import load_graphs, save_graphs, load_tensors, save_tensors
 from ..transform import metis_partition_assignment, partition_graph_with_halo
-from ..partition import reshuffle_graph
 from .graph_partition_book import BasicPartitionBook, RangePartitionBook
 
 def _get_inner_node_mask(graph, ntype_id):

--- a/python/dgl/distributed/partition.py
+++ b/python/dgl/distributed/partition.py
@@ -484,10 +484,10 @@ def partition_graph(g, graph_name, num_parts, out_path, num_hops=1, part_method=
                     for ntype in g.ntypes}
             orig_eids = {etype: F.boolean_mask(orig_eids, orig_etype == g.get_etype_id(etype)) \
                     for etype in g.etypes}
-        elif not reshuffle and len(g.etypes) == 1:
+        elif not reshuffle and len(g.etypes) == 1 and return_mapping:
             orig_nids = F.arange(0, sim_g.number_of_nodes())
             orig_eids = F.arange(0, sim_g.number_of_edges())
-        elif not reshuffle:
+        elif not reshuffle and return_mapping:
             orig_nids = {ntype: F.arange(0, g.number_of_nodes(ntype)) for ntype in g.ntypes}
             orig_eids = {etype: F.arange(0, g.number_of_edges(etype)) for etype in g.etypes}
     else:

--- a/python/dgl/distributed/partition.py
+++ b/python/dgl/distributed/partition.py
@@ -475,13 +475,15 @@ def partition_graph(g, graph_name, num_parts, out_path, num_hops=1, part_method=
                                                                 reshuffle=reshuffle)
         if reshuffle and return_mapping and len(g.etypes) > 1:
             # Get the type IDs
-            orig_ntype = sim_g.ndata[NTYPE][orig_nids]
-            orig_etype = sim_g.edata[ETYPE][orig_eids]
+            orig_ntype = F.gather_row(sim_g.ndata[NTYPE], orig_nids)
+            orig_etype = F.gather_row(sim_g.edata[ETYPE], orig_eids)
             # Mapping between shuffled global IDs to original per-type IDs
-            orig_nids = sim_g.ndata[NID][orig_nids]
-            orig_eids = sim_g.edata[EID][orig_eids]
-            orig_nids = {ntype: orig_nids[orig_ntype == g.get_ntype_id(ntype)] for ntype in g.ntypes}
-            orig_eids = {etype: orig_eids[orig_etype == g.get_etype_id(etype)] for etype in g.etypes}
+            orig_nids = F.gather_row(sim_g.ndata[NID], orig_nids)
+            orig_eids = F.gather_row(sim_g.edata[EID], orig_eids)
+            orig_nids = {ntype: F.boolean_mask(orig_nids, orig_ntype == g.get_ntype_id(ntype)) \
+                    for ntype in g.ntypes}
+            orig_eids = {etype: F.boolean_mask(orig_eids, orig_etype == g.get_etype_id(etype)) \
+                    for etype in g.etypes}
         elif not reshuffle and len(g.etypes) == 1:
             orig_nids = F.arange(0, sim_g.number_of_nodes())
             orig_eids = F.arange(0, sim_g.number_of_edges())

--- a/python/dgl/partition.py
+++ b/python/dgl/partition.py
@@ -351,6 +351,6 @@ def metis_partition(g, k, extra_cached_hops=0, reshuffle=False,
         return None
 
     # Then we split the original graph into parts based on the METIS partitioning results.
-    return partition_graph_with_halo(g, node_part, extra_cached_hops, reshuffle)
+    return partition_graph_with_halo(g, node_part, extra_cached_hops, reshuffle)[0]
 
 _init_api("dgl.partition")

--- a/python/dgl/partition.py
+++ b/python/dgl/partition.py
@@ -146,6 +146,12 @@ def partition_graph_with_halo(g, node_part, extra_cached_hops, reshuffle=False):
     --------
     a dict of DGLGraphs
         The key is the partition ID and the value is the DGLGraph of the partition.
+    Tensor
+        1D tensor that stores the mapping between the reshuffled node IDs and
+        the original node IDs if 'reshuffle=True'. Otherwise, return None.
+    Tensor
+        1D tensor that stores the mapping between the reshuffled edge IDs and
+        the original edge IDs if 'reshuffle=True'. Otherwise, return None.
     '''
     assert len(node_part) == g.number_of_nodes()
     if reshuffle:
@@ -194,7 +200,10 @@ def partition_graph_with_halo(g, node_part, extra_cached_hops, reshuffle=False):
         subg.edata['inner_edge'] = inner_edge
         subg_dict[i] = subg
     print('Construct subgraphs: {:.3f} seconds'.format(time.time() - start))
-    return subg_dict
+    if reshuffle:
+        return subg_dict, orig_nids, orig_eids
+    else:
+        return subg_dict, None, None
 
 
 def metis_partition_assignment(g, k, balance_ntypes=None, balance_edges=False):

--- a/tests/compute/test_transform.py
+++ b/tests/compute/test_transform.py
@@ -504,7 +504,7 @@ def get_nodeflow(g, node_ids, num_layers):
 def test_partition_with_halo():
     g = create_large_graph(1000)
     node_part = np.random.choice(4, g.number_of_nodes())
-    subgs = dgl.transform.partition_graph_with_halo(g, node_part, 2, reshuffle=True)
+    subgs, _, _ = dgl.transform.partition_graph_with_halo(g, node_part, 2, reshuffle=True)
     for part_id, subg in subgs.items():
         node_ids = np.nonzero(node_part == part_id)[0]
         lnode_ids = np.nonzero(F.asnumpy(subg.ndata['inner_node']))[0]

--- a/tests/distributed/test_partition.py
+++ b/tests/distributed/test_partition.py
@@ -146,7 +146,6 @@ def check_hetero_partition(hg, part_method):
     assert len(orig_nids) == len(hg.ntypes)
     assert len(orig_eids) == len(hg.etypes)
     for ntype in hg.ntypes:
-        print(ntype, len(orig_nids[ntype]), hg.number_of_nodes(ntype))
         assert len(orig_nids[ntype]) == hg.number_of_nodes(ntype)
     for etype in hg.etypes:
         assert len(orig_eids[etype]) == hg.number_of_edges(etype)

--- a/tests/distributed/test_partition.py
+++ b/tests/distributed/test_partition.py
@@ -141,11 +141,46 @@ def check_hetero_partition(hg, part_method):
     num_parts = 4
     num_hops = 1
 
-    partition_graph(hg, 'test', num_parts, '/tmp/partition', num_hops=num_hops,
-                    part_method=part_method, reshuffle=True)
+    orig_nids, orig_eids = partition_graph(hg, 'test', num_parts, '/tmp/partition', num_hops=num_hops,
+                                           part_method=part_method, reshuffle=True, return_mapping=True)
+    assert len(orig_nids) == len(hg.ntypes)
+    assert len(orig_eids) == len(hg.etypes)
+    for ntype in hg.ntypes:
+        print(ntype, len(orig_nids[ntype]), hg.number_of_nodes(ntype))
+        assert len(orig_nids[ntype]) == hg.number_of_nodes(ntype)
+    for etype in hg.etypes:
+        assert len(orig_eids[etype]) == hg.number_of_edges(etype)
     parts = []
     for i in range(num_parts):
         part_g, node_feats, edge_feats, gpb, _, ntypes, etypes = load_partition('/tmp/partition/test.json', i)
+        # Verify the mapping between the reshuffled IDs and the original IDs.
+        # These are partition-local IDs.
+        part_src_ids, part_dst_ids = part_g.edges()
+        # These are reshuffled global homogeneous IDs.
+        part_src_ids = part_g.ndata[dgl.NID][part_src_ids]
+        part_dst_ids = part_g.ndata[dgl.NID][part_dst_ids]
+        part_eids = part_g.edata[dgl.EID]
+        # These are reshuffled per-type IDs.
+        src_ntype_ids, part_src_ids = gpb.map_to_per_ntype(part_src_ids)
+        dst_ntype_ids, part_dst_ids = gpb.map_to_per_ntype(part_dst_ids)
+        etype_ids, part_eids = gpb.map_to_per_etype(part_eids)
+        # These are original per-type IDs.
+        for etype_id, etype in enumerate(hg.etypes):
+            part_src_ids1 = part_src_ids[etype_ids == etype_id]
+            src_ntype_ids1 = src_ntype_ids[etype_ids == etype_id]
+            part_dst_ids1 = part_dst_ids[etype_ids == etype_id]
+            dst_ntype_ids1 = dst_ntype_ids[etype_ids == etype_id]
+            part_eids1 = part_eids[etype_ids == etype_id]
+            assert np.all(F.asnumpy(src_ntype_ids1 == src_ntype_ids1[0]))
+            assert np.all(F.asnumpy(dst_ntype_ids1 == dst_ntype_ids1[0]))
+            src_ntype = hg.ntypes[src_ntype_ids1[0]]
+            dst_ntype = hg.ntypes[dst_ntype_ids1[0]]
+            orig_src_ids1 = orig_nids[src_ntype][part_src_ids1]
+            orig_dst_ids1 = orig_nids[dst_ntype][part_dst_ids1]
+            orig_eids1 = orig_eids[etype][part_eids1]
+            orig_eids2 = hg.edge_ids(orig_src_ids1, orig_dst_ids1, etype=etype)
+            assert len(orig_eids1) == len(orig_eids2)
+            assert np.all(F.asnumpy(orig_eids1) == F.asnumpy(orig_eids2))
         parts.append(part_g)
         verify_graph_feats(hg, part_g, node_feats)
     verify_hetero_graph(hg, parts)


### PR DESCRIPTION
## Description
When we partition a graph, we reshuffle node/edge IDs. Sometimes users need this ID mapping between shuffled IDs and the original IDs so that they can adjust other data related to the partitioned graph.

## Checklist
Please feel free to remove inapplicable items for your PR.
- [ ] The PR title starts with [$CATEGORY] (such as [NN], [Model], [Doc], [Feature]])
- [ ] Changes are complete (i.e. I finished coding on this PR)
- [ ] All changes have test coverage
- [ ] Code is well-documented
- [ ] To the my best knowledge, examples are either not affected by this change,
      or have been fixed to be compatible with this change
- [ ] Related issue is referred in this PR
- [ ] If the PR is for a new model/paper, I've updated the example index [here](../examples/README.md).

## Changes
<!-- You could use following template
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)
-->
