### PR TITLE
[Feature] Add left normalizer for GCN

### DIFF
--- a/python/dgl/nn/mxnet/conv/graphconv.py
+++ b/python/dgl/nn/mxnet/conv/graphconv.py
@@ -144,8 +144,8 @@ class GraphConv(gluon.Block):
                  activation=None,
                  allow_zero_in_degree=False):
         super(GraphConv, self).__init__()
-        if norm not in ('none', 'both', 'right'):
-            raise DGLError('Invalid norm value. Must be either "none", "both" or "right".'
+        if norm not in ('none', 'both', 'right', 'left'):
+            raise DGLError('Invalid norm value. Must be either "none", "both", "right" or "left".'
                            ' But got "{}".'.format(norm))
         self._in_feats = in_feats
         self._out_feats = out_feats

--- a/python/dgl/nn/mxnet/conv/graphconv.py
+++ b/python/dgl/nn/mxnet/conv/graphconv.py
@@ -32,10 +32,18 @@ class GraphConv(gluon.Block):
     out_feats : int
         Output feature size; i.e., the number of dimensions of :math:`h_i^{(l+1)}`.
     norm : str, optional
-        How to apply the normalizer. If is `'right'`, divide the aggregated messages
-        by each node's in-degrees, which is equivalent to averaging the received messages.
-        If is `'none'`, no normalization is applied. Default is `'both'`,
-        where the :math:`c_{ij}` in the paper is applied.
+        How to apply the normalizer.  Can be one of the following values:
+
+        * ``right``, to divide the aggregated messages by each node's in-degrees,
+          which is equivalent to averaging the received messages.
+
+        * ``none``, where no normalization is applied.
+
+        * ``both`` (default), where the messages are scaled with :math:`c_{ji}` above, equivalent
+          to symmetric Laplacian normalization.
+
+        * ``left``, to divide the messages sent out from each node by its out-degrees,
+          equivalent to random walk Laplacian normalziation.
     weight : bool, optional
         If True, apply a linear layer. Otherwise, aggregating the messages
         without a weight matrix.
@@ -230,14 +238,17 @@ class GraphConv(gluon.Block):
                                    'suppress the check and let the code run.')
 
             feat_src, feat_dst = expand_as_pair(feat, graph)
-
-            if self._norm == 'both':
-                degs = graph.out_degrees().as_in_context(feat_src.context).astype('float32')
+            if self._norm in ['both', 'left']:
+                degs = graph.out_degrees().as_in_context(feat_dst.context).astype('float32')
                 degs = mx.nd.clip(degs, a_min=1, a_max=float("inf"))
-                norm = mx.nd.power(degs, -0.5)
+                if self._norm == 'both':
+                    norm = mx.nd.power(degs, -0.5)
+                else:
+                    norm = 1.0 / degs
                 shp = norm.shape + (1,) * (feat_src.ndim - 1)
                 norm = norm.reshape(shp)
                 feat_src = feat_src * norm
+
 
             if weight is not None:
                 if self.weight is not None:
@@ -264,7 +275,7 @@ class GraphConv(gluon.Block):
                 if weight is not None:
                     rst = mx.nd.dot(rst, weight)
 
-            if self._norm != 'none':
+            if self._norm in ['both', 'right']:
                 degs = graph.in_degrees().as_in_context(feat_dst.context).astype('float32')
                 degs = mx.nd.clip(degs, a_min=1, a_max=float("inf"))
                 if self._norm == 'both':

--- a/python/dgl/nn/pytorch/conv/graphconv.py
+++ b/python/dgl/nn/pytorch/conv/graphconv.py
@@ -278,8 +278,8 @@ class GraphConv(nn.Module):
                  activation=None,
                  allow_zero_in_degree=False):
         super(GraphConv, self).__init__()
