### PR TITLE
[Build] Fix weird CUDA 10.2 and 11.1 compilation issues

### DIFF
--- a/src/array/cuda/cuda_filter.cu
+++ b/src/array/cuda/cuda_filter.cu
@@ -10,10 +10,10 @@
 #include "../../runtime/cuda/cuda_hashtable.cuh"
 #include "./dgl_cub.cuh"
 
+using namespace dgl::runtime::cuda;
+
 namespace dgl {
 namespace array {
-
-using namespace dgl::runtime::cuda;
 
 namespace {
 


### PR DESCRIPTION
Currently the master branch will fail to compile on CUDA 10.2 and 11.1 because it cannot recognize `OrderedHashTable` as a template.