### PR TITLE
[Distributed] Enable distributed EdgeDataLoader

### DIFF
--- a/python/dgl/distributed/dist_graph.py
+++ b/python/dgl/distributed/dist_graph.py
@@ -515,10 +515,10 @@ class DistGraph:
         self._client.map_shared_data(self._gpb)
 
     def __getstate__(self):
-        return self.graph_name, self._gpb
+        return self.graph_name, self._gpb, self._canonical_etypes
 
     def __setstate__(self, state):
-        self.graph_name, self._gpb_input = state
+        self.graph_name, self._gpb_input, self._canonical_etypes = state
         self._init()
 
         self._ndata_store = {}
@@ -977,9 +977,7 @@ class DistGraph:
 
         Parameters
         ----------
-        edges : tensor
-            The edge ID array.
-        eid : Int Tensor
+        edges : Int Tensor
             Each element is an ID. The tensor must have the same device type
               and ID data type as the graph's.
 

--- a/python/dgl/distributed/dist_graph.py
+++ b/python/dgl/distributed/dist_graph.py
@@ -505,7 +505,10 @@ class DistGraph:
                                            self.ntypes[dst_tid]))
         self._etype2canonical = {}
         for src_type, etype, dst_type in self._canonical_etypes:
-            self._etype2canonical[etype] = (src_type, etype, dst_type)
+            if etype in self._etype2canonical:
+                self._etype2canonical[etype] = ()
+            else:
+                self._etype2canonical[etype] = (src_type, etype, dst_type)
 
     def _init(self):
         self._client = get_kvstore()
@@ -526,7 +529,10 @@ class DistGraph:
 
         self._etype2canonical = {}
         for src_type, etype, dst_type in self._canonical_etypes:
-            self._etype2canonical[etype] = (src_type, etype, dst_type)
+            if etype in self._etype2canonical:
+                self._etype2canonical[etype] = ()
+            else:
+                self._etype2canonical[etype] = (src_type, etype, dst_type)
         self._ndata_store = {}
         self._edata_store = {}
         self._ndata = NodeDataView(self)
@@ -1056,8 +1062,11 @@ class DistGraph:
             if isinstance(edges, tuple):
                 subg = {etype: self.find_edges(edges[etype], etype[1]) for etype in edges}
             else:
-                subg = {self._etype2canonical[etype]: self.find_edges(edges[etype], etype) \
-                        for etype in edges}
+                subg = {}
+                for etype in edges:
+                    assert len(self._etype2canonical[etype]) == 3, \
+                            'the etype in input edges is ambiguous'
+                    subg[self._etype2canonical[etype]] = self.find_edges(edges[etype], etype)
             num_nodes = {ntype: self.number_of_nodes(ntype) for ntype in self.ntypes}
             subg = dgl_heterograph(subg, num_nodes_dict=num_nodes)
         else:

--- a/python/dgl/distributed/dist_graph.py
+++ b/python/dgl/distributed/dist_graph.py
@@ -1059,6 +1059,7 @@ class DistGraph:
 
         if relabel_nodes:
             subg = compact_graphs(subg)
+        assert store_ids, 'edge_subgraph always stores original node/edge IDs.'
         return subg
 
     def get_partition_book(self):

--- a/python/dgl/distributed/graph_services.py
+++ b/python/dgl/distributed/graph_services.py
@@ -405,6 +405,7 @@ def sample_neighbors(g, nodes, fanout, edge_dir='in', prob=None, replace=False):
         etype_ids, idx = F.sort_1d(etype_ids)
         src, dst = F.gather_row(src, idx), F.gather_row(dst, idx)
         eid = F.gather_row(frontier.edata[EID], idx)
+        assert len(eid) > 0
         _, src = gpb.map_to_per_ntype(src)
         _, dst = gpb.map_to_per_ntype(dst)
 

--- a/tests/distributed/test_distributed_sampling.py
+++ b/tests/distributed/test_distributed_sampling.py
@@ -37,14 +37,14 @@ def start_sample_client(rank, tmpdir, disable_shared_mem):
     dgl.distributed.exit_client()
     return sampled_graph
 
-def start_find_edges_client(rank, tmpdir, disable_shared_mem, eids):
+def start_find_edges_client(rank, tmpdir, disable_shared_mem, eids, etype=None):
     gpb = None
     if disable_shared_mem:
         _, _, _, gpb, _, _, _ = load_partition(tmpdir / 'test_find_edges.json', rank)
     dgl.distributed.initialize("rpc_ip_config.txt")
     dist_graph = DistGraph("test_find_edges", gpb=gpb)
     try:
