### PR TITLE
[Doc] Fix a typo in the tutorial for link prediction

### DIFF
--- a/tutorials/blitz/4_link_predict.py
+++ b/tutorials/blitz/4_link_predict.py
@@ -99,7 +99,7 @@ neg_u, neg_v = np.where(adj_neg != 0)
 
 neg_eids = np.random.choice(len(neg_u), g.number_of_edges())
 test_neg_u, test_neg_v = neg_u[neg_eids[:test_size]], neg_v[neg_eids[:test_size]]
-train_neg_u, train_neg_v = neg_u[neg_eids[test_size:]], neg_v[neg_eids[test_size:]]
+train_neg_u, train_neg_v = neg_u[neg_eids[train_size:]], neg_v[neg_eids[train_size:]]
 
 
 ######################################################################


### PR DESCRIPTION
# Description


There is a typo in the sample codes for the section Prepare training and testing sets.

```
train_size = g.number_of_edges() - test_size
test_pos_u, test_pos_v = u[eids[:test_size]], v[eids[:test_size]]
# Should be "train_size" in the line below
train_pos_u, train_pos_v = u[eids[test_size:]], v[eids[test_size:]]
```

# Checklist
Please feel free to remove inapplicable items for your PR.

[V] The PR title starts with [$CATEGORY] (such as [NN], [Model], [Doc], [Feature]])
[V] Changes are complete (i.e. I finished coding on this PR)
[V] Related issue is referred in this PR