### PR TITLE
[Example] Use 0 workers for PCQM4M by default

### DIFF
--- a/examples/pytorch/ogb_lsc/PCQM4M/main.py
+++ b/examples/pytorch/ogb_lsc/PCQM4M/main.py
@@ -113,8 +113,8 @@ def main():
                         help='input batch size for training (default: 256)')
     parser.add_argument('--epochs', type=int, default=100,
                         help='number of epochs to train (default: 100)')
-    parser.add_argument('--num_workers', type=int, default=4,
-                        help='number of workers (default: 4)')
+    parser.add_argument('--num_workers', type=int, default=0,
+                        help='number of workers (default: 0)')
     parser.add_argument('--log_dir', type=str, default="",
                         help='tensorboard log directory. If not specified, '
                              'tensorboard will not be used.')


### PR DESCRIPTION
## Description
As mentioned in #2349 , to use 4 workers in data loading can increase CPU memory usage with limited gain.

## Checklist
Please feel free to remove inapplicable items for your PR.
- [x] The PR title starts with [$CATEGORY] (such as [NN], [Model], [Doc], [Feature]])
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage
- [ ] Code is well-documented
- [x] To the my best knowledge, examples are either not affected by this change,
      or have been fixed to be compatible with this change
- [x] Related issue is referred in this PR
- [ ] If the PR is for a new model/paper, I've updated the example index [here](../examples/README.md).