### PR TITLE
[Feature] enable preload in NodeDataLoader

### DIFF
--- a/examples/pytorch/graphsage/train_sampling.py
+++ b/examples/pytorch/graphsage/train_sampling.py
@@ -68,6 +68,7 @@ def run(args, device, data):
         train_nid,
         sampler,
         device=dataloader_device,
+        preload=args.preload,
         batch_size=args.batch_size,
         shuffle=True,
         drop_last=False,
@@ -146,6 +147,9 @@ if __name__ == '__main__':
                                 "on GPU when using it to save time for data copy. This may "
                                 "be undesired if they cannot fit in GPU memory at once. "
                                 "This flag disables that.")
+    argparser.add_argument('--preload', type=int, default=0,
+                           help="Number of preload number in NodeDataLoader. If > 0,"
+                           " preload is enabled in background thread.")
     args = argparser.parse_args()
 
     if args.gpu >= 0:


### PR DESCRIPTION
## Description
<!-- Brief description. Refer to the related issues if existed.
It'll be great if relevant reviewers can be assigned as well.-->
This is a sub-feature of https://github.com/dmlc/dgl/issues/3294

In this change, preload is enabled in NodeDataLoader. If greater than 0, data is continuously preloaded in a background python thread and put into a queue with size of ``preload``. In each iteration, data will be popped from queue and returned in main thread. This feature will then speed up the data loading. 0 is the default value which means no preload at all.

![image](https://user-images.githubusercontent.com/85214957/131611009-5220d84d-1de3-4f21-bfa7-6fb341b4db1b.png)


## Checklist
Please feel free to remove inapplicable items for your PR.
- [x] The PR title starts with [$CATEGORY] (such as [NN], [Model], [Doc], [Feature]])
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage
- [x] Code is well-documented
- [x] To the best of my knowledge, examples are either not affected by this change,
      or have been fixed to be compatible with this change
- [x] Related issue is referred in this PR
- [x] If the PR is for a new model/paper, I've updated the example index [here](../examples/README.md).

## Changes
<!-- You could use following template
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)
-->
