### PR TITLE
allow for configuring default_dir

### DIFF
--- a/python/dgl/backend/__init__.py
+++ b/python/dgl/backend/__init__.py
@@ -74,7 +74,12 @@ def load_backend(mod_name):
                 setattr(thismod, api, _gen_missing_api(api, mod_name))
 
 def get_preferred_backend():
-    config_path = os.path.join(os.path.expanduser('~'), '.dgl', 'config.json')
+    default_dir = None
+    if "DGLDEFAULTDIR" in os.environ:
+        default_dir = os.getenv('DGLDEFAULTDIR')
+    else:
+        default_dir = os.path.join(os.path.expanduser('~'), '.dgl')
+    config_path = os.path.join(default_dir, 'config.json')
     backend_name = None
     if "DGLBACKEND" in os.environ:
         backend_name = os.getenv('DGLBACKEND')
@@ -88,7 +93,7 @@ def get_preferred_backend():
     else:
         print("DGL backend not selected or invalid.  "
               "Assuming PyTorch for now.", file=sys.stderr)
-        set_default_backend('pytorch')
+        set_default_backend(default_dir, 'pytorch')
         return 'pytorch'
 
 

--- a/python/dgl/backend/set_default_backend.py
+++ b/python/dgl/backend/set_default_backend.py
@@ -2,8 +2,7 @@ import argparse
 import os
 import json
 
-def set_default_backend(backend_name):
-    default_dir = os.path.join(os.path.expanduser('~'), '.dgl')
+def set_default_backend(default_dir, backend_name):
     if not os.path.exists(default_dir):
         os.makedirs(default_dir)
     config_path = os.path.join(default_dir, 'config.json')
@@ -16,7 +15,8 @@ def set_default_backend(backend_name):
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser()
+    parser.add_argument("default_dir", type=str, default=os.path.join(os.path.expanduser('~'), '.dgl'))
     parser.add_argument("backend", nargs=1, type=str, choices=[
                         'pytorch', 'tensorflow', 'mxnet'], help="Set default backend")
     args = parser.parse_args()
-    set_default_backend(args.backend[0])
+    set_default_backend(args.default_dir, args.backend[0])


### PR DESCRIPTION
## Description
Relates to feature request (set_default_dir #3276) (https://github.com/dmlc/dgl/issues/3276)
Allows for using an environment variable to set the default DGL directory where config.json is stored

## Checklist
Please feel free to remove inapplicable items for your PR.
- [X] Changes are complete (i.e. I finished coding on this PR)
- [X] To the best of my knowledge, examples are either not affected by this change,
      or have been fixed to be compatible with this change

## Changes
Two small changes in backend that allow for default_dir to be configured by an environment variable named DGLDEFAULTDIR