### PR TITLE
[Bugfix] three bugs related to using DGL as a subdirectory(third_party) of another project.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -211,7 +211,7 @@ set(GOOGLE_TEST 0) # Turn off dmlc-core test
 
 # Compile METIS
 if(NOT MSVC)
-  set(GKLIB_PATH "${CMAKE_SOURCE_DIR}/third_party/METIS/GKlib")
+  set(GKLIB_PATH "${CMAKE_CURRENT_SOURCE_DIR}/third_party/METIS/GKlib")
   include(${GKLIB_PATH}/GKlibSystem.cmake)
   include_directories(${GKLIB_PATH})
   include_directories("third_party/METIS/include/")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -250,7 +250,7 @@ target_link_libraries(dgl ${DGL_LINKER_LIBS} ${DGL_RUNTIME_LINKER_LIBS})
 if(MSVC)
   add_custom_command(
     TARGET dgl POST_BUILD COMMAND
-    cmd.exe /c "COPY /Y Release\\dgl.dll .")
+    ${CMAKE_COMMAND} -E copy "$<TARGET_FILE:dgl>" "$<TARGET_FILE_DIR:dgl>/..")
 endif(MSVC)
 
 # Tensor adapter libraries

--- a/src/runtime/shared_mem.cc
+++ b/src/runtime/shared_mem.cc
@@ -86,6 +86,7 @@ void *SharedMemory::CreateNew(size_t sz) {
   return ptr_;
 #else
   LOG(FATAL) << "Shared memory is not supported on Windows.";
+  return nullptr;
 #endif  // _WIN32
 }
 
@@ -101,6 +102,7 @@ void *SharedMemory::Open(size_t sz) {
   return ptr_;
 #else
   LOG(FATAL) << "Shared memory is not supported on Windows.";
+  return nullptr;
 #endif  // _WIN32
 }
 
@@ -115,6 +117,7 @@ bool SharedMemory::Exist(const std::string &name) {
   }
 #else
   LOG(FATAL) << "Shared memory is not supported on Windows.";
+  return false;
 #endif  // _WIN32
 }
 


### PR DESCRIPTION
## Description
<!-- Brief description. Refer to the related issues if existed.
It'll be great if relevant reviewers can be assigned as well.-->
1. **[Bugfix] fix a compile error for Debug-BuildType on Windows Platform**
When using CMakeLists.txt to build the "Debug" BuildType on the Windows Platform, it has three compile errors (C4716) in the file "dgl\src\runtime\shared_mem.cc":
'dgl::runtime::SharedMemory::CreateNew': must return a value
'dgl::runtime::SharedMemory::Open': must return a value
'dgl::runtime::SharedMemory::Exist': must return a value

2. **[Bugfix] cmake error "cannot find load file" when DGL as a sub_directory of another project**
When using DGL as a subdirectory in a CMake Project, the "CMAKE_SOURCE_DIR" here will return the parent cmake scope dir, which is not a expected dir.
Maybe it is better to use "CMAKE_CURRENT_SOURCE_DIR" to set "GKLIB_PATH".

3. **[Bugfix] cmd cmake error when DGL as a subdirectory**
When DGL as a subdirectory of another project, the WORKING_DIRECTORY of "add_custom_command" will be incorrect at the line 255 of "CMakeLists.txt", such that making a cmake "setlocal" error.

## Checklist
Please feel free to remove inapplicable items for your PR.
- [x] The PR title starts with [$CATEGORY] (such as [NN], [Model], [Doc], [Feature]])
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] Code is well-documented
- [x] To the best of my knowledge, examples are either not affected by this change,
      or have been fixed to be compatible with this change

## Changes
<!-- You could use following template
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)
-->
1. **[Bugfix] fix a compile error for Debug-BuildType on Windows Platform**
- Three missed return statements are complemented.
2. **[Bugfix] cmake error "cannot find load file" when DGL as a sub_directory of another project**
- Using `CMAKE_CURRENT_SOURCE_DIR" instead of `CMAKE_SOURCE_DIR`
3. **[Bugfix] cmd cmake error when DGL as a subdirectory**
- Using `${CMAKE_COMMAND} -E copy "$<TARGET_FILE:dgl>" "$<TARGET_FILE_DIR:dgl>/.."` instead of `cmd.exe /c "COPY /Y Release\\dgl.dll ."`