### PR TITLE
[Bugfix] set omp thread number for graph server

### DIFF
--- a/python/dgl/distributed/dist_context.py
+++ b/python/dgl/distributed/dist_context.py
@@ -204,7 +204,7 @@ def initialize(ip_config, num_servers=1, num_workers=0,
 
         Default: ``'socket'``
     num_worker_threads: int
-        The number of threads in a worker process.
+        The number of omp threads in server and worker processes.
 
     Note
     ----
@@ -226,6 +226,7 @@ def initialize(ip_config, num_servers=1, num_workers=0,
             'Please define DGL_CONF_PATH to run DistGraph server'
         formats = os.environ.get('DGL_GRAPH_FORMAT', 'csc').split(',')
         formats = [f.strip() for f in formats]
+        utils.set_num_threads(num_worker_threads)
         serv = DistGraphServer(int(os.environ.get('DGL_SERVER_ID')),
                                os.environ.get('DGL_IP_CONFIG'),
                                int(os.environ.get('DGL_NUM_SERVER')),


### PR DESCRIPTION
## Description
<!-- Brief description. Refer to the related issues if existed.
It'll be great if relevant reviewers can be assigned as well.-->
The rpc call is actually computed in server process, so I think it is necessary to set openmp thread number for server as well.

If not set, openmp will choose an optimal number of threads, which is usually number of cpu cores. 

In my experiments with 50 machines, 16 cores each machine, with graphsage model and batchsize=10000, [neighbor sampling](https://github.com/dmlc/dgl/blob/master/src/array/cpu/rowwise_pick.h#L112) will usually have some thousands of rows to process.  With default omp thread number, the sampling will take about 30ms, and take up all cpu resources (~1300% cpu usage with 16 cores). When set omp thread number to 1, the sampling will take about 4ms, and use only 1 core (~100% cpu usage). 

I am not very clear about why fewer threads leads to faster sampling, maybe it is caused by omp thread creating overhead or something. But at least my experiment shows the necessity of letting user to choose the number of threads.



## Checklist
Please feel free to remove inapplicable items for your PR.
- [x] The PR title starts with [$CATEGORY] (such as [NN], [Model], [Doc], [Feature]])
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage
- [x] Code is well-documented
- [x] To the best of my knowledge, examples are either not affected by this change,
      or have been fixed to be compatible with this change

## Changes
set omp thread number for server in dist_context.py
<!-- You could use following template
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)
-->
