### PR TITLE
[bugfix][example] Fix RGCN example so that test_acc is always computed at last epoch

### DIFF
--- a/examples/pytorch/rgcn/entity_classify_mp.py
+++ b/examples/pytorch/rgcn/entity_classify_mp.py
@@ -385,7 +385,7 @@ def run(proc_id, n_gpus, n_cpus, args, devices, dataset, split, queue=None):
         vend = time.time()
         validation_time += (vend - vstart)
 
-        if epoch > 0 and do_test:
+        if epoch == args.n_epochs - 1 or (epoch > 0 and do_test):
             tstart = time.time()
             if (queue is not None) or (proc_id == 0):
                 test_logits, test_seeds = evaluate(model, embed_layer,


### PR DESCRIPTION
## Description
Make it so that test_acc will always be computed at the last epoch, so as to have the final reported test accuracy actually reflect the final accuracy, as well as prevent errors when the test accuracy does not get computed:
```
UnboundLocalError: local variable 'test_acc' referenced before assignment
```

## Checklist
Please feel free to remove inapplicable items for your PR.
- [x] The PR title starts with [$CATEGORY] (such as [NN], [Model], [Doc], [Feature]])
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] To the my best knowledge, examples are either not affected by this change,
      or have been fixed to be compatible with this change


