### PR TITLE
[BugFix] extract gz into target dir

### DIFF
--- a/python/dgl/data/utils.py
+++ b/python/dgl/data/utils.py
@@ -219,7 +219,8 @@ def extract_archive(file, target_dir, overwrite=False):
         import gzip
         import shutil
         with gzip.open(file, 'rb') as f_in:
-            with open(file[:-3], 'wb') as f_out:
+            target_file = os.path.join(target_dir, os.path.basename(file)[:-3])
+            with open(target_file, 'wb') as f_out:
                 shutil.copyfileobj(f_in, f_out)
     elif file.endswith('.zip'):
         import zipfile

--- a/tests/compute/test_data.py
+++ b/tests/compute/test_data.py
@@ -2,6 +2,9 @@ import dgl.data as data
 import unittest
 import backend as F
 import numpy as np
+import gzip
+import tempfile
+import os
 
 
 @unittest.skipIf(F._default_context_str == 'gpu', reason="Datasets don't need to be tested on GPU.")
@@ -139,6 +142,20 @@ def test_reddit():
     assert np.array_equal(dst, np.sort(dst))
 
 
+@unittest.skipIf(F._default_context_str == 'gpu', reason="Datasets don't need to be tested on GPU.")
+def test_extract_archive():
+    # gzip
+    with tempfile.TemporaryDirectory() as src_dir:
+        gz_file = 'gz_archive'
+        gz_path = os.path.join(src_dir, gz_file + '.gz')
+        content = b"test extract archive gzip"
+        with gzip.open(gz_path, 'wb') as f:
+            f.write(content)
+        with tempfile.TemporaryDirectory() as dst_dir:
+            data.utils.extract_archive(gz_path, dst_dir, overwrite=True)
+            assert os.path.exists(os.path.join(dst_dir, gz_file))
+
+
 if __name__ == '__main__':
     test_minigc()
     test_gin()
@@ -146,3 +163,4 @@ if __name__ == '__main__':
     test_tudataset_regression()
     test_fraud()
     test_fakenews()
+    test_extract_archive()


### PR DESCRIPTION
## Description
<!-- Brief description. Refer to the related issues if existed.
It'll be great if relevant reviewers can be assigned as well.-->
reported in https://discuss.dgl.ai/t/extract-archive-does-not-extract-file-in-target-folder-when-using-gz-file/2365

extracted gz file is not placed in user specified target dir.
## Checklist
Please feel free to remove inapplicable items for your PR.
- [ ] The PR title starts with [$CATEGORY] (such as [NN], [Model], [Doc], [Feature]])
- [ ] Changes are complete (i.e. I finished coding on this PR)
- [ ] All changes have test coverage
- [ ] Code is well-documented
- [ ] To the best of my knowledge, examples are either not affected by this change,
      or have been fixed to be compatible with this change
- [ ] Related issue is referred in this PR
- [ ] If the PR is for a new model/paper, I've updated the example index [here](../examples/README.md).

## Changes
<!-- You could use following template
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)
-->
