### PR TITLE
[Doc] Fix CoraFull number of edges inconsistency in documentation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -90,10 +90,10 @@ if(MSVC)
 else(MSVC)
   include(CheckCXXCompilerFlag)
   check_cxx_compiler_flag("-std=c++11"    SUPPORT_CXX11)
-  set(CMAKE_C_FLAGS "-O2 -Wall -fPIC -march=native ${CMAKE_C_FLAGS}")
+  set(CMAKE_C_FLAGS "-O2 -Wall -fPIC ${CMAKE_C_FLAGS}")
   # We still use c++11 flag in CPU build because gcc5.4 (our default compiler) is
   # not fully compatible with c++14 feature.
-  set(CMAKE_CXX_FLAGS "-O2 -Wall -fPIC -std=c++11 -march=native ${CMAKE_CXX_FLAGS}")
+  set(CMAKE_CXX_FLAGS "-O2 -Wall -fPIC -std=c++11 ${CMAKE_CXX_FLAGS}")
   if(NOT APPLE)
     set(CMAKE_SHARED_LINKER_FLAGS "-Wl,--warn-common ${CMAKE_SHARED_LINKER_FLAGS}")
   endif(NOT APPLE)

--- a/docs/source/gen_dataset_stat.py
+++ b/docs/source/gen_dataset_stat.py
@@ -2,7 +2,7 @@ from pytablewriter import RstGridTableWriter, MarkdownTableWriter
 import numpy as np
 import pandas as pd
 from dgl import DGLGraph
-from dgl.data.gnn_benckmark import AmazonCoBuy, CoraFull, Coauthor
+from dgl.data.gnn_benchmark import AmazonCoBuy, CoraFull, Coauthor
 from dgl.data.karate import KarateClub
 from dgl.data.gindt import GINDataset
 from dgl.data.bitcoinotc import BitcoinOTC

--- a/python/dgl/data/__init__.py
+++ b/python/dgl/data/__init__.py
@@ -13,7 +13,7 @@ from .sbm import SBMMixture, SBMMixtureDataset
 from .reddit import RedditDataset
 from .ppi import PPIDataset, LegacyPPIDataset
 from .tu import TUDataset, LegacyTUDataset
-from .gnn_benckmark import AmazonCoBuy, CoraFull, Coauthor, AmazonCoBuyComputerDataset, \
+from .gnn_benchmark import AmazonCoBuy, CoraFull, Coauthor, AmazonCoBuyComputerDataset, \
     AmazonCoBuyPhotoDataset, CoauthorPhysicsDataset, CoauthorCSDataset, CoraFullDataset
 from .karate import KarateClub, KarateClubDataset
 from .gindt import GINDataset

--- a/python/dgl/data/gnn_benchmark.py
+++ b/python/dgl/data/gnn_benchmark.py
@@ -152,7 +152,8 @@ class CoraFullDataset(GNNBenchmarkDataset):
     Statistics:
 
     - Nodes: 19,793
-    - Edges: 130,622
+    - Edges: 126,842 (note that the original dataset has 65,311 edges but DGL adds
+      the reverse edges and remove the duplicates, hence with a different number)
     - Number of Classes: 70
     - Node feature size: 8,710
 


### PR DESCRIPTION
## Description
DGL removes the duplicate edges after adding the reverse edges, thus giving a different number from the original dataset.

Also fixes a long-standing typo.  Surprised that nobody noticed.