### PR TITLE
EdgeWeightNorm Fix doc

### DIFF
--- a/python/dgl/nn/pytorch/conv/graphconv.py
+++ b/python/dgl/nn/pytorch/conv/graphconv.py
@@ -21,12 +21,12 @@ class EdgeWeightNorm(nn.Module):
 
     Mathematically, setting ``norm='both'`` yields the following normalization term:
 
-    .. math:
+    .. math::
       c_{ji} = (\sqrt{\sum_{k\in\mathcal{N}(j)}e_{jk}}\sqrt{\sum_{k\in\mathcal{N}(i)}e_{ki}})
 
     And, setting ``norm='right'`` yields the following normalization term:
 
-    .. math:
+    .. math::
       c_{ji} = (\sum_{k\in\mathcal{N}(i)}}e_{ki})
 
     where :math:`e_{ji}` is the scalar weight on the edge from node :math:`j` to node :math:`i`.


### PR DESCRIPTION
## Description
in https://docs.dgl.ai/en/0.6.x/api/python/nn.pytorch.html#edgeweightnorm
we can't see two math formulas that would be displayed to us.

## Changes
`math:` to `math::`