-        u, v = dist_graph.find_edges(eids)
+        u, v = dist_graph.find_edges(eids, etype=etype)
     except Exception as e:
         print(e)
         u, v = None, None
@@ -114,8 +114,9 @@ def check_rpc_find_edges_shuffle(tmpdir, num_server):
     g.readonly()
     num_parts = num_server
 
-    partition_graph(g, 'test_find_edges', num_parts, tmpdir,
-                    num_hops=1, part_method='metis', reshuffle=True)
+    orig_nid, orig_eid = partition_graph(g, 'test_find_edges', num_parts, tmpdir,
+                                         num_hops=1, part_method='metis',
+                                         reshuffle=True, return_mapping=True)
 
     pserver_list = []
     ctx = mp.get_context('spawn')
@@ -126,19 +127,56 @@ def check_rpc_find_edges_shuffle(tmpdir, num_server):
         time.sleep(1)
         pserver_list.append(p)
 
-    orig_nid = F.zeros((g.number_of_nodes(),), dtype=F.int64, ctx=F.cpu())
-    orig_eid = F.zeros((g.number_of_edges(),), dtype=F.int64, ctx=F.cpu())
-    for i in range(num_server):
-        part, _, _, _, _, _, _ = load_partition(tmpdir / 'test_find_edges.json', i)
-        orig_nid[part.ndata[dgl.NID]] = part.ndata['orig_id']
-        orig_eid[part.edata[dgl.EID]] = part.edata['orig_id']
-
     time.sleep(3)
     eids = F.tensor(np.random.randint(g.number_of_edges(), size=100))
     u, v = g.find_edges(orig_eid[eids])
     du, dv = start_find_edges_client(0, tmpdir, num_server > 1, eids)
     du = orig_nid[du]
     dv = orig_nid[dv]
+    assert F.array_equal(u, du)
+    assert F.array_equal(v, dv)
+
+def create_random_hetero():
+    num_nodes = {'n1': 10000, 'n2': 10010, 'n3': 10020}
+    etypes = [('n1', 'r1', 'n2'),
+              ('n1', 'r2', 'n3'),
+              ('n2', 'r3', 'n3')]
+    edges = {}
+    for etype in etypes:
+        src_ntype, _, dst_ntype = etype
+        arr = spsp.random(num_nodes[src_ntype], num_nodes[dst_ntype], density=0.001, format='coo',
+                          random_state=100)
+        edges[etype] = (arr.row, arr.col)
+    return dgl.heterograph(edges, num_nodes)
+
+def check_rpc_hetero_find_edges_shuffle(tmpdir, num_server):
+    ip_config = open("rpc_ip_config.txt", "w")
+    for _ in range(num_server):
+        ip_config.write('{}\n'.format(get_local_usable_addr()))
+    ip_config.close()
+
+    g = create_random_hetero()
+    num_parts = num_server
+
+    orig_nid, orig_eid = partition_graph(g, 'test_find_edges', num_parts, tmpdir,
+                                         num_hops=1, part_method='metis',
+                                         reshuffle=True, return_mapping=True)
+
+    pserver_list = []
+    ctx = mp.get_context('spawn')
+    for i in range(num_server):
+        p = ctx.Process(target=start_server, args=(i, tmpdir, num_server > 1,
+                                                   'test_find_edges', ['csr', 'coo']))
+        p.start()
+        time.sleep(1)
+        pserver_list.append(p)
+
+    time.sleep(3)
+    eids = F.tensor(np.random.randint(g.number_of_edges('r1'), size=100))
+    u, v = g.find_edges(orig_eid['r1'][eids], etype='r1')
+    du, dv = start_find_edges_client(0, tmpdir, num_server > 1, eids, etype='r1')
+    du = orig_nid['n1'][du]
+    dv = orig_nid['n2'][dv]
     assert F.array_equal(u, du)
     assert F.array_equal(v, dv)
 
@@ -150,6 +188,7 @@ def test_rpc_find_edges_shuffle(num_server):
     import tempfile
     os.environ['DGL_DIST_MODE'] = 'distributed'
     with tempfile.TemporaryDirectory() as tmpdirname:
+        check_rpc_hetero_find_edges_shuffle(Path(tmpdirname), num_server)
         check_rpc_find_edges_shuffle(Path(tmpdirname), num_server)
 
 def check_rpc_get_degree_shuffle(tmpdir, num_server):
