### PR TITLE
[Performance][Kernel] Eliminating ctor&dtor zand IsNullArray overhead in random walks

### DIFF
--- a/src/graph/sampling/randomwalks/metapath_randomwalk.h
+++ b/src/graph/sampling/randomwalks/metapath_randomwalk.h
@@ -116,6 +116,7 @@ std::pair<dgl_id_t, bool> MetapathRandomWalkStep(
  * \param terminate Predicate for terminating the current random walk path.
  *
  * \return A pair of ID of next successor (-1 if not exist), as well as whether to terminate.
+ * \note This function is called only if all the probability arrays are null.
  */
 template<DLDeviceType XPU, typename IdxType>
 std::pair<dgl_id_t, bool> MetapathRandomWalkStepUniform(

--- a/src/graph/sampling/randomwalks/metapath_randomwalk.h
+++ b/src/graph/sampling/randomwalks/metapath_randomwalk.h
@@ -74,7 +74,7 @@ std::pair<dgl_id_t, bool> MetapathRandomWalkStep(
   if (size == 0)
     return std::make_pair(-1, true);
 
-  // Use a reference to the original array instead of copying 
+  // Use a reference to the original array instead of copying
   // This avoids updating the ref counts atomically from different threads
   // and avoids cache ping-ponging in the tight loop
   const FloatArray &prob_etype = prob[etype];
@@ -179,14 +179,15 @@ IdArray MetapathBasedRandomWalk(
   for (dgl_type_t etype = 0; etype < hg->NumEdgeTypes(); ++etype)
     edges_by_type.push_back(hg->GetAdj(etype, true, "csr"));
 
-  // Hoist the check for Uniform vs Non uniform edge distribution to avoid putting it on the hot path
+  // Hoist the check for Uniform vs Non uniform edge distribution
+  // to avoid putting it on the hot path
   StepFunc<IdxType> step;
   bool isUniform = true;
-  for (const auto &etype_prob: prob) {
+  for (const auto &etype_prob : prob) {
     if (!IsNullArray(etype_prob)) {
       isUniform = false;
-      break;      
-    } 
+      break;
+    }
   }
   if (!isUniform) {
     step =
@@ -196,7 +197,7 @@ IdArray MetapathBasedRandomWalk(
             data, curr, len, edges_by_type, metapath_data, prob, terminate);
       };
   } else {
-    step = 
+    step =
       [&edges_by_type, metapath_data, &prob, terminate]
       (IdxType *data, dgl_id_t curr, int64_t len) {
         return MetapathRandomWalkStepUniform<XPU, IdxType>(

--- a/src/graph/sampling/randomwalks/metapath_randomwalk.h
+++ b/src/graph/sampling/randomwalks/metapath_randomwalk.h
@@ -74,7 +74,10 @@ std::pair<dgl_id_t, bool> MetapathRandomWalkStep(
   if (size == 0)
     return std::make_pair(-1, true);
 
-  FloatArray prob_etype = prob[etype];
+  // Use a reference to the original array instead of copying 
+  // This avoids updating the ref counts atomically from different threads
+  // and avoids cache ping-ponging in the tight loop
+  const FloatArray &prob_etype = prob[etype];
   IdxType idx = 0;
   if (IsNullArray(prob_etype)) {
     // empty probability array; assume uniform
@@ -93,6 +96,55 @@ std::pair<dgl_id_t, bool> MetapathRandomWalkStep(
       idx = RandomEngine::ThreadLocal()->Choice<IdxType>(prob_selected);
     });
   }
+  curr = succ[idx];
+
+  return std::make_pair(curr, terminate(data, curr, len));
+}
+
+/*!
+ * \brief Select one successor of metapath-based random walk, given the path generated
+ * so far specifically for the uniform probability distribution.
+ *
+ * \param data The path generated so far, of type \c IdxType.
+ * \param curr The last node ID generated.
+ * \param len The number of nodes generated so far.  Note that the seed node is always
+ *            included as \c data[0], and the successors start from \c data[1].
+ *
+ * \param edges_by_type Vector of results from \c GetAdj() by edge type.
+ * \param metapath_data Edge types of given metapath.
+ * \param prob Transition probability per edge type, for this special case this will be a NullArray
+ * \param terminate Predicate for terminating the current random walk path.
+ *
+ * \return A pair of ID of next successor (-1 if not exist), as well as whether to terminate.
+ */
+template<DLDeviceType XPU, typename IdxType>
+std::pair<dgl_id_t, bool> MetapathRandomWalkStepUniform(
+    IdxType *data,
+    dgl_id_t curr,
+    int64_t len,
+    const std::vector<std::vector<IdArray> > &edges_by_type,
+    const IdxType *metapath_data,
+    const std::vector<FloatArray> &prob,
+    TerminatePredicate<IdxType> terminate) {
+  dgl_type_t etype = metapath_data[len];
+
+  // Note that since the selection of successors is very lightweight (especially in the
+  // uniform case), we want to reduce the overheads (even from object copies or object
+  // construction) as much as possible.
+  // Using Successors() slows down by 2x.
+  // Using OutEdges() slows down by 10x.
+  const std::vector<NDArray> &csr_arrays = edges_by_type[etype];
+  const IdxType *offsets = static_cast<IdxType *>(csr_arrays[0]->data);
+  const IdxType *all_succ = static_cast<IdxType *>(csr_arrays[1]->data);
+  const IdxType *succ = all_succ + offsets[curr];
+
+  const int64_t size = offsets[curr + 1] - offsets[curr];
+  if (size == 0)
+    return std::make_pair(-1, true);
+
+  IdxType idx = 0;
+  // Guaranteed uniform distribution
+  idx = RandomEngine::ThreadLocal()->RandInt(size);
   curr = succ[idx];
 
   return std::make_pair(curr, terminate(data, curr, len));
@@ -127,12 +179,30 @@ IdArray MetapathBasedRandomWalk(
   for (dgl_type_t etype = 0; etype < hg->NumEdgeTypes(); ++etype)
     edges_by_type.push_back(hg->GetAdj(etype, true, "csr"));
 
-  StepFunc<IdxType> step =
-    [&edges_by_type, metapath_data, &prob, terminate]
-    (IdxType *data, dgl_id_t curr, int64_t len) {
-      return MetapathRandomWalkStep<XPU, IdxType>(
-          data, curr, len, edges_by_type, metapath_data, prob, terminate);
-    };
+  // Hoist the check for Uniform vs Non uniform edge distribution to avoid putting it on the hot path
+  StepFunc<IdxType> step;
+  bool isUniform = true;
+  for (const auto &etype_prob: prob) {
+    if (!IsNullArray(etype_prob)) {
+      isUniform = false;
+      break;      
+    } 
+  }
+  if (!isUniform) {
+    step =
+      [&edges_by_type, metapath_data, &prob, terminate]
+      (IdxType *data, dgl_id_t curr, int64_t len) {
+        return MetapathRandomWalkStep<XPU, IdxType>(
+            data, curr, len, edges_by_type, metapath_data, prob, terminate);
+      };
+  } else {
+    step = 
+      [&edges_by_type, metapath_data, &prob, terminate]
+      (IdxType *data, dgl_id_t curr, int64_t len) {
+        return MetapathRandomWalkStepUniform<XPU, IdxType>(
+            data, curr, len, edges_by_type, metapath_data, prob, terminate);
+      };
+  }
 
   return GenericRandomWalk<XPU, IdxType>(seeds, max_num_steps, step);
 }


### PR DESCRIPTION
Added a special implementation for MetapathBasedRandomWalkStep for the Uniform randomwalk case

## Description
<!-- Brief description. Refer to the related issues if existed.
It'll be great if relevant reviewers can be assigned as well.-->
There is a big performance issue with the implementation of the `MetapathRandomWalkStep` function. Specifically with the lines - 

```
FloatArray prob_etype = prob[etype];
  IdxType idx = 0;
  if (IsNullArray(prob_etype)) {
```

The copy constructor and destructors of type FloatArray update the reference count for the underlying data buffer. This is an atomic operation since FloatArray is supposed to be thread safe. But when `MetapathRandomWalkStep` function is called from multiple threads potentially running on multiple cores, the same integer value (refcount) is read and written concurrently from all the threads. This leads to cache ping-ponging and a severe performance hit. The first change in this PR removes the call to the copy constructor and destructor by making `prob_etype` a reference instead of a copy. 

This only solves the problem partially. `IsNullArray` check performed only every step for every randomwalk also hurts the performance. This PR creates a separate version of the `MetapathRandomWalkStep` to be used in the uniform case - `MetapathRandomWalkStepUniform`. The `IsNullArray` check is hoisted to the point where the step lambda is created. 

The implementation before and after is tested with a simple randomwalk invocation like - 

```
num_walks = 1000
num_seeds = 1000
seeds = np.random.choice(max_src_id + 1, num_seeds, replace=False)
seeds = np.repeat(seeds, num_walks)
start = time.time()
paths = dgl.sampling.random_walk(g, seeds, length=6)[0]
end = time.time()
```

When tested on the [ml-1m](https://grouplens.org/datasets/movielens/1m/) on a 48 core system the baseline performance is - 
> Using backend: pytorch
> random walk: 0.8552s

With the changes in the PR the new performance numbers for the uniform case are - 
> Using backend: pytorch
> random walk: 0.0348s

A similar performance improvement is also seen on other graphs. The performance on the Non-Uniform case should also be improved because of eliminating the call to the copy constructor and destructor. 

## Checklist
Please feel free to remove inapplicable items for your PR.
- [x] The PR title starts with [$CATEGORY] (such as [NN], [Model], [Doc], [Feature]])
- [x] Changes are complete (i.e. I finished coding on this PR)
- [ ] All changes have test coverage
- [x] Code is well-documented
- [x] To the my best knowledge, examples are either not affected by this change,
      or have been fixed to be compatible with this change
- [ ] Related issue is referred in this PR
- [ ] If the PR is for a new model/paper, I've updated the example index [here](../examples/README.md).

## Changes
<!-- You could use following template
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)
-->
