### PR TITLE
[bugfix] Only link the pytorch tensordispatcher against libtorch

### DIFF
--- a/src/runtime/tensordispatch.cc
+++ b/src/runtime/tensordispatch.cc
@@ -39,8 +39,10 @@ bool TensorDispatcher::Load(const char *path) {
 #else   // !WIN32
   handle_ = dlopen(path, RTLD_LAZY);
 
-  if (!handle_)
+  if (!handle_) {
+    LOG(WARNING) << "TensorDispatcher: dlopen failed: " << dlerror();
     return false;
+  }
 
   for (int i = 0; i < num_entries_; ++i) {
     entrypoints_[i] = dlsym(handle_, names_[i]);

--- a/tensoradapter/pytorch/CMakeLists.txt
+++ b/tensoradapter/pytorch/CMakeLists.txt
@@ -27,8 +27,15 @@ set(TORCH_TARGET_NAME "tensoradapter_pytorch_${TORCH_VER}")
 file(GLOB TA_TORCH_SRC *.cpp)
 add_library(${TORCH_TARGET_NAME} SHARED "${TA_TORCH_SRC}")
 
+if (MSVC)
+  # Linking on windows requires all libraries
+  set(TENSORADAPTER_TORCH_LIBS ${TORCH_LIBRARIES})
+else()
+  set(TENSORADAPTER_TORCH_LIBS ${TORCH_LIBRARY})
+endif(MSVC)
+
 message(STATUS "tensoradapter found PyTorch includes: ${TORCH_INCLUDE_DIRS}")
-message(STATUS "tensoradapter found PyTorch lib: ${TORCH_LIBRARY}")
+message(STATUS "tensoradapter found PyTorch lib: ${TENSORADAPTER_TORCH_LIBS}")
 
 target_include_directories(
   ${TORCH_TARGET_NAME} PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}/../include")
@@ -36,6 +43,6 @@ target_include_directories(
   ${TORCH_TARGET_NAME} PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}/../../third_party/dlpack/include")
 target_include_directories(
   ${TORCH_TARGET_NAME} PRIVATE "${TORCH_INCLUDE_DIRS}")
-target_link_libraries(${TORCH_TARGET_NAME} PRIVATE "${TORCH_LIBRARY}")
+target_link_libraries(${TORCH_TARGET_NAME} PRIVATE "${TENSORADAPTER_TORCH_LIBS}")
 set_property(TARGET ${TORCH_TARGET_NAME} PROPERTY CXX_STANDARD 14)
 message(STATUS "Configured target ${TORCH_TARGET_NAME}")

--- a/tensoradapter/pytorch/CMakeLists.txt
+++ b/tensoradapter/pytorch/CMakeLists.txt
@@ -28,7 +28,7 @@ file(GLOB TA_TORCH_SRC *.cpp)
 add_library(${TORCH_TARGET_NAME} SHARED "${TA_TORCH_SRC}")
 
 message(STATUS "tensoradapter found PyTorch includes: ${TORCH_INCLUDE_DIRS}")
-message(STATUS "tensoradapter found PyTorch lib: ${TORCH_LIBRARIES}")
+message(STATUS "tensoradapter found PyTorch lib: ${TORCH_LIBRARY}")
 
 target_include_directories(
   ${TORCH_TARGET_NAME} PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}/../include")
@@ -36,6 +36,6 @@ target_include_directories(
   ${TORCH_TARGET_NAME} PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}/../../third_party/dlpack/include")
 target_include_directories(
   ${TORCH_TARGET_NAME} PRIVATE "${TORCH_INCLUDE_DIRS}")
-target_link_libraries(${TORCH_TARGET_NAME} PRIVATE "${TORCH_LIBRARIES}")
+target_link_libraries(${TORCH_TARGET_NAME} PRIVATE "${TORCH_LIBRARY}")
 set_property(TARGET ${TORCH_TARGET_NAME} PROPERTY CXX_STANDARD 14)
 message(STATUS "Configured target ${TORCH_TARGET_NAME}")


### PR DESCRIPTION
## Description
This fixes #3220.

Currently, the tensoradapter is linked against all the of the dependencies of libtorch, including specific cuda libraries, despite only depending on symbols in libtorch (as far as I can tell).

This PR changes it to only depend on libtorch, which on systems without the exact same cuda version that DGL was built against, enables the tensoradapter, where it previously was silently being disabled.

## Checklist
Please feel free to remove inapplicable items for your PR.
- [x] The PR title starts with [$CATEGORY] (such as [NN], [Model], [Doc], [Feature]])
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage
- [x] Code is well-documented
- [x] To the best of my knowledge, examples are either not affected by this change,
      or have been fixed to be compatible with this change
- [x] Related issue is referred in this PR

## Changes
Change the CMakeLists.txt to only link against libtorch.

Add a warning message if `dlopen` fails.
