### PR TITLE
[Feature] Implement one thread multiple socket

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -34,6 +34,7 @@ dgl_option(BUILD_CPP_TEST "Build cpp unittest executables" OFF)
 dgl_option(LIBCXX_ENABLE_PARALLEL_ALGORITHMS "Enable the parallel algorithms library. This requires the PSTL to be available." OFF)
 dgl_option(USE_S3 "Build with S3 support" OFF)
 dgl_option(USE_HDFS "Build with HDFS support" OFF) # Set env HADOOP_HDFS_HOME if needed
+dgl_option(USE_EPOLL "Build with epoll for socket communicator" OFF)
 
 # Set debug compile option for gdb, only happens when -DCMAKE_BUILD_TYPE=DEBUG
 if (NOT MSVC)
@@ -119,6 +120,14 @@ if(USE_AVX)
     message(STATUS "Build with AVX optimization.")
   endif(USE_LIBXSMM)
 endif(USE_AVX)
+
+if (USE_EPOLL)
+  check_include_file("sys/epoll.h" USE_EPOLL)
+  if (USE_EPOLL)
+    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -DUSE_EPOLL")
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DUSE_EPOLL")
+  endif()
+endif ()
 
 # Build with fp16 to support mixed precision training.
 if(USE_FP16)

--- a/python/dgl/distributed/rpc.py
+++ b/python/dgl/distributed/rpc.py
@@ -1,5 +1,6 @@
 """RPC components. They are typically functions or utilities used by both
 server and clients."""
+import os
 import abc
 import pickle
 import random
@@ -111,7 +112,8 @@ def create_sender(max_queue_size, net_type):
     net_type : str
         Networking type. Current options are: 'socket'.
     """
-    _CAPI_DGLRPCCreateSender(int(max_queue_size), net_type)
+    max_thread_count = int(os.getenv('DGL_SOCKET_MAX_THREAD_COUNT', '0'))
+    _CAPI_DGLRPCCreateSender(int(max_queue_size), net_type, max_thread_count)
 
 def create_receiver(max_queue_size, net_type):
     """Create rpc receiver of this process.
@@ -123,7 +125,8 @@ def create_receiver(max_queue_size, net_type):
     net_type : str
         Networking type. Current options are: 'socket'.
     """
-    _CAPI_DGLRPCCreateReceiver(int(max_queue_size), net_type)
+    max_thread_count = int(os.getenv('DGL_SOCKET_MAX_THREAD_COUNT', '0'))
+    _CAPI_DGLRPCCreateReceiver(int(max_queue_size), net_type, max_thread_count)
 
 def finalize_sender():
     """Finalize rpc sender of this process.

--- a/src/graph/network.cc
+++ b/src/graph/network.cc
@@ -206,7 +206,7 @@ DGL_REGISTER_GLOBAL("network._CAPI_DGLSenderCreate")
     int64_t msg_queue_size = args[1];
     network::Sender* sender = nullptr;
     if (type == "socket") {
-      sender = new network::SocketSender(msg_queue_size);
+      sender = new network::SocketSender(msg_queue_size, 0);
     } else {
       LOG(FATAL) << "Unknown communicator type: " << type;
     }
@@ -220,7 +220,7 @@ DGL_REGISTER_GLOBAL("network._CAPI_DGLReceiverCreate")
     int64_t msg_queue_size = args[1];
     network::Receiver* receiver = nullptr;
     if (type == "socket") {
-      receiver = new network::SocketReceiver(msg_queue_size);
+      receiver = new network::SocketReceiver(msg_queue_size, 0);
     } else {
       LOG(FATAL) << "Unknown communicator type: " << type;
     }

