### PR TITLE
[BugFix] initialize data if null when converting from row sorted coo to csr

### DIFF
--- a/src/array/cpu/spmat_op_impl_coo.cc
+++ b/src/array/cpu/spmat_op_impl_coo.cc
@@ -323,7 +323,7 @@ template <class IdType> CSRMatrix SortedCOOToCSR(const COOMatrix &coo) {
   Bp[0] = 0;
 
   IdType *const fill_data =
-      data ? nullptr : static_cast<IdType *>(coo.data->data);
+      data ? nullptr : static_cast<IdType *>(ret_data->data);
 
   if (NNZ > 0) {
     auto num_threads = omp_get_max_threads();

--- a/tests/compute/test_transform.py
+++ b/tests/compute/test_transform.py
@@ -847,6 +847,16 @@ def test_to_simple(idtype):
     assert 'h' not in sg.nodes['user'].data
     assert 'hh' not in sg.nodes['user'].data
 
+    # verify DGLGraph.edge_ids() after dgl.to_simple()
+    # in case ids are not initialized in underlying coo2csr()
+    u = F.tensor([0, 1, 2])
+    v = F.tensor([1, 2, 3])
+    eids = F.tensor([0, 1, 2])
+    g = dgl.graph((u, v))
+    assert F.array_equal(g.edge_ids(u, v), eids)
+    sg = dgl.to_simple(g)
+    assert F.array_equal(sg.edge_ids(u, v), eids)
+
 @parametrize_dtype
 def test_to_block(idtype):
     def check(g, bg, ntype, etype, dst_nodes, include_dst_in_src=True):


### PR DESCRIPTION


## Description
<!-- Brief description. Refer to the related issues if existed.
It'll be great if relevant reviewers can be assigned as well.-->

bug fix for https://github.com/dmlc/dgl/pull/3326. coo.data was not initialized when converting row sorted coo to csr on cpu.

## Checklist
Please feel free to remove inapplicable items for your PR.
- [x] The PR title starts with [$CATEGORY] (such as [NN], [Model], [Doc], [Feature]])
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage
- [x] Code is well-documented
- [x] To the best of my knowledge, examples are either not affected by this change,
      or have been fixed to be compatible with this change
- [x] Related issue is referred in this PR
- [x] If the PR is for a new model/paper, I've updated the example index [here](../examples/README.md).

## Changes
<!-- You could use following template
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)
-->
