### PR TITLE
[Bugfix] Limit memory consumption in COOToCSR() to be O(N+M).

### DIFF
--- a/src/array/cpu/spmat_op_impl_coo.cc
+++ b/src/array/cpu/spmat_op_impl_coo.cc
@@ -415,9 +415,16 @@ CSRMatrix COOToCSR(COOMatrix coo) {
     std::vector<std::vector<IdType>> local_ptrs;
     std::vector<int64_t> thread_prefixsum;
 
-#pragma omp parallel
+    // get the number of threads OpenMP would spawn
+    int max_threads = omp_get_max_threads();
+    if (max_threads * N > 2*NNZ) {
+      max_threads = std::max(1, static_cast<int>((2*NNZ) / N));
+    }
+
+    const int num_threads = max_threads;
+
+#pragma omp parallel num_threads(num_threads)
     {
-      const int num_threads = omp_get_num_threads();
       const int thread_id = omp_get_thread_num();
       CHECK_LT(thread_id, num_threads);
 


### PR DESCRIPTION
## Description
This limits the number of threads used to convert COO to CSR when the COO is unordered, to prevent using an excessive amount of memory. This is a temporary fix for #3307, since it limits parallelism.

## Checklist
Please feel free to remove inapplicable items for your PR.
- [x] The PR title starts with [$CATEGORY] (such as [NN], [Model], [Doc], [Feature]])
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage
- [x] Code is well-documented
- [x] To the best of my knowledge, examples are either not affected by this change,
      or have been fixed to be compatible with this change
- [x] Related issue is referred in this PR

