### PR TITLE
[Performance, CPU] Rewriting OpenMP pragmas into parallel_for

### DIFF
--- a/include/dgl/runtime/parallel_for.h
+++ b/include/dgl/runtime/parallel_for.h
@@ -74,14 +74,12 @@ void parallel_for(
     auto chunk_size = divup((end - begin), num_threads);
     auto begin_tid = begin + tid * chunk_size;
     if (begin_tid < end) {
-      for (auto i = begin_tid; i < std::min(end, chunk_size + begin_tid); i++) {
-        f(i);
-      }
+      auto end_tid = std::min(end, chunk_size + begin_tid);
+      f(begin_tid, end_tid);
     }
   }
 #else
-  for (auto i = begin; i < end; i++)
-    f(i);
+  f(begin, end);
 #endif
 }
 
@@ -98,7 +96,7 @@ void parallel_for(
     const size_t begin,
     const size_t end,
     F&& f) {
-  parallel_for(begin, end, default_grain_size(), f);
+  parallel_for(begin, end, default_grain_size(), std::forward<F>(f));
 }
 }  // namespace runtime
 }  // namespace dgl

--- a/src/array/cpu/array_op_impl.cc
+++ b/src/array/cpu/array_op_impl.cc
@@ -5,11 +5,13 @@
  */
 #include <dgl/array.h>
 #include <dgl/runtime/ndarray.h>