@@ -475,6 +514,8 @@ if __name__ == "__main__":
         check_rpc_get_degree_shuffle(Path(tmpdirname), 2)
         check_rpc_find_edges_shuffle(Path(tmpdirname), 2)
         check_rpc_find_edges_shuffle(Path(tmpdirname), 1)
+        check_rpc_hetero_find_edges_shuffle(Path(tmpdirname), 1)
+        check_rpc_hetero_find_edges_shuffle(Path(tmpdirname), 2)
         check_rpc_in_subgraph_shuffle(Path(tmpdirname), 2)
         check_rpc_sampling_shuffle(Path(tmpdirname), 1)
         check_rpc_sampling_shuffle(Path(tmpdirname), 2)

--- a/tests/distributed/test_mp_dataloader.py
+++ b/tests/distributed/test_mp_dataloader.py
@@ -1,6 +1,7 @@
 import dgl
 import unittest
 import os
+from scipy import sparse as spsp
 from dgl.data import CitationGraphDataset
 from dgl.distributed import sample_neighbors
 from dgl.distributed import partition_graph, load_partition, load_partition_book
@@ -166,7 +167,7 @@ def test_dist_dataloader(tmpdir, num_server, num_workers, drop_last, reshuffle):
         p.join()
     ptrainer.join()
 
-def start_node_dataloader(rank, tmpdir, num_server, num_workers, orig_nid, orig_eid):
+def start_node_dataloader(rank, tmpdir, num_server, num_workers, orig_nid, orig_eid, groundtruth_g):
     import dgl
     import torch as th
     dgl.distributed.initialize("mp_ip_config.txt")
