### PR TITLE
[Doc]Update link_predict.py docstring

### DIFF
--- a/examples/pytorch/rgcn/link_predict.py
+++ b/examples/pytorch/rgcn/link_predict.py
@@ -6,9 +6,7 @@ Code: https://github.com/MichSchli/RelationPrediction
 Difference compared to MichSchli/RelationPrediction
 * Report raw metrics instead of filtered metrics.
 * By default, we use uniform edge sampling instead of neighbor-based edge
-  sampling used in author's code. In practice, we find it achieves similar MRR
-  probably because the model only uses one GNN layer so messages are propagated
-  among immediate neighbors. User could specify "--edge-sampler=neighbor" to switch
+  sampling used in author's code. In practice, we find it achieves similar MRR. User could specify "--edge-sampler=neighbor" to switch
   to neighbor-based edge sampling.
 """
 


### PR DESCRIPTION
Related to issue #2956 
corrected docstring, the model uses two R-GCN layers



## Description
<!-- Brief description. Refer to the related issues if existed.
It'll be great if relevant reviewers can be assigned as well.-->

## Checklist
Please feel free to remove inapplicable items for your PR.
- [x] The PR title starts with [$CATEGORY] (such as [NN], [Model], [Doc], [Feature]])
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage
- [x] Code is well-documented
- [x] To the my best knowledge, examples are either not affected by this change,
      or have been fixed to be compatible with this change
- [x] Related issue is referred in this PR
-  [x] If the PR is for a new model/paper, I've updated the example index [here](../examples/README.md).

