### PR TITLE
[bugfix] Fix compilation with CUDA 11.5's CUB

### DIFF
--- a/src/array/cuda/dgl_cub.cuh
+++ b/src/array/cuda/dgl_cub.cuh
@@ -10,7 +10,9 @@
 // include cub in a safe manner
 #define CUB_NS_PREFIX namespace dgl {
 #define CUB_NS_POSTFIX }
+#define CUB_NS_QUALIFIER ::dgl::cub
 #include "cub/cub.cuh"
+#undef CUB_NS_QUALIFIER
 #undef CUB_NS_POSTFIX
 #undef CUB_NS_PREFIX
 


### PR DESCRIPTION
## Description
New in CUB 11.5 is the requirement to define `CUB_NS_QUALIFIER`. This PR adds this definition and is backwards compatible.

## Checklist
Please feel free to remove inapplicable items for your PR.
- [x] The PR title starts with [$CATEGORY] (such as [NN], [Model], [Doc], [Feature]])
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage
- [x] Code is well-documented
- [x] To the best of my knowledge, examples are either not affected by this change,
      or have been fixed to be compatible with this change



