### PR TITLE
[Fix] Fix wrong cub include problem

### DIFF
--- a/src/array/cuda/rowwise_sampling.cu
+++ b/src/array/cuda/rowwise_sampling.cu
@@ -7,9 +7,9 @@
 #include <dgl/random.h>
 #include <dgl/runtime/device_api.h>
 #include <curand_kernel.h>
-#include <cub/cub.cuh>
 #include <numeric>
 
+#include "./dgl_cub.cuh"
 #include "../../kernel/cuda/atomic.cuh"
 #include "../../runtime/cuda/cuda_common.h"
 


### PR DESCRIPTION
## Description
This causes problem with pytorch 1.9 on cuda11.1

## Checklist
Please feel free to remove inapplicable items for your PR.
- [ ] The PR title starts with [$CATEGORY] (such as [NN], [Model], [Doc], [Feature]])
- [ ] Changes are complete (i.e. I finished coding on this PR)
- [ ] All changes have test coverage
- [ ] Code is well-documented
- [ ] To the my best knowledge, examples are either not affected by this change,
      or have been fixed to be compatible with this change
- [ ] Related issue is referred in this PR
- [ ] If the PR is for a new model/paper, I've updated the example index [here](../examples/README.md).

## Changes
<!-- You could use following template
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)
-->
