### PR TITLE
[Doc] fix formula display issue in EdgeWeightNorm

### DIFF
--- a/python/dgl/nn/pytorch/conv/graphconv.py
+++ b/python/dgl/nn/pytorch/conv/graphconv.py
@@ -27,7 +27,7 @@ class EdgeWeightNorm(nn.Module):
     And, setting ``norm='right'`` yields the following normalization term:
 
     .. math::
-      c_{ji} = (\sum_{k\in\mathcal{N}(i)}}e_{ki})
+      c_{ji} = (\sum_{k\in\mathcal{N}(i)}e_{ki})
 
     where :math:`e_{ji}` is the scalar weight on the edge from node :math:`j` to node :math:`i`.
 


### PR DESCRIPTION
## Description
<!-- Brief description. Refer to the related issues if existed.
It'll be great if relevant reviewers can be assigned as well.-->
formula in EdgeWeightNorm is not displayed as expected in docs.dgl.ai. fix it.

## Checklist
Please feel free to remove inapplicable items for your PR.
- [x] The PR title starts with [$CATEGORY] (such as [NN], [Model], [Doc], [Feature]])
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage
- [x] Code is well-documented
- [x] To the best of my knowledge, examples are either not affected by this change,
      or have been fixed to be compatible with this change
- [x] Related issue is referred in this PR
- [x] If the PR is for a new model/paper, I've updated the example index [here](../examples/README.md).

## Changes
<!-- You could use following template
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)
-->
