### PR TITLE
[Bugfix] Handle case where process has no elements to update, in NCCL communicator

### DIFF
--- a/src/runtime/cuda/nccl_api.cu
+++ b/src/runtime/cuda/nccl_api.cu
@@ -176,7 +176,7 @@ std::pair<IdArray, NDArray> SparsePush(
   Workspace<DType> send_value(device, ctx, num_in*num_feat);
 
   // permute the indices and values
-  {
+  if (num_in > 0) {
     const dim3 block(256);
     const dim3 grid((num_in+block.x-1)/block.x);
 


### PR DESCRIPTION
## Description
If a process has no elements to update in an iteration, it try to launch a kernel with zero threads, which results in an error. This conditionally launches the kernel if there are elements to process.

## Checklist
Please feel free to remove inapplicable items for your PR.
- [x] The PR title starts with [$CATEGORY] (such as [NN], [Model], [Doc], [Feature]])
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] To the my best knowledge, examples are either not affected by this change,
      or have been fixed to be compatible with this change

