### PR TITLE
[BugFix] Fix bugs in GPU sampling and enable unit tests for dataloaders on the GPU

### DIFF
--- a/python/dgl/dataloading/dataloader.py
+++ b/python/dgl/dataloading/dataloader.py
@@ -80,7 +80,7 @@ class _EidExcluder():
             assert self._filter is not None
             if isinstance(parent_eids, Mapping):
                 located_eids = {k: self._filter[k].find_included_indices(parent_eids[k])
-                                for k, v in parent_eids.items()}
+                                for k, v in parent_eids.items() if k in self._filter}
             else:
                 located_eids = self._filter.find_included_indices(parent_eids)
             return located_eids
@@ -820,8 +820,9 @@ class EdgeCollator(Collator):
             neg_srcdst = {self.g.canonical_etypes[0]: neg_srcdst}
         # Get dtype from a tuple of tensors
         dtype = F.dtype(list(neg_srcdst.values())[0][0])
+        ctx = F.context(pair_graph)
         neg_edges = {
-            etype: neg_srcdst.get(etype, (F.tensor([], dtype), F.tensor([], dtype)))
+            etype: neg_srcdst.get(etype, (F.tensor([], dtype).to(ctx), F.tensor([], dtype).to(ctx)))
             for etype in self.g.canonical_etypes}
         neg_pair_graph = heterograph(
             neg_edges, {ntype: self.g.number_of_nodes(ntype) for ntype in self.g.ntypes})

--- a/python/dgl/dataloading/dataloader.py
+++ b/python/dgl/dataloading/dataloader.py
@@ -822,8 +822,8 @@ class EdgeCollator(Collator):
         dtype = F.dtype(list(neg_srcdst.values())[0][0])
         ctx = F.context(pair_graph)
         neg_edges = {
-            etype: neg_srcdst.get(etype,
-                (F.copy_to(F.tensor([], dtype), ctx), F.copy_to(F.tensor([], dtype), ctx)))
+            etype: neg_srcdst.get(etype, (F.copy_to(F.tensor([], dtype), ctx),
+                                          F.copy_to(F.tensor([], dtype), ctx)))
             for etype in self.g.canonical_etypes}
         neg_pair_graph = heterograph(
             neg_edges, {ntype: self.g.number_of_nodes(ntype) for ntype in self.g.ntypes})

--- a/python/dgl/dataloading/dataloader.py
+++ b/python/dgl/dataloading/dataloader.py
@@ -822,7 +822,8 @@ class EdgeCollator(Collator):
         dtype = F.dtype(list(neg_srcdst.values())[0][0])
         ctx = F.context(pair_graph)
         neg_edges = {
-            etype: neg_srcdst.get(etype, (F.tensor([], dtype).to(ctx), F.tensor([], dtype).to(ctx)))
+            etype: neg_srcdst.get(etype,
+                (F.copy_to(F.tensor([], dtype), ctx), F.copy_to(F.tensor([], dtype), ctx)))
             for etype in self.g.canonical_etypes}
         neg_pair_graph = heterograph(
             neg_edges, {ntype: self.g.number_of_nodes(ntype) for ntype in self.g.ntypes})

--- a/src/graph/sampling/neighbor/neighbor.cc
+++ b/src/graph/sampling/neighbor/neighbor.cc
@@ -93,7 +93,7 @@ HeteroSubgraph SampleNeighbors(
         hg->NumVertices(src_vtype),
         hg->NumVertices(dst_vtype),
         hg->DataType(), hg->Context());
-      induced_edges[etype] = aten::NullArray();
+      induced_edges[etype] = aten::NullArray(hg->DataType(), hg->Context());
     } else if (fanouts[etype] == -1) {
       const auto &earr = (dir == EdgeDir::kOut) ?
         hg->OutEdges(etype, nodes_ntype) :

--- a/src/graph/sampling/neighbor/neighbor.cc
+++ b/src/graph/sampling/neighbor/neighbor.cc
@@ -1,5 +1,5 @@
 /*!
- *  Copyright (c) 2020 by Contributors
+ *  Copyright (c) 2020-2021 by Contributors
  * \file graph/sampling/neighbor.cc
  * \brief Definition of neighborhood-based sampler APIs.
  */


### PR DESCRIPTION
## Description

This fixes several bugs in the GPU sampling and thus enables unit tests `tests/pytorch/test_dataloader.py` for the GPU. 
`node_dataloader()/edge_dataloder()/neighbor_sampler_dataloder()` now pass the GPU unit tests.


## Checklist
Please feel free to remove inapplicable items for your PR.
- [x] The PR title starts with [$CATEGORY] (such as [NN], [Model], [Doc], [Feature]])
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage
- [x] Code is well-documented
- [x] To the best of my knowledge, examples are either not affected by this change,
      or have been fixed to be compatible with this change

## Changes
- Modify `python/dgl/dataloading/dataloader.py`: fix several bugs for GPU sampling
- Modify `src/graph/sampling/neighbor/neighbor.cc`: fix a corner case for GPU sampling
- Modify `tests/pytorch/test_dataloader.py`: enable unit tests for the GPU
