### PR TITLE
[Bugfix][Examples] Fix graphsage multigpu training example training set size

### DIFF
--- a/examples/pytorch/graphsage/train_sampling_multi_gpu.py
+++ b/examples/pytorch/graphsage/train_sampling_multi_gpu.py
@@ -82,9 +82,9 @@ def run(proc_id, n_gpus, args, devices, data):
     train_mask = train_g.ndata['train_mask']
     val_mask = val_g.ndata['val_mask']
     test_mask = ~(test_g.ndata['train_mask'] | test_g.ndata['val_mask'])
-    train_nid = train_mask.nonzero().sqeeze(0)
-    val_nid = val_mask.nonzero().squeeze(0)
-    test_nid = test_mask.nonzero().squeeze(0)
+    train_nid = train_mask.nonzero().squeeze(-1)
+    val_nid = val_mask.nonzero().squeeze(-1)
+    test_nid = test_mask.nonzero().squeeze(-1)
 
     # Create PyTorch DataLoader for constructing blocks
     sampler = dgl.dataloading.MultiLayerNeighborSampler(

--- a/examples/pytorch/graphsage/train_sampling_multi_gpu.py
+++ b/examples/pytorch/graphsage/train_sampling_multi_gpu.py
@@ -13,7 +13,7 @@ from torch.nn.parallel import DistributedDataParallel
 import tqdm
 
 from model import SAGE
-from load_graph import load_reddit, inductive_split
+from load_graph import load_reddit, inductive_split, load_ogb
 
 def compute_acc(pred, labels):
     """
@@ -82,10 +82,9 @@ def run(proc_id, n_gpus, args, devices, data):
     train_mask = train_g.ndata['train_mask']
     val_mask = val_g.ndata['val_mask']
     test_mask = ~(test_g.ndata['train_mask'] | test_g.ndata['val_mask'])
-    train_nid = train_mask.nonzero().squeeze()
-    val_nid = val_mask.nonzero().squeeze()
-    test_nid = test_mask.nonzero().squeeze()
-    train_nid = train_nid[:n_gpus * args.batch_size + 1]
+    train_nid = train_mask.nonzero().sqeeze(0)
+    val_nid = val_mask.nonzero().squeeze(0)
+    test_nid = test_mask.nonzero().squeeze(0)
 
     # Create PyTorch DataLoader for constructing blocks
     sampler = dgl.dataloading.MultiLayerNeighborSampler(
@@ -172,6 +171,7 @@ if __name__ == '__main__':
     argparser = argparse.ArgumentParser("multi-gpu training")
     argparser.add_argument('--gpu', type=str, default='0',
                            help="Comma separated list of GPU device IDs.")
+    argparser.add_argument('--dataset', type=str, default='reddit')
     argparser.add_argument('--num-epochs', type=int, default=20)
     argparser.add_argument('--num-hidden', type=int, default=16)
     argparser.add_argument('--num-layers', type=int, default=2)
@@ -195,7 +195,13 @@ if __name__ == '__main__':
     devices = list(map(int, args.gpu.split(',')))
     n_gpus = len(devices)
 
-    g, n_classes = load_reddit()
+    if args.dataset == 'reddit':
+        g, n_classes = load_reddit()
+    elif args.dataset == 'ogbn-products':
+        g, n_classes = load_ogb('ogbn-products')
+    else:
+        raise Exception('unknown dataset')
+
     # Construct graph
     g = dgl.as_heterograph(g)
 

--- a/examples/pytorch/graphsage/train_sampling_multi_gpu.py
+++ b/examples/pytorch/graphsage/train_sampling_multi_gpu.py
@@ -82,9 +82,9 @@ def run(proc_id, n_gpus, args, devices, data):
     train_mask = train_g.ndata['train_mask']
     val_mask = val_g.ndata['val_mask']
     test_mask = ~(test_g.ndata['train_mask'] | test_g.ndata['val_mask'])
-    train_nid = train_mask.nonzero().squeeze(-1)
-    val_nid = val_mask.nonzero().squeeze(-1)
-    test_nid = test_mask.nonzero().squeeze(-1)
+    train_nid = train_mask.nonzero().squeeze()
+    val_nid = val_mask.nonzero().squeeze()
+    test_nid = test_mask.nonzero().squeeze()
 
     # Create PyTorch DataLoader for constructing blocks
     sampler = dgl.dataloading.MultiLayerNeighborSampler(


### PR DESCRIPTION
## Description
The training set was being silently cut down to a single batch in the example. This restores training on the whole training set, and adds `ogbn-products` dataset.

## Checklist
Please feel free to remove inapplicable items for your PR.
- [x] The PR title starts with [$CATEGORY] (such as [NN], [Model], [Doc], [Feature]])
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage
- [x] Code is well-documented
- [x] To the my best knowledge, examples are either not affected by this change,
      or have been fixed to be compatible with this change



