### PR TITLE
[Example][Performance] Enable faster validation for pytorch graphsage example

### DIFF
--- a/examples/pytorch/graphsage/model.py
+++ b/examples/pytorch/graphsage/model.py
@@ -58,8 +58,9 @@ class SAGE(nn.Module):
                 g,
                 th.arange(g.num_nodes()).to(g.device),
                 sampler,
+                device=device if num_workers == 0 else None,
                 batch_size=batch_size,
-                shuffle=True,
+                shuffle=False,
                 drop_last=False,
                 num_workers=num_workers)
 


### PR DESCRIPTION
## Description
This provides a speedup during the validation/testing of the graphsage example by letting `to_block` be performed on the GPU when the number of workers is zero, and does not shuffle the dataset in validation/testing.

## Checklist
Please feel free to remove inapplicable items for your PR.
- [x] The PR title starts with [$CATEGORY] (such as [NN], [Model], [Doc], [Feature]])
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage
- [x] Code is well-documented
- [x] To the best of my knowledge, examples are either not affected by this change,
      or have been fixed to be compatible with this change