-        if norm not in ('none', 'both', 'right'):
-            raise DGLError('Invalid norm value. Must be either "none", "both" or "right".'
+        if norm not in ('none', 'both', 'right', 'left'):
+            raise DGLError('Invalid norm value. Must be either "none", "both", "right" or "left".'
                            ' But got "{}".'.format(norm))
         self._in_feats = in_feats
         self._out_feats = out_feats

--- a/python/dgl/nn/pytorch/conv/graphconv.py
+++ b/python/dgl/nn/pytorch/conv/graphconv.py
@@ -173,10 +173,18 @@ class GraphConv(nn.Module):
     out_feats : int
         Output feature size; i.e., the number of dimensions of :math:`h_i^{(l+1)}`.
     norm : str, optional
-        How to apply the normalizer. If is `'right'`, divide the aggregated messages
-        by each node's in-degrees, which is equivalent to averaging the received messages.
-        If is `'none'`, no normalization is applied. Default is `'both'`,
-        where the :math:`c_{ji}` in the paper is applied.
+        How to apply the normalizer.  Can be one of the following values:
+
+        * ``right``, to divide the aggregated messages by each node's in-degrees,
+          which is equivalent to averaging the received messages.
+
+        * ``none``, where no normalization is applied.
+
+        * ``both`` (default), where the messages are scaled with :math:`c_{ji}` above, equivalent
+          to symmetric Laplacian normalization.
+
+        * ``left``, to divide the messages sent out from each node by its out-degrees,
+          equivalent to random walk Laplacian normalziation.
     weight : bool, optional
         If True, apply a linear layer. Otherwise, aggregating the messages
         without a weight matrix.
@@ -395,9 +403,12 @@ class GraphConv(nn.Module):
 
             # (BarclayII) For RGCN on heterogeneous graphs we need to support GCN on bipartite.
             feat_src, feat_dst = expand_as_pair(feat, graph)
-            if self._norm == 'both':
+            if self._norm in ['left', 'both']:
                 degs = graph.out_degrees().float().clamp(min=1)
-                norm = th.pow(degs, -0.5)
+                if self._norm == 'both':
+                    norm = th.pow(degs, -0.5)
+                else:
+                    norm = 1.0 / degs
                 shp = norm.shape + (1,) * (feat_src.dim() - 1)
                 norm = th.reshape(norm, shp)
                 feat_src = feat_src * norm
@@ -425,7 +436,7 @@ class GraphConv(nn.Module):
                 if weight is not None:
                     rst = th.matmul(rst, weight)
 
-            if self._norm != 'none':
+            if self._norm in ['right', 'both']:
                 degs = graph.in_degrees().float().clamp(min=1)
                 if self._norm == 'both':
                     norm = th.pow(degs, -0.5)

--- a/python/dgl/nn/tensorflow/conv/graphconv.py
+++ b/python/dgl/nn/tensorflow/conv/graphconv.py
@@ -34,10 +34,18 @@ class GraphConv(layers.Layer):
     out_feats : int
         Output feature size; i.e., the number of dimensions of :math:`h_i^{(l+1)}`.
     norm : str, optional
-        How to apply the normalizer. If is `'right'`, divide the aggregated messages
-        by each node's in-degrees, which is equivalent to averaging the received messages.
-        If is `'none'`, no normalization is applied. Default is `'both'`,
-        where the :math:`c_{ij}` in the paper is applied.
+        How to apply the normalizer.  Can be one of the following values:
+
+        * ``right``, to divide the aggregated messages by each node's in-degrees,
+          which is equivalent to averaging the received messages.
+
+        * ``none``, where no normalization is applied.
+
+        * ``both`` (default), where the messages are scaled with :math:`c_{ji}` above, equivalent
+          to symmetric Laplacian normalization.
+
+        * ``left``, to divide the messages sent out from each node by its out-degrees,
+          equivalent to random walk Laplacian normalziation.
     weight : bool, optional
         If True, apply a linear layer. Otherwise, aggregating the messages
         without a weight matrix.
@@ -230,13 +238,15 @@ class GraphConv(layers.Layer):
                                    'suppress the check and let the code run.')
 
             feat_src, feat_dst = expand_as_pair(feat, graph)
-
-            if self._norm == 'both':
+            if self._norm in ['both', 'left']:
                 degs = tf.clip_by_value(tf.cast(graph.out_degrees(), tf.float32),
                                         clip_value_min=1,
                                         clip_value_max=np.inf)
