### PR TITLE
[Dataloading] Make loader iters iterator

### DIFF
--- a/python/dgl/dataloading/pytorch/__init__.py
+++ b/python/dgl/dataloading/pytorch/__init__.py
@@ -14,7 +14,7 @@ class _ScalarDataBatcherIter:
         self.batch_size = batch_size
         self.index = 0
         self.drop_last = drop_last
-        
+
     def __iter__(self):
         return self
 
@@ -216,7 +216,7 @@ class _NodeDataLoaderIter:
         self.device = node_dataloader.device
         self.node_dataloader = node_dataloader
         self.iter_ = iter(node_dataloader.dataloader)
-        
+
     def __iter__(self):
         return self
 
@@ -233,7 +233,7 @@ class _EdgeDataLoaderIter:
         self.device = edge_dataloader.device
         self.edge_dataloader = edge_dataloader
         self.iter_ = iter(edge_dataloader.dataloader)
-        
+
     def __iter__(self):
         return self
 

--- a/python/dgl/dataloading/pytorch/__init__.py
+++ b/python/dgl/dataloading/pytorch/__init__.py
@@ -14,6 +14,9 @@ class _ScalarDataBatcherIter:
         self.batch_size = batch_size
         self.index = 0
         self.drop_last = drop_last
+        
+    def __iter__(self):
+        return self
 
     def __next__(self):
         num_items = self.dataset.shape[0]
@@ -213,6 +216,9 @@ class _NodeDataLoaderIter:
         self.device = node_dataloader.device
         self.node_dataloader = node_dataloader
         self.iter_ = iter(node_dataloader.dataloader)
+        
+    def __iter__(self):
+        return self
 
     def __next__(self):
         # input_nodes, output_nodes, blocks
@@ -227,6 +233,9 @@ class _EdgeDataLoaderIter:
         self.device = edge_dataloader.device
         self.edge_dataloader = edge_dataloader
         self.iter_ = iter(edge_dataloader.dataloader)
+        
+    def __iter__(self):
+        return self
 
     def __next__(self):
         result_ = next(self.iter_)

--- a/tests/pytorch/test_dataloader.py
+++ b/tests/pytorch/test_dataloader.py
@@ -179,6 +179,7 @@ def test_neighbor_sampler_dataloader():
     for _g, nid, collator, mode in zip(graphs, nids, collators, modes):
         dl = DataLoader(
             collator.dataset, collate_fn=collator.collate, batch_size=2, shuffle=True, drop_last=False)
+        assert isinstance(iter(dl), Iterator)
         _check_neighbor_sampling_dataloader(_g, nid, dl, mode, collator)
 
 def test_graph_dataloader():
@@ -186,6 +187,7 @@ def test_graph_dataloader():
     num_batches = 2
     minigc_dataset = dgl.data.MiniGCDataset(batch_size * num_batches, 10, 20)
     data_loader = dgl.dataloading.GraphDataLoader(minigc_dataset, batch_size=batch_size, shuffle=True)
+    assert isinstance(iter(data_loader), Iterator)
     for graph, label in data_loader:
         assert isinstance(graph, dgl.DGLGraph)
         assert F.asnumpy(label).shape[0] == batch_size
@@ -226,6 +228,7 @@ def test_node_dataloader():
     dataloader = dgl.dataloading.NodeDataLoader(
         g2, {nty: g2.nodes(nty) for nty in g2.ntypes},
         sampler, device=F.ctx(), batch_size=batch_size)
+    assert isinstance(iter(dataloader), Iterator)
     for input_nodes, output_nodes, blocks in dataloader:
         _check_device(input_nodes)
         _check_device(output_nodes)
@@ -280,6 +283,8 @@ def test_edge_dataloader():
         g2, {ety: g2.edges(form='eid', etype=ety) for ety in g2.canonical_etypes},
         sampler, device=F.ctx(), negative_sampler=neg_sampler,
         batch_size=batch_size)
+    
+    assert isinstance(iter(dataloader), Iterator)
     for input_nodes, pos_pair_graph, neg_pair_graph, blocks in dataloader:
         _check_device(input_nodes)
         _check_device(pos_pair_graph)

--- a/tests/pytorch/test_dataloader.py
+++ b/tests/pytorch/test_dataloader.py
@@ -3,6 +3,7 @@ import backend as F
 import unittest
 from torch.utils.data import DataLoader
 from collections import defaultdict
+from collections.abc import Iterator
 from itertools import product
 
 def _check_neighbor_sampling_dataloader(g, nids, dl, mode, collator):


### PR DESCRIPTION
## Description
Makes all loader iters return `self` in `__iter_` to enable type-checking with `collections.abc.Iterator`
This allows checks in Libraries like PyTorch Lightning (https://github.com/PyTorchLightning/pytorch-lightning/issues/7164)
## Checklist
Please feel free to remove inapplicable items for your PR.
- [x] The PR title starts with [$CATEGORY] (such as [NN], [Model], [Doc], [Feature]])
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage
- [x] Code is well-documented
- [x] To the my best knowledge, examples are either not affected by this change,
      or have been fixed to be compatible with this change
- [x] Related issue is referred in this PR
## Changes
 - Add `__iter__` to all Iterators
