### PR TITLE
Remove __len__ method from DGLGraph

### DIFF
--- a/python/dgl/heterograph.py
+++ b/python/dgl/heterograph.py
@@ -2447,13 +2447,6 @@ class DGLHeteroGraph(object):
         else:
             return self._graph.number_of_edges(self.get_etype_id(etype))
 
-    def __len__(self):
-        """Deprecated: please directly call :func:`number_of_nodes`
-        """
-        dgl_warning('DGLGraph.__len__ is deprecated.'
-                    'Please directly call DGLGraph.number_of_nodes.')
-        return self.number_of_nodes()
-
     @property
     def is_multigraph(self):
         """Return whether the graph is a multigraph with parallel edges.

--- a/tests/compute/test_graph.py
+++ b/tests/compute/test_graph.py
@@ -59,7 +59,6 @@ def test_query():
     def _test_one(g):
         assert g.number_of_nodes() == 10
         assert g.number_of_edges() == 20
-        assert len(g) == 10
 
         for i in range(10):
             assert g.has_node(i)
@@ -131,7 +130,6 @@ def test_query():
     def _test_csr_one(g):
         assert g.number_of_nodes() == 10
         assert g.number_of_edges() == 20
-        assert len(g) == 10
 
         for i in range(10):
             assert g.has_node(i)

--- a/tutorials/models/1_gnn/4_rgcn.py
+++ b/tutorials/models/1_gnn/4_rgcn.py
@@ -313,7 +313,7 @@ g = DGLGraph((data.edge_src, data.edge_dst))
 g.edata.update({'rel_type': edge_type, 'norm': edge_norm})
 
 # create model
-model = Model(len(g),
+model = Model(g.num_nodes(),
               n_hidden,
               num_classes,
               num_rels,


### PR DESCRIPTION
PyCharm accesses the `__len__` method for every variable during debugging, which will output lots of warning messages for DGLGraph objects.  Very uncomfortable.

Fixes #2901 .