### PR TITLE
[Bug] Fix edge ID exclusion when both g and g_sampling are specified in EdgeDataLoader

### DIFF
--- a/python/dgl/dataloading/dataloader.py
+++ b/python/dgl/dataloading/dataloader.py
@@ -739,7 +739,7 @@ class EdgeCollator(Collator):
         seed_nodes = pair_graph.ndata[NID]
 
         exclude_eids = _find_exclude_eids(
-            self.g,
+            self.g_sampling,
             self.exclude,
             items,
             reverse_eid_map=self.reverse_eids,
@@ -782,7 +782,7 @@ class EdgeCollator(Collator):
         seed_nodes = pair_graph.ndata[NID]
 
         exclude_eids = _find_exclude_eids(
-            self.g,
+            self.g_sampling,
             self.exclude,
             items,
             reverse_eid_map=self.reverse_eids,


### PR DESCRIPTION
When both `g` and `g_sampling` are specified, the edge IDs to exclude should be from `g_sampling` rather than `g`.