### PR TITLE
[Doc] Fix the example code of negative sampler

### DIFF
--- a/python/dgl/dataloading/negative_sampler.py
+++ b/python/dgl/dataloading/negative_sampler.py
@@ -49,7 +49,7 @@ class Uniform(_BaseNegativeSampler):
     --------
     >>> g = dgl.graph(([0, 1, 2], [1, 2, 3]))
     >>> neg_sampler = dgl.dataloading.negative_sampler.Uniform(2)
-    >>> neg_sampler(g, [0, 1])
+    >>> neg_sampler(g, torch.tensor([0, 1]))
     (tensor([0, 0, 1, 1]), tensor([1, 0, 2, 3]))
     """
     def __init__(self, k):


### PR DESCRIPTION
## Description
<!-- Brief description. Refer to the related issues if existed.
It'll be great if relevant reviewers can be assigned as well.-->

Fix the example code of the negative sampler, where the argument `eid` is required to be `Tensor or dict[etype, Tensor]`.


