### PR TITLE
[Model] Fixed AttributeError in GCMC example with new version of torchtext (0.9+).

### DIFF
--- a/examples/pytorch/gcmc/README.md
+++ b/examples/pytorch/gcmc/README.md
@@ -11,7 +11,7 @@ Credit: Jiani Zhang ([@jennyzhang0215](https://github.com/jennyzhang0215))
 ## Dependencies
 * PyTorch 1.2+
 * pandas
-* torchtext 0.4+ (if using user and item contents as node features)
+* torchtext 0.9+ (if using user and item contents as node features)
 * spacy (if using user and item contents as node features)
     - You will also need to run `python -m spacy download en_core_web_sm`
 

--- a/examples/pytorch/gcmc/data.py
+++ b/examples/pytorch/gcmc/data.py
@@ -514,7 +514,7 @@ class MovieLens(object):
         else:
             raise NotImplementedError
 
-        TEXT = torchtext.data.Field(tokenize='spacy', tokenizer_language='en_core_web_sm')
+        TEXT = torchtext.legacy.data.Field(tokenize='spacy', tokenizer_language='en_core_web_sm')
         embedding = torchtext.vocab.GloVe(name='840B', dim=300)
 
         title_embedding = np.zeros(shape=(self.movie_info.shape[0], 300), dtype=np.float32)


### PR DESCRIPTION
## Description
When reproducing [GCMC example](https://github.com/dmlc/dgl/tree/master/examples/pytorch/gcmc) using the newer version of PyTorch (1.8+) with torchtext 0.9+ I kept getting the following error:

```
Total user number = 943, movie number = 1682
Traceback (most recent call last):
  File "train.py", line 241, in <module>
    train(args)
  File "train.py", line 71, in train
    dataset = MovieLens(args.data_name, args.device, use_one_hot_fea=args.use_one_hot_fea, symm=args.gcn_agg_norm_symm,
  File "/workspace/gcmc/data.py", line 175, in __init__
    self.movie_feature = th.FloatTensor(self._process_movie_fea()).to(self._device)
  File "/workspace/gcmc/data.py", line 517, in _process_movie_fea
    TEXT = torchtext.data.Field(tokenize='spacy', tokenizer_language='en_core_web_sm')
AttributeError: module 'torchtext.data' has no attribute 'Field'
```

This is because in torchtext 0.9 this field got removed as can be seen here:
"Backwards Incompatible" section in https://github.com/pytorch/text/releases/tag/v0.9.0-rc5
In particular we see that `torchtext.data.Field` -> `torchtext.legacy.data.Field`

With the proposed change, the example becomes reproducible again:

```
Total user number = 943, movie number = 1682
.vector_cache/glove.840B.300d.zip: 2.18GB [06:50, 5.30MB/s]
100%|█████████████████████████████████████████████▉| 2196016/2196017 [02:08<00:00, 17086.88it/s]
unknown cannot be matched, index=266, name=ml-100k
Feature dim:
user: torch.Size([943, 23])
movie: torch.Size([1682, 320])
```

## Changes
<!-- You could use following template
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)
-->
- Replaced `torchtext.data.Field` with `torchtext.legacy.data.Field` in `data.py`
