### PR TITLE
Fixing issue #2921

### DIFF
--- a/python/dgl/nn/pytorch/conv/gatconv.py
+++ b/python/dgl/nn/pytorch/conv/gatconv.py
@@ -168,7 +168,7 @@ class GATConv(nn.Module):
         else:
             self.register_buffer('bias', None)
         if residual:
-            if self._in_dst_feats != out_feats:
+            if self._in_dst_feats != out_feats * out_feats:
                 self.res_fc = nn.Linear(
                     self._in_dst_feats, num_heads * out_feats, bias=False)
             else:

--- a/python/dgl/nn/pytorch/conv/gatconv.py
+++ b/python/dgl/nn/pytorch/conv/gatconv.py
@@ -168,7 +168,7 @@ class GATConv(nn.Module):
         else:
             self.register_buffer('bias', None)
         if residual:
-            if self._in_dst_feats != out_feats * out_feats:
+            if self._in_dst_feats != out_feats * num_heads:
                 self.res_fc = nn.Linear(
                     self._in_dst_feats, num_heads * out_feats, bias=False)
             else:


### PR DESCRIPTION
A linear layer (res_fc) is used to reshape features to the shape of the output feature of GATConv (in dimensions of out_feats * num_heads) for the residual connection. However, the previous conditional check failed to cover this. 
