### PR TITLE
[BugFix] fix typo in variable name

### DIFF
--- a/python/dgl/data/fakenews.py
+++ b/python/dgl/data/fakenews.py
@@ -168,7 +168,7 @@ class FakeNewsDataset(DGLBuiltinDataset):
                               'feature': self.feature,
                               'train_mask': self.train_mask,
                               'val_mask': self.val_mask,
-                              'test_mask': self.train_mask})
+                              'test_mask': self.test_mask})
 
     def has_cache(self):
         """ check whether there are processed data in `self.save_path` """


### PR DESCRIPTION
## Description
<!-- Brief description. Refer to the related issues if existed.
It'll be great if relevant reviewers can be assigned as well.-->
Fix typo in variable name (train_mask -> test_mask)

## Checklist
Please feel free to remove inapplicable items for your PR.
- [x] The PR title starts with [$CATEGORY] (such as [NN], [Model], [Doc], [Feature]])
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage
- [x] Code is well-documented
- [x] To the best of my knowledge, examples are either not affected by this change,
      or have been fixed to be compatible with this change
