### PR TITLE
[Doc] changing of output dimension

### DIFF
--- a/docs/source/guide/message-efficient.rst
+++ b/docs/source/guide/message-efficient.rst
@@ -30,7 +30,7 @@ implementation would be like:
     import torch
     import torch.nn as nn
 
-    linear = nn.Parameter(torch.FloatTensor(size=(node_feat_dim * 2, 1)))
+    linear = nn.Parameter(torch.FloatTensor(size=(node_feat_dim * 2, out_dim)))
     def concat_message_function(edges):
          return {'cat_feat': torch.cat([edges.src['feat'], edges.dst['feat']])}
     g.apply_edges(concat_message_function)
@@ -48,8 +48,8 @@ respectively:
 
     import dgl.function as fn
 
-    linear_src = nn.Parameter(torch.FloatTensor(size=(node_feat_dim, 1)))
-    linear_dst = nn.Parameter(torch.FloatTensor(size=(node_feat_dim, 1)))
+    linear_src = nn.Parameter(torch.FloatTensor(size=(node_feat_dim, out_dim)))
+    linear_dst = nn.Parameter(torch.FloatTensor(size=(node_feat_dim, out_dim)))
     out_src = g.ndata['feat'] @ linear_src
     out_dst = g.ndata['feat'] @ linear_dst
     g.srcdata.update({'out_src': out_src})

--- a/docs/source/guide_cn/message-efficient.rst
+++ b/docs/source/guide_cn/message-efficient.rst
@@ -20,7 +20,7 @@ DGL建议用户尽量减少边的特征维数。
     import torch
     import torch.nn as nn
 
-    linear = nn.Parameter(torch.FloatTensor(size=(node_feat_dim * 2, 1)))
+    linear = nn.Parameter(torch.FloatTensor(size=(node_feat_dim * 2, out_dim)))
     def concat_message_function(edges):
          return {'cat_feat': torch.cat([edges.src.ndata['feat'], edges.dst.ndata['feat']])}
     g.apply_edges(concat_message_function)
@@ -35,8 +35,8 @@ DGL建议用户尽量减少边的特征维数。
 
     import dgl.function as fn
 
-    linear_src = nn.Parameter(torch.FloatTensor(size=(node_feat_dim, 1)))
-    linear_dst = nn.Parameter(torch.FloatTensor(size=(node_feat_dim, 1)))
+    linear_src = nn.Parameter(torch.FloatTensor(size=(node_feat_dim, out_dim)))
+    linear_dst = nn.Parameter(torch.FloatTensor(size=(node_feat_dim, out_dim)))
     out_src = g.ndata['feat'] @ linear_src
     out_dst = g.ndata['feat'] @ linear_dst
     g.srcdata.update({'out_src': out_src})


### PR DESCRIPTION
## Description
<!-- Brief description. Refer to the related issues if existed.
It'll be great if relevant reviewers can be assigned as well.-->
Specifying output dimension of 1 may be too special and misleading. It can be more clear, if we change it to a variable "out_dim", which is similar to the "node_feat_dim". @zhjwy9343 

## Checklist
Please feel free to remove inapplicable items for your PR.
- [x] The PR title starts with [$CATEGORY] (such as [NN], [Model], [Doc], [Feature]])
- [x] Changes are complete (i.e. I finished coding on this PR)
- [ ] All changes have test coverage
- [ ] Code is well-documented
- [x] To the my best knowledge, examples are either not affected by this change,
      or have been fixed to be compatible with this change
- [ ] Related issue is referred in this PR
- [ ] If the PR is for a new model/paper, I've updated the example index [here](../examples/README.md).

