### PR TITLE
[Doc] Fix a typo in the tutorial for Neighbor Sampling

### DIFF
--- a/tutorials/large/L0_neighbor_sampling_overview.py
+++ b/tutorials/large/L0_neighbor_sampling_overview.py
@@ -78,7 +78,7 @@ By the end of this tutorial, you will be able to
 #
 # Neighbor sampling addresses this issue by selecting a subset of the
 # neighbors to perform aggregation. For instance, to compute
-# :math:`\boldsymbol{h}_8^{(2)}`, you can choose two of the neighbors
+# :math:`\boldsymbol{h}_5^{(2)}`, you can choose two of the neighbors
 # instead of all of them to aggregate, as in the following animation:
 #
 # |image2|


### PR DESCRIPTION
Fix a typo in the tutorial for "Introduction of Neighbor Sampling for GNN Training".

## Description

There is a typo in the text. The term is inconsistent with the gif demo.

## Checklist

[V] The PR title starts with [$CATEGORY] (such as [NN], [Model], [Doc], [Feature]])
[V] Changes are complete (i.e. I finished coding on this PR)
[V] Related issue is referred in this PR