@@ -176,8 +177,13 @@ def start_node_dataloader(rank, tmpdir, num_server, num_workers, orig_nid, orig_
         _, _, _, gpb, _, _, _ = load_partition(tmpdir / 'test_sampling.json', rank)
     num_nodes_to_sample = 202
     batch_size = 32
-    train_nid = th.arange(num_nodes_to_sample)
     dist_graph = DistGraph("test_mp", gpb=gpb, part_config=tmpdir / 'test_sampling.json')
+    assert len(dist_graph.ntypes) == len(groundtruth_g.ntypes)
+    assert len(dist_graph.etypes) == len(groundtruth_g.etypes)
+    if len(dist_graph.etypes) == 1:
+        train_nid = th.arange(num_nodes_to_sample)
+    else:
+        train_nid = {'n3': th.arange(num_nodes_to_sample)}
 
     for i in range(num_server):
         part, _, _, _, _, _, _ = load_partition(tmpdir / 'test_sampling.json', i)
@@ -197,25 +203,22 @@ def start_node_dataloader(rank, tmpdir, num_server, num_workers, orig_nid, orig_
             drop_last=False,
             num_workers=num_workers)
 
-        groundtruth_g = CitationGraphDataset("cora")[0]
-        max_nid = []
-
         for epoch in range(2):
             for idx, (_, _, blocks) in zip(range(0, num_nodes_to_sample, batch_size), dataloader):
                 block = blocks[-1]
-                o_src, o_dst =  block.edges()
-                src_nodes_id = block.srcdata[dgl.NID][o_src]
-                dst_nodes_id = block.dstdata[dgl.NID][o_dst]
-                src_nodes_id = orig_nid[src_nodes_id]
-                dst_nodes_id = orig_nid[dst_nodes_id]
-                has_edges = groundtruth_g.has_edges_between(src_nodes_id, dst_nodes_id)
-                assert np.all(F.asnumpy(has_edges))
-                max_nid.append(np.max(F.asnumpy(dst_nodes_id)))
+                for src_type, etype, dst_type in block.canonical_etypes:
+                    o_src, o_dst =  block.edges(etype=etype)
+                    src_nodes_id = block.srcnodes[src_type].data[dgl.NID][o_src]
+                    dst_nodes_id = block.dstnodes[dst_type].data[dgl.NID][o_dst]
+                    src_nodes_id = orig_nid[src_type][src_nodes_id]
+                    dst_nodes_id = orig_nid[dst_type][dst_nodes_id]
+                    has_edges = groundtruth_g.has_edges_between(src_nodes_id, dst_nodes_id, etype=etype)
+                    assert np.all(F.asnumpy(has_edges))
                 # assert np.all(np.unique(np.sort(F.asnumpy(dst_nodes_id))) == np.arange(idx, batch_size))
     del dataloader
     dgl.distributed.exit_client() # this is needed since there's two test here in one process
 
-def start_edge_dataloader(rank, tmpdir, num_server, num_workers, orig_nid, orig_eid):
+def start_edge_dataloader(rank, tmpdir, num_server, num_workers, orig_nid, orig_eid, groundtruth_g):
     import dgl
     import torch as th
     dgl.distributed.initialize("mp_ip_config.txt")
@@ -225,8 +228,13 @@ def start_edge_dataloader(rank, tmpdir, num_server, num_workers, orig_nid, orig_
         _, _, _, gpb, _, _, _ = load_partition(tmpdir / 'test_sampling.json', rank)
     num_edges_to_sample = 202
     batch_size = 32
-    train_eid = th.arange(num_edges_to_sample)
     dist_graph = DistGraph("test_mp", gpb=gpb, part_config=tmpdir / 'test_sampling.json')
+    assert len(dist_graph.ntypes) == len(groundtruth_g.ntypes)
+    assert len(dist_graph.etypes) == len(groundtruth_g.etypes)
+    if len(dist_graph.etypes) == 1:
+        train_eid = th.arange(num_edges_to_sample)
+    else:
+        train_eid = {dist_graph.etypes[0]: th.arange(num_edges_to_sample)}
 
     for i in range(num_server):
         part, _, _, _, _, _, _ = load_partition(tmpdir / 'test_sampling.json', i)
@@ -246,44 +254,37 @@ def start_edge_dataloader(rank, tmpdir, num_server, num_workers, orig_nid, orig_
             drop_last=False,
             num_workers=num_workers)
 
-        groundtruth_g = CitationGraphDataset("cora")[0]
-        max_nid = []
-
         for epoch in range(2):
             for idx, (input_nodes, pos_pair_graph, blocks) in zip(range(0, num_edges_to_sample, batch_size), dataloader):
                 block = blocks[-1]
-                o_src, o_dst =  block.edges()
-                src_nodes_id = block.srcdata[dgl.NID][o_src]
-                dst_nodes_id = block.dstdata[dgl.NID][o_dst]
-                src_nodes_id = orig_nid[src_nodes_id]
-                dst_nodes_id = orig_nid[dst_nodes_id]
-                has_edges = groundtruth_g.has_edges_between(src_nodes_id, dst_nodes_id)
-                assert np.all(F.asnumpy(has_edges))
-                assert np.all(F.asnumpy(block.dstdata[dgl.NID]) == F.asnumpy(pos_pair_graph.ndata[dgl.NID]))
-                max_nid.append(np.max(F.asnumpy(dst_nodes_id)))
+                for src_type, etype, dst_type in block.canonical_etypes:
+                    o_src, o_dst =  block.edges(etype=etype)
+                    src_nodes_id = block.srcnodes[src_type].data[dgl.NID][o_src]
+                    dst_nodes_id = block.dstnodes[dst_type].data[dgl.NID][o_dst]
+                    src_nodes_id = orig_nid[src_type][src_nodes_id]
+                    dst_nodes_id = orig_nid[dst_type][dst_nodes_id]
+                    has_edges = groundtruth_g.has_edges_between(src_nodes_id, dst_nodes_id, etype=etype)
+                    assert np.all(F.asnumpy(has_edges))
+                    assert np.all(F.asnumpy(block.dstnodes[dst_type].data[dgl.NID]) == F.asnumpy(pos_pair_graph.nodes[dst_type].data[dgl.NID]))
                 # assert np.all(np.unique(np.sort(F.asnumpy(dst_nodes_id))) == np.arange(idx, batch_size))
     del dataloader
     dgl.distributed.exit_client() # this is needed since there's two test here in one process
 
-@unittest.skipIf(os.name == 'nt', reason='Do not support windows yet')
-@unittest.skipIf(dgl.backend.backend_name != 'pytorch', reason='Only support PyTorch for now')
-@pytest.mark.parametrize("num_server", [3])
-@pytest.mark.parametrize("num_workers", [0, 4])
-@pytest.mark.parametrize("dataloader_type", ["node", "edge"])
-def test_dataloader(tmpdir, num_server, num_workers, dataloader_type):
+def check_dataloader(g, tmpdir, num_server, num_workers, dataloader_type):
     ip_config = open("mp_ip_config.txt", "w")
     for _ in range(num_server):
         ip_config.write('{}\n'.format(get_local_usable_addr()))
     ip_config.close()
 
-    g = CitationGraphDataset("cora")[0]
-    print(g.idtype)
     num_parts = num_server
     num_hops = 1
-
     orig_nid, orig_eid = partition_graph(g, 'test_sampling', num_parts, tmpdir,
                                          num_hops=num_hops, part_method='metis',
                                          reshuffle=True, return_mapping=True)
+    if not isinstance(orig_nid, dict):
+        orig_nid = {g.ntypes[0]: orig_nid}
+    if not isinstance(orig_eid, dict):
+        orig_eid = {g.etypes[0]: orig_eid}
 
     pserver_list = []
     ctx = mp.get_context('spawn')
@@ -300,13 +301,13 @@ def test_dataloader(tmpdir, num_server, num_workers, dataloader_type):
     ptrainer_list = []
     if dataloader_type == 'node':
         p = ctx.Process(target=start_node_dataloader, args=(
-            0, tmpdir, num_server, num_workers, orig_nid, orig_eid))
+            0, tmpdir, num_server, num_workers, orig_nid, orig_eid, g))
         p.start()
         time.sleep(1)
         ptrainer_list.append(p)
     elif dataloader_type == 'edge':
         p = ctx.Process(target=start_edge_dataloader, args=(
-            0, tmpdir, num_server, num_workers, orig_nid, orig_eid))
+            0, tmpdir, num_server, num_workers, orig_nid, orig_eid, g))
         p.start()
         time.sleep(1)
         ptrainer_list.append(p)
