### PR TITLE
[Build] Fix NCCL building crashes when using submodules but with system NCCL installed

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -162,11 +162,12 @@ if(USE_CUDA)
 
   if (USE_SYSTEM_NCCL)
     include(cmake/util/FindNccl.cmake)
+    include_directories(${NCCL_INCLUDE_DIR})
   else()
     include(cmake/modules/NCCL.cmake)
+    cuda_include_directories(BEFORE ${NCCL_INCLUDE_DIR})
   endif()
 
-  include_directories(${NCCL_INCLUDE_DIR})
   list(APPEND DGL_LINKER_LIBS ${NCCL_LIBRARY})
 endif(USE_CUDA)
 


### PR DESCRIPTION
Sometimes when you installed an older NCCL in system but plan to use NCCL submodules it will crash with an error:
```
/mnt/b/gq/dgl/src/runtime/cuda/nccl_api.cu(580): error: identifier "ncclSend" is undefined
          detected during instantiation of "void dgl::runtime::cuda::NCCLCommunicator::AllToAllV(const DType *, const int64_t *, DType *, const int64_t *, cudaStream_t) [with DType=int32_t]"
(591): here

/mnt/b/gq/dgl/src/runtime/cuda/nccl_api.cu(584): error: identifier "ncclRecv" is undefined
          detected during instantiation of "void dgl::runtime::cuda::NCCLCommunicator::AllToAllV(const DType *, const int64_t *, DType *, const int64_t *, cudaStream_t) [with DType=int32_t]"
(591): here
... (and more)
```