### PR TITLE
[Bug] Fix a cub compile error for CUDA 11.5

### DIFF
--- a/src/array/cuda/dgl_cub.cuh
+++ b/src/array/cuda/dgl_cub.cuh
@@ -10,7 +10,9 @@
 // include cub in a safe manner
 #define CUB_NS_PREFIX namespace dgl {
 #define CUB_NS_POSTFIX }
+#define CUB_NS_QUALIFIER ::dgl::cub
 #include "cub/cub.cuh"
+#undef CUB_NS_QUALIFIER
 #undef CUB_NS_POSTFIX
 #undef CUB_NS_PREFIX
 


### PR DESCRIPTION
## Description
Compile with CUDA 11.5 show this " #error CUB requires a definition of CUB_NS_QUALIFIER when CUB_NS_PREFIX/POSTFIX are defined." for /src/array/cuda/./dgl_generated_array_nonzero.cu.o

See cub reference https://github.com/NVIDIA/cub/commit/6c7b8be7079edc7473534861cfa853abd9ff6182 
## Checklist
Please feel free to remove inapplicable items for your PR.
- [x] The PR title starts with [$CATEGORY] (such as [NN], [Model], [Doc], [Feature]])
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage
- [x] Code is well-documented
- [x] To the best of my knowledge, examples are either not affected by this change,
      or have been fixed to be compatible with this change
- [x] Related issue is referred in this PR


## Changes
- [x] src/array/cuda/dgl_cub.cuh