@@ -315,13 +316,40 @@ def test_dataloader(tmpdir, num_server, num_workers, dataloader_type):
     for p in ptrainer_list:
         p.join()
 
+def create_random_hetero():
+    num_nodes = {'n1': 10000, 'n2': 10010, 'n3': 10020}
+    etypes = [('n1', 'r1', 'n2'),
+              ('n1', 'r2', 'n3'),
+              ('n2', 'r3', 'n3')]
+    edges = {}
+    for etype in etypes:
+        src_ntype, _, dst_ntype = etype
+        arr = spsp.random(num_nodes[src_ntype], num_nodes[dst_ntype], density=0.001, format='coo',
+                          random_state=100)
+        edges[etype] = (arr.row, arr.col)
+    g = dgl.heterograph(edges, num_nodes)
+    g.nodes['n1'].data['feat'] = F.unsqueeze(F.arange(0, g.number_of_nodes('n1')), 1)
+    g.edges['r1'].data['feat'] = F.unsqueeze(F.arange(0, g.number_of_edges('r1')), 1)
+    return g
+
+@unittest.skipIf(os.name == 'nt', reason='Do not support windows yet')
+@unittest.skipIf(dgl.backend.backend_name != 'pytorch', reason='Only support PyTorch for now')
+@pytest.mark.parametrize("num_server", [3])
+@pytest.mark.parametrize("num_workers", [0, 4])
+@pytest.mark.parametrize("dataloader_type", ["node", "edge"])
+def test_dataloader(tmpdir, num_server, num_workers, dataloader_type):
+    g = CitationGraphDataset("cora")[0]
+    check_dataloader(g, tmpdir, num_server, num_workers, dataloader_type)
+    g = create_random_hetero()
+    check_dataloader(g, tmpdir, num_server, num_workers, dataloader_type)
+
 if __name__ == "__main__":
     import tempfile
     with tempfile.TemporaryDirectory() as tmpdirname:
         test_standalone(Path(tmpdirname))
+        test_dataloader(Path(tmpdirname), 3, 4, 'node')
+        test_dataloader(Path(tmpdirname), 3, 4, 'edge')
         test_dist_dataloader(Path(tmpdirname), 3, 0, True, True)
         test_dist_dataloader(Path(tmpdirname), 3, 4, True, True)
         test_dist_dataloader(Path(tmpdirname), 3, 0, True, False)
         test_dist_dataloader(Path(tmpdirname), 3, 4, True, False)
-        test_dataloader(Path(tmpdirname), 3, 4, 'node')
-        test_dataloader(Path(tmpdirname), 3, 4, 'edge')


### PR DESCRIPTION
## Description
This PR makes `EdgeDataLoader` work on a distributed graph. In addition, it enables `find_edges` on distributed heterogeneous graphs and `edge_subgraph` on distributed heterogeneous graphs.

## Checklist
Please feel free to remove inapplicable items for your PR.
- [ ] The PR title starts with [$CATEGORY] (such as [NN], [Model], [Doc], [Feature]])
- [ ] Changes are complete (i.e. I finished coding on this PR)
- [ ] All changes have test coverage
- [ ] Code is well-documented
- [ ] To the my best knowledge, examples are either not affected by this change,
      or have been fixed to be compatible with this change
- [ ] Related issue is referred in this PR
- [ ] If the PR is for a new model/paper, I've updated the example index [here](../examples/README.md).

## Changes
<!-- You could use following template
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)
-->
