### PR TITLE
[Doc] Fix a typo in the tutorial for link prediction

### DIFF
--- a/tutorials/blitz/4_link_predict.py
+++ b/tutorials/blitz/4_link_predict.py
@@ -90,7 +90,7 @@ eids = np.random.permutation(eids)
 test_size = int(len(eids) * 0.1)
 train_size = g.number_of_edges() - test_size
 test_pos_u, test_pos_v = u[eids[:test_size]], v[eids[:test_size]]
-train_pos_u, train_pos_v = u[eids[test_size:]], v[eids[test_size:]]
+train_pos_u, train_pos_v = u[eids[train_size:]], v[eids[train_size:]]
 
 # Find all negative edges and split them for training and testing
 adj = sp.coo_matrix((np.ones(len(u)), (u.numpy(), v.numpy())))


### PR DESCRIPTION

## Description
There is a typo in the sample codes for the section *Prepare training and testing sets*.

```
train_size = g.number_of_edges() - test_size
test_pos_u, test_pos_v = u[eids[:test_size]], v[eids[:test_size]]
# Should be "train_size" in the line below
train_pos_u, train_pos_v = u[eids[test_size:]], v[eids[test_size:]]
```


## Checklist
Please feel free to remove inapplicable items for your PR.
- [V] The PR title starts with [$CATEGORY] (such as [NN], [Model], [Doc], [Feature]])
- [V] Changes are complete (i.e. I finished coding on this PR)
- [V] Related issue is referred in this PR

