### PR TITLE
[CPU, Parallel] Rewriting omp parallel regions with parallel_for, part 1

### DIFF
--- a/src/array/cpu/array_op_impl.cc
+++ b/src/array/cpu/array_op_impl.cc
@@ -5,11 +5,13 @@
  */
 #include <dgl/array.h>
 #include <dgl/runtime/ndarray.h>
+#include <dgl/runtime/parallel_for.h>
 #include <numeric>
 #include "../arith.h"
 
 namespace dgl {
 using runtime::NDArray;
+using runtime::parallel_for;
 namespace aten {
 namespace impl {
 
@@ -51,10 +53,10 @@ IdArray BinaryElewise(IdArray lhs, IdArray rhs) {
   IdType* ret_data = static_cast<IdType*>(ret->data);
   // TODO(BarclayII): this usually incurs lots of overhead in thread spawning, scheduling,
   // etc., especially since the workload is very light.  Need to replace with parallel_for.
-// #pragma omp parallel for
-  for (int64_t i = 0; i < lhs->shape[0]; ++i) {
+  std::cout << "BinaryElewise1 " << lhs->shape[0] << "\n";
+  parallel_for(0, lhs->shape[0], [=](size_t i){
     ret_data[i] = Op::Call(lhs_data[i], rhs_data[i]);
-  }
+  });
   return ret;
 }
 
@@ -88,10 +90,9 @@ IdArray BinaryElewise(IdArray lhs, IdType rhs) {
   IdType* ret_data = static_cast<IdType*>(ret->data);
   // TODO(BarclayII): this usually incurs lots of overhead in thread spawning, scheduling,
   // etc., especially since the workload is very light.  Need to replace with parallel_for.
-// #pragma omp parallel for
-  for (int64_t i = 0; i < lhs->shape[0]; ++i) {
+  parallel_for(0, lhs->shape[0], 10000, [=](size_t i) {
     ret_data[i] = Op::Call(lhs_data[i], rhs);
-  }
+  });
   return ret;
 }
 
@@ -125,10 +126,11 @@ IdArray BinaryElewise(IdType lhs, IdArray rhs) {
   IdType* ret_data = static_cast<IdType*>(ret->data);
   // TODO(BarclayII): this usually incurs lots of overhead in thread spawning, scheduling,
   // etc., especially since the workload is very light.  Need to replace with parallel_for.
-// #pragma omp parallel for
-  for (int64_t i = 0; i < rhs->shape[0]; ++i) {
-    ret_data[i] = Op::Call(lhs, rhs_data[i]);
-  }
+  std::cout << "BinaryElewise3 " << rhs->shape[0] << "\n";
+  parallel_for(0, rhs->shape[0],
+               [=](size_t i) {
+                 ret_data[i] = Op::Call(lhs, rhs_data[i]);
+               });
   return ret;
 }
 
@@ -162,10 +164,10 @@ IdArray UnaryElewise(IdArray lhs) {
   IdType* ret_data = static_cast<IdType*>(ret->data);
   // TODO(BarclayII): this usually incurs lots of overhead in thread spawning, scheduling,
   // etc., especially since the workload is very light.  Need to replace with parallel_for.
-// #pragma omp parallel for
-  for (int64_t i = 0; i < lhs->shape[0]; ++i) {
+  std::cout << "UnaryElewise1 " << lhs->shape[0] << "\n";
+  parallel_for(0, lhs->shape[0], [=](size_t i) {
     ret_data[i] = Op::Call(lhs_data[i]);
-  }
+  });
   return ret;
 }
 

--- a/src/array/cpu/array_pack.cc
+++ b/src/array/cpu/array_pack.cc
@@ -4,11 +4,13 @@
  * \brief Array index select CPU implementation
  */
 #include <dgl/array.h>
+#include <dgl/runtime/parallel_for.h>
 #include <tuple>
 #include <utility>
 
 namespace dgl {
 using runtime::NDArray;
+using runtime::parallel_for;
 namespace aten {
 namespace impl {
 
@@ -29,11 +31,10 @@ std::pair<NDArray, IdArray> ConcatSlices(NDArray array, IdArray lengths) {
   NDArray concat = NDArray::Empty({total_length}, array->dtype, array->ctx);
   DType *concat_data = static_cast<DType *>(concat->data);
 
-#pragma omp parallel for
-  for (int64_t i = 0; i < rows; ++i) {
+  parallel_for(0, rows, [=](size_t i) {
     for (int64_t j = 0; j < length_data[i]; ++j)
       concat_data[offsets_data[i] + j] = array_data[i * stride + j];
-  }
+  });
 
   return std::make_pair(concat, offsets);
 }
@@ -56,8 +57,7 @@ std::tuple<NDArray, IdArray, IdArray> Pack(NDArray array, DType pad_value) {
 
   IdArray length = NewIdArray(rows, array->ctx);
   int64_t *length_data = static_cast<int64_t *>(length->data);
-#pragma omp parallel for
-  for (int64_t i = 0; i < rows; ++i) {
+  parallel_for(0, rows, [=](size_t i) {
     int64_t j;
     for (j = 0; j < cols; ++j) {
       const DType val = array_data[i * cols + j];
@@ -65,7 +65,7 @@ std::tuple<NDArray, IdArray, IdArray> Pack(NDArray array, DType pad_value) {
         break;
     }
     length_data[i] = j;
-  }
+  });
 
   auto ret = ConcatSlices<XPU, DType, int64_t>(array, length);
   return std::make_tuple(ret.first, length, ret.second);

--- a/src/array/cpu/csr_sort.cc
+++ b/src/array/cpu/csr_sort.cc
@@ -4,6 +4,7 @@
  * \brief CSR sorting
  */
 #include <dgl/array.h>
+#include <dgl/runtime/parallel_for.h>
 #include <numeric>
 #include <algorithm>
 #include <vector>
@@ -48,30 +49,27 @@ void CSRSort_(CSRMatrix* csr) {
     csr->data = aten::Range(0, nnz, csr->indptr->dtype.bits, csr->indptr->ctx);
   }
   IdType* eid_data = static_cast<IdType*>(csr->data->data);
-#pragma omp parallel
-  {
-    std::vector<ShufflePair> reorder_vec;
-#pragma omp for
-    for (int64_t row = 0; row < num_rows; row++) {
-      const int64_t num_cols = indptr_data[row + 1] - indptr_data[row];
-      IdType *col = indices_data + indptr_data[row];
-      IdType *eid = eid_data + indptr_data[row];
 
-      reorder_vec.resize(num_cols);
-      for (int64_t i = 0; i < num_cols; i++) {
-        reorder_vec[i].first = col[i];
-        reorder_vec[i].second = eid[i];
-      }
-      std::sort(reorder_vec.begin(), reorder_vec.end(),
-                [](const ShufflePair &e1, const ShufflePair &e2) {
-                  return e1.first < e2.first;
-                });
-      for (int64_t i = 0; i < num_cols; i++) {
-        col[i] = reorder_vec[i].first;
-        eid[i] = reorder_vec[i].second;
-      }
+  runtime::parallel_for(0, num_rows, [=](uint64_t row) {
+    const int64_t num_cols = indptr_data[row + 1] - indptr_data[row];
+    std::vector<ShufflePair> reorder_vec(num_cols);
+    IdType *col = indices_data + indptr_data[row];
+    IdType *eid = eid_data + indptr_data[row];
+
+    for (int64_t i = 0; i < num_cols; i++) {
+      reorder_vec[i].first = col[i];
+      reorder_vec[i].second = eid[i];
     }
-  }
+    std::sort(reorder_vec.begin(), reorder_vec.end(),
+              [](const ShufflePair &e1, const ShufflePair &e2) {
+                return e1.first < e2.first;
+              });
+    for (int64_t i = 0; i < num_cols; i++) {
+      col[i] = reorder_vec[i].first;
+      eid[i] = reorder_vec[i].second;
+    }
+  });
+
   csr->sorted = true;
 }
 

--- a/src/array/cpu/csr_sum.cc
+++ b/src/array/cpu/csr_sum.cc
@@ -5,6 +5,7 @@
  */
 
 #include <dgl/array.h>
+#include <dgl/runtime/parallel_for.h>
 #include <parallel_hashmap/phmap.h>
 #include <vector>
 #include "array_utils.h"
@@ -25,16 +26,15 @@ void CountNNZPerRow(
     IdType* C_indptr_data,
     int64_t M) {
   int64_t n = A_indptr.size();
-  phmap::flat_hash_set<IdType> set;
-#pragma omp parallel for firstprivate(set)
-  for (IdType i = 0; i < M; ++i) {
-    set.clear();
+
+  runtime::parallel_for(0, M, [=](size_t i) {
+    phmap::flat_hash_set<IdType> set;
     for (int64_t k = 0; k < n; ++k) {
       for (IdType u = A_indptr[k][i]; u < A_indptr[k][i + 1]; ++u)
         set.insert(A_indices[k][u]);
     }
     C_indptr_data[i] = set.size();
-  }
+  });
 }
 
 template <typename IdType>
@@ -61,10 +61,8 @@ void ComputeIndicesAndData(
     DType* C_weights_data,
     int64_t M) {
   int64_t n = A_indptr.size();
-  phmap::flat_hash_map<IdType, DType> map;
-#pragma omp parallel for firstprivate(map)
-  for (int64_t i = 0; i < M; ++i) {
-    map.clear();
+  runtime::parallel_for(0, M, [=](size_t i) {
+    phmap::flat_hash_map<IdType, DType> map;
     for (int64_t k = 0; k < n; ++k) {
       for (IdType u = A_indptr[k][i]; u < A_indptr[k][i + 1]; ++u) {
         IdType kA = A_indices[k][u];
@@ -72,14 +70,13 @@ void ComputeIndicesAndData(
         map[kA] += vA;
       }
     }
-
     IdType j = C_indptr_data[i];
     for (auto it : map) {
       C_indices_data[j] = it.first;
       C_weights_data[j] = it.second;
       ++j;
     }
-  }
+  });
 }
 
 };  // namespace

--- a/src/array/cpu/sddmm.h
+++ b/src/array/cpu/sddmm.h
@@ -8,6 +8,7 @@
 
 #include <dgl/array.h>
 #include <dgl/bcast.h>
+#include <dgl/runtime/parallel_for.h>
 #include "../selector.h"
 
 namespace dgl {
@@ -40,8 +41,7 @@ void SDDMMCsr(const BcastOff& bcast,
                 rhs_dim = bcast.rhs_len,
                 reduce_size = bcast.reduce_size;
   DType* O = out.Ptr<DType>();
-#pragma omp parallel for
-  for (IdType rid = 0; rid < csr.num_rows; ++rid) {
+  runtime::parallel_for(0, csr.num_rows, [=](IdType rid) {
     const IdType row_start = indptr[rid], row_end = indptr[rid + 1];
     for (IdType j = row_start; j < row_end; ++j) {
       const IdType cid = indices[j];
@@ -57,7 +57,7 @@ void SDDMMCsr(const BcastOff& bcast,
         out_off[k] = Op::Call(lhs_off, rhs_off, reduce_size);
       }
     }
-  }
+  });
 }
 
 /*!
@@ -86,9 +86,7 @@ void SDDMMCoo(const BcastOff& bcast,
                 rhs_dim = bcast.rhs_len,
                 reduce_size = bcast.reduce_size;
   DType* O = out.Ptr<DType>();
-  const int64_t nnz = coo.row->shape[0];
-#pragma omp parallel for
-  for (IdType i = 0; i < nnz; ++i) {
+  runtime::parallel_for(0, coo.row->shape[0], [=](size_t i) {
     const IdType rid = row[i];
     const IdType cid = col[i];
     const IdType eid = has_idx? edges[i] : i;
@@ -102,7 +100,7 @@ void SDDMMCoo(const BcastOff& bcast,
         Y + Selector<RhsTarget>::Call(rid, eid, cid) * rhs_dim + rhs_add * reduce_size : nullptr;
       out_off[k] = Op::Call(lhs_off, rhs_off, bcast.reduce_size);
     }
-  }
+  });
 }
 
 namespace op {

--- a/src/array/cpu/segment_reduce.h
+++ b/src/array/cpu/segment_reduce.h
@@ -7,6 +7,7 @@
 #define DGL_ARRAY_CPU_SEGMENT_REDUCE_H_
 
 #include <dgl/array.h>
+#include <dgl/runtime/parallel_for.h>
 
 namespace dgl {
 namespace aten {
@@ -27,14 +28,13 @@ void SegmentSum(NDArray feat, NDArray offsets, NDArray out) {
   const DType* feat_data = feat.Ptr<DType>();
   const IdType* offsets_data = offsets.Ptr<IdType>();
   DType *out_data = out.Ptr<DType>();
-#pragma omp parallel for
-  for (int i = 0; i < n; ++i) {
+  runtime::parallel_for(0, n, [=](size_t i) {
     for (IdType j = offsets_data[i]; j < offsets_data[i + 1]; ++j) {
       for (int k = 0; k < dim; ++k) {
         out_data[i * dim + k] += feat_data[j * dim + k];
       }
     }
-  }
+  });
 }
 
 /*!
@@ -58,8 +58,7 @@ void SegmentCmp(NDArray feat, NDArray offsets,
   IdType *arg_data = arg.Ptr<IdType>();
   std::fill(out_data, out_data + out.NumElements(), Cmp::zero);
   std::fill(arg_data, arg_data + arg.NumElements(), -1);
-#pragma omp parallel for
-  for (int i = 0; i < n; ++i) {
+  runtime::parallel_for(0, n, [=](size_t i) {
     for (IdType j = offsets_data[i]; j < offsets_data[i + 1]; ++j) {
       for (int k = 0; k < dim; ++k) {
         const DType val = feat_data[j * dim + k];
@@ -69,7 +68,7 @@ void SegmentCmp(NDArray feat, NDArray offsets,
         }
       }
     }
-  }
+  });
 }
 
 /*!
@@ -114,14 +113,13 @@ void BackwardSegmentCmp(NDArray feat, NDArray arg, NDArray out) {
   const DType* feat_data = feat.Ptr<DType>();
   const IdType* arg_data = arg.Ptr<IdType>();
   DType* out_data = out.Ptr<DType>();
-#pragma omp parallel for
-  for (int i = 0; i < n; ++i) {
+  runtime::parallel_for(0, n, [=](size_t i) {
     for (int k = 0; k < dim; ++k) {
       int write_row = arg_data[i * dim + k];
       if (write_row >= 0)
         out_data[write_row * dim + k] = feat_data[i * dim + k];
     }
-  }
+  });
 }
 
 }  // namespace cpu


### PR DESCRIPTION
This PR re-implements parallel code that uses OpenMP parallel regions with `parallel_for` construct. 
Only `parallel_for` with default grain size is used.
This is the first part of modifications.