+#include <dgl/runtime/parallel_for.h>
 #include <numeric>
 #include "../arith.h"
 
 namespace dgl {
 using runtime::NDArray;
+using runtime::parallel_for;
 namespace aten {
 namespace impl {
 
@@ -51,8 +53,7 @@ IdArray BinaryElewise(IdArray lhs, IdArray rhs) {
   IdType* ret_data = static_cast<IdType*>(ret->data);
   // TODO(BarclayII): this usually incurs lots of overhead in thread spawning, scheduling,
   // etc., especially since the workload is very light.  Need to replace with parallel_for.
-// #pragma omp parallel for
-  for (int64_t i = 0; i < lhs->shape[0]; ++i) {
+  for (size_t i = 0; i < lhs->shape[0]; i++) {
     ret_data[i] = Op::Call(lhs_data[i], rhs_data[i]);
   }
   return ret;
@@ -88,8 +89,7 @@ IdArray BinaryElewise(IdArray lhs, IdType rhs) {
   IdType* ret_data = static_cast<IdType*>(ret->data);
   // TODO(BarclayII): this usually incurs lots of overhead in thread spawning, scheduling,
   // etc., especially since the workload is very light.  Need to replace with parallel_for.
-// #pragma omp parallel for
-  for (int64_t i = 0; i < lhs->shape[0]; ++i) {
+  for (size_t i = 0; i < lhs->shape[0]; i++) {
     ret_data[i] = Op::Call(lhs_data[i], rhs);
   }
   return ret;
@@ -125,8 +125,7 @@ IdArray BinaryElewise(IdType lhs, IdArray rhs) {
   IdType* ret_data = static_cast<IdType*>(ret->data);
   // TODO(BarclayII): this usually incurs lots of overhead in thread spawning, scheduling,
   // etc., especially since the workload is very light.  Need to replace with parallel_for.
-// #pragma omp parallel for
-  for (int64_t i = 0; i < rhs->shape[0]; ++i) {
+  for (size_t i = 0; i < rhs->shape[0]; i++) {
     ret_data[i] = Op::Call(lhs, rhs_data[i]);
   }
   return ret;
@@ -162,8 +161,7 @@ IdArray UnaryElewise(IdArray lhs) {
   IdType* ret_data = static_cast<IdType*>(ret->data);
   // TODO(BarclayII): this usually incurs lots of overhead in thread spawning, scheduling,
   // etc., especially since the workload is very light.  Need to replace with parallel_for.
-// #pragma omp parallel for
-  for (int64_t i = 0; i < lhs->shape[0]; ++i) {
+  for (size_t i = 0; i < lhs->shape[0]; i++) {
     ret_data[i] = Op::Call(lhs_data[i]);
   }
   return ret;

--- a/src/array/cpu/array_pack.cc
+++ b/src/array/cpu/array_pack.cc
@@ -4,11 +4,13 @@
  * \brief Array index select CPU implementation
  */
 #include <dgl/array.h>
+#include <dgl/runtime/parallel_for.h>
 #include <tuple>
 #include <utility>
 
 namespace dgl {
 using runtime::NDArray;
+using runtime::parallel_for;
 namespace aten {
 namespace impl {
 
@@ -29,11 +31,10 @@ std::pair<NDArray, IdArray> ConcatSlices(NDArray array, IdArray lengths) {
   NDArray concat = NDArray::Empty({total_length}, array->dtype, array->ctx);
   DType *concat_data = static_cast<DType *>(concat->data);
 
-#pragma omp parallel for
-  for (int64_t i = 0; i < rows; ++i) {
+  parallel_for(0, rows, [=](size_t i) {
     for (int64_t j = 0; j < length_data[i]; ++j)
       concat_data[offsets_data[i] + j] = array_data[i * stride + j];
-  }
+  });
 
   return std::make_pair(concat, offsets);
 }
@@ -56,8 +57,7 @@ std::tuple<NDArray, IdArray, IdArray> Pack(NDArray array, DType pad_value) {
 
   IdArray length = NewIdArray(rows, array->ctx);
   int64_t *length_data = static_cast<int64_t *>(length->data);
-#pragma omp parallel for
-  for (int64_t i = 0; i < rows; ++i) {
+  parallel_for(0, rows, [=](size_t i) {
     int64_t j;
     for (j = 0; j < cols; ++j) {
       const DType val = array_data[i * cols + j];
@@ -65,7 +65,7 @@ std::tuple<NDArray, IdArray, IdArray> Pack(NDArray array, DType pad_value) {
         break;
     }
     length_data[i] = j;
-  }
+  });
 
   auto ret = ConcatSlices<XPU, DType, int64_t>(array, length);
   return std::make_tuple(ret.first, length, ret.second);

--- a/src/array/cpu/array_scatter.cc
+++ b/src/array/cpu/array_scatter.cc
@@ -4,6 +4,7 @@
  * \brief Array scatter CPU implementation
  */
 #include <dgl/array.h>
+#include <dgl/runtime/parallel_for.h>
 
 namespace dgl {
 using runtime::NDArray;
@@ -39,9 +40,9 @@ void Scatter_(IdArray index, NDArray value, NDArray out) {
   const IdType* idx = index.Ptr<IdType>();
   const DType* val = value.Ptr<DType>();
   DType* outd = out.Ptr<DType>();
-#pragma omp parallel for
-  for (int64_t i = 0; i < len; ++i)
+  runtime::parallel_for(0, len, [&](size_t i) {
     outd[idx[i]] = val[i];
+  });
 }
 
 template void Scatter_<kDLCPU, int32_t, int32_t>(IdArray, NDArray, NDArray);

--- a/src/array/cpu/array_scatter.cc
+++ b/src/array/cpu/array_scatter.cc
@@ -40,8 +40,10 @@ void Scatter_(IdArray index, NDArray value, NDArray out) {
   const IdType* idx = index.Ptr<IdType>();
   const DType* val = value.Ptr<DType>();
   DType* outd = out.Ptr<DType>();
-  runtime::parallel_for(0, len, [&](size_t i) {
-    outd[idx[i]] = val[i];
+  runtime::parallel_for(0, len, [&](size_t b, size_t e) {
+    for (auto i = b; i < e; ++i) {
+      outd[idx[i]] = val[i];
+    }
   });
 }
 

--- a/src/array/cpu/csr_get_data.cc
+++ b/src/array/cpu/csr_get_data.cc
@@ -71,30 +71,34 @@ NDArray CSRGetData(
 
   if (csr.sorted) {
     // use binary search on each row
-    parallel_for(0, retlen, [&](int64_t p) {
-      const IdType row_id = row_data[p * row_stride], col_id = col_data[p * col_stride];
-      CHECK(row_id >= 0 && row_id < csr.num_rows) << "Invalid row index: " << row_id;
-      CHECK(col_id >= 0 && col_id < csr.num_cols) << "Invalid col index: " << col_id;
-      const IdType *start_ptr = indices_data + indptr_data[row_id];
-      const IdType *end_ptr = indices_data + indptr_data[row_id + 1];
-      auto it = std::lower_bound(start_ptr, end_ptr, col_id);
-      if (it != end_ptr && *it == col_id) {
-        const IdType idx = it - indices_data;
-        IdType eid = data ? data[idx] : idx;
-        ret_data[p] = return_eids ? eid : weight_data[eid];
+    parallel_for(0, retlen, [&](size_t b, size_t e) {
+      for (auto p = b; p < e; ++p) {
+        const IdType row_id = row_data[p * row_stride], col_id = col_data[p * col_stride];
+        CHECK(row_id >= 0 && row_id < csr.num_rows) << "Invalid row index: " << row_id;
+        CHECK(col_id >= 0 && col_id < csr.num_cols) << "Invalid col index: " << col_id;
+        const IdType *start_ptr = indices_data + indptr_data[row_id];
+        const IdType *end_ptr = indices_data + indptr_data[row_id + 1];
+        auto it = std::lower_bound(start_ptr, end_ptr, col_id);
+        if (it != end_ptr && *it == col_id) {
+          const IdType idx = it - indices_data;
+          IdType eid = data ? data[idx] : idx;
+          ret_data[p] = return_eids ? eid : weight_data[eid];
+        }
       }
     });
   } else {
     // linear search on each row
-    parallel_for(0, retlen, [&](int64_t p) {
-      const IdType row_id = row_data[p * row_stride], col_id = col_data[p * col_stride];
-      CHECK(row_id >= 0 && row_id < csr.num_rows) << "Invalid row index: " << row_id;
-      CHECK(col_id >= 0 && col_id < csr.num_cols) << "Invalid col index: " << col_id;
-      for (IdType idx = indptr_data[row_id]; idx < indptr_data[row_id + 1]; ++idx) {
-        if (indices_data[idx] == col_id) {
-          IdType eid = data ? data[idx] : idx;
-          ret_data[p] = return_eids ? eid : weight_data[eid];
-          break;
+    parallel_for(0, retlen, [&](size_t b, size_t e) {
+      for (auto p = b; p < e; ++p) {
+        const IdType row_id = row_data[p * row_stride], col_id = col_data[p * col_stride];
+        CHECK(row_id >= 0 && row_id < csr.num_rows) << "Invalid row index: " << row_id;
+        CHECK(col_id >= 0 && col_id < csr.num_cols) << "Invalid col index: " << col_id;
+        for (IdType idx = indptr_data[row_id]; idx < indptr_data[row_id + 1]; ++idx) {
+          if (indices_data[idx] == col_id) {
+            IdType eid = data ? data[idx] : idx;
+            ret_data[p] = return_eids ? eid : weight_data[eid];
+            break;
+          }
         }
       }
     });

--- a/src/array/cpu/csr_sort.cc
+++ b/src/array/cpu/csr_sort.cc
@@ -50,23 +50,25 @@ void CSRSort_(CSRMatrix* csr) {
   }
   IdType* eid_data = static_cast<IdType*>(csr->data->data);
 
-  runtime::parallel_for(0, num_rows, [=](uint64_t row) {
-    const int64_t num_cols = indptr_data[row + 1] - indptr_data[row];
-    std::vector<ShufflePair> reorder_vec(num_cols);
-    IdType *col = indices_data + indptr_data[row];
-    IdType *eid = eid_data + indptr_data[row];
+  runtime::parallel_for(0, num_rows, [=](size_t b, size_t e) {
+    for (auto row = b; row < e; ++row) {
+      const int64_t num_cols = indptr_data[row + 1] - indptr_data[row];
+      std::vector<ShufflePair> reorder_vec(num_cols);
+      IdType *col = indices_data + indptr_data[row];
+      IdType *eid = eid_data + indptr_data[row];
 
-    for (int64_t i = 0; i < num_cols; i++) {
-      reorder_vec[i].first = col[i];
-      reorder_vec[i].second = eid[i];
-    }
-    std::sort(reorder_vec.begin(), reorder_vec.end(),
-              [](const ShufflePair &e1, const ShufflePair &e2) {
-                return e1.first < e2.first;
-              });
-    for (int64_t i = 0; i < num_cols; i++) {
-      col[i] = reorder_vec[i].first;
-      eid[i] = reorder_vec[i].second;
+      for (int64_t i = 0; i < num_cols; i++) {
+        reorder_vec[i].first = col[i];
+        reorder_vec[i].second = eid[i];
+      }
+      std::sort(reorder_vec.begin(), reorder_vec.end(),
+                [](const ShufflePair &e1, const ShufflePair &e2) {
+                  return e1.first < e2.first;
+                });
+      for (int64_t i = 0; i < num_cols; i++) {
+        col[i] = reorder_vec[i].first;
+        eid[i] = reorder_vec[i].second;
+      }
     }
   });
 
@@ -99,34 +101,36 @@ std::pair<CSRMatrix, NDArray> CSRSortByTag(
   auto out_indices_data = static_cast<IdType *>(output.indices->data);
   auto out_eid_data = static_cast<IdType *>(output.data->data);
 
-  runtime::parallel_for(0, num_rows, [&](size_t src) {
-    const IdType start = indptr_data[src];
-    const IdType end = indptr_data[src + 1];
+  runtime::parallel_for(0, num_rows, [&](size_t b, size_t e) {
+    for (auto src = b; src < e; ++src) {
+      const IdType start = indptr_data[src];
+      const IdType end = indptr_data[src + 1];
 
-    auto tag_pos_row = tag_pos_data + src * (num_tags + 1);
-    std::vector<IdType> pointer(num_tags, 0);
+      auto tag_pos_row = tag_pos_data + src * (num_tags + 1);
+      std::vector<IdType> pointer(num_tags, 0);
 
-    for (IdType ptr = start ; ptr < end ; ++ptr) {
-      const IdType dst = indices_data[ptr];
-      const TagType tag = tag_data[dst];
-      CHECK_LT(tag, num_tags);
-      ++tag_pos_row[tag + 1];
-    }  // count
+      for (IdType ptr = start ; ptr < end ; ++ptr) {
+        const IdType dst = indices_data[ptr];
+        const TagType tag = tag_data[dst];
+        CHECK_LT(tag, num_tags);
+        ++tag_pos_row[tag + 1];
+      }  // count
 
-    for (TagType tag = 1 ; tag <= num_tags; ++tag) {
-      tag_pos_row[tag] += tag_pos_row[tag - 1];
-    }  // cumulate
+      for (TagType tag = 1 ; tag <= num_tags; ++tag) {
+        tag_pos_row[tag] += tag_pos_row[tag - 1];
+      }  // cumulate
 
-    for (IdType ptr = start ; ptr < end ; ++ptr) {
-      const IdType dst = indices_data[ptr];
-      const IdType eid = eid_data[ptr];
-      const TagType tag = tag_data[dst];
-      const IdType offset = tag_pos_row[tag] + pointer[tag];
-      CHECK_LT(offset, tag_pos_row[tag + 1]);
-      ++pointer[tag];
+      for (IdType ptr = start ; ptr < end ; ++ptr) {
+        const IdType dst = indices_data[ptr];
+        const IdType eid = eid_data[ptr];
+        const TagType tag = tag_data[dst];
+        const IdType offset = tag_pos_row[tag] + pointer[tag];
+        CHECK_LT(offset, tag_pos_row[tag + 1]);
+        ++pointer[tag];
 
-      out_indices_data[start + offset] = dst;
-      out_eid_data[start + offset] = eid;
+        out_indices_data[start + offset] = dst;
+        out_eid_data[start + offset] = eid;
+      }
     }
   });
   output.sorted = false;

--- a/src/array/cpu/csr_sum.cc
+++ b/src/array/cpu/csr_sum.cc
@@ -27,13 +27,15 @@ void CountNNZPerRow(
     int64_t M) {
   int64_t n = A_indptr.size();
 
-  runtime::parallel_for(0, M, [=](size_t i) {
-    phmap::flat_hash_set<IdType> set;
-    for (int64_t k = 0; k < n; ++k) {
-      for (IdType u = A_indptr[k][i]; u < A_indptr[k][i + 1]; ++u)
-        set.insert(A_indices[k][u]);
+  runtime::parallel_for(0, M, [=](size_t b, size_t e) {
+    for (size_t i = b; i < e; ++i) {
+      phmap::flat_hash_set<IdType> set;
+      for (int64_t k = 0; k < n; ++k) {
+        for (IdType u = A_indptr[k][i]; u < A_indptr[k][i + 1]; ++u)
+          set.insert(A_indices[k][u]);
+      }
+      C_indptr_data[i] = set.size();
     }
-    C_indptr_data[i] = set.size();
   });
 }
 
@@ -61,20 +63,22 @@ void ComputeIndicesAndData(
     DType* C_weights_data,
     int64_t M) {
   int64_t n = A_indptr.size();
-  runtime::parallel_for(0, M, [=](size_t i) {
-    phmap::flat_hash_map<IdType, DType> map;
-    for (int64_t k = 0; k < n; ++k) {
-      for (IdType u = A_indptr[k][i]; u < A_indptr[k][i + 1]; ++u) {
-        IdType kA = A_indices[k][u];
-        DType vA = A_data[k][A_eids[k] ? A_eids[k][u] : u];
-        map[kA] += vA;
+  runtime::parallel_for(0, M, [=](size_t b, size_t e) {
+    for (auto i = b; i < e; ++i) {
+      phmap::flat_hash_map<IdType, DType> map;
+      for (int64_t k = 0; k < n; ++k) {
+        for (IdType u = A_indptr[k][i]; u < A_indptr[k][i + 1]; ++u) {
+          IdType kA = A_indices[k][u];
+          DType vA = A_data[k][A_eids[k] ? A_eids[k][u] : u];
+          map[kA] += vA;
+        }
       }
-    }
-    IdType j = C_indptr_data[i];
-    for (auto it : map) {
-      C_indices_data[j] = it.first;
-      C_weights_data[j] = it.second;
-      ++j;
+      IdType j = C_indptr_data[i];
+      for (auto it : map) {
+        C_indices_data[j] = it.first;
+        C_weights_data[j] = it.second;
+        ++j;
+      }
     }
   });
 }

--- a/src/array/cpu/csr_sum.cc
+++ b/src/array/cpu/csr_sum.cc
@@ -5,6 +5,7 @@
  */
 
 #include <dgl/array.h>
+#include <dgl/runtime/parallel_for.h>
 #include <parallel_hashmap/phmap.h>
 #include <vector>
 #include "array_utils.h"
@@ -25,16 +26,15 @@ void CountNNZPerRow(
     IdType* C_indptr_data,
     int64_t M) {
   int64_t n = A_indptr.size();
-  phmap::flat_hash_set<IdType> set;
-#pragma omp parallel for firstprivate(set)
-  for (IdType i = 0; i < M; ++i) {
-    set.clear();
+
+  runtime::parallel_for(0, M, [=](size_t i) {
+    phmap::flat_hash_set<IdType> set;
     for (int64_t k = 0; k < n; ++k) {
       for (IdType u = A_indptr[k][i]; u < A_indptr[k][i + 1]; ++u)
         set.insert(A_indices[k][u]);
     }
     C_indptr_data[i] = set.size();
-  }
+  });
 }
 
 template <typename IdType>
@@ -61,10 +61,8 @@ void ComputeIndicesAndData(
     DType* C_weights_data,
     int64_t M) {
   int64_t n = A_indptr.size();
-  phmap::flat_hash_map<IdType, DType> map;
-#pragma omp parallel for firstprivate(map)
-  for (int64_t i = 0; i < M; ++i) {
-    map.clear();
+  runtime::parallel_for(0, M, [=](size_t i) {
+    phmap::flat_hash_map<IdType, DType> map;
     for (int64_t k = 0; k < n; ++k) {
       for (IdType u = A_indptr[k][i]; u < A_indptr[k][i + 1]; ++u) {
         IdType kA = A_indices[k][u];
@@ -72,14 +70,13 @@ void ComputeIndicesAndData(
         map[kA] += vA;
       }
     }
-
     IdType j = C_indptr_data[i];
     for (auto it : map) {
       C_indices_data[j] = it.first;
       C_weights_data[j] = it.second;
       ++j;
     }
-  }
+  });
 }
 
 };  // namespace

--- a/src/array/cpu/csr_union.cc
+++ b/src/array/cpu/csr_union.cc
@@ -4,7 +4,7 @@
  * \brief COO sorting
  */
 #include <dgl/array.h>
-
+#include <dgl/runtime/parallel_for.h>
 #include <numeric>
 #include <algorithm>
 #include <vector>
@@ -54,6 +54,7 @@ CSRMatrix UnionCsr(const std::vector<CSRMatrix>& csrs) {
     for (int64_t i = 1; i <= csrs[0].num_rows; ++i) {
       std::vector<int64_t> indices_off;
       res_indptr[i] = indptr_data[0][i];
+
       indices_off.push_back(indptr_data[0][i-1]);
       for (size_t j = 1; j < csrs.size(); ++j) {
         res_indptr[i] += indptr_data[j][i];
@@ -74,7 +75,6 @@ CSRMatrix UnionCsr(const std::vector<CSRMatrix>& csrs) {
             }
           }  // for check out of bound
         }  // for
-
         res_indices[off] = min;
         res_data[off] = data_data[min_idx][indices_off[min_idx]];
         indices_off[min_idx] += 1;

--- a/src/array/cpu/rowwise_pick.h
+++ b/src/array/cpu/rowwise_pick.h
@@ -147,6 +147,7 @@ COOMatrix CSRRowWisePick(CSRMatrix mat, IdArray rows,
         global_prefix[t+1] += global_prefix[t];
       }
     }
+
     #pragma omp barrier
     const IdxType thread_offset = global_prefix[thread_id];
 

--- a/src/array/cpu/segment_reduce.h
+++ b/src/array/cpu/segment_reduce.h
@@ -28,10 +28,12 @@ void SegmentSum(NDArray feat, NDArray offsets, NDArray out) {
   const DType* feat_data = feat.Ptr<DType>();
   const IdType* offsets_data = offsets.Ptr<IdType>();
   DType *out_data = out.Ptr<DType>();
-  runtime::parallel_for(0, n, [=](size_t i) {
-    for (IdType j = offsets_data[i]; j < offsets_data[i + 1]; ++j) {
-      for (int k = 0; k < dim; ++k) {
-        out_data[i * dim + k] += feat_data[j * dim + k];
+  runtime::parallel_for(0, n, [=](int b, int e) {
+    for (auto i = b; i < e; ++i) {
+      for (IdType j = offsets_data[i]; j < offsets_data[i + 1]; ++j) {
+        for (int k = 0; k < dim; ++k) {
+          out_data[i * dim + k] += feat_data[j * dim + k];
+        }
       }
     }
   });
@@ -58,13 +60,15 @@ void SegmentCmp(NDArray feat, NDArray offsets,
   IdType *arg_data = arg.Ptr<IdType>();
   std::fill(out_data, out_data + out.NumElements(), Cmp::zero);
   std::fill(arg_data, arg_data + arg.NumElements(), -1);
-  runtime::parallel_for(0, n, [=](size_t i) {
-    for (IdType j = offsets_data[i]; j < offsets_data[i + 1]; ++j) {
-      for (int k = 0; k < dim; ++k) {
-        const DType val = feat_data[j * dim + k];
-        if (Cmp::Call(out_data[i * dim + k], val)) {
-          out_data[i * dim + k] = val;
-          arg_data[i * dim + k] = j;
+  runtime::parallel_for(0, n, [=](int b, int e) {
+    for (auto i = b; i < e; ++i) {
+      for (IdType j = offsets_data[i]; j < offsets_data[i + 1]; ++j) {
+        for (int k = 0; k < dim; ++k) {
+          const DType val = feat_data[j * dim + k];
+          if (Cmp::Call(out_data[i * dim + k], val)) {
+            out_data[i * dim + k] = val;
+            arg_data[i * dim + k] = j;
+          }
         }
       }
     }
@@ -113,11 +117,13 @@ void BackwardSegmentCmp(NDArray feat, NDArray arg, NDArray out) {
   const DType* feat_data = feat.Ptr<DType>();
   const IdType* arg_data = arg.Ptr<IdType>();
   DType* out_data = out.Ptr<DType>();
-  runtime::parallel_for(0, n, [=](size_t i) {
-    for (int k = 0; k < dim; ++k) {
-      int write_row = arg_data[i * dim + k];
-      if (write_row >= 0)
-        out_data[write_row * dim + k] = feat_data[i * dim + k];
+  runtime::parallel_for(0, n, [=](int b, int e) {
+    for (auto i = b; i < e; ++i) {
+      for (int k = 0; k < dim; ++k) {
+        int write_row = arg_data[i * dim + k];
+        if (write_row >= 0)
+          out_data[write_row * dim + k] = feat_data[i * dim + k];
+      }
     }
   });
 }

--- a/src/array/cpu/segment_reduce.h
+++ b/src/array/cpu/segment_reduce.h
@@ -7,6 +7,7 @@
 #define DGL_ARRAY_CPU_SEGMENT_REDUCE_H_
 
 #include <dgl/array.h>
+#include <dgl/runtime/parallel_for.h>
 
 namespace dgl {
 namespace aten {
@@ -27,14 +28,13 @@ void SegmentSum(NDArray feat, NDArray offsets, NDArray out) {
   const DType* feat_data = feat.Ptr<DType>();
   const IdType* offsets_data = offsets.Ptr<IdType>();
   DType *out_data = out.Ptr<DType>();
-#pragma omp parallel for
-  for (int i = 0; i < n; ++i) {
+  runtime::parallel_for(0, n, [=](size_t i) {
     for (IdType j = offsets_data[i]; j < offsets_data[i + 1]; ++j) {
       for (int k = 0; k < dim; ++k) {
         out_data[i * dim + k] += feat_data[j * dim + k];
       }
     }
-  }
+  });
 }
 
 /*!
@@ -58,8 +58,7 @@ void SegmentCmp(NDArray feat, NDArray offsets,
   IdType *arg_data = arg.Ptr<IdType>();
   std::fill(out_data, out_data + out.NumElements(), Cmp::zero);
   std::fill(arg_data, arg_data + arg.NumElements(), -1);
-#pragma omp parallel for
-  for (int i = 0; i < n; ++i) {
+  runtime::parallel_for(0, n, [=](size_t i) {
     for (IdType j = offsets_data[i]; j < offsets_data[i + 1]; ++j) {
       for (int k = 0; k < dim; ++k) {
         const DType val = feat_data[j * dim + k];
@@ -69,7 +68,7 @@ void SegmentCmp(NDArray feat, NDArray offsets,
         }
       }
     }
-  }
+  });
 }
 
 /*!
@@ -114,14 +113,13 @@ void BackwardSegmentCmp(NDArray feat, NDArray arg, NDArray out) {
   const DType* feat_data = feat.Ptr<DType>();
   const IdType* arg_data = arg.Ptr<IdType>();
   DType* out_data = out.Ptr<DType>();
-#pragma omp parallel for
-  for (int i = 0; i < n; ++i) {
+  runtime::parallel_for(0, n, [=](size_t i) {
     for (int k = 0; k < dim; ++k) {
       int write_row = arg_data[i * dim + k];
       if (write_row >= 0)
         out_data[write_row * dim + k] = feat_data[i * dim + k];
     }
-  }
+  });
 }
 
 }  // namespace cpu

--- a/src/array/cpu/spmm.h
+++ b/src/array/cpu/spmm.h
@@ -48,13 +48,15 @@ void SpMMSumCsrXbyak(dgl::ElemWiseAddUpdate<Op>* cpu_spec, const BcastOff& bcast
   const IdType* edges = csr.data.Ptr<IdType>();
   int64_t dim = bcast.out_len, lhs_dim = bcast.lhs_len, rhs_dim = bcast.rhs_len;
 
-  runtime::parallel_for(0, csr.num_rows, [&](size_t rid) {
-    const IdType row_start = indptr[rid], row_end = indptr[rid + 1];
-    DType* out_off = O + rid * dim;
-    for (IdType j = row_start; j < row_end; ++j) {
-      const IdType cid = indices[j];
-      const IdType eid = has_idx ? edges[j] : j;
-      cpu_spec->run(out_off, X + cid * lhs_dim, W + eid * rhs_dim, dim);
+  runtime::parallel_for(0, csr.num_rows, [&](size_t b, size_t e) {
+    for (auto rid = b; rid < e; ++rid) {
+      const IdType row_start = indptr[rid], row_end = indptr[rid + 1];
+      DType* out_off = O + rid * dim;
+      for (IdType j = row_start; j < row_end; ++j) {
+        const IdType cid = indices[j];
+        const IdType eid = has_idx ? edges[j] : j;
+        cpu_spec->run(out_off, X + cid * lhs_dim, W + eid * rhs_dim, dim);
+      }
     }
   });
 }
@@ -80,20 +82,22 @@ void SpMMSumCsrNaive(const BcastOff& bcast, const CSRMatrix& csr, const DType* X
   const IdType* indices = csr.indices.Ptr<IdType>();
   const IdType* edges = csr.data.Ptr<IdType>();
   int64_t dim = bcast.out_len, lhs_dim = bcast.lhs_len, rhs_dim = bcast.rhs_len;
-  runtime::parallel_for(0, csr.num_rows, [&](size_t rid) {
-    const IdType row_start = indptr[rid], row_end = indptr[rid + 1];
-    DType* out_off = O + rid * dim;
-    for (IdType j = row_start; j < row_end; ++j) {
-      const IdType cid = indices[j];
-      const IdType eid = has_idx ? edges[j] : j;
-      for (int64_t k = 0; k < dim; ++k) {
-        const int64_t lhs_add = bcast.use_bcast ? bcast.lhs_offset[k] : k;
-        const int64_t rhs_add = bcast.use_bcast ? bcast.rhs_offset[k] : k;
-        const DType* lhs_off =
-          Op::use_lhs ? X + cid * lhs_dim + lhs_add : nullptr;
-        const DType* rhs_off =
-          Op::use_rhs ? W + eid * rhs_dim + rhs_add : nullptr;
-        out_off[k] += Op::Call(lhs_off, rhs_off);
+  runtime::parallel_for(0, csr.num_rows, [&](size_t b, size_t e) {
+    for (auto rid = b; rid < e; ++rid) {
+      const IdType row_start = indptr[rid], row_end = indptr[rid + 1];
+      DType* out_off = O + rid * dim;
+      for (IdType j = row_start; j < row_end; ++j) {
+        const IdType cid = indices[j];
+        const IdType eid = has_idx ? edges[j] : j;
+        for (int64_t k = 0; k < dim; ++k) {
+          const int64_t lhs_add = bcast.use_bcast ? bcast.lhs_offset[k] : k;
+          const int64_t rhs_add = bcast.use_bcast ? bcast.rhs_offset[k] : k;
+          const DType* lhs_off =
+            Op::use_lhs ? X + cid * lhs_dim + lhs_add : nullptr;
+          const DType* rhs_off =
+            Op::use_rhs ? W + eid * rhs_dim + rhs_add : nullptr;
+          out_off[k] += Op::Call(lhs_off, rhs_off);
+        }
       }
     }
   });
@@ -270,26 +274,28 @@ void SpMMCmpCsr(const BcastOff& bcast, const CSRMatrix& csr, NDArray ufeat,
 #endif  // USE_AVX
 #endif  // _WIN32
 
-    runtime::parallel_for(0, csr.num_rows, [&](size_t rid) {
-      const IdType row_start = indptr[rid], row_end = indptr[rid + 1];
-      DType* out_off = O + rid * dim;
-      IdType* argx_off = argX + rid * dim;
-      IdType* argw_off = argW + rid * dim;
-      for (IdType j = row_start; j < row_end; ++j) {
-        const IdType cid = indices[j];
-        const IdType eid = has_idx ? edges[j] : j;
-        for (int64_t k = 0; k < dim; ++k) {
-          const int64_t lhs_add = bcast.use_bcast ? bcast.lhs_offset[k] : k;
-          const int64_t rhs_add = bcast.use_bcast ? bcast.rhs_offset[k] : k;
-          const DType* lhs_off =
-            Op::use_lhs ? X + cid * lhs_dim + lhs_add : nullptr;
-          const DType* rhs_off =
-            Op::use_rhs ? W + eid * rhs_dim + rhs_add : nullptr;
-          const DType val = Op::Call(lhs_off, rhs_off);
-          if (Cmp::Call(out_off[k], val)) {
-            out_off[k] = val;
-            if (Op::use_lhs) argx_off[k] = cid;
-            if (Op::use_rhs) argw_off[k] = eid;
+    runtime::parallel_for(0, csr.num_rows, [&](size_t b, size_t e) {
+      for (auto rid = b; rid < e; ++rid) {
+        const IdType row_start = indptr[rid], row_end = indptr[rid + 1];
+        DType* out_off = O + rid * dim;
+        IdType* argx_off = argX + rid * dim;
+        IdType* argw_off = argW + rid * dim;
+        for (IdType j = row_start; j < row_end; ++j) {
+          const IdType cid = indices[j];
+          const IdType eid = has_idx ? edges[j] : j;
+          for (int64_t k = 0; k < dim; ++k) {
+            const int64_t lhs_add = bcast.use_bcast ? bcast.lhs_offset[k] : k;
+            const int64_t rhs_add = bcast.use_bcast ? bcast.rhs_offset[k] : k;
+            const DType* lhs_off =
+              Op::use_lhs ? X + cid * lhs_dim + lhs_add : nullptr;
+            const DType* rhs_off =
+              Op::use_rhs ? W + eid * rhs_dim + rhs_add : nullptr;
+            const DType val = Op::Call(lhs_off, rhs_off);
+            if (Cmp::Call(out_off[k], val)) {
+              out_off[k] = val;
+              if (Op::use_lhs) argx_off[k] = cid;
+              if (Op::use_rhs) argw_off[k] = eid;
+            }
           }
         }
       }

--- a/src/array/cpu/spmm.h
+++ b/src/array/cpu/spmm.h
@@ -8,6 +8,7 @@
 
 #include <dgl/array.h>
 #include <dgl/bcast.h>
+#include <dgl/runtime/parallel_for.h>
 #include <algorithm>
 #include <limits>
 #include <memory>
@@ -46,8 +47,8 @@ void SpMMSumCsrXbyak(dgl::ElemWiseAddUpdate<Op>* cpu_spec, const BcastOff& bcast
   const IdType* indices = csr.indices.Ptr<IdType>();
   const IdType* edges = csr.data.Ptr<IdType>();
   int64_t dim = bcast.out_len, lhs_dim = bcast.lhs_len, rhs_dim = bcast.rhs_len;
-#pragma omp parallel for
-  for (IdType rid = 0; rid < csr.num_rows; ++rid) {
+
+  runtime::parallel_for(0, csr.num_rows, [&](size_t rid) {
     const IdType row_start = indptr[rid], row_end = indptr[rid + 1];
     DType* out_off = O + rid * dim;
     for (IdType j = row_start; j < row_end; ++j) {
@@ -55,7 +56,7 @@ void SpMMSumCsrXbyak(dgl::ElemWiseAddUpdate<Op>* cpu_spec, const BcastOff& bcast
       const IdType eid = has_idx ? edges[j] : j;
       cpu_spec->run(out_off, X + cid * lhs_dim, W + eid * rhs_dim, dim);
     }
-  }
+  });
 }
 #endif  // USE_AVX
 #endif  // _WIN32
@@ -79,8 +80,7 @@ void SpMMSumCsrNaive(const BcastOff& bcast, const CSRMatrix& csr, const DType* X
   const IdType* indices = csr.indices.Ptr<IdType>();
   const IdType* edges = csr.data.Ptr<IdType>();
   int64_t dim = bcast.out_len, lhs_dim = bcast.lhs_len, rhs_dim = bcast.rhs_len;
-#pragma omp parallel for
-  for (IdType rid = 0; rid < csr.num_rows; ++rid) {
+  runtime::parallel_for(0, csr.num_rows, [&](size_t rid) {
     const IdType row_start = indptr[rid], row_end = indptr[rid + 1];
     DType* out_off = O + rid * dim;
     for (IdType j = row_start; j < row_end; ++j) {
@@ -96,7 +96,7 @@ void SpMMSumCsrNaive(const BcastOff& bcast, const CSRMatrix& csr, const DType* X
         out_off[k] += Op::Call(lhs_off, rhs_off);
       }
     }
-  }
+  });
 }
 
 /*!
@@ -270,31 +270,30 @@ void SpMMCmpCsr(const BcastOff& bcast, const CSRMatrix& csr, NDArray ufeat,
 #endif  // USE_AVX
 #endif  // _WIN32
 
-#pragma omp parallel for
-  for (IdType rid = 0; rid < csr.num_rows; ++rid) {
-    const IdType row_start = indptr[rid], row_end = indptr[rid + 1];
-    DType* out_off = O + rid * dim;
-    IdType* argx_off = argX + rid * dim;
-    IdType* argw_off = argW + rid * dim;
-    for (IdType j = row_start; j < row_end; ++j) {
-      const IdType cid = indices[j];
-      const IdType eid = has_idx ? edges[j] : j;
-      for (int64_t k = 0; k < dim; ++k) {
-        const int64_t lhs_add = bcast.use_bcast ? bcast.lhs_offset[k] : k;
-        const int64_t rhs_add = bcast.use_bcast ? bcast.rhs_offset[k] : k;
-        const DType* lhs_off =
-          Op::use_lhs ? X + cid * lhs_dim + lhs_add : nullptr;
-        const DType* rhs_off =
-          Op::use_rhs ? W + eid * rhs_dim + rhs_add : nullptr;
-        const DType val = Op::Call(lhs_off, rhs_off);
-        if (Cmp::Call(out_off[k], val)) {
-          out_off[k] = val;
-          if (Op::use_lhs) argx_off[k] = cid;
-          if (Op::use_rhs) argw_off[k] = eid;
+    runtime::parallel_for(0, csr.num_rows, [&](size_t rid) {
+      const IdType row_start = indptr[rid], row_end = indptr[rid + 1];
+      DType* out_off = O + rid * dim;
+      IdType* argx_off = argX + rid * dim;
+      IdType* argw_off = argW + rid * dim;
+      for (IdType j = row_start; j < row_end; ++j) {
+        const IdType cid = indices[j];
+        const IdType eid = has_idx ? edges[j] : j;
+        for (int64_t k = 0; k < dim; ++k) {
+          const int64_t lhs_add = bcast.use_bcast ? bcast.lhs_offset[k] : k;
+          const int64_t rhs_add = bcast.use_bcast ? bcast.rhs_offset[k] : k;
+          const DType* lhs_off =
+            Op::use_lhs ? X + cid * lhs_dim + lhs_add : nullptr;
+          const DType* rhs_off =
+            Op::use_rhs ? W + eid * rhs_dim + rhs_add : nullptr;
+          const DType val = Op::Call(lhs_off, rhs_off);
+          if (Cmp::Call(out_off[k], val)) {
+            out_off[k] = val;
+            if (Op::use_lhs) argx_off[k] = cid;
+            if (Op::use_rhs) argw_off[k] = eid;
+          }
         }
       }
-    }
-  }
+    });
 #if !defined(_WIN32)
 #ifdef USE_AVX
 #ifdef USE_LIBXSMM

--- a/src/graph/graph_op.cc
+++ b/src/graph/graph_op.cc
@@ -262,14 +262,16 @@ IdArray GraphOp::MapParentIdToSubgraphId(IdArray parent_vids, IdArray query) {
 
   const bool is_sorted = std::is_sorted(parent_data, parent_data + parent_len);
   if (is_sorted) {
-    runtime::parallel_for(0, query_len, [&](size_t i) {
-      const dgl_id_t id = query_data[i];
-      const auto it = std::find(parent_data, parent_data + parent_len, id);
-      // If the vertex Id doesn't exist, the vid in the subgraph is -1.
-      if (it != parent_data + parent_len) {
-        rst_data[i] = it - parent_data;
-      } else {
-        rst_data[i] = -1;
+    runtime::parallel_for(0, query_len, [&](size_t b, size_t e) {
+      for (auto i = b; i < e; ++i) {
+        const dgl_id_t id = query_data[i];
+        const auto it = std::find(parent_data, parent_data + parent_len, id);
+        // If the vertex Id doesn't exist, the vid in the subgraph is -1.
+        if (it != parent_data + parent_len) {
+          rst_data[i] = it - parent_data;
+        } else {
+          rst_data[i] = -1;
+        }
       }
     });
   } else {
@@ -278,14 +280,16 @@ IdArray GraphOp::MapParentIdToSubgraphId(IdArray parent_vids, IdArray query) {
       const dgl_id_t id = parent_data[i];
       parent_map[id] = i;
     }
-    runtime::parallel_for(0, query_len, [&](size_t i) {
-      const dgl_id_t id = query_data[i];
-      auto it = parent_map.find(id);
-      // If the vertex Id doesn't exist, the vid in the subgraph is -1.
-      if (it != parent_map.end()) {
-        rst_data[i] = it->second;
-      } else {
-        rst_data[i] = -1;
+    runtime::parallel_for(0, query_len, [&](size_t b, size_t e) {
+      for (auto i = b; i < e; ++i) {
+        const dgl_id_t id = query_data[i];
+        auto it = parent_map.find(id);
+        // If the vertex Id doesn't exist, the vid in the subgraph is -1.
+        if (it != parent_map.end()) {
+          rst_data[i] = it->second;
+        } else {
+          rst_data[i] = -1;
+        }
       }
     });
   }
@@ -566,12 +570,14 @@ DGL_REGISTER_GLOBAL("transform._CAPI_DGLPartitionWithHalo")
     graph_ptr->GetInCSR();
     std::vector<std::shared_ptr<HaloSubgraph> > subgs(max_part_id + 1);
     int num_partitions = part_nodes.size();
-    runtime::parallel_for(0, num_partitions, [&](size_t i) {
-      auto nodes = aten::VecToIdArray(part_nodes[i]);
-      HaloSubgraph subg = GraphOp::GetSubgraphWithHalo(graph_ptr, nodes, num_hops);
-      std::shared_ptr<HaloSubgraph> subg_ptr(new HaloSubgraph(subg));
-      int part_id = part_ids[i];
-      subgs[part_id] = subg_ptr;
+    runtime::parallel_for(0, num_partitions, [&](size_t b, size_t e) {
+      for (auto i = b; i < e; ++i) {
+        auto nodes = aten::VecToIdArray(part_nodes[i]);
+        HaloSubgraph subg = GraphOp::GetSubgraphWithHalo(graph_ptr, nodes, num_hops);
+        std::shared_ptr<HaloSubgraph> subg_ptr(new HaloSubgraph(subg));
+        int part_id = part_ids[i];
+        subgs[part_id] = subg_ptr;
+      }
     });
     List<SubgraphRef> ret_list;
     for (size_t i = 0; i < subgs.size(); i++) {
@@ -730,21 +736,23 @@ IdArray MapIds(IdArray ids, IdArray range_starts, IdArray range_ends, IdArray ty
   const IdType *typed_map_data = static_cast<IdType *>(typed_map->data);
   IdType *types_data = static_cast<IdType *>(ret->data);
   IdType *per_type_ids_data = static_cast<IdType *>(ret->data) + num_ids;
-  runtime::parallel_for(0, ids->shape[0], [&](size_t i) {
-    IdType id = ids_data[i];
-    auto it = std::lower_bound(range_end_data, range_end_data + num_ranges, id);
-    // The range must exist.
-    BUG_IF_FAIL(it != range_end_data + num_ranges);
-    size_t range_id = it - range_end_data;
-    int type_id = range_id % num_types;
-    types_data[i] = type_id;
-    int part_id = range_id / num_types;
-    BUG_IF_FAIL(part_id < num_parts);
-    if (part_id == 0) {
-      per_type_ids_data[i] = id - range_start_data[range_id];
-    } else {
-      per_type_ids_data[i] = id - range_start_data[range_id]
+  runtime::parallel_for(0, ids->shape[0], [&](size_t b, size_t e) {
+    for (auto i = b; i < e; ++i) {
+      IdType id = ids_data[i];
+      auto it = std::lower_bound(range_end_data, range_end_data + num_ranges, id);
+      // The range must exist.
+      BUG_IF_FAIL(it != range_end_data + num_ranges);
+      size_t range_id = it - range_end_data;
+      int type_id = range_id % num_types;
+      types_data[i] = type_id;
+      int part_id = range_id / num_types;
+      BUG_IF_FAIL(part_id < num_parts);
+      if (part_id == 0) {
+        per_type_ids_data[i] = id - range_start_data[range_id];
+      } else {
+        per_type_ids_data[i] = id - range_start_data[range_id]
           + typed_map_data[num_parts * type_id + part_id - 1];
+      }
     }
   });
   return ret;

--- a/src/graph/graph_op.cc
+++ b/src/graph/graph_op.cc
@@ -8,6 +8,7 @@
 #include <dgl/immutable_graph.h>
 #include <dgl/packed_func_ext.h>
 #include <dgl/runtime/container.h>
+#include <dgl/runtime/parallel_for.h>
 #include <algorithm>
 #include "../c_api_common.h"
 
@@ -261,8 +262,7 @@ IdArray GraphOp::MapParentIdToSubgraphId(IdArray parent_vids, IdArray query) {
 
   const bool is_sorted = std::is_sorted(parent_data, parent_data + parent_len);
   if (is_sorted) {
-#pragma omp parallel for
-    for (int64_t i = 0; i < query_len; i++) {
+    runtime::parallel_for(0, query_len, [&](size_t i) {
       const dgl_id_t id = query_data[i];
       const auto it = std::find(parent_data, parent_data + parent_len, id);
       // If the vertex Id doesn't exist, the vid in the subgraph is -1.
@@ -271,15 +271,14 @@ IdArray GraphOp::MapParentIdToSubgraphId(IdArray parent_vids, IdArray query) {
       } else {
         rst_data[i] = -1;
       }
-    }
+    });
   } else {
     std::unordered_map<dgl_id_t, dgl_id_t> parent_map;
     for (int64_t i = 0; i < parent_len; i++) {
       const dgl_id_t id = parent_data[i];
       parent_map[id] = i;
     }
-#pragma omp parallel for
-    for (int64_t i = 0; i < query_len; i++) {
+    runtime::parallel_for(0, query_len, [&](size_t i) {
       const dgl_id_t id = query_data[i];
       auto it = parent_map.find(id);
       // If the vertex Id doesn't exist, the vid in the subgraph is -1.
@@ -288,7 +287,7 @@ IdArray GraphOp::MapParentIdToSubgraphId(IdArray parent_vids, IdArray query) {
       } else {
         rst_data[i] = -1;
       }
-    }
+    });
   }
   return rst;
 }
@@ -567,14 +566,13 @@ DGL_REGISTER_GLOBAL("transform._CAPI_DGLPartitionWithHalo")
     graph_ptr->GetInCSR();
     std::vector<std::shared_ptr<HaloSubgraph> > subgs(max_part_id + 1);
     int num_partitions = part_nodes.size();
-#pragma omp parallel for
-    for (int i = 0; i < num_partitions; i++) {
+    runtime::parallel_for(0, num_partitions, [&](size_t i) {
       auto nodes = aten::VecToIdArray(part_nodes[i]);
       HaloSubgraph subg = GraphOp::GetSubgraphWithHalo(graph_ptr, nodes, num_hops);
       std::shared_ptr<HaloSubgraph> subg_ptr(new HaloSubgraph(subg));
       int part_id = part_ids[i];
       subgs[part_id] = subg_ptr;
-    }
+    });
     List<SubgraphRef> ret_list;
     for (size_t i = 0; i < subgs.size(); i++) {
       ret_list.push_back(SubgraphRef(subgs[i]));
@@ -732,8 +730,7 @@ IdArray MapIds(IdArray ids, IdArray range_starts, IdArray range_ends, IdArray ty
   const IdType *typed_map_data = static_cast<IdType *>(typed_map->data);
   IdType *types_data = static_cast<IdType *>(ret->data);
   IdType *per_type_ids_data = static_cast<IdType *>(ret->data) + num_ids;
-#pragma omp parallel for
-  for (int64_t i = 0; i < ids->shape[0]; i++) {
+  runtime::parallel_for(0, ids->shape[0], [&](size_t i) {
     IdType id = ids_data[i];
     auto it = std::lower_bound(range_end_data, range_end_data + num_ranges, id);
     // The range must exist.
@@ -749,7 +746,7 @@ IdArray MapIds(IdArray ids, IdArray range_starts, IdArray range_ends, IdArray ty
       per_type_ids_data[i] = id - range_start_data[range_id]
           + typed_map_data[num_parts * type_id + part_id - 1];
     }
-  }
+  });
   return ret;
 }
 

--- a/src/graph/heterograph_capi.cc
+++ b/src/graph/heterograph_capi.cc
@@ -630,18 +630,18 @@ DGL_REGISTER_GLOBAL("heterograph_index._CAPI_DGLHeteroCreateFormat")
 .set_body([] (DGLArgs args, DGLRetValue* rv) {
     HeteroGraphRef hg = args[0];
     dgl_format_code_t code = hg->GetRelationGraph(0)->GetAllowedFormats();
-    auto get_format_f = [&](size_t etype) {
-      auto bg = std::dynamic_pointer_cast<UnitGraph>(hg->GetRelationGraph(etype));
-      for (auto format : CodeToSparseFormats(code))
-        bg->GetFormat(format);
+    auto get_format_f = [&](size_t etype_b, size_t etype_e) {
+      for (auto etype = etype_b; etype < etype_e; ++etype) {
+        auto bg = std::dynamic_pointer_cast<UnitGraph>(hg->GetRelationGraph(etype));
+        for (auto format : CodeToSparseFormats(code))
+          bg->GetFormat(format);
+      }
     };
 
 #if !(defined(DGL_USE_CUDA))
   runtime::parallel_for(0, hg->NumEdgeTypes(), get_format_f);
 #else
-  for (int64_t etype = 0; etype < hg->NumEdgeTypes(); ++etype) {
-    get_format_f(etype);
-  }
+  get_format_f(0, hg->NumEdgeTypes());
 #endif
 });
 

--- a/src/graph/network.cc
+++ b/src/graph/network.cc
@@ -9,6 +9,7 @@
 
 #include <dgl/runtime/container.h>
 #include <dgl/runtime/ndarray.h>
+#include <dgl/runtime/parallel_for.h>
 #include <dgl/packed_func_ext.h>
 #include <dgl/immutable_graph.h>
 #include <dgl/nodeflow.h>
@@ -829,15 +830,14 @@ DGL_REGISTER_GLOBAL("network._CAPI_FastPull")
     char *return_data = new char[ID_size*row_size];
     const int64_t local_ids_size = local_ids.size();
     // Copy local data
-#pragma omp parallel for
-    for (int64_t i = 0; i < local_ids_size; ++i) {
+    runtime::parallel_for(0, local_ids_size, [&](size_t i) {
       CHECK_GE(ID_size*row_size, local_ids_orginal[i] * row_size + row_size);
       CHECK_GE(data_size, local_ids[i] * row_size + row_size);
       CHECK_GE(local_ids[i], 0);
       memcpy(return_data + local_ids_orginal[i] * row_size,
              local_data_char + local_ids[i] * row_size,
              row_size);
-    }
+    });
     // Recv remote message
     for (int i = 0; i < msg_count; ++i) {
       KVStoreMsg *kv_msg = recv_kv_message(receiver);

--- a/src/graph/network.cc
+++ b/src/graph/network.cc
@@ -830,13 +830,15 @@ DGL_REGISTER_GLOBAL("network._CAPI_FastPull")
     char *return_data = new char[ID_size*row_size];
     const int64_t local_ids_size = local_ids.size();
     // Copy local data
-    runtime::parallel_for(0, local_ids_size, [&](size_t i) {
-      CHECK_GE(ID_size*row_size, local_ids_orginal[i] * row_size + row_size);
-      CHECK_GE(data_size, local_ids[i] * row_size + row_size);
-      CHECK_GE(local_ids[i], 0);
-      memcpy(return_data + local_ids_orginal[i] * row_size,
-             local_data_char + local_ids[i] * row_size,
-             row_size);
+    runtime::parallel_for(0, local_ids_size, [&](size_t b, size_t e) {
+      for (auto i = b; i < e; ++i) {
+        CHECK_GE(ID_size*row_size, local_ids_orginal[i] * row_size + row_size);
+        CHECK_GE(data_size, local_ids[i] * row_size + row_size);
+        CHECK_GE(local_ids[i], 0);
+        memcpy(return_data + local_ids_orginal[i] * row_size,
+               local_data_char + local_ids[i] * row_size,
+               row_size);
+      }
     });
     // Recv remote message
     for (int i = 0; i < msg_count; ++i) {

--- a/src/graph/sampler.cc
+++ b/src/graph/sampler.cc
@@ -851,17 +851,19 @@ std::vector<NodeFlow> NeighborSamplingImpl(const ImmutableGraphPtr gptr,
     BuildCsr(*gptr, neigh_type);
     // generate node flows
     std::vector<NodeFlow> nflows(num_workers);
-    runtime::parallel_for(0, num_workers, [&](size_t i) {
-      // create per-worker seed nodes.
-      const int64_t start = (batch_start_id + i) * batch_size;
-      const int64_t end = std::min(start + batch_size, num_seeds);
-      // TODO(minjie): the vector allocation/copy is unnecessary
-      std::vector<dgl_id_t> worker_seeds(end - start);
-      std::copy(seed_nodes_data + start, seed_nodes_data + end,
-                worker_seeds.begin());
-      nflows[i] = SamplerOp::NeighborSample(
+    runtime::parallel_for(0, num_workers, [&](size_t b, size_t e) {
+      for (auto i = b; i < e; ++i) {
+        // create per-worker seed nodes.
+        const int64_t start = (batch_start_id + i) * batch_size;
+        const int64_t end = std::min(start + batch_size, num_seeds);
+        // TODO(minjie): the vector allocation/copy is unnecessary
+        std::vector<dgl_id_t> worker_seeds(end - start);
+        std::copy(seed_nodes_data + start, seed_nodes_data + end,
+                  worker_seeds.begin());
+        nflows[i] = SamplerOp::NeighborSample(
           gptr.get(), worker_seeds, neigh_type, num_hops, expand_factor,
           add_self_loop, probability);
+      }
     });
     return nflows;
 }
@@ -977,16 +979,18 @@ DGL_REGISTER_GLOBAL("sampling._CAPI_LayerSampling")
     BuildCsr(*gptr, neigh_type);
     // generate node flows
     std::vector<NodeFlow> nflows(num_workers);
-    runtime::parallel_for(0, num_workers, [&](size_t i) {
-      // create per-worker seed nodes.
-      const int64_t start = (batch_start_id + i) * batch_size;
-      const int64_t end = std::min(start + batch_size, num_seeds);
-      // TODO(minjie): the vector allocation/copy is unnecessary
-      std::vector<dgl_id_t> worker_seeds(end - start);
-      std::copy(seed_nodes_data + start, seed_nodes_data + end,
-                worker_seeds.begin());
-      nflows[i] = SamplerOp::LayerUniformSample(
-          gptr.get(), worker_seeds, neigh_type, layer_sizes);
+    runtime::parallel_for(0, num_workers, [&](size_t b, size_t e) {
+      for (auto i = b; i < e; ++i) {
+        // create per-worker seed nodes.
+        const int64_t start = (batch_start_id + i) * batch_size;
+        const int64_t end = std::min(start + batch_size, num_seeds);
+        // TODO(minjie): the vector allocation/copy is unnecessary
+        std::vector<dgl_id_t> worker_seeds(end - start);
+        std::copy(seed_nodes_data + start, seed_nodes_data + end,
+                  worker_seeds.begin());
+        nflows[i] = SamplerOp::LayerUniformSample(
+            gptr.get(), worker_seeds, neigh_type, layer_sizes);
+      }
     });
     *rv = List<NodeFlow>(nflows);
   });
@@ -1465,51 +1469,53 @@ public:
     std::vector<SubgraphRef> positive_subgs(num_workers);
     std::vector<SubgraphRef> negative_subgs(num_workers);
 
-    runtime::parallel_for(0, num_workers, [&](size_t i) {
-      const int64_t start = (batch_curr_id_ + i) * batch_size_;
-      const int64_t end = std::min(start + batch_size_, num_seeds_);
-      const int64_t num_edges = end - start;
-      IdArray worker_seeds;
+    runtime::parallel_for(0, num_workers, [&](size_t b, size_t e) {
+      for (auto i = b; i < e; ++i) {
+        const int64_t start = (batch_curr_id_ + i) * batch_size_;
+        const int64_t end = std::min(start + batch_size_, num_seeds_);
+        const int64_t num_edges = end - start;
+        IdArray worker_seeds;
 
-      if (replacement_ == false) {
-        worker_seeds = seed_edges_.CreateView({num_edges}, DLDataType{kDLInt, 64, 1},
-                                              sizeof(dgl_id_t) * start);
-      } else {
-        std::vector<dgl_id_t> seeds;
-        const dgl_id_t *seed_edge_ids = static_cast<const dgl_id_t *>(seed_edges_->data);
-        // sampling of each edge is a standalone event
-        for (int64_t i = 0; i < num_edges; ++i) {
-          int64_t seed = static_cast<const int64_t>(
-              RandomEngine::ThreadLocal()->RandInt(num_seeds_));
-          seeds.push_back(seed_edge_ids[seed]);
+        if (replacement_ == false) {
+          worker_seeds = seed_edges_.CreateView({num_edges}, DLDataType{kDLInt, 64, 1},
+                                                sizeof(dgl_id_t) * start);
+        } else {
+          std::vector<dgl_id_t> seeds;
+          const dgl_id_t *seed_edge_ids = static_cast<const dgl_id_t *>(seed_edges_->data);
+          // sampling of each edge is a standalone event
+          for (int64_t i = 0; i < num_edges; ++i) {
+            int64_t seed = static_cast<const int64_t>(
+                RandomEngine::ThreadLocal()->RandInt(num_seeds_));
+            seeds.push_back(seed_edge_ids[seed]);
+          }
+
+          worker_seeds = aten::VecToIdArray(seeds, seed_edges_->dtype.bits);
         }
 
-        worker_seeds = aten::VecToIdArray(seeds, seed_edges_->dtype.bits);
-      }
+        EdgeArray arr = gptr_->FindEdges(worker_seeds);
+        const dgl_id_t *src_ids = static_cast<const dgl_id_t *>(arr.src->data);
+        const dgl_id_t *dst_ids = static_cast<const dgl_id_t *>(arr.dst->data);
+        std::vector<dgl_id_t> src_vec(src_ids, src_ids + num_edges);
+        std::vector<dgl_id_t> dst_vec(dst_ids, dst_ids + num_edges);
+        // TODO(zhengda) what if there are duplicates in the src and dst vectors.
 
-      EdgeArray arr = gptr_->FindEdges(worker_seeds);
-      const dgl_id_t *src_ids = static_cast<const dgl_id_t *>(arr.src->data);
-      const dgl_id_t *dst_ids = static_cast<const dgl_id_t *>(arr.dst->data);
-      std::vector<dgl_id_t> src_vec(src_ids, src_ids + num_edges);
-      std::vector<dgl_id_t> dst_vec(dst_ids, dst_ids + num_edges);
-      // TODO(zhengda) what if there are duplicates in the src and dst vectors.
-
-      Subgraph subg = gptr_->EdgeSubgraph(worker_seeds, false);
-      positive_subgs[i] = ConvertRef(subg);
-      // For chunked negative sampling, we accept "chunk-head" for corrupting head
-      // nodes and "chunk-tail" for corrupting tail nodes.
-      if (neg_mode_.substr(0, 5) == "chunk") {
-        NegSubgraph neg_subg = genChunkedNegEdgeSubgraph(subg, neg_mode_.substr(6),
-                                                         neg_sample_size_,
-                                                         exclude_positive_,
-                                                         check_false_neg_);
-        negative_subgs[i] = ConvertRef(neg_subg);
-      } else if (neg_mode_ == "head" || neg_mode_ == "tail") {
-        NegSubgraph neg_subg = genNegEdgeSubgraph(subg, neg_mode_,
-                                                  neg_sample_size_,
-                                                  exclude_positive_,
-                                                  check_false_neg_);
-        negative_subgs[i] = ConvertRef(neg_subg);
+        Subgraph subg = gptr_->EdgeSubgraph(worker_seeds, false);
+        positive_subgs[i] = ConvertRef(subg);
+        // For chunked negative sampling, we accept "chunk-head" for corrupting head
+        // nodes and "chunk-tail" for corrupting tail nodes.
+        if (neg_mode_.substr(0, 5) == "chunk") {
+          NegSubgraph neg_subg = genChunkedNegEdgeSubgraph(subg, neg_mode_.substr(6),
+                                                           neg_sample_size_,
+                                                           exclude_positive_,
+                                                           check_false_neg_);
+          negative_subgs[i] = ConvertRef(neg_subg);
+        } else if (neg_mode_ == "head" || neg_mode_ == "tail") {
+          NegSubgraph neg_subg = genNegEdgeSubgraph(subg, neg_mode_,
+                                                    neg_sample_size_,
+                                                    exclude_positive_,
+                                                    check_false_neg_);
+          negative_subgs[i] = ConvertRef(neg_subg);
+        }
       }
     });
     if (neg_mode_.size() > 0) {

--- a/src/graph/sampling/randomwalks/randomwalks_cpu.h
+++ b/src/graph/sampling/randomwalks/randomwalks_cpu.h
@@ -48,22 +48,24 @@ std::pair<IdArray, IdArray> GenericRandomWalk(
   IdxType *traces_data = traces.Ptr<IdxType>();
   IdxType *eids_data = eids.Ptr<IdxType>();
 
-  runtime::parallel_for(0, num_seeds, [&](size_t seed_id) {
-    int64_t i;
-    dgl_id_t curr = seed_data[seed_id];
-    traces_data[seed_id * trace_length] = curr;
+  runtime::parallel_for(0, num_seeds, [&](size_t seed_begin, size_t seed_end) {
+    for (auto seed_id = seed_begin; seed_id < seed_end; seed_id++) {
+      int64_t i;
+      dgl_id_t curr = seed_data[seed_id];
+      traces_data[seed_id * trace_length] = curr;
 
-    for (i = 0; i < max_num_steps; ++i) {
-      const auto &succ = step(traces_data + seed_id * max_num_steps, curr, i);
-      traces_data[seed_id * trace_length + i + 1] = curr = std::get<0>(succ);
-      eids_data[seed_id * max_num_steps + i] = std::get<1>(succ);
-      if (std::get<2>(succ))
-        break;
-    }
+      for (i = 0; i < max_num_steps; ++i) {
+        const auto &succ = step(traces_data + seed_id * max_num_steps, curr, i);
+        traces_data[seed_id * trace_length + i + 1] = curr = std::get<0>(succ);
+        eids_data[seed_id * max_num_steps + i] = std::get<1>(succ);
+        if (std::get<2>(succ))
+          break;
+      }
 
-    for (; i < max_num_steps; ++i) {
-      traces_data[seed_id * trace_length + i + 1] = -1;
-      eids_data[seed_id * max_num_steps + i] = -1;
+      for (; i < max_num_steps; ++i) {
+        traces_data[seed_id * trace_length + i + 1] = -1;
+        eids_data[seed_id * max_num_steps + i] = -1;
+      }
     }
   });
 

--- a/src/graph/sampling/randomwalks/randomwalks_cpu.h
+++ b/src/graph/sampling/randomwalks/randomwalks_cpu.h
@@ -9,6 +9,7 @@
 
 #include <dgl/base_heterograph.h>
 #include <dgl/array.h>
+#include <dgl/runtime/parallel_for.h>
 #include <tuple>
 #include <utility>
 #include "randomwalks_impl.h"
@@ -47,8 +48,7 @@ std::pair<IdArray, IdArray> GenericRandomWalk(
   IdxType *traces_data = traces.Ptr<IdxType>();
   IdxType *eids_data = eids.Ptr<IdxType>();
 
-#pragma omp parallel for
-  for (int64_t seed_id = 0; seed_id < num_seeds; ++seed_id) {
+  runtime::parallel_for(0, num_seeds, [&](size_t seed_id) {
     int64_t i;
     dgl_id_t curr = seed_data[seed_id];
     traces_data[seed_id * trace_length] = curr;
@@ -65,7 +65,7 @@ std::pair<IdArray, IdArray> GenericRandomWalk(
       traces_data[seed_id * trace_length + i + 1] = -1;
       eids_data[seed_id * max_num_steps + i] = -1;
     }
-  }
+  });
 
   return std::make_pair(traces, eids);
 }

--- a/src/graph/transform/cpu/knn.cc
+++ b/src/graph/transform/cpu/knn.cc
@@ -235,19 +235,21 @@ void KdTreeKNN(const NDArray& data_points, const IdArray& data_offsets,
     KDTreeNDArrayAdapter<FloatType, IdType> kdtree(feature_size, current_data_points);
 
     // query
-    parallel_for(0, q_length, [&](IdType q) {
-      std::vector<IdType> out_buffer(k);
-      std::vector<FloatType> out_dist_buffer(k);
+    parallel_for(0, q_length, [&](IdType b, IdType e) {
+      for (auto q = b; q < e; ++q) {
+        std::vector<IdType> out_buffer(k);
+        std::vector<FloatType> out_dist_buffer(k);
 
-      auto curr_out_offset = k * q + out_offset;
-      const FloatType* q_point = current_query_pts_data + q * feature_size;
-      size_t num_matches = kdtree.GetIndex()->knnSearch(
-        q_point, k, out_buffer.data(), out_dist_buffer.data());
+        auto curr_out_offset = k * q + out_offset;
+        const FloatType* q_point = current_query_pts_data + q * feature_size;
+        size_t num_matches = kdtree.GetIndex()->knnSearch(
+            q_point, k, out_buffer.data(), out_dist_buffer.data());
 
-      for (size_t i = 0; i < num_matches; ++i) {
-        query_out[curr_out_offset] = q + q_offset;
-        data_out[curr_out_offset] = out_buffer[i] + d_offset;
-        curr_out_offset++;
+        for (size_t i = 0; i < num_matches; ++i) {
+          query_out[curr_out_offset] = q + q_offset;
+          data_out[curr_out_offset] = out_buffer[i] + d_offset;
+          curr_out_offset++;
+        }
       }
     });
   }
@@ -272,28 +274,30 @@ void BruteForceKNN(const NDArray& data_points, const IdArray& data_offsets,
 
     std::vector<FloatType> dist_buffer(k);
 
-    parallel_for(q_start, q_end, [&](IdType q_idx) {
-      std::vector<FloatType> dist_buffer(k);
-      for (IdType k_idx = 0; k_idx < k; ++k_idx) {
-        query_out[q_idx * k + k_idx] = q_idx;
-        dist_buffer[k_idx] = std::numeric_limits<FloatType>::max();
-      }
-      FloatType worst_dist = std::numeric_limits<FloatType>::max();
-
-      for (IdType d_idx = d_start; d_idx < d_end; ++d_idx) {
-        FloatType tmp_dist = EuclideanDistWithCheck<FloatType, IdType>(
-          query_points_data + q_idx * feature_size,
-          data_points_data + d_idx * feature_size,
-          feature_size, worst_dist);
-
-        if (tmp_dist == std::numeric_limits<FloatType>::max()) {
-          continue;
+    parallel_for(q_start, q_end, [&](IdType b, IdType e) {
+      for (auto q_idx = b; q_idx < e; ++q_idx) {
+        std::vector<FloatType> dist_buffer(k);
+        for (IdType k_idx = 0; k_idx < k; ++k_idx) {
+          query_out[q_idx * k + k_idx] = q_idx;
+          dist_buffer[k_idx] = std::numeric_limits<FloatType>::max();
         }
+        FloatType worst_dist = std::numeric_limits<FloatType>::max();
 
-        IdType out_offset = q_idx * k;
-        HeapInsert<FloatType, IdType>(
-          data_out + out_offset, dist_buffer.data(), d_idx, tmp_dist, k);
-        worst_dist = dist_buffer[0];
+        for (IdType d_idx = d_start; d_idx < d_end; ++d_idx) {
+          FloatType tmp_dist = EuclideanDistWithCheck<FloatType, IdType>(
+            query_points_data + q_idx * feature_size,
+            data_points_data + d_idx * feature_size,
+            feature_size, worst_dist);
+
+          if (tmp_dist == std::numeric_limits<FloatType>::max()) {
+            continue;
+          }
+
+          IdType out_offset = q_idx * k;
+          HeapInsert<FloatType, IdType>(
+            data_out + out_offset, dist_buffer.data(), d_idx, tmp_dist, k);
+          worst_dist = dist_buffer[0];
+        }
       }
     });
   }
@@ -357,22 +361,24 @@ void NNDescent(const NDArray& points, const IdArray& offsets,
     IdType segment_size = point_idx_end - point_idx_start;
 
     // random initialization
-    runtime::parallel_for(point_idx_start, point_idx_end, [&](size_t i) {
-      IdType local_idx = i - point_idx_start;
+    runtime::parallel_for(point_idx_start, point_idx_end, [&](size_t b, size_t e) {
+      for (auto i = b; i < e; ++i) {
+        IdType local_idx = i - point_idx_start;
 
-      dgl::RandomEngine::ThreadLocal()->UniformChoice<IdType>(
-        k, segment_size, neighbors + i * k, false);
+        dgl::RandomEngine::ThreadLocal()->UniformChoice<IdType>(
+          k, segment_size, neighbors + i * k, false);
 
-      for (IdType n = 0; n < k; ++n) {
-        central_nodes[i * k + n] = i;
-        neighbors[i * k + n] += point_idx_start;
-        flags[local_idx * k + n] = true;
-        neighbors_dists[local_idx * k + n] = impl::EuclideanDist<FloatType, IdType>(
-          points_data + i * feature_size,
-          points_data + neighbors[i * k + n] * feature_size,
-          feature_size);
+        for (IdType n = 0; n < k; ++n) {
+          central_nodes[i * k + n] = i;
+          neighbors[i * k + n] += point_idx_start;
+          flags[local_idx * k + n] = true;
+          neighbors_dists[local_idx * k + n] = impl::EuclideanDist<FloatType, IdType>(
+            points_data + i * feature_size,
+            points_data + neighbors[i * k + n] * feature_size,
+            feature_size);
+        }
+        impl::BuildHeap<FloatType, IdType>(neighbors + i * k, neighbors_dists + local_idx * k, k);
       }
-      impl::BuildHeap<FloatType, IdType>(neighbors + i * k, neighbors_dists + local_idx * k, k);
     });
 
     size_t num_updates = 0;
@@ -380,54 +386,58 @@ void NNDescent(const NDArray& points, const IdArray& offsets,
       num_updates = 0;
 
       // initialize candidates array as empty value
-      runtime::parallel_for(point_idx_start, point_idx_end, [&](size_t i) {
-        IdType local_idx = i - point_idx_start;
-        for (IdType c = 0; c < num_candidates; ++c) {
-          new_candidates[local_idx * num_candidates + c] = num_nodes;
-          old_candidates[local_idx * num_candidates + c] = num_nodes;
-          new_candidates_dists[local_idx * num_candidates + c] =
-            std::numeric_limits<FloatType>::max();
-          old_candidates_dists[local_idx * num_candidates + c] =
-            std::numeric_limits<FloatType>::max();
+      runtime::parallel_for(point_idx_start, point_idx_end, [&](size_t b, size_t e) {
+        for (auto i = b; i < e; ++i) {
+          IdType local_idx = i - point_idx_start;
+          for (IdType c = 0; c < num_candidates; ++c) {
+            new_candidates[local_idx * num_candidates + c] = num_nodes;
+            old_candidates[local_idx * num_candidates + c] = num_nodes;
+            new_candidates_dists[local_idx * num_candidates + c] =
+              std::numeric_limits<FloatType>::max();
+            old_candidates_dists[local_idx * num_candidates + c] =
+              std::numeric_limits<FloatType>::max();
+          }
         }
       });
 
       // randomly select neighbors as candidates
       int num_threads = omp_get_max_threads();
-      runtime::parallel_for(0, num_threads, [&](size_t tid) {
-        for (IdType i = point_idx_start; i < point_idx_end; ++i) {
-          IdType local_idx = i - point_idx_start;
-          for (IdType n = 0; n < k; ++n) {
-            IdType neighbor_idx = neighbors[i * k + n];
-            bool is_new = flags[local_idx * k + n];
-            IdType local_neighbor_idx = neighbor_idx - point_idx_start;
-            FloatType random_dist = dgl::RandomEngine::ThreadLocal()->Uniform<FloatType>();
+      runtime::parallel_for(0, num_threads, [&](size_t b, size_t e) {
+        for (auto tid = b; tid < e; ++tid) {
+          for (IdType i = point_idx_start; i < point_idx_end; ++i) {
+            IdType local_idx = i - point_idx_start;
+            for (IdType n = 0; n < k; ++n) {
+              IdType neighbor_idx = neighbors[i * k + n];
+              bool is_new = flags[local_idx * k + n];
+              IdType local_neighbor_idx = neighbor_idx - point_idx_start;
+              FloatType random_dist = dgl::RandomEngine::ThreadLocal()->Uniform<FloatType>();
 
-            if (is_new) {
-              if (local_idx % num_threads == tid) {
-                impl::HeapInsert<FloatType, IdType>(
-                  new_candidates + local_idx * num_candidates,
-                  new_candidates_dists + local_idx * num_candidates,
-                  neighbor_idx, random_dist, num_candidates, true);
-              }
-              if (local_neighbor_idx % num_threads == tid) {
-                impl::HeapInsert<FloatType, IdType>(
-                  new_candidates + local_neighbor_idx * num_candidates,
-                  new_candidates_dists + local_neighbor_idx * num_candidates,
-                  i, random_dist, num_candidates, true);
-              }
-            } else {
-              if (local_idx % num_threads == tid) {
-                impl::HeapInsert<FloatType, IdType>(
-                  old_candidates + local_idx * num_candidates,
-                  old_candidates_dists + local_idx * num_candidates,
-                  neighbor_idx, random_dist, num_candidates, true);
-              }
-              if (local_neighbor_idx % num_threads == tid) {
-                impl::HeapInsert<FloatType, IdType>(
-                  old_candidates + local_neighbor_idx * num_candidates,
-                  old_candidates_dists + local_neighbor_idx * num_candidates,
-                  i, random_dist, num_candidates, true);
+              if (is_new) {
+                if (local_idx % num_threads == tid) {
+                  impl::HeapInsert<FloatType, IdType>(
+                    new_candidates + local_idx * num_candidates,
+                    new_candidates_dists + local_idx * num_candidates,
+                    neighbor_idx, random_dist, num_candidates, true);
+                }
+                if (local_neighbor_idx % num_threads == tid) {
+                  impl::HeapInsert<FloatType, IdType>(
+                    new_candidates + local_neighbor_idx * num_candidates,
+                    new_candidates_dists + local_neighbor_idx * num_candidates,
+                    i, random_dist, num_candidates, true);
+                }
+              } else {
+                if (local_idx % num_threads == tid) {
+                  impl::HeapInsert<FloatType, IdType>(
+                    old_candidates + local_idx * num_candidates,
+                    old_candidates_dists + local_idx * num_candidates,
+                    neighbor_idx, random_dist, num_candidates, true);
+                }
+                if (local_neighbor_idx % num_threads == tid) {
+                  impl::HeapInsert<FloatType, IdType>(
+                    old_candidates + local_neighbor_idx * num_candidates,
+                    old_candidates_dists + local_neighbor_idx * num_candidates,
+                    i, random_dist, num_candidates, true);
+                }
               }
             }
           }
@@ -435,15 +445,17 @@ void NNDescent(const NDArray& points, const IdArray& offsets,
       });
 
       // mark all elements in new_candidates as false
-      runtime::parallel_for(point_idx_start, point_idx_end, [&](size_t i) {
-        IdType local_idx = i - point_idx_start;
-        for (IdType n = 0; n < k; ++n) {
-          IdType n_idx = neighbors[i * k + n];
+      runtime::parallel_for(point_idx_start, point_idx_end, [&](size_t b, size_t e) {
+        for (auto i = b; i < e; ++i) {
+          IdType local_idx = i - point_idx_start;
+          for (IdType n = 0; n < k; ++n) {
+            IdType n_idx = neighbors[i * k + n];
 
-          for (IdType c = 0; c < num_candidates; ++c) {
-            if (new_candidates[local_idx * num_candidates + c] == n_idx) {
-              flags[local_idx * k + n] = false;
-              break;
+            for (IdType c = 0; c < num_candidates; ++c) {
+              if (new_candidates[local_idx * num_candidates + c] == n_idx) {
+                flags[local_idx * k + n] = false;
+                break;
+              }
             }
           }
         }
@@ -458,48 +470,51 @@ void NNDescent(const NDArray& points, const IdArray& offsets,
         nnd_updates_t updates(block_size);
 
         // generate updates
-        runtime::parallel_for(block_start, block_end, [&](size_t i) {
-          IdType local_idx = i - point_idx_start;
-          for (IdType c1 = 0; c1 < num_candidates; ++c1) {
-            IdType new_c1 = new_candidates[local_idx * num_candidates + c1];
-            if (new_c1 == num_nodes) continue;
-            IdType c1_local = new_c1 - point_idx_start;
+        runtime::parallel_for(block_start, block_end, [&](size_t b, size_t e) {
+          for (auto i = b; i < e; ++i) {
+            IdType local_idx = i - point_idx_start;
 
-            // new-new
-            for (IdType c2 = c1; c2 < num_candidates; ++c2) {
-              IdType new_c2 = new_candidates[local_idx * num_candidates + c2];
-              if (new_c2 == num_nodes) continue;
-              IdType c2_local = new_c2 - point_idx_start;
+            for (IdType c1 = 0; c1 < num_candidates; ++c1) {
+              IdType new_c1 = new_candidates[local_idx * num_candidates + c1];
+              if (new_c1 == num_nodes) continue;
+              IdType c1_local = new_c1 - point_idx_start;
 
-              FloatType worst_c1_dist = neighbors_dists[c1_local * k];
-              FloatType worst_c2_dist = neighbors_dists[c2_local * k];
-              FloatType new_dist = impl::EuclideanDistWithCheck<FloatType, IdType>(
-                points_data + new_c1 * feature_size,
-                points_data + new_c2 * feature_size,
-                feature_size,
-                std::max(worst_c1_dist, worst_c2_dist));
+              // new-new
+              for (IdType c2 = c1; c2 < num_candidates; ++c2) {
+                IdType new_c2 = new_candidates[local_idx * num_candidates + c2];
+                if (new_c2 == num_nodes) continue;
+                IdType c2_local = new_c2 - point_idx_start;
 
-              if (new_dist < worst_c1_dist || new_dist < worst_c2_dist) {
-                updates[i - block_start].push_back(std::make_tuple(new_c1, new_c2, new_dist));
+                FloatType worst_c1_dist = neighbors_dists[c1_local * k];
+                FloatType worst_c2_dist = neighbors_dists[c2_local * k];
+                FloatType new_dist = impl::EuclideanDistWithCheck<FloatType, IdType>(
+                  points_data + new_c1 * feature_size,
+                  points_data + new_c2 * feature_size,
+                  feature_size,
+                  std::max(worst_c1_dist, worst_c2_dist));
+
+                if (new_dist < worst_c1_dist || new_dist < worst_c2_dist) {
+                  updates[i - block_start].push_back(std::make_tuple(new_c1, new_c2, new_dist));
+                }
               }
-            }
 
-            // new-old
-            for (IdType c2 = 0; c2 < num_candidates; ++c2) {
-              IdType old_c2 = old_candidates[local_idx * num_candidates + c2];
-              if (old_c2 == num_nodes) continue;
-              IdType c2_local = old_c2 - point_idx_start;
+              // new-old
+              for (IdType c2 = 0; c2 < num_candidates; ++c2) {
+                IdType old_c2 = old_candidates[local_idx * num_candidates + c2];
+                if (old_c2 == num_nodes) continue;
+                IdType c2_local = old_c2 - point_idx_start;
 
-              FloatType worst_c1_dist = neighbors_dists[c1_local * k];
-              FloatType worst_c2_dist = neighbors_dists[c2_local * k];
-              FloatType new_dist = impl::EuclideanDistWithCheck<FloatType, IdType>(
-                points_data + new_c1 * feature_size,
-                points_data + old_c2 * feature_size,
-                feature_size,
-                std::max(worst_c1_dist, worst_c2_dist));
+                FloatType worst_c1_dist = neighbors_dists[c1_local * k];
+                FloatType worst_c2_dist = neighbors_dists[c2_local * k];
+                FloatType new_dist = impl::EuclideanDistWithCheck<FloatType, IdType>(
+                  points_data + new_c1 * feature_size,
+                  points_data + old_c2 * feature_size,
+                  feature_size,
+                  std::max(worst_c1_dist, worst_c2_dist));
 
-              if (new_dist < worst_c1_dist || new_dist < worst_c2_dist) {
-                updates[i - block_start].push_back(std::make_tuple(new_c1, old_c2, new_dist));
+                if (new_dist < worst_c1_dist || new_dist < worst_c2_dist) {
+                  updates[i - block_start].push_back(std::make_tuple(new_c1, old_c2, new_dist));
+                }
               }
             }
           }

--- a/src/graph/transform/partition_hetero.cc
+++ b/src/graph/transform/partition_hetero.cc
@@ -253,13 +253,15 @@ DGL_REGISTER_GLOBAL("partition._CAPI_DGLPartitionWithHalo_Hetero")
     ugptr->GetOutCSR();
     std::vector<std::shared_ptr<HaloHeteroSubgraph>> subgs(max_part_id + 1);
     int num_partitions = part_nodes.size();
-    runtime::parallel_for(0, num_partitions, [&](size_t i) {
-      auto nodes = aten::VecToIdArray(part_nodes[i]);
-      HaloHeteroSubgraph subg = GetSubgraphWithHalo(hgptr, nodes, num_hops);
-      std::shared_ptr<HaloHeteroSubgraph> subg_ptr(
-        new HaloHeteroSubgraph(subg));
-      int part_id = part_ids[i];
-      subgs[part_id] = subg_ptr;
+    runtime::parallel_for(0, num_partitions, [&](int b, int e) {
+      for (auto i = b; i < e; i++) {
+        auto nodes = aten::VecToIdArray(part_nodes[i]);
+        HaloHeteroSubgraph subg = GetSubgraphWithHalo(hgptr, nodes, num_hops);
+        std::shared_ptr<HaloHeteroSubgraph> subg_ptr(
+          new HaloHeteroSubgraph(subg));
+        int part_id = part_ids[i];
+        subgs[part_id] = subg_ptr;
+      }
     });
     List<HeteroSubgraphRef> ret_list;
     for (size_t i = 0; i < subgs.size(); i++) {

--- a/src/graph/transform/partition_hetero.cc
+++ b/src/graph/transform/partition_hetero.cc
@@ -4,15 +4,16 @@
  * \brief Call Metis partitioning
  */
 
-#if !defined(_WIN32)
-#include <GKlib.h>
-#endif  // !defined(_WIN32)
-
 #include <dgl/base_heterograph.h>
 #include <dgl/packed_func_ext.h>
+#include <dgl/runtime/parallel_for.h>
 
 #include "../heterograph.h"
 #include "../unit_graph.h"
+
+#if !defined(_WIN32)
+#include <GKlib.h>
+#endif  // !defined(_WIN32)
 
 using namespace dgl::runtime;
 
@@ -252,15 +253,14 @@ DGL_REGISTER_GLOBAL("partition._CAPI_DGLPartitionWithHalo_Hetero")
     ugptr->GetOutCSR();
     std::vector<std::shared_ptr<HaloHeteroSubgraph>> subgs(max_part_id + 1);
     int num_partitions = part_nodes.size();
-#pragma omp parallel for
-    for (int i = 0; i < num_partitions; i++) {
+    runtime::parallel_for(0, num_partitions, [&](size_t i) {
       auto nodes = aten::VecToIdArray(part_nodes[i]);
       HaloHeteroSubgraph subg = GetSubgraphWithHalo(hgptr, nodes, num_hops);
       std::shared_ptr<HaloHeteroSubgraph> subg_ptr(
         new HaloHeteroSubgraph(subg));
       int part_id = part_ids[i];
       subgs[part_id] = subg_ptr;
-    }
+    });
     List<HeteroSubgraphRef> ret_list;
     for (size_t i = 0; i < subgs.size(); i++) {
       ret_list.push_back(HeteroSubgraphRef(subgs[i]));

--- a/src/random/random.cc
+++ b/src/random/random.cc
@@ -23,8 +23,10 @@ DGL_REGISTER_GLOBAL("rng._CAPI_SetSeed")
 .set_body([] (DGLArgs args, DGLRetValue *rv) {
     const int seed = args[0];
 
-    runtime::parallel_for(0, omp_get_max_threads(), [&](size_t i) {
-      RandomEngine::ThreadLocal()->SetSeed(seed);
+    runtime::parallel_for(0, omp_get_max_threads(), [&](size_t b, size_t e) {
+      for (auto i = b; i < e; ++i) {
+        RandomEngine::ThreadLocal()->SetSeed(seed);
+      }
     });
 #ifdef DGL_USE_CUDA
     auto* thr_entry = CUDAThreadEntry::ThreadLocal();

--- a/src/random/random.cc
+++ b/src/random/random.cc
@@ -7,6 +7,7 @@
 #include <dmlc/omp.h>
 #include <dgl/runtime/registry.h>
 #include <dgl/runtime/packed_func.h>
+#include <dgl/runtime/parallel_for.h>
 #include <dgl/random.h>
 #include <dgl/array.h>
 
@@ -21,10 +22,10 @@ namespace dgl {
 DGL_REGISTER_GLOBAL("rng._CAPI_SetSeed")
 .set_body([] (DGLArgs args, DGLRetValue *rv) {
     const int seed = args[0];
-#pragma omp parallel for
-    for (int i = 0; i < omp_get_max_threads(); ++i) {
+
+    runtime::parallel_for(0, omp_get_max_threads(), [&](size_t i) {
       RandomEngine::ThreadLocal()->SetSeed(seed);
-    }
+    });
 #ifdef DGL_USE_CUDA
     auto* thr_entry = CUDAThreadEntry::ThreadLocal();
     if (!thr_entry->curand_gen) {

--- a/src/rpc/rpc.cc
+++ b/src/rpc/rpc.cc
@@ -11,6 +11,7 @@
 #endif
 
 #include <dgl/runtime/container.h>
+#include <dgl/runtime/parallel_for.h>
 #include <dgl/packed_func_ext.h>
 #include <dgl/array.h>
 #include <dgl/random.h>
@@ -454,15 +455,14 @@ DGL_REGISTER_GLOBAL("distributed.rpc._CAPI_DGLRPCFastPull")
                                       DLContext{kDLCPU, 0});
   char* return_data = static_cast<char*>(res_tensor->data);
   // Copy local data
-#pragma omp parallel for
-  for (int64_t i = 0; i < local_ids.size(); ++i) {
+  parallel_for(0, local_ids.size(), [&](size_t i) {
     CHECK_GE(ID_size*row_size, local_ids_orginal[i]*row_size+row_size);
     CHECK_GE(data_size, local_ids[i] * row_size + row_size);
     CHECK_GE(local_ids[i], 0);
     memcpy(return_data + local_ids_orginal[i] * row_size,
            local_data_char + local_ids[i] * row_size,
            row_size);
-  }
+  });
   // Recv remote message
   for (int i = 0; i < msg_count; ++i) {
     RPCMessage msg;

--- a/src/rpc/rpc.cc
+++ b/src/rpc/rpc.cc
@@ -455,13 +455,15 @@ DGL_REGISTER_GLOBAL("distributed.rpc._CAPI_DGLRPCFastPull")
                                       DLContext{kDLCPU, 0});
   char* return_data = static_cast<char*>(res_tensor->data);
   // Copy local data
-  parallel_for(0, local_ids.size(), [&](size_t i) {
-    CHECK_GE(ID_size*row_size, local_ids_orginal[i]*row_size+row_size);
-    CHECK_GE(data_size, local_ids[i] * row_size + row_size);
-    CHECK_GE(local_ids[i], 0);
-    memcpy(return_data + local_ids_orginal[i] * row_size,
-           local_data_char + local_ids[i] * row_size,
-           row_size);
+  parallel_for(0, local_ids.size(), [&](size_t b, size_t e) {
+    for (auto i = b; i < e; ++i) {
+      CHECK_GE(ID_size*row_size, local_ids_orginal[i]*row_size+row_size);
+      CHECK_GE(data_size, local_ids[i] * row_size + row_size);
+      CHECK_GE(local_ids[i], 0);
+      memcpy(return_data + local_ids_orginal[i] * row_size,
+             local_data_char + local_ids[i] * row_size,
+             row_size);
+    }
   });
   // Recv remote message
   for (int i = 0; i < msg_count; ++i) {


### PR DESCRIPTION
The PR replaces uses of OpenMP `parallel for` pragma with `parallel_for` primitive wherever it was possible (no `reduction`, `atomic`, `critical` or `barrier` clauses). 

This PR continues and includes work introduced by #3023 and #3027. The mentioned PRs contain initial benchmarking and information about performance regressions. This PR includes commits from earlier PRs and replaces additional pragmas. The earlier PR are going to be closed.
