### PR TITLE
[bugfix] Fix check for num_workers for using _ScalarDataBatcher

### DIFF
--- a/python/dgl/dataloading/pytorch/dataloader.py
+++ b/python/dgl/dataloading/pytorch/dataloader.py
@@ -353,7 +353,7 @@ def _init_dataloader(collator, device, dataloader_kwargs, use_ddp, ddp_seed):
     use_scalar_batcher = False
     scalar_batcher = None
 
-    if th.device(device) != th.device('cpu') and dataloader_kwargs.get('num_workers', 0) != 0:
+    if th.device(device) != th.device('cpu') and dataloader_kwargs.get('num_workers', 0) == 0:
         batch_size = dataloader_kwargs.get('batch_size', 1)
 
         if batch_size > 1:


### PR DESCRIPTION
## Description
It looks like when we refactored in #3046, we changed the check for `num_workers == 0` to `num_workers != 0`. This PR restores the original functionality introduced in #2716, such that when the output device is on the GPU and the number of workers is 0, a pytorch tensor will be used to store the batch, rather than a python list.

This fix results in a ~2x reduction in the runtime of the dataloader, depending on the size of the fanouts.

## Checklist
Please feel free to remove inapplicable items for your PR.
- [x] The PR title starts with [$CATEGORY] (such as [NN], [Model], [Doc], [Feature]])
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage
- [x] Code is well-documented
- [x] To the best of my knowledge, examples are either not affected by this change,
      or have been fixed to be compatible with this change
- [x] Related issue is referred in this PR

## Changes
Changed the check for number of workers.
