### PR TITLE
[BugFix] skip frames whose num_rows is zero in dgl.heterograph.combin…

### DIFF
--- a/python/dgl/heterograph.py
+++ b/python/dgl/heterograph.py
@@ -6028,20 +6028,23 @@ def combine_frames(frames, ids, col_names=None):
         The resulting frame
     """
     # find common columns and check if their schemes match
-    if col_names is None:
-        schemes = {key: scheme for key, scheme in frames[ids[0]].schemes.items()}
-    else:
-        schemes = {key: frames[ids[0]].schemes[key] for key in col_names}
+    schemes = None
     for frame_id in ids:
         frame = frames[frame_id]
-        if frame.num_rows != 0:
-            for key, scheme in list(schemes.items()):
-                if key in frame.schemes:
-                    if frame.schemes[key] != scheme:
-                        raise DGLError('Cannot concatenate column %s with shape %s and shape %s' %
-                                       (key, frame.schemes[key], scheme))
-                else:
-                    del schemes[key]
+        if frame.num_rows == 0:
+            continue
+        if schemes is None:
+            schemes = frame.schemes
+            if col_names is not None:
+                schemes = {key: frame.schemes[key] for key in col_names}
+            continue
+        for key, scheme in list(schemes.items()):
+            if key in frame.schemes:
+                if frame.schemes[key] != scheme:
+                    raise DGLError('Cannot concatenate column %s with shape %s and shape %s' %
+                                   (key, frame.schemes[key], scheme))
+            else:
+                del schemes[key]
 
     if len(schemes) == 0:
         return None


### PR DESCRIPTION

## Description
<!-- Brief description. Refer to the related issues if existed.
It'll be great if relevant reviewers can be assigned as well.-->
bug fix for this ticket: https://github.com/dmlc/dgl/issues/2493

## Checklist
Please feel free to remove inapplicable items for your PR.
- [x] The PR title starts with [$CATEGORY] (such as [NN], [Model], [Doc], [Feature]])
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage
- [x] Code is well-documented
- [x] To the my best knowledge, examples are either not affected by this change,
      or have been fixed to be compatible with this change
- [x] Related issue is referred in this PR
- [x] If the PR is for a new model/paper, I've updated the example index [here](../examples/README.md).

## Changes
<!-- You could use following template
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)
-->
