### PR TITLE
[Tools] Refactor tools/launch.py to handle more python binary names

### DIFF
--- a/tests/tools/test_launch.py
+++ b/tests/tools/test_launch.py
@@ -1,0 +1,64 @@
+import unittest
+
+from tools.launch import wrap_udf_in_torch_dist_launcher
+
+
+class TestWrapUdfInTorchDistLauncher(unittest.TestCase):
+    """wrap_udf_in_torch_dist_launcher()"""
+
+    def test_simple(self):
+        # test that a simple udf_command is correctly wrapped
+        udf_command = "python3.7 path/to/some/trainer.py arg1 arg2"
+        wrapped_udf_command = wrap_udf_in_torch_dist_launcher(
+            udf_command=udf_command,
+            num_trainers=2,
+            num_nodes=2,
+            node_rank=1,
+            master_addr="127.0.0.1",
+            master_port=1234,
+        )
+        expected = "python3.7 -m torch.distributed.launch " \
+                   "--nproc_per_node=2 --nnodes=2 --node_rank=1 --master_addr=127.0.0.1 " \
+                   "--master_port=1234 path/to/some/trainer.py arg1 arg2"
+        self.assertEqual(wrapped_udf_command, expected)
+
+    def test_chained_udf(self):
+        # test that a chained udf_command is properly handled
+        udf_command = "cd path/to && python3.7 path/to/some/trainer.py arg1 arg2"
+        wrapped_udf_command = wrap_udf_in_torch_dist_launcher(
+            udf_command=udf_command,
+            num_trainers=2,
+            num_nodes=2,
+            node_rank=1,
+            master_addr="127.0.0.1",
+            master_port=1234,
+        )
+        expected = "cd path/to && python3.7 -m torch.distributed.launch " \
+                   "--nproc_per_node=2 --nnodes=2 --node_rank=1 --master_addr=127.0.0.1 " \
+                   "--master_port=1234 path/to/some/trainer.py arg1 arg2"
+        self.assertEqual(wrapped_udf_command, expected)
+
+    def test_py_versions(self):
+        # test that this correctly handles different py versions/binaries
+        py_binaries = (
+            "python3.7", "python3.8", "python3.9", "python3", "python"
+        )
+        udf_command = "{python_bin} path/to/some/trainer.py arg1 arg2"
+
+        for py_bin in py_binaries:
+            wrapped_udf_command = wrap_udf_in_torch_dist_launcher(
+                udf_command=udf_command.format(python_bin=py_bin),
+                num_trainers=2,
+                num_nodes=2,
+                node_rank=1,
+                master_addr="127.0.0.1",
+                master_port=1234,
+            )
+            expected = "{python_bin} -m torch.distributed.launch ".format(python_bin=py_bin) + \
+                       "--nproc_per_node=2 --nnodes=2 --node_rank=1 --master_addr=127.0.0.1 " \
+                       "--master_port=1234 path/to/some/trainer.py arg1 arg2"
+            self.assertEqual(wrapped_udf_command, expected)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tools/launch.py
+++ b/tools/launch.py
@@ -186,11 +186,11 @@ def construct_torch_dist_launcher_cmd(
                          "--master_addr={master_addr} " \
                          "--master_port={master_port}"
     return torch_cmd_template.format(
-        nproc_per_node=str(num_trainers),
-        nnodes=str(num_nodes),
-        node_rank=str(node_rank),
-        master_addr=str(master_addr),
-        master_port=str(master_port)
+        nproc_per_node=num_trainers,
+        nnodes=num_nodes,
+        node_rank=node_rank,
+        master_addr=master_addr,
+        master_port=master_port
     )
 
 
@@ -252,7 +252,7 @@ def wrap_udf_in_torch_dist_launcher(
             python_bin = candidate_python_bin
             break
 
-    # transforms the udf_command from (ignoring pre-commands):
+    # transforms the udf_command from:
     #     python path/to/dist_trainer.py arg0 arg1
     # to:
     #     python -m torch.distributed.launch [DIST TORCH ARGS] path/to/dist_trainer.py arg0 arg1


### PR DESCRIPTION
## Description
This PR fixes `tools/launch.py` to correctly handle udf_commands like: `python3.7 train_dist.py`.

Context: Currently, `tools/launch.py` will incorrectly mangle a udf_command like: `python3.7 train_dist.py` into something like:
```
# tools/launch.py will attempt to run the below incorrectly-mangled cmd on remote workers.
# Note that the ".7" has been incorrectly split!
python3 -m torch.distributed.launch [TORCH DIST ARGS] .7 train_dist.py

# this is the correct cmd
python3.7 -m torch.distributed.launch [TORCH DIST ARGS] train_dist.py
```

This is because in the `tools/launch.py` code, it does a blind string replace for a substring like "python3" and replaces it with "python3 " (note the space).

This PR somewhat generalizes the way it does the search+replace by first searching for more specific binary names like "python3.7, python3.8" before falling back to more generic "python3, python" binary names.

Testing: I've written unit tests to validate the behavior of the new helper methods. Further, I've done an end-to-end test and verified that my distributed trainer code (that uses `python3.7`) correctly works with these changes.

Addresses issue: https://github.com/dmlc/dgl/issues/3161

## Checklist
Please feel free to remove inapplicable items for your PR.
- [x] The PR title starts with [$CATEGORY] (such as [NN], [Model], [Doc], [Feature]])
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage
- [x] Code is well-documented
- [x] To the my best knowledge, examples are either not affected by this change,
      or have been fixed to be compatible with this change
- [x] Related issue is referred in this PR

## Changes
<!-- You could use following template
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)
-->
