### PR TITLE
[Distributed] Fix a bug in parallel graph partition

### DIFF
--- a/examples/pytorch/rgcn/experimental/verify_mag_partitions.py
+++ b/examples/pytorch/rgcn/experimental/verify_mag_partitions.py
@@ -5,7 +5,9 @@ import dgl
 import torch as th
 from ogb.nodeproppred import DglNodePropPredDataset
 
-with open('outputs/mag.json') as json_file:
+partitions_folder = 'outputs'
+graph_name = 'mag'
+with open('{}/{}.json'.format(partitions_folder, graph_name)) as json_file:
     metadata = json.load(json_file)
 num_parts = metadata['num_parts']
 
@@ -24,8 +26,8 @@ hg.nodes['paper'].data['feat'] = hg_orig.nodes['paper'].data['feat']
 node_feats = {}
 edge_feats = {}
 for partid in range(num_parts):
-    part_node_feats = dgl.data.utils.load_tensors('outputs/part{}/node_feat.dgl'.format(partid))
-    part_edge_feats = dgl.data.utils.load_tensors('outputs/part{}/edge_feat.dgl'.format(partid))
+    part_node_feats = dgl.data.utils.load_tensors('{}/part{}/node_feat.dgl'.format(partitions_folder, partid))
+    part_edge_feats = dgl.data.utils.load_tensors('{}/part{}/edge_feat.dgl'.format(partitions_folder, partid))
     for key in part_node_feats:
         if key in node_feats:
             node_feats[key].append(part_node_feats[key])
@@ -52,6 +54,8 @@ for key in etype_map:
     etype_id = etype_map[key]
     etypes[etype_id] = key
 
+etype2canonical = {etype: (srctype, etype, dsttype) for srctype, etype, dsttype in hg.canonical_etypes}
+
 node_map = metadata['node_map']
 for key in node_map:
     node_map[key] = th.stack([th.tensor(row) for row in node_map[key]], 0)
@@ -66,16 +70,46 @@ for ntype in node_map:
 for etype in edge_map:
     assert hg.number_of_edges(etype) == th.sum(edge_map[etype][:,1] - edge_map[etype][:,0])
 
+eid = []
+gpb = dgl.distributed.graph_partition_book.RangePartitionBook(0, 2, node_map, edge_map,
+        {ntype:i for i, ntype in enumerate(hg.ntypes)},
+        {etype:i for i, etype in enumerate(hg.etypes)})
+subg0 = dgl.load_graphs('{}/part0/graph.dgl'.format(partitions_folder))[0][0]
+for etype in hg.etypes:
+    type_eid = th.zeros((1,), dtype=th.int64)
+    eid.append(gpb.map_to_homo_eid(type_eid, etype))
+eid = th.cat(eid)
+part_id = gpb.eid2partid(eid)
+assert np.all(part_id.numpy() == 0)
+local_eid = gpb.eid2localeid(eid, 0)
+assert np.all(local_eid.numpy() == eid.numpy())
+assert np.all((subg0.edata[dgl.EID][local_eid] == eid).numpy())
+lsrc, ldst = subg0.find_edges(local_eid)
+gsrc, gdst = subg0.ndata[dgl.NID][lsrc], subg0.ndata[dgl.NID][ldst]
+assert np.all(gsrc.numpy() == lsrc.numpy())
+assert np.all(gdst.numpy() == ldst.numpy())
+etids, _ = gpb.map_to_per_etype(eid)
+src_tids, _ = gpb.map_to_per_ntype(gsrc)
+dst_tids, _ = gpb.map_to_per_ntype(gdst)
+canonical_etypes = []
+etype_ids = th.arange(0, len(etypes))
+for src_tid, etype_id, dst_tid in zip(src_tids, etype_ids, dst_tids):
+    canonical_etypes.append((ntypes[src_tid], etypes[etype_id], ntypes[dst_tid]))
+for etype in canonical_etypes:
+    assert etype in hg.canonical_etypes
+
 # Load the graph partition structure.
 orig_node_ids = {ntype: [] for ntype in hg.ntypes}
 orig_edge_ids = {etype: [] for etype in hg.etypes}
 for partid in range(num_parts):
     print('test part', partid)