-                norm = tf.pow(degs, -0.5)
-                shp = norm.shape + (1,) * (feat_src.ndim - 1)
+                if self._norm == 'both':
+                    norm = tf.pow(degs, -0.5)
+                else:
+                    norm = 1.0 / degs
+                shp = norm.shape + (1,) * (feat_dst.ndim - 1)
                 norm = tf.reshape(norm, shp)
                 feat_src = feat_src * norm
 
@@ -265,7 +275,7 @@ class GraphConv(layers.Layer):
                 if weight is not None:
                     rst = tf.matmul(rst, weight)
 
-            if self._norm != 'none':
+            if self._norm in ['both', 'right']:
                 degs = tf.clip_by_value(tf.cast(graph.in_degrees(), tf.float32),
                                         clip_value_min=1,
                                         clip_value_max=np.inf)

--- a/python/dgl/nn/tensorflow/conv/graphconv.py
+++ b/python/dgl/nn/tensorflow/conv/graphconv.py
@@ -145,8 +145,8 @@ class GraphConv(layers.Layer):
                  activation=None,
                  allow_zero_in_degree=False):
         super(GraphConv, self).__init__()
-        if norm not in ('none', 'both', 'right'):
-            raise DGLError('Invalid norm value. Must be either "none", "both" or "right".'
+        if norm not in ('none', 'both', 'right', 'left'):
+            raise DGLError('Invalid norm value. Must be either "none", "both", "right" or "left".'
                            ' But got "{}".'.format(norm))
         self._in_feats = in_feats
         self._out_feats = out_feats

--- a/tests/mxnet/test_nn.py
+++ b/tests/mxnet/test_nn.py
@@ -81,7 +81,7 @@ def test_graph_conv(idtype, out_dim):
 
 @parametrize_dtype
 @pytest.mark.parametrize('g', get_cases(['homo', 'block-bipartite'], exclude=['zero-degree', 'dglgraph']))
-@pytest.mark.parametrize('norm', ['none', 'both', 'right'])
+@pytest.mark.parametrize('norm', ['none', 'both', 'right', 'left'])
 @pytest.mark.parametrize('weight', [True, False])
 @pytest.mark.parametrize('bias', [False])
 @pytest.mark.parametrize('out_dim', [1, 2])

--- a/tests/pytorch/test_nn.py
+++ b/tests/pytorch/test_nn.py
@@ -81,7 +81,7 @@ def test_graph_conv0(out_dim):
 
 @parametrize_dtype
 @pytest.mark.parametrize('g', get_cases(['homo', 'bipartite'], exclude=['zero-degree', 'dglgraph']))
-@pytest.mark.parametrize('norm', ['none', 'both', 'right'])
+@pytest.mark.parametrize('norm', ['none', 'both', 'right', 'left'])
 @pytest.mark.parametrize('weight', [True, False])
 @pytest.mark.parametrize('bias', [True, False])
 @pytest.mark.parametrize('out_dim', [1, 2])

--- a/tests/tensorflow/test_nn.py
+++ b/tests/tensorflow/test_nn.py
@@ -74,7 +74,7 @@ def test_graph_conv(out_dim):
 
 @parametrize_dtype
 @pytest.mark.parametrize('g', get_cases(['homo', 'block-bipartite'], exclude=['zero-degree', 'dglgraph']))
-@pytest.mark.parametrize('norm', ['none', 'both', 'right'])
+@pytest.mark.parametrize('norm', ['none', 'both', 'right', 'left'])
 @pytest.mark.parametrize('weight', [True, False])
 @pytest.mark.parametrize('bias', [True, False])
 @pytest.mark.parametrize('out_dim', [1, 2])


### PR DESCRIPTION
## Description
This is identical to random walk Laplacian normalization, where the messages are first divided by the out degrees before aggregation.

Used by the model in https://github.com/harvardnlp/botnet-detection.  First brought up in #3050 .

## Checklist
Please feel free to remove inapplicable items for your PR.
- [x] The PR title starts with [$CATEGORY] (such as [NN], [Model], [Doc], [Feature]])
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage
- [x] Code is well-documented
- [x] To the my best knowledge, examples are either not affected by this change,
      or have been fixed to be compatible with this change
- [x] Related issue is referred in this PR
- [x] If the PR is for a new model/paper, I've updated the example index [here](../examples/README.md).