### PR TITLE
[NN] Small bug fix for out_feat = 1 with self loops

### DIFF
--- a/python/dgl/nn/pytorch/conv/relgraphconv.py
+++ b/python/dgl/nn/pytorch/conv/relgraphconv.py
@@ -362,6 +362,8 @@ class RelGraphConv(nn.Module):
                          fn.sum(msg='msg', out='h'))
             # apply bias and activation
             node_repr = g.dstdata['h']
+            if len(node_repr.shape) == 1:
+                node_repr = node_repr[..., None]
             if self.layer_norm:
                 node_repr = self.layer_norm_weight(node_repr)
             if self.bias:


### PR DESCRIPTION
When using self_loops with out_feat=1, the shapes are as follow : 
node_repr : (graph_size)
loop_message : (graph_size, 1)
So the addition uses broadcasting and the output is of size (graph_size, graph_size)

I just added a check to add an axis when out_feat=1