### PR TITLE
[bugfix] fix default ntypes/etypes consistency between dgl.DGLGraph a…

### DIFF
--- a/python/dgl/heterograph.py
+++ b/python/dgl/heterograph.py
@@ -39,8 +39,8 @@ class DGLHeteroGraph(object):
     # pylint: disable=unused-argument, dangerous-default-value
     def __init__(self,
                  gidx=[],
-                 ntypes=['_U'],
-                 etypes=['_V'],
+                 ntypes=['_N'],
+                 etypes=['_E'],
                  node_frames=None,
                  edge_frames=None,
                  **deprecate_kwargs):

--- a/tests/compute/test_graph.py
+++ b/tests/compute/test_graph.py
@@ -369,6 +369,13 @@ def test_is_sorted():
    assert src_sorted == True
    assert dst_sorted == False
 
+
+def test_default_types():
+    dg = dgl.DGLGraph()
+    g = dgl.graph(([], []))
+    assert dg.ntypes == g.ntypes
+    assert dg.etypes == g.etypes
+
 if __name__ == '__main__':
     test_query()
     test_mutation()
@@ -377,3 +384,4 @@ if __name__ == '__main__':
     test_find_edges()
     test_hypersparse_query()
     test_is_sorted()
+    test_default_types()


### PR DESCRIPTION

## Description
<!-- Brief description. Refer to the related issues if existed.
It'll be great if relevant reviewers can be assigned as well.-->
fix default ntypes/etypes consistency between dgl.DGLGraph and dgl.graph

fix for https://github.com/dmlc/dgl/issues/3168.
## Checklist
Please feel free to remove inapplicable items for your PR.
- [x] The PR title starts with [$CATEGORY] (such as [NN], [Model], [Doc], [Feature]])
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage
- [x] Code is well-documented
- [x] To the my best knowledge, examples are either not affected by this change,
      or have been fixed to be compatible with this change
- [x] Related issue is referred in this PR
- [x] If the PR is for a new model/paper, I've updated the example index [here](../examples/README.md).

## Changes
<!-- You could use following template
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)
-->