--- a/src/rpc/network/communicator.h
+++ b/src/rpc/network/communicator.h
@@ -28,11 +28,14 @@ class Sender {
   /*!
    * \brief Sender constructor
    * \param queue_size size (bytes) of message queue. 
+   * \param max_thread_count size of thread pool. 0 for no limit
    * Note that, the queue_size parameter is optional.
    */
-  explicit Sender(int64_t queue_size = 0) {
+  explicit Sender(int64_t queue_size = 0, int max_thread_count = 0) {
     CHECK_GE(queue_size, 0);
+    CHECK_GE(max_thread_count, 0);
     queue_size_ = queue_size;
+    max_thread_count_ = max_thread_count;
   }
 
   virtual ~Sender() {}
@@ -86,6 +89,10 @@ class Sender {
    * \brief Size of message queue
    */
   int64_t queue_size_;
+  /*!
+   * \brief Size of thread pool. 0 for no limit
+   */
+  int max_thread_count_;
 };
 
 /*!
@@ -101,13 +108,16 @@ class Receiver {
   /*!
    * \brief Receiver constructor
    * \param queue_size size of message queue.
+   * \param max_thread_count size of thread pool. 0 for no limit
    * Note that, the queue_size parameter is optional.
    */
-  explicit Receiver(int64_t queue_size = 0) {
+  explicit Receiver(int64_t queue_size = 0, int max_thread_count = 0) {
     if (queue_size < 0) {
       LOG(FATAL) << "queue_size cannot be a negative number.";
     }
+    CHECK_GE(max_thread_count, 0);
     queue_size_ = queue_size;
+    max_thread_count_ = max_thread_count;
   }
 
   virtual ~Receiver() {}
@@ -165,6 +175,10 @@ class Receiver {
    * \brief Size of message queue
    */
   int64_t queue_size_;
+  /*!
+   * \brief Size of thread pool. 0 for no limit
+   */
+  int max_thread_count_;
 };
 
 }  // namespace network

--- a/src/rpc/network/msg_queue.cc
+++ b/src/rpc/network/msg_queue.cc
@@ -72,6 +72,7 @@ STATUS MessageQueue::Remove(Message* msg, bool is_blocking) {
   queue_.pop();
   msg->data = old_msg.data;
   msg->size = old_msg.size;
+  msg->receiver_id = old_msg.receiver_id;
   msg->deallocator = old_msg.deallocator;
   free_size_ += old_msg.size;
   cond_not_full_.notify_one();

--- a/src/rpc/network/msg_queue.h
+++ b/src/rpc/network/msg_queue.h
@@ -57,6 +57,10 @@ struct Message {
    */
   int64_t size;
   /*!
+   * \brief message receiver id
+   */
+  int receiver_id = -1;
+  /*!
    * \brief user-defined deallocator, which can be nullptr
    */
   std::function<void(Message*)> deallocator = nullptr;

--- a/src/rpc/network/socket_pool.cc
+++ b/src/rpc/network/socket_pool.cc
@@ -1,0 +1,110 @@
+/*!
+ *  Copyright (c) 2021 by Contributors
+ * \file socket_pool.cc
+ * \brief Socket pool of nonblocking sockets for DGL distributed training.
+ */
+#include "socket_pool.h"
+
+#include <dmlc/logging.h>
+#include "tcp_socket.h"
+
+#ifdef USE_EPOLL
+#include <sys/epoll.h>
+#endif
+
+namespace dgl {
+namespace network {
+
+SocketPool::SocketPool() {
+#ifdef USE_EPOLL
+  epfd_ = epoll_create1(0);
+  if (epfd_ < 0) {
+    LOG(FATAL) << "SocketPool cannot create epfd";
+  }
+#endif
+}
+
+void SocketPool::AddSocket(std::shared_ptr<TCPSocket> socket, int socket_id,
+  int events) {
+  int fd = socket->Socket();
+  tcp_sockets_[fd] = socket;
+  socket_ids_[fd] = socket_id;
+
+#ifdef USE_EPOLL
+  epoll_event e;
+  e.data.fd = fd;
+  if (events == READ) {
+    e.events = EPOLLIN;
+  } else if (events == WRITE) {
+    e.events = EPOLLOUT;
+  } else if (events == READ + WRITE) {
+    e.events = EPOLLIN | EPOLLOUT;
+  }
+  if (epoll_ctl(epfd_, EPOLL_CTL_ADD, fd, &e) < 0) {
+    LOG(FATAL) << "SocketPool cannot add socket";
+  }
+  socket->SetNonBlocking(true);
+#else
+  if (tcp_sockets_.size() > 1) {
+    LOG(FATAL) << "SocketPool supports only one socket if not use epoll."
+      "Please turn on USE_EPOLL on building";
+  }
+#endif
+}
+
+size_t SocketPool::RemoveSocket(std::shared_ptr<TCPSocket> socket) {
+  int fd = socket->Socket();
+  socket_ids_.erase(fd);
+  tcp_sockets_.erase(fd);
+#ifdef USE_EPOLL
+  epoll_ctl(epfd_, EPOLL_CTL_DEL, fd, NULL);
+#endif
+  return socket_ids_.size();
+}
+
+SocketPool::~SocketPool() {
+#ifdef USE_EPOLL
+  for (auto& id : socket_ids_) {
+    int fd = id.first;
+    epoll_ctl(epfd_, EPOLL_CTL_DEL, fd, NULL);
+  }
+#endif
+}
+
+std::shared_ptr<TCPSocket> SocketPool::GetActiveSocket(int* socket_id) {
+  if (socket_ids_.empty()) {
+    return nullptr;
+  }
+
+  for (;;) {
+    while (pending_fds_.empty()) {
+      Wait();
+    }
+    int fd = pending_fds_.front();
+    pending_fds_.pop();
+
+    // Check if this socket is not removed
+    if (socket_ids_.find(fd) != socket_ids_.end()) {
+      *socket_id = socket_ids_[fd];
+      return tcp_sockets_[fd];
+    }
+  }
+
+  return nullptr;
+}
+
+void SocketPool::Wait() {
+#ifdef USE_EPOLL
+  static const int MAX_EVENTS = 10;
+  epoll_event events[MAX_EVENTS];
+  int nfd = epoll_wait(epfd_, events, MAX_EVENTS, -1 /*Timeout*/);
+  for (int i = 0; i < nfd; ++i) {
+    pending_fds_.push(events[i].data.fd);
+  }
+#else
+  pending_fds_.push(tcp_sockets_.begin()->second->Socket());
+#endif
+}
+
+}  // namespace network
+}  // namespace dgl

--- a/src/rpc/network/socket_pool.h
+++ b/src/rpc/network/socket_pool.h
@@ -1,0 +1,97 @@
+/*!
+ *  Copyright (c) 2021 by Contributors
+ * \file socket_pool.h
+ * \brief Socket pool of nonblocking sockets for DGL distributed training.
+ */
+#ifndef DGL_RPC_NETWORK_SOCKET_POOL_H_
+#define DGL_RPC_NETWORK_SOCKET_POOL_H_
+
+#include <unordered_map>
+#include <queue>
+#include <memory>
+
+namespace dgl {
+namespace network {
+
+class TCPSocket;
+
+/*!
+ * \brief SocketPool maintains a group of nonblocking sockets, and can provide
+ * active sockets.
+ * Currently SocketPool is based on epoll, a scalable I/O event notification
+ * mechanism in Linux operating system. 
+ */
+class SocketPool {
+ public:
+  /*!
+   * \brief socket mode read/receive
+   */
+  static const int READ = 1;
+  /*!
+   * \brief socket mode write/send
+   */
+  static const int WRITE = 2;
+  /*!
+   * \brief SocketPool constructor
+   */
+  SocketPool();
+
+  /*!
+   * \brief Add a socket to SocketPool
+   * \param socket tcp socket to add
+   * \param socket_id receiver/sender id of the socket
+   * \param events READ, WRITE or READ + WRITE
+   */
+  void AddSocket(std::shared_ptr<TCPSocket> socket, int socket_id,
+    int events = READ);
+
+  /*!
+   * \brief Remove socket from SocketPool
+   * \param socket tcp socket to remove
+   * \return number of remaing sockets in the pool
+   */
+  size_t RemoveSocket(std::shared_ptr<TCPSocket> socket);
+
+  /*!
+   * \brief SocketPool destructor
+   */
+  ~SocketPool();
+
+  /*!
+   * \brief Get current active socket. This is a blocking method
+   * \param socket_id output parameter of the socket_id of active socket
+   * \return active TCPSocket
+   */
+  std::shared_ptr<TCPSocket> GetActiveSocket(int* socket_id);
+
+ private:
+  /*!
+   * \brief Wait for event notification
+   */
+  void Wait();
+
+  /*!
+   * \brief map from fd to TCPSocket
+   */
+  std::unordered_map<int, std::shared_ptr<TCPSocket>> tcp_sockets_;
+
+  /*!
+   * \brief map from fd to socket_id
+   */
+  std::unordered_map<int, int> socket_ids_;
+
+  /*!
+   * \brief fd for epoll base
+   */
+  int epfd_;
+
+  /*!
+   * \brief queue for current active fds
+   */
+  std::queue<int> pending_fds_;
+};
+
+}  // namespace network
+}  // namespace dgl
+
+#endif  // DGL_RPC_NETWORK_SOCKET_POOL_H_

--- a/src/rpc/network/tcp_socket.cc
+++ b/src/rpc/network/tcp_socket.cc
@@ -119,7 +119,7 @@ bool TCPSocket::Accept(TCPSocket * socket, std::string * ip, int * port) {
 }
 
 #ifdef _WIN32
-bool TCPSocket::SetBlocking(bool flag) {
+bool TCPSocket::SetNonBlocking(bool flag) {
   int result;
   u_long argp = flag ? 1 : 0;
 
@@ -134,7 +134,7 @@ bool TCPSocket::SetBlocking(bool flag) {
   return true;
 }
 #else   // !_WIN32
-bool TCPSocket::SetBlocking(bool flag) {
+bool TCPSocket::SetNonBlocking(bool flag) {
   int opts;
 
   if ((opts = fcntl(socket_, F_GETFL)) < 0) {
@@ -205,7 +205,7 @@ int64_t TCPSocket::Receive(char * buffer, int64_t size_buffer) {
   do {  // retry if EINTR failure appears
     number_recv = recv(socket_, buffer, size_buffer, 0);
   } while (number_recv == -1 && errno == EINTR);
-  if (number_recv == -1) {
+  if (number_recv == -1 && errno != EAGAIN && errno != EWOULDBLOCK) {
     LOG(ERROR) << "recv error: " << strerror(errno);
   }
 

--- a/src/rpc/network/tcp_socket.h
+++ b/src/rpc/network/tcp_socket.h
@@ -70,12 +70,12 @@ class TCPSocket {
               int * port_client);
 
   /*!
-   * \brief SetBlocking() is needed refering to this example of epoll:
+   * \brief SetNonBlocking() is needed refering to this example of epoll:
    * http://www.kernel.org/doc/man-pages/online/pages/man4/epoll.4.html
-   * \param flag flag for blocking
+   * \param flag true for nonblocking, false for blocking
    * \return true for success and false for failure
    */
-  bool SetBlocking(bool flag);
+  bool SetNonBlocking(bool flag);
 
   /*!
    * \brief Set timeout for socket

--- a/src/rpc/rpc.cc
+++ b/src/rpc/rpc.cc
@@ -87,8 +87,10 @@ DGL_REGISTER_GLOBAL("distributed.rpc._CAPI_DGLRPCCreateSender")
 .set_body([] (DGLArgs args, DGLRetValue* rv) {
   int64_t msg_queue_size = args[0];
   std::string type = args[1];
+  int max_thread_count = args[2];
   if (type.compare("socket") == 0) {
-    RPCContext::ThreadLocal()->sender = std::make_shared<network::SocketSender>(msg_queue_size);
+    RPCContext::ThreadLocal()->sender =
+      std::make_shared<network::SocketSender>(msg_queue_size, max_thread_count);
   } else {
     LOG(FATAL) << "Unknown communicator type for rpc receiver: " << type;
   }
@@ -98,8 +100,10 @@ DGL_REGISTER_GLOBAL("distributed.rpc._CAPI_DGLRPCCreateReceiver")
 .set_body([] (DGLArgs args, DGLRetValue* rv) {
   int64_t msg_queue_size = args[0];
   std::string type = args[1];
+  int max_thread_count = args[2];
   if (type.compare("socket") == 0) {
-    RPCContext::ThreadLocal()->receiver = std::make_shared<network::SocketReceiver>(msg_queue_size);
+    RPCContext::ThreadLocal()->receiver =
+      std::make_shared<network::SocketReceiver>(msg_queue_size, max_thread_count);
   } else {
     LOG(FATAL) << "Unknown communicator type for rpc sender: " << type;
   }

--- a/src/runtime/semaphore_wrapper.cc
+++ b/src/runtime/semaphore_wrapper.cc
@@ -1,0 +1,47 @@
+/*!
+ *  Copyright (c) 2021 by Contributors
+ * \file semaphore_wrapper.cc
+ * \brief A simple corss platform semaphore wrapper
+ */
+#include "semaphore_wrapper.h"
+
+#include <dmlc/logging.h>
+
+namespace dgl {
+namespace runtime {
+
+#ifdef _WIN32
+
+Semaphore::Semaphore() {
+  sem_ = CreateSemaphore(nullptr, 0, INT_MAX, nullptr);
+  if (!sem_) {
+    LOG(FATAL) << "Cannot create semaphore";
+  }
+}
+
+void Semaphore::Wait() {
+  WaitForSingleObject(sem_, INFINITE);
+}
+
+void Semaphore::Post() {
+  ReleaseSemaphore(sem_, 1, nullptr);
+}
+
+#else
+
+Semaphore::Semaphore() {
+  sem_init(&sem_, 0, 0);
+}
+
+void Semaphore::Wait() {
+  sem_wait(&sem_);
+}
+
+void Semaphore::Post() {
+  sem_post(&sem_);
+}
+
+#endif
+
+}  // namespace runtime
+}  // namespace dgl

--- a/src/runtime/semaphore_wrapper.h
+++ b/src/runtime/semaphore_wrapper.h
@@ -1,0 +1,47 @@
+/*!
+ *  Copyright (c) 2021 by Contributors
+ * \file semaphore_wrapper.h
+ * \brief A simple corss platform semaphore wrapper
+ */
+#ifndef DGL_RUNTIME_SEMAPHORE_WRAPPER_H_
+#define DGL_RUNTIME_SEMAPHORE_WRAPPER_H_
+
+#ifdef _WIN32
+#include <windows.h>
+#else
+#include <semaphore.h>
+#endif
+
+
+namespace dgl {
+namespace runtime {
+
+/*!
+ * \brief A simple crossplatform Semaphore wrapper
+ */
+class Semaphore {
+ public:
+  /*!
+   * \brief Semaphore constructor
+   */
+  Semaphore();
+  /*!
+   * \brief blocking wait, decrease semaphore by 1
+   */
+  void Wait();
+  /*!
+   * \brief increase semaphore by 1
+   */
+  void Post();
+ private:
+#ifdef _WIN32
+  HANDLE sem_;
+#else
+  sem_t sem_;
+#endif
+};
+
+}  // namespace runtime
+}  // namespace dgl
+
+#endif  // DGL_RUNTIME_SEMAPHORE_WRAPPER_H_

--- a/tests/cpp/socket_communicator_test.cc
+++ b/tests/cpp/socket_communicator_test.cc
@@ -25,6 +25,7 @@ using dgl::network::Message;
 using dgl::network::DefaultMessageDeleter;
 
 const int64_t kQueueSize = 500 * 1024;
+const int kThreadNum = 2;
 
 #ifndef WIN32
 
@@ -61,7 +62,7 @@ TEST(SocketCommunicatorTest, SendAndRecv) {
 }
 
 void start_client() {
-  SocketSender sender(kQueueSize);
+  SocketSender sender(kQueueSize, kThreadNum);
   for (int i = 0; i < kNumReceiver; ++i) {
     sender.AddReceiver(ip_addr[i], i);
   }
@@ -89,7 +90,7 @@ void start_client() {
 
 void start_server(int id) {
   sleep(5);
-  SocketReceiver receiver(kQueueSize);
+  SocketReceiver receiver(kQueueSize, kThreadNum);
   receiver.Wait(ip_addr[id], kNumSender);
   for (int i = 0; i < kNumMessage; ++i) {
     for (int n = 0; n < kNumSender; ++n) {
@@ -168,7 +169,7 @@ static void start_client() {
   std::string ip_addr((std::istreambuf_iterator<char>(t)),
                        std::istreambuf_iterator<char>());
   t.close();
-  SocketSender sender(kQueueSize);
+  SocketSender sender(kQueueSize, kThreadNum);
   sender.AddReceiver(ip_addr.c_str(), 0);
   sender.Connect();
   char* str_data = new char[9];
@@ -185,7 +186,7 @@ static bool start_server() {
   std::string ip_addr((std::istreambuf_iterator<char>(t)),
                        std::istreambuf_iterator<char>());
   t.close();
-  SocketReceiver receiver(kQueueSize);
+  SocketReceiver receiver(kQueueSize, kThreadNum);
   receiver.Wait(ip_addr.c_str(), 1);
   Message msg;
   EXPECT_EQ(receiver.RecvFrom(&msg, 0), REMOVE_SUCCESS);


### PR DESCRIPTION
## Description

Implement one thread multiple socket with epoll on linux platform. 
Current SocketSender and SocketReceiver will create one thread for each socket. When number of nodes, number of servers/trainers/samplers in each node increase, there will be several thousands of threads created for socket communicating. That is a waste of resources because creating threads requires some memory, and context switch between threads takes time.

### Changes
* Add an argument of max_thread_count for socket communicator's sender and receiver. They will create at most max_thread_count threads instead of one thread for each socket. If max_thread_count is set to zero (by default), it will fallback to one thread per socket.
* Add a class SocketPool to maintain a group of sockets. The sockets in SocketPool will be set to nonblocking, and SocketPool provides a blocking interface GetActiveSocket to get a socket has something to read/write.
* SocketSender now uses thread-level shared message queue. So one thread can handle multiple sending sockets easily.
* SocketReceiver now uses SocketPool to maintain its sockets. Each time this thread will take an active socket out of the pool, and receive message from it.
* Add a semphore in SocketReceiver to prevent busy wait in SocketReceiver::Recv.
* Add a CMake flag 'USE_EPOLL' with default to OFF to control this feature. 
* Currently only supports linux platform because epoll is a linux kernel system call. There are equivalents in other platforms like kqueue for FreeBSD, /dev/poll for Solaris, etc. And there are some cross-platform event-based libraries like [libevent](https://libevent.org/). We can do this in the future.
### Results 
We tested the change in a cluster with 50 containers, each has 4 cores,  2 servers and 2 clients (just like the DGL training model, with 2 graph server, 1 trainer and 1 sampler), and they do all-to-all communications. Every iteration, all clients send a empty rpc messages to all servers, then wait for their responses. 
In current implement, there will be 800 threads each container. With nonblocking socket with epoll, the average iteration time is 8% shorter than current implementation. And with adjusting max_thread_count argument, we can have the same boost with 400 threads each container.

Update: With this change: Add a semphore in SocketReceiver to prevent busy wait in SocketReceiver::Recv, there is another 30% speedup. 



<!-- Brief description. Refer to the related issues if existed.
It'll be great if relevant reviewers can be assigned as well.-->

## Checklist
Please feel free to remove inapplicable items for your PR.
- [x] The PR title starts with [$CATEGORY] (such as [NN], [Model], [Doc], [Feature]])
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage
- [x] Code is well-documented
- [x] To the my best knowledge, examples are either not affected by this change,
      or have been fixed to be compatible with this change
