### PR TITLE
[Model] add activation in the last layer of graphSAGE model

### DIFF
--- a/examples/pytorch/graphsage/model.py
+++ b/examples/pytorch/graphsage/model.py
@@ -31,8 +31,8 @@ class SAGE(nn.Module):
         h = x
         for l, (layer, block) in enumerate(zip(self.layers, blocks)):
             h = layer(block, h)
+            h = self.activation(h)
             if l != len(self.layers) - 1:
-                h = self.activation(h)
                 h = self.dropout(h)
         return h
 
@@ -69,8 +69,8 @@ class SAGE(nn.Module):
                 block = block.int().to(device)
                 h = x[input_nodes].to(device)
                 h = layer(block, h)
+                h = self.activation(h)
                 if l != len(self.layers) - 1:
-                    h = self.activation(h)
                     h = self.dropout(h)
 
                 y[output_nodes] = h.cpu()


### PR DESCRIPTION
## Description
According to the SAGE paper, the forward and inference function should add activation in the last layer. However, current example of graphSAGE model has no activation in the last layer.

## Checklist
Please feel free to remove inapplicable items for your PR.
- [x] The PR title starts with [$CATEGORY] (such as [NN], [Model], [Doc], [Feature]])
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] Code is well-documented
- [x] To the my best knowledge, examples are either not affected by this change,
      or have been fixed to be compatible with this change

## Changes
- [x] Add activation in the last layer of forward and inference function in SAGE model.