-    part_file = 'outputs/part{}/graph.dgl'.format(partid)
+    part_file = '{}/part{}/graph.dgl'.format(partitions_folder, partid)
     subg = dgl.load_graphs(part_file)[0][0]
     subg_src_id, subg_dst_id = subg.edges()
-    subg_src_id = subg.ndata['orig_id'][subg_src_id]
-    subg_dst_id = subg.ndata['orig_id'][subg_dst_id]
+    orig_src_id = subg.ndata['orig_id'][subg_src_id]
+    orig_dst_id = subg.ndata['orig_id'][subg_dst_id]
+    global_src_id = subg.ndata[dgl.NID][subg_src_id]
+    global_dst_id = subg.ndata[dgl.NID][subg_dst_id]
     subg_ntype = subg.ndata[dgl.NTYPE]
     subg_etype = subg.edata[dgl.ETYPE]
     for ntype_id in th.unique(subg_ntype):
@@ -99,11 +133,19 @@ for partid in range(num_parts):
 
     for etype_id in th.unique(subg_etype):
         etype = etypes[etype_id]
+        srctype, _, dsttype = etype2canonical[etype]
         idx = subg_etype == etype_id
-        exist = hg[etype].has_edges_between(subg_src_id[idx], subg_dst_id[idx])
+        exist = hg[etype].has_edges_between(orig_src_id[idx], orig_dst_id[idx])
         assert np.all(exist.numpy())
-        eid = hg[etype].edge_ids(subg_src_id[idx], subg_dst_id[idx])
+        eid = hg[etype].edge_ids(orig_src_id[idx], orig_dst_id[idx])
         assert np.all(eid.numpy() == subg.edata['orig_id'][idx].numpy())
+
+        ntype_ids, type_nid = nid_map(global_src_id[idx])
+        assert len(th.unique(ntype_ids)) == 1
+        assert ntypes[ntype_ids[0]] == srctype
+        ntype_ids, type_nid = nid_map(global_dst_id[idx])
+        assert len(th.unique(ntype_ids)) == 1
+        assert ntypes[ntype_ids[0]] == dsttype
 
         # This is global IDs after reshuffle.
         eid = subg.edata[dgl.EID][idx]

--- a/examples/pytorch/rgcn/experimental/write_mag.py
+++ b/examples/pytorch/rgcn/experimental/write_mag.py
@@ -15,10 +15,6 @@ for etype in hg_orig.canonical_etypes:
 hg = dgl.heterograph(subgs)
 hg.nodes['paper'].data['feat'] = hg_orig.nodes['paper'].data['feat']
 print(hg)
-#subg_nodes = {}
-#for ntype in hg.ntypes:
-#    subg_nodes[ntype] = np.random.choice(hg.number_of_nodes(ntype), int(hg.number_of_nodes(ntype) / 5), replace=False)
-#hg = dgl.compact_graphs(dgl.node_subgraph(hg, subg_nodes))
 
 # OGB-MAG is stored in heterogeneous format. We need to convert it into homogeneous format.
 g = dgl.to_homogeneous(hg)
@@ -46,11 +42,43 @@ for ntype in hg.ntypes:
 dgl.data.utils.save_tensors("node_feat.dgl", node_feats)
 
 # Store the metadata of edges.
+# ParMETIS cannot handle duplicated edges and self-loops. We should remove them
+# in the preprocessing.
 src_id, dst_id = g.edges()
