### PR TITLE
[Doc] Fix CoraFull number of edges inconsistency in doc

### DIFF
--- a/docs/source/gen_dataset_stat.py
+++ b/docs/source/gen_dataset_stat.py
@@ -2,7 +2,7 @@ from pytablewriter import RstGridTableWriter, MarkdownTableWriter
 import numpy as np
 import pandas as pd
 from dgl import DGLGraph
-from dgl.data.gnn_benckmark import AmazonCoBuy, CoraFull, Coauthor
+from dgl.data.gnn_benchmark import AmazonCoBuy, CoraFull, Coauthor
 from dgl.data.karate import KarateClub
 from dgl.data.gindt import GINDataset
 from dgl.data.bitcoinotc import BitcoinOTC

--- a/python/dgl/data/__init__.py
+++ b/python/dgl/data/__init__.py
@@ -13,7 +13,7 @@ from .sbm import SBMMixture, SBMMixtureDataset
 from .reddit import RedditDataset
 from .ppi import PPIDataset, LegacyPPIDataset
 from .tu import TUDataset, LegacyTUDataset
-from .gnn_benckmark import AmazonCoBuy, CoraFull, Coauthor, AmazonCoBuyComputerDataset, \
+from .gnn_benchmark import AmazonCoBuy, CoraFull, Coauthor, AmazonCoBuyComputerDataset, \
     AmazonCoBuyPhotoDataset, CoauthorPhysicsDataset, CoauthorCSDataset, CoraFullDataset
 from .karate import KarateClub, KarateClubDataset
 from .gindt import GINDataset

--- a/python/dgl/data/gnn_benchmark.py
+++ b/python/dgl/data/gnn_benchmark.py
@@ -152,7 +152,8 @@ class CoraFullDataset(GNNBenchmarkDataset):
     Statistics:
 
     - Nodes: 19,793
-    - Edges: 130,622
+    - Edges: 126,842 (note that the original dataset has 65,311 edges but DGL adds
+      the reverse edges and remove the duplicates, hence with a different number)
     - Number of Classes: 70
     - Node feature size: 8,710
 


### PR DESCRIPTION
## Description
DGL removes the duplicate edges after adding the reverse edges, thus giving a different number from the original dataset.

Also fixes a long-standing typo.  Surprised that nobody noticed including myself.