### PR TITLE
Avoid duplicate DistTensor in Node/EdgeDataView in dist_graph.py

### DIFF
--- a/python/dgl/distributed/dist_graph.py
+++ b/python/dgl/distributed/dist_graph.py
@@ -177,21 +177,25 @@ class NodeDataView(MutableMapping):
         # When this is created, the server may already load node data. We need to
         # initialize the node data in advance.
         names = g._get_ndata_names(ntype)
+        is_empty = False
         if ntype is None:
             self._data = g._ndata_store
+            is_empty = len(self._data) == 0
         else:
             if ntype in g._ndata_store:
                 self._data = g._ndata_store[ntype]
             else:
                 self._data = {}
                 g._ndata_store[ntype] = self._data
-        for name in names:
-            assert name.is_node()
-            policy = PartitionPolicy(name.policy_str, g.get_partition_book())
-            dtype, shape, _ = g._client.get_data_meta(str(name))
-            # We create a wrapper on the existing tensor in the kvstore.
-            self._data[name.get_name()] = DistTensor(shape, dtype, name.get_name(),
-                                                     part_policy=policy)
+                is_empty = True
+        if is_empty:
+            for name in names:
+                assert name.is_node()
+                policy = PartitionPolicy(name.policy_str, g.get_partition_book())
+                dtype, shape, _ = g._client.get_data_meta(str(name))
+                # We create a wrapper on the existing tensor in the kvstore.
+                self._data[name.get_name()] = DistTensor(shape, dtype, name.get_name(),
+                                                         part_policy=policy)
 
     def _get_names(self):
         return list(self._data.keys())
@@ -231,21 +235,25 @@ class EdgeDataView(MutableMapping):
         # When this is created, the server may already load edge data. We need to
         # initialize the edge data in advance.
         names = g._get_edata_names(etype)
+        is_empty = False
         if etype is None:
             self._data = g._edata_store
+            is_empty = len(self._data)
         else:
             if etype in g._edata_store:
                 self._data = g._edata_store[etype]
             else:
                 self._data = {}
                 g._edata_store[etype] = self._data
-        for name in names:
-            assert name.is_edge()
-            policy = PartitionPolicy(name.policy_str, g.get_partition_book())
-            dtype, shape, _ = g._client.get_data_meta(str(name))
-            # We create a wrapper on the existing tensor in the kvstore.
-            self._data[name.get_name()] = DistTensor(shape, dtype, name.get_name(),
-                                                     part_policy=policy)
+                is_empty = True
+        if is_empty:
+            for name in names:
+                assert name.is_edge()
+                policy = PartitionPolicy(name.policy_str, g.get_partition_book())
+                dtype, shape, _ = g._client.get_data_meta(str(name))
+                # We create a wrapper on the existing tensor in the kvstore.
+                self._data[name.get_name()] = DistTensor(shape, dtype, name.get_name(),
+                                                         part_policy=policy)
 
     def _get_names(self):
         return list(self._data.keys())

--- a/python/dgl/distributed/dist_graph.py
+++ b/python/dgl/distributed/dist_graph.py
@@ -177,18 +177,15 @@ class NodeDataView(MutableMapping):
         # When this is created, the server may already load node data. We need to
         # initialize the node data in advance.
         names = g._get_ndata_names(ntype)
-        is_empty = False
         if ntype is None:
             self._data = g._ndata_store
-            is_empty = len(self._data) == 0
         else:
             if ntype in g._ndata_store:
                 self._data = g._ndata_store[ntype]
             else:
                 self._data = {}
                 g._ndata_store[ntype] = self._data
-                is_empty = True
-        if is_empty:
+        if len(self._data) == 0:
             for name in names:
                 assert name.is_node()
                 policy = PartitionPolicy(name.policy_str, g.get_partition_book())
@@ -235,18 +232,15 @@ class EdgeDataView(MutableMapping):
         # When this is created, the server may already load edge data. We need to
         # initialize the edge data in advance.
         names = g._get_edata_names(etype)
-        is_empty = False
         if etype is None:
             self._data = g._edata_store
-            is_empty = len(self._data)
         else:
             if etype in g._edata_store:
                 self._data = g._edata_store[etype]
             else:
                 self._data = {}
                 g._edata_store[etype] = self._data
-                is_empty = True
-        if is_empty:
+        if len(self._data) == 0:
             for name in names:
                 assert name.is_edge()
                 policy = PartitionPolicy(name.policy_str, g.get_partition_book())


### PR DESCRIPTION
## Description

`self._data` gets re-assigned every time `HeteroData/EdgeView` is created.

## Checklist
Please feel free to remove inapplicable items for your PR.
- [ ] The PR title starts with [$CATEGORY] (such as [NN], [Model], [Doc], [Feature]])
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage
- [x] Code is well-documented
- [x] To the best of my knowledge, examples are either not affected by this change,
      or have been fixed to be compatible with this change
- [ ] Related issue is referred in this PR
- [ ] If the PR is for a new model/paper, I've updated the example index [here](../examples/README.md).

## Changes
Just added one line to check if `self._data' is empty.