### PR TITLE
[Randomwalk] Fix off-by-one bug in GenericRandomWalk()

### DIFF
--- a/src/graph/sampling/randomwalks/randomwalks_cpu.h
+++ b/src/graph/sampling/randomwalks/randomwalks_cpu.h
@@ -59,7 +59,7 @@ std::pair<IdArray, IdArray> GenericRandomWalk(
       CHECK_LT(curr, max_nodes) << "Seed node ID exceeds the maximum number of nodes.";
 
       for (i = 0; i < max_num_steps; ++i) {
-        const auto &succ = step(traces_data + seed_id * max_num_steps, curr, i);
+        const auto &succ = step(traces_data + seed_id * trace_length, curr, i);
         traces_data[seed_id * trace_length + i + 1] = curr = std::get<0>(succ);
         eids_data[seed_id * max_num_steps + i] = std::get<1>(succ);
         if (std::get<2>(succ))


### PR DESCRIPTION
## Description
This PR fixes an off-by-one bug in `GenericRandomWalk()`. The `traces_data` is a tensor with shape=[num_seed_nodes, trace_length] which is supposed to store the visited node ids for each seed node.

The line in question is supposed to something like:
```
dgl_id_t curr;  // current node_id in rwalk
int64_t i;  // current step iter
...
// perform an rwalk step()
const auto &succ = step(&traces_data[seed_id, :], curr, i);
```

However, in the current implementation the indexing into `traces_data` is incorrect: it's off by one, so traces from other seed nodes can clobber other seed node traces.

Anecdotally, when I was implementing a new Step() function where I needed to read into the passed in `traces_data`, I observed a memory corruption bug (leading to crashes), which led me to this bug. Enabling multithreading (running rwalks for multiple seed nodes concurrently) led to frequent segfaults/failures. This PR fixed the memory corruption bugs on my end.

## Checklist
Please feel free to remove inapplicable items for your PR.
- [x ] The PR title starts with [$CATEGORY] (such as [NN], [Model], [Doc], [Feature]])
- [x ] Changes are complete (i.e. I finished coding on this PR)
- [x ] All changes have test coverage
- [x ] Code is well-documented
- [x ] To the best of my knowledge, examples are either not affected by this change,
      or have been fixed to be compatible with this change
- [ ] Related issue is referred in this PR

## Changes