-edge_data = th.stack([src_id, dst_id,
-                      g.edata['orig_id'],
-                      g.edata[dgl.ETYPE]], 1)
+# Remove self-loops
+self_loop_idx = src_id == dst_id
+not_self_loop_idx = src_id != dst_id
+self_loop_src_id = src_id[self_loop_idx]
+self_loop_dst_id = dst_id[self_loop_idx]
+self_loop_orig_id = g.edata['orig_id'][self_loop_idx]
+self_loop_etype = g.edata[dgl.ETYPE][self_loop_idx]
+src_id = src_id[not_self_loop_idx]
+dst_id = dst_id[not_self_loop_idx]
+orig_id = g.edata['orig_id'][not_self_loop_idx]
+etype = g.edata[dgl.ETYPE][not_self_loop_idx]
+# Remove duplicated edges.
+ids = (src_id * g.number_of_nodes() + dst_id).numpy()
+uniq_ids, idx = np.unique(ids, return_index=True)
+duplicate_idx = np.setdiff1d(np.arange(len(ids)), idx)
+duplicate_src_id = src_id[duplicate_idx]
+duplicate_dst_id = dst_id[duplicate_idx]
+duplicate_orig_id = orig_id[duplicate_idx]
+duplicate_etype = etype[duplicate_idx]
+src_id = src_id[idx]
+dst_id = dst_id[idx]
+orig_id = orig_id[idx]
+etype = etype[idx]
+edge_data = th.stack([src_id, dst_id, orig_id, etype], 1)
 np.savetxt('mag_edges.txt', edge_data.numpy(), fmt='%d', delimiter=' ')
+removed_edge_data = th.stack([th.cat([self_loop_src_id, duplicate_src_id]),
+                              th.cat([self_loop_dst_id, duplicate_dst_id]),
+                              th.cat([self_loop_orig_id, duplicate_orig_id]),
+                              th.cat([self_loop_etype, duplicate_etype])],
+                             1)
+np.savetxt('mag_removed_edges.txt', removed_edge_data.numpy(), fmt='%d', delimiter=' ')
+print('There are {} edges, remove {} self-loops and {} duplicated edges'.format(g.number_of_edges(),
+                                                                                len(self_loop_src_id),
+                                                                                len(duplicate_src_id)))
 
 # Store the edge features
 edge_feats = {}
@@ -60,7 +88,7 @@ for etype in hg.etypes:
 dgl.data.utils.save_tensors("edge_feat.dgl", edge_feats)
 
 # Store the basic metadata of the graph.
-graph_stats = [g.number_of_nodes(), g.number_of_edges(), num_node_weights]
+graph_stats = [g.number_of_nodes(), len(src_id), num_node_weights]
 with open('mag_stats.txt', 'w') as filehandle:
     filehandle.writelines("{} {} {}".format(graph_stats[0], graph_stats[1], graph_stats[2]))
 

--- a/tools/convert_partition.py
+++ b/tools/convert_partition.py
@@ -270,7 +270,6 @@ for part_id in range(num_parts):
     part_dir = output_dir + '/part' + str(part_id)
     os.makedirs(part_dir, exist_ok=True)
     dgl.save_graphs(part_dir + '/graph.dgl', [compact_g1])
-num_nodes < max_nid
 
 part_metadata = {'graph_name': graph_name,
                  'num_nodes': num_nodes,

--- a/tools/convert_partition.py
+++ b/tools/convert_partition.py
@@ -29,7 +29,8 @@ parser.add_argument('--edge-attr-dtype', type=str, default=None,
                     help='The data type of the edge attributes')
 parser.add_argument('--output', required=True, type=str,
                     help='The output directory of the partitioned results')
-parser.add_argument('--removed-edges', help='file where we have edges that were dropped', default=None, type=str)
+parser.add_argument('--removed-edges', help='a file that contains the removed self-loops and duplicated edges',
+                    default=None, type=str)
 
 args = parser.parse_args()
 


### PR DESCRIPTION
## Description
ParMETIS cannot handle self-loops and duplicated edges correctly. Previous steps cannot generate graph partitions that contain all edges in the original input graph. This PR fixes this by removing the self-loops and duplicated edges and save them separately. After ParMETIS, we merge the removed edges back.

## Checklist
Please feel free to remove inapplicable items for your PR.
- [ ] The PR title starts with [$CATEGORY] (such as [NN], [Model], [Doc], [Feature]])
- [ ] Changes are complete (i.e. I finished coding on this PR)
- [ ] All changes have test coverage
- [ ] Code is well-documented
- [ ] To the best of my knowledge, examples are either not affected by this change,
      or have been fixed to be compatible with this change
- [ ] Related issue is referred in this PR
- [ ] If the PR is for a new model/paper, I've updated the example index [here](../examples/README.md).

## Changes
<!-- You could use following template
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)
-->
