### PR TITLE
[CPU, Parallel] parallel_for with default grain size

### DIFF
--- a/src/runtime/parallel_for.cpp
+++ b/src/runtime/parallel_for.cpp
@@ -1,0 +1,11 @@
+/*!
+ *  Copyright (c) 2016 by Contributors
+ * Implementation of C API (reference: tvm/src/api/c_api.cc)
+ * \file c_api.cc
+ */
+
+namespace dgl {
+namespace runtime {
+DefaultGrainSizeT default_grain_size;
+}  // namespace runtime
+}  // namesoace dgl


### PR DESCRIPTION
This PR introduces implementation of `parallel_for` function with default grain size.

Default grain size is set to 1 in which case `parallel_for` acts as OpenMP parallel for pragma with static scheduling, or can be globally set to a value controlled with environment variable `DGL_PARALLEL_FOR_GRAIN_SIZE`.

The idea behind this implementation is that user could start parallelizing code with `parallel_for` with default grain size, and set grain size either through environment variable or by using `parallel_for` with grain size parameter when performance requirements are not satisfied.