### PR TITLE
[WIP] Multi client groups

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -34,7 +34,6 @@ dgl_option(BUILD_CPP_TEST "Build cpp unittest executables" OFF)
 dgl_option(LIBCXX_ENABLE_PARALLEL_ALGORITHMS "Enable the parallel algorithms library. This requires the PSTL to be available." OFF)
 dgl_option(USE_S3 "Build with S3 support" OFF)
 dgl_option(USE_HDFS "Build with HDFS support" OFF) # Set env HADOOP_HDFS_HOME if needed
-dgl_option(USE_EPOLL "Build with epoll for socket communicator" OFF)
 
 # Set debug compile option for gdb, only happens when -DCMAKE_BUILD_TYPE=DEBUG
 if (NOT MSVC)
@@ -120,14 +119,6 @@ if(USE_AVX)
     message(STATUS "Build with AVX optimization.")
   endif(USE_LIBXSMM)
 endif(USE_AVX)
-
-if (USE_EPOLL)
-  check_include_file("sys/epoll.h" USE_EPOLL)
-  if (USE_EPOLL)
-    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -DUSE_EPOLL")
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DUSE_EPOLL")
-  endif()
-endif ()
 
 # Build with fp16 to support mixed precision training.
 if(USE_FP16)

--- a/python/dgl/distributed/rpc.py
+++ b/python/dgl/distributed/rpc.py
@@ -138,7 +138,7 @@ def finalize_receiver():
     """
     _CAPI_DGLRPCFinalizeReceiver()
 
-def receiver_wait(ip_addr, port, num_senders):
+def receiver_wait(ip_addr, port, num_senders, blocking=True):
     """Wait all of the senders' connections.
 
     This api will be blocked until all the senders connect to the receiver.
@@ -152,7 +152,7 @@ def receiver_wait(ip_addr, port, num_senders):
     num_senders : int
         total number of senders
     """
-    _CAPI_DGLRPCReceiverWait(ip_addr, int(port), int(num_senders))
+    _CAPI_DGLRPCReceiverWait(ip_addr, int(port), int(num_senders), blocking)
 
 def add_receiver_addr(ip_addr, port, recv_id):
     """Add Receiver's IP address to sender's namebook.

--- a/python/dgl/distributed/rpc_server.py
+++ b/python/dgl/distributed/rpc_server.py
@@ -73,6 +73,7 @@ def start_server(server_id, ip_config, num_servers, num_clients, server_state, \
     client_namebook = {}
     for _ in range(num_clients):
         req, _ = rpc.recv_request()
+        assert isinstance(req, rpc.ClientRegisterRequest)
         addr_list.append(req.ip_addr)
     addr_list.sort()
     for client_id, addr in enumerate(addr_list):

--- a/src/rpc/network/common.cc
+++ b/src/rpc/network/common.cc
@@ -125,5 +125,26 @@ void StringAppendF(string* dst, const char* format, ...) {
   va_end(ap);
 }
 
+std::pair<std::string, int> ParseAddress(const char *addr) {
+  std::vector<std::string> substring;
+  std::vector<std::string> ip_and_port;
+  SplitStringUsing(addr, "//", &substring);
+  // Check address format
+  if (substring[0] != "socket:" || substring.size() != 2) {
+    LOG(FATAL) << "Incorrect address format:" << addr
+               << " Please provide right address format, "
+               << "e.g, 'socket://127.0.0.1:50051'. ";
+  }
+  // Get IP and port
+  SplitStringUsing(substring[1], ":", &ip_and_port);
+  if (ip_and_port.size() != 2) {
+    LOG(FATAL) << "Incorrect address format:" << addr
+               << " Please provide right address format, "
+               << "e.g, 'socket://127.0.0.1:50051'. ";
+  }
+
+  return std::make_pair(ip_and_port[0], stoi(ip_and_port[1]));
+}
+
 }  // namespace network
 }  // namespace dgl

--- a/src/rpc/network/common.h
+++ b/src/rpc/network/common.h
@@ -126,6 +126,7 @@ void SplitStringToIteratorUsing(const StringType& full,
 std::string StringPrintf(const char* format, ...);
 void SStringPrintf(std::string* dst, const char* format, ...);
 void StringAppendF(std::string* dst, const char* format, ...);
+std::pair<std::string, int> ParseAddress(const char *addr);
 
 }  // namespace network
 }  // namespace dgl

--- a/src/rpc/network/common.h
+++ b/src/rpc/network/common.h
@@ -12,6 +12,7 @@
 #include <set>
 #include <string>
 #include <vector>
+#include <utility>
 
 namespace dgl {
 namespace network {

--- a/src/rpc/network/communicator.h
+++ b/src/rpc/network/communicator.h
@@ -125,11 +125,12 @@ class Receiver {
   /*!
    * \brief Wait for all the Senders to connect
    * \param addr Networking address, e.g., 'socket://127.0.0.1:50051', 'mpi://0'
+   * \param num_sender total number of Senders
    * \return True for success and False for fail
    *
    * Wait() is not thread-safe and only one thread can invoke this API.
    */
-  virtual bool Wait(const char* addr, int) = 0;
+  virtual bool Wait(const char* addr, int num_sender) = 0;
 
   /*!
    * \brief Recv data from Sender

--- a/src/rpc/network/communicator.h
+++ b/src/rpc/network/communicator.h
@@ -125,12 +125,11 @@ class Receiver {
   /*!
    * \brief Wait for all the Senders to connect
    * \param addr Networking address, e.g., 'socket://127.0.0.1:50051', 'mpi://0'
-   * \param num_sender total number of Senders
    * \return True for success and False for fail
    *
    * Wait() is not thread-safe and only one thread can invoke this API.
    */
-  virtual bool Wait(const char* addr, int num_sender) = 0;
+  virtual bool Wait(const char* addr, int) = 0;
 
   /*!
    * \brief Recv data from Sender

--- a/src/rpc/network/communicator.h
+++ b/src/rpc/network/communicator.h
@@ -126,11 +126,13 @@ class Receiver {
    * \brief Wait for all the Senders to connect
    * \param addr Networking address, e.g., 'socket://127.0.0.1:50051', 'mpi://0'
    * \param num_sender total number of Senders
+   * \param blocking if true, blocks until expected number of Senders connected
    * \return True for success and False for fail
    *
    * Wait() is not thread-safe and only one thread can invoke this API.
    */
-  virtual bool Wait(const char* addr, int num_sender) = 0;
+  virtual bool Wait(const char *addr, const int num_sender,
+                    const bool blocking = true) = 0;
 
   /*!
    * \brief Recv data from Sender

--- a/src/rpc/network/msg_queue.h
+++ b/src/rpc/network/msg_queue.h
@@ -32,6 +32,7 @@ typedef int STATUS;
 #define  QUEUE_FULL      3404   // Cannot add message when queue is full
 #define  REMOVE_SUCCESS  3405   // Remove message successfully
 #define  QUEUE_EMPTY     3406   // Cannot remove when queue is empty
+#define  QUEUE_NOT_FOUND 3407   // Target queue is not found
 
 /*!
  * \brief Message used by network communicator and message queue.

--- a/src/rpc/network/socket_communicator.cc
+++ b/src/rpc/network/socket_communicator.cc
@@ -315,7 +315,7 @@ int64_t RecvDataSize(TCPSocket *socket) {
 
 void RecvData(TCPSocket *socket, char *buffer, const int64_t &data_size,
               int64_t *received_bytes) {
-  //CHECK_GE(data_size, 0);
+  CHECK_GT(data_size, 0);
   while (*received_bytes < data_size) {
     int64_t max_len = data_size - *received_bytes;
     int64_t tmp = socket->Receive(buffer + *received_bytes, max_len);
@@ -363,13 +363,12 @@ void SocketReceiver::RecvLoop(const int thread_id) {
         buffer = new char[data_size];
         received_bytes = 0;
       } else if (data_size == 0) {
-        LOG(WARNING)<<"-------- data_size is zero, not expected.....";
         // Received stop signal
         socket_pool.RemoveSocket(socket);
-        //continue;
-      }
-      else{
-        LOG(WARNING)<<"------ data_size:"<<data_size<<", expected, should remove socket???";
+        continue;
+      } else {
+        // already closed socket
+        continue;
       }
     }
 

--- a/src/rpc/network/socket_communicator.cc
+++ b/src/rpc/network/socket_communicator.cc
@@ -9,6 +9,7 @@
 #include <stdlib.h>
 #include <time.h>
 #include <memory>
+#include <algorithm>
 
 #include "socket_communicator.h"
 #include "../../c_api_common.h"
@@ -249,7 +250,7 @@ STATUS SocketReceiver::Recv(Message *msg, int *send_id) {
   bool fetched = false;
   while (!stop_) {
     lk.lock();
-    for (auto &&p : msg_queue_) { // TODO: more smart fetch is required.
+    for (auto &&p : msg_queue_) {
       code = p.second->Remove(msg, false);
       if (code == QUEUE_EMPTY) {
         continue;

--- a/src/rpc/network/socket_communicator.cc
+++ b/src/rpc/network/socket_communicator.cc
@@ -186,138 +186,113 @@ void SocketSender::SendLoop(
 
 /////////////////////////////////////// SocketReceiver ///////////////////////////////////////////
 
-bool SocketReceiver::Wait(const char* addr, int num_sender) {
+bool SocketReceiver::Wait(const char *addr, int num_sender) {
   CHECK_NOTNULL(addr);
-  CHECK_GT(num_sender, 0);
-  std::vector<std::string> substring;
-  std::vector<std::string> ip_and_port;
-  SplitStringUsing(addr, "//", &substring);
-  // Check address format
-  if (substring[0] != "socket:" || substring.size() != 2) {
-    LOG(FATAL) << "Incorrect address format:" << addr
-               << " Please provide right address format, "
-               << "e.g, 'socket://127.0.0.1:50051'. ";
-  }
-  // Get IP and port
-  SplitStringUsing(substring[1], ":", &ip_and_port);
-  if (ip_and_port.size() != 2) {
-    LOG(FATAL) << "Incorrect address format:" << addr
-               << " Please provide right address format, "
-               << "e.g, 'socket://127.0.0.1:50051'. ";
-  }
-  std::string ip = ip_and_port[0];
-  int port = stoi(ip_and_port[1]);
-  // Initialize message queue for each connection
-  num_sender_ = num_sender;
-#ifdef USE_EPOLL
-  if (max_thread_count_ == 0 || max_thread_count_ > num_sender_) {
-      max_thread_count_ = num_sender_;
-  }
-#else
-  max_thread_count_ = num_sender_;
-#endif
-  // Initialize socket and socket-thread
-  server_socket_ = new TCPSocket();
-  // Bind socket
+  const auto &ip_port = ParseAddress(addr);
+  const auto &ip = ip_port.first;
+  const auto &port = ip_port.second;
+
+  server_socket_ = std::make_shared<TCPSocket>();
   if (server_socket_->Bind(ip.c_str(), port) == false) {
     LOG(FATAL) << "Cannot bind to " << ip << ":" << port;
   }
-
-  // Listen
   if (server_socket_->Listen(kMaxConnection) == false) {
     LOG(FATAL) << "Cannot listen on " << ip << ":" << port;
   }
-  // Accept all sender sockets
-  std::string accept_ip;
-  int accept_port;
-  sockets_.resize(max_thread_count_);
-  for (int i = 0; i < num_sender_; ++i) {
-    int thread_id = i % max_thread_count_;
-    auto socket = std::make_shared<TCPSocket>();
-    sockets_[thread_id][i] = socket;
-    msg_queue_[i] = std::make_shared<MessageQueue>(queue_size_);
-    if (server_socket_->Accept(socket.get(), &accept_ip, &accept_port) == false) {
-      LOG(WARNING) << "Error on accept socket.";
-      return false;
-    }
+
+  if (max_thread_count_ == 0) {
+    max_thread_count_ = std::max(0x2, num_sender);
   }
-  mq_iter_ = msg_queue_.begin();
+  int hc = std::thread::hardware_concurrency();
+  if (max_thread_count_ > hc) {
+    LOG(INFO) << "The target max thread count[" << max_thread_count_
+              << "] is larger than std::thread::hardware_concurrency[" << hc
+              << "]. Let's trim to [" << hc << "].";
+    max_thread_count_ = hc;
+  }
+
+  socket_pool_.resize(max_thread_count_);
 
   for (int thread_id = 0; thread_id < max_thread_count_; ++thread_id) {
-    // create new thread for each socket
-    threads_.push_back(std::make_shared<std::thread>(
-      RecvLoop,
-      sockets_[thread_id],
-      msg_queue_,
-      &queue_sem_));
+    threads_.emplace_back(std::make_shared<std::thread>(
+        &SocketReceiver::RecvLoop, this, thread_id));
   }
+
+  threads_.emplace_back(std::make_shared<std::thread>([this]() {
+    server_socket_->SetNonBlocking(true);
+    std::string accept_ip;
+    int accept_port;
+    while (!stop_) {
+      auto &&accept_socket = std::make_shared<TCPSocket>();
+      if (!server_socket_->Accept(accept_socket.get(), &accept_ip,
+                                  &accept_port)) {
+        continue;
+      }
+      int sender_id = num_sender_++;
+      int thread_id = sender_id % max_thread_count_;
+      auto &&msg_queue = std::make_shared<MessageQueue>(queue_size_);
+      auto &&recv_ctx = std::make_shared<RecvContext>();
+      std::unique_lock<std::mutex> lk(mtx_);
+      msg_queue_[sender_id] = msg_queue;
+      recv_contexts_[sender_id] = recv_ctx;
+      socket_pool_[thread_id].AddSocket(accept_socket, sender_id);
+      lk.unlock();
+    }
+  }));
 
   return true;
 }
 
-STATUS SocketReceiver::Recv(Message* msg, int* send_id) {
-  // queue_sem_ is a semaphore indicating how many elements in multiple
-  // message queues.
-  // When calling queue_sem_.Wait(), this Recv will be suspended until
-  // queue_sem_ > 0, decrease queue_sem_ by 1, then start to fetch a message.
-  queue_sem_.Wait();
-  for (;;) {
-    for (; mq_iter_ != msg_queue_.end(); ++mq_iter_) {
-      STATUS code = mq_iter_->second->Remove(msg, false);
+STATUS SocketReceiver::Recv(Message *msg, int *send_id) {
+  std::unique_lock<std::mutex> lk(mtx_, std::defer_lock);
+  STATUS code = -1;
+  bool fetched = false;
+  while (!stop_) {
+    lk.lock();
+    for (auto &&p : msg_queue_) { // TODO: more smart fetch is required.
+      code = p.second->Remove(msg, false);
       if (code == QUEUE_EMPTY) {
-        continue;  // jump to the next queue
+        continue;
       } else {
-        *send_id = mq_iter_->first;
-        ++mq_iter_;
-        return code;
+        *send_id = p.first;
+        fetched = true;
+        break;
       }
     }
-    mq_iter_ = msg_queue_.begin();
+    lk.unlock();
+    if (fetched) {
+      break;
+    }
   }
-}
-
-STATUS SocketReceiver::RecvFrom(Message* msg, int send_id) {
-  // Get message from specified message queue
-  queue_sem_.Wait();
-  STATUS code = msg_queue_[send_id]->Remove(msg);
   return code;
 }
 
-void SocketReceiver::Finalize() {
-  // Send a signal to tell the message queue to finish its job
-  for (auto& mq : msg_queue_) {
-    // wait until queue is empty
-    while (mq.second->Empty() == false) {
-#ifdef _WIN32
-        // just loop
-#else   // !_WIN32
-        usleep(1000);
-#endif  // _WIN32
-    }
-    mq.second->SignalFinished(mq.first);
+STATUS SocketReceiver::RecvFrom(Message *msg, int sender_id) {
+  // Get message from specified message queue
+  std::unique_lock<std::mutex> lk(mtx_);
+  if (msg_queue_.count(sender_id) == 0) {
+    LOG(FATAL) << "No message queue for sender_id: " << sender_id;
   }
-  // Block main thread until all socket-threads finish their jobs
-  for (auto& thread : threads_) {
-    thread->join();
-  }
-  // Clear all sockets
-  for (auto& group_sockets : sockets_) {
-    for (auto& socket : group_sockets) {
-      socket.second->Close();
-    }
-  }
-  server_socket_->Close();
-  delete server_socket_;
+  auto mq = msg_queue_[sender_id];
+  lk.unlock();
+  return mq->Remove(msg);
 }
 
-int64_t RecvDataSize(TCPSocket* socket) {
+void SocketReceiver::Finalize() {
+  stop_ = true;
+
+  for (auto &thread : threads_) {
+    thread->join();
+  }
+}
+
+int64_t RecvDataSize(TCPSocket *socket) {
   int64_t received_bytes = 0;
   int64_t data_size = 0;
   while (static_cast<size_t>(received_bytes) < sizeof(int64_t)) {
     int64_t max_len = sizeof(int64_t) - received_bytes;
     int64_t tmp = socket->Receive(
-      reinterpret_cast<char*>(&data_size) + received_bytes,
-      max_len);
+        reinterpret_cast<char *>(&data_size) + received_bytes, max_len);
     if (tmp == -1) {
       if (received_bytes > 0) {
         // We want to finish reading full data_size
@@ -330,8 +305,8 @@ int64_t RecvDataSize(TCPSocket* socket) {
   return data_size;
 }
 
-void RecvData(TCPSocket* socket, char* buffer, const int64_t &data_size,
-  int64_t *received_bytes) {
+void RecvData(TCPSocket *socket, char *buffer, const int64_t &data_size,
+              int64_t *received_bytes) {
   while (*received_bytes < data_size) {
     int64_t max_len = data_size - *received_bytes;
     int64_t tmp = socket->Receive(buffer + *received_bytes, max_len);
@@ -343,56 +318,44 @@ void RecvData(TCPSocket* socket, char* buffer, const int64_t &data_size,
   }
 }
 
-void SocketReceiver::RecvLoop(
-  std::unordered_map<int /* Sender (virtual) ID */,
-    std::shared_ptr<TCPSocket>> sockets,
-  std::unordered_map<int /* Sender (virtual) ID */,
-    std::shared_ptr<MessageQueue>> queues,
-  runtime::Semaphore *queue_sem) {
-  std::unordered_map<int, std::unique_ptr<RecvContext>> recv_contexts;
-  SocketPool socket_pool;
-  for (auto& socket : sockets) {
-    auto &sender_id = socket.first;
-    socket_pool.AddSocket(socket.second, sender_id);
-    recv_contexts[sender_id] = std::unique_ptr<RecvContext>(new RecvContext());
-  }
-
-  // Main loop to receive messages
-  for (;;) {
-    int sender_id;
-    // Get active socket using epoll
-    std::shared_ptr<TCPSocket> socket = socket_pool.GetActiveSocket(&sender_id);
-    if (queues[sender_id]->EmptyAndNoMoreAdd()) {
-      // This sender has already stopped
-      if (socket_pool.RemoveSocket(socket) == 0) {
-        return;
-      }
+void SocketReceiver::RecvLoop(const int thread_id) {
+  CHECK_GE(thread_id, 0);
+  CHECK_LT(thread_id, socket_pool_.size());
+  auto &&socket_pool = socket_pool_[thread_id];
+  while (!stop_) {
+    int sender_id = -1;
+    auto socket = socket_pool.GetActiveSocket(&sender_id);
+    if (!socket) {
+      // no active socket
       continue;
     }
+    std::unique_lock<std::mutex> lk(mtx_);
+    if (msg_queue_.count(sender_id) == 0) {
+      LOG(FATAL) << "No message queue could be found for sender_id~"
+                 << sender_id;
+    }
+    auto msg_queue = msg_queue_[sender_id];
+    if (recv_contexts_.count(sender_id) == 0) {
+      LOG(FATAL) << "No recv context could be found for sender_id~"
+                 << sender_id;
+    }
+    auto ctx = recv_contexts_[sender_id];
+    lk.unlock();
 
-    // Nonblocking socket might be interrupted at any point. So we need to
-    // store the partially received data
-    std::unique_ptr<RecvContext> &ctx = recv_contexts[sender_id];
+    // recv message
     int64_t &data_size = ctx->data_size;
     int64_t &received_bytes = ctx->received_bytes;
-    char*& buffer = ctx->buffer;
+    char *&buffer = ctx->buffer;
 
     if (data_size == -1) {
       // This is a new message, so receive the data size first
       data_size = RecvDataSize(socket.get());
       if (data_size > 0) {
-        try {
-          buffer = new char[data_size];
-        } catch(const std::bad_alloc&) {
-          LOG(FATAL) << "Cannot allocate enough memory for message, "
-                     << "(message size: " << data_size << ")";
-        }
+        buffer = new char[data_size];
         received_bytes = 0;
       } else if (data_size == 0) {
         // Received stop signal
-        if (socket_pool.RemoveSocket(socket) == 0) {
-          return;
-        }
+        socket_pool.RemoveSocket(socket);
       }
     }
 
@@ -403,13 +366,9 @@ void SocketReceiver::RecvLoop(
       msg.data = buffer;
       msg.size = data_size;
       msg.deallocator = DefaultMessageDeleter;
-      queues[sender_id]->Add(msg);
-
+      msg_queue->Add(msg);
       // Reset recv context
       data_size = -1;
-
-      // Signal queue semaphore
-      queue_sem->Post();
     }
   }
 }

--- a/src/rpc/network/socket_communicator.h
+++ b/src/rpc/network/socket_communicator.h
@@ -209,7 +209,7 @@ class SocketReceiver : public Receiver {
   /*!
    * \brief number of sender
    */
-  int num_sender_;
+  std::atomic<int> num_sender_;
 
   /*!
    * \brief server socket for listening connections

--- a/src/rpc/network/socket_communicator.h
+++ b/src/rpc/network/socket_communicator.h
@@ -151,25 +151,27 @@ class SocketReceiver : public Receiver {
     * \brief Wait for all the Senders to connect
     * \param addr Networking address, e.g., 'socket://127.0.0.1:50051', 'mpi://0'
     * \param num_sender expected number of Senders but more than expected is supported
+    * \param blocking if true, blocks until expected number of Senders connected
     * \return True for success and False for fail
     *
     * Wait() is not thread-safe and only one thread can invoke this API. It's
     * non-blocking and wait until Finalize() is called explicitly.
     */
-    bool Wait(const char *addr, int num_sender) override;
+    bool Wait(const char *addr, const int num_sender,
+              const bool blocking = true) override;
 
-   /*!
-    * \brief Recv data from Sender. Actually removing data from msg_queue.
-    * \param msg pointer of data message
-    * \param send_id which sender current msg comes from
-    * \return Status code
-    *
-    * (1) The Recv() API is blocking, which will not
-    *     return until getting data from message queue.
-    * (2) The Recv() API is thread-safe.
-    * (3) Memory allocated by communicator but will not own it after the
-    * function returns.
-    */
+    /*!
+     * \brief Recv data from Sender. Actually removing data from msg_queue.
+     * \param msg pointer of data message
+     * \param send_id which sender current msg comes from
+     * \return Status code
+     *
+     * (1) The Recv() API is blocking, which will not
+     *     return until getting data from message queue.
+     * (2) The Recv() API is thread-safe.
+     * (3) Memory allocated by communicator but will not own it after the
+     * function returns.
+     */
     STATUS Recv(Message *msg, int *send_id);
 
    /*!

--- a/src/rpc/network/socket_communicator.h
+++ b/src/rpc/network/socket_communicator.h
@@ -144,8 +144,8 @@ class SocketReceiver : public Receiver {
    * \param queue_size size of message queue.
    * \param max_thread_count size of thread pool. 0 for no limit
    */
-   SocketReceiver(int64_t queue_size, int max_thread_count)
-       : Receiver(queue_size, max_thread_count), num_sender_(0), stop_(false) {}
+    SocketReceiver(int64_t queue_size, int max_thread_count)
+     : Receiver(queue_size, max_thread_count), num_sender_(0), stop_(false) {}
 
    /*!
     * \brief Wait for all the Senders to connect
@@ -156,7 +156,7 @@ class SocketReceiver : public Receiver {
     * Wait() is not thread-safe and only one thread can invoke this API. It's
     * non-blocking and wait until Finalize() is called explicitly.
     */
-   bool Wait(const char *addr, int num_sender) override;
+    bool Wait(const char *addr, int num_sender) override;
 
    /*!
     * \brief Recv data from Sender. Actually removing data from msg_queue.
@@ -170,7 +170,7 @@ class SocketReceiver : public Receiver {
     * (3) Memory allocated by communicator but will not own it after the
     * function returns.
     */
-   STATUS Recv(Message *msg, int *send_id);
+    STATUS Recv(Message *msg, int *send_id);
 
    /*!
     * \brief Recv data from a specified Sender. Actually removing data from msg_queue.
@@ -184,19 +184,19 @@ class SocketReceiver : public Receiver {
     * (3) Memory allocated by communicator but will not own it after the
     * function returns.
     */
-   STATUS RecvFrom(Message *msg, int send_id);
+    STATUS RecvFrom(Message *msg, int send_id);
 
    /*!
     * \brief Finalize SocketReceiver
     *
     * Finalize() is not thread-safe and only one thread can invoke this API.
     */
-   void Finalize();
+    void Finalize();
 
    /*!
     * \brief Communicator type: 'socket'
     */
-   inline std::string Type() const { return std::string("socket"); }
+    inline std::string Type() const { return std::string("socket"); }
 
  private:
   struct RecvContext {

--- a/src/rpc/network/socket_communicator.h
+++ b/src/rpc/network/socket_communicator.h
@@ -173,8 +173,9 @@ class SocketReceiver : public Receiver {
    STATUS Recv(Message *msg, int *send_id);
 
    /*!
-    * \brief Recv data from a specified Sender. Actually removing data from
-    * msg_queue. \param msg pointer of data message \param send_id sender's ID
+    * \brief Recv data from a specified Sender. Actually removing data from msg_queue.
+    * \param msg pointer of data message
+    * \param send_id sender's ID
     * \return Status code
     *
     * (1) The RecvFrom() API is blocking, which will not

--- a/src/rpc/network/socket_pool.cc
+++ b/src/rpc/network/socket_pool.cc
@@ -116,5 +116,5 @@ void SocketPool::Wait() {
 #endif
 }
 
-} // namespace network
-} // namespace dgl
+}  // namespace network
+}  // namespace dgl

--- a/src/rpc/network/socket_pool.cc
+++ b/src/rpc/network/socket_pool.cc
@@ -104,6 +104,8 @@ void SocketPool::Wait() {
 
 SocketPool::SocketPool() { LOG(FATAL) << "Not implemented..."; }
 
+SocketPool::SocketPool(SocketPool&&) { LOG(FATAL) << "Not implemented..."; }
+
 void SocketPool::AddSocket(std::shared_ptr<TCPSocket> socket, int socket_id,
                            int events) {
   LOG(FATAL) << "Not implemented...";

--- a/src/rpc/network/socket_pool.cc
+++ b/src/rpc/network/socket_pool.cc
@@ -4,13 +4,11 @@
  * \brief Socket pool of nonblocking sockets for DGL distributed training.
  */
 #include "socket_pool.h"
-
-#include "tcp_socket.h"
 #include <dmlc/logging.h>
-
 #if defined(__linux__)
 #include <sys/epoll.h>
 #endif
+#include "tcp_socket.h"
 
 namespace dgl {
 namespace network {
@@ -126,5 +124,5 @@ void SocketPool::Wait() { LOG(FATAL) << "Not implemented..."; }
 
 #endif
 
-} // namespace network
-} // namespace dgl
+}  // namespace network
+}  // namespace dgl

--- a/src/rpc/network/socket_pool.cc
+++ b/src/rpc/network/socket_pool.cc
@@ -104,7 +104,8 @@ void SocketPool::Wait() {
 
 SocketPool::SocketPool() { LOG(FATAL) << "Not implemented..."; }
 
-void SocketPool::AddSocket(std::shared_ptr<TCPSocket> socket, int socket_id) {
+void SocketPool::AddSocket(std::shared_ptr<TCPSocket> socket, int socket_id,
+                           int events) {
   LOG(FATAL) << "Not implemented...";
 }
 

--- a/src/rpc/network/socket_pool.h
+++ b/src/rpc/network/socket_pool.h
@@ -9,6 +9,7 @@
 #include <unordered_map>
 #include <queue>
 #include <memory>
+#include <mutex>
 
 namespace dgl {
 namespace network {
@@ -35,6 +36,7 @@ class SocketPool {
    * \brief SocketPool constructor
    */
   SocketPool();
+  SocketPool(SocketPool&&);
 
   /*!
    * \brief Add a socket to SocketPool
@@ -89,6 +91,11 @@ class SocketPool {
    * \brief queue for current active fds
    */
   std::queue<int> pending_fds_;
+
+  /*!
+   * \brief mutex for safe access
+   */
+  std::mutex mtx_;
 };
 
 }  // namespace network

--- a/src/rpc/network/tcp_socket.cc
+++ b/src/rpc/network/tcp_socket.cc
@@ -99,9 +99,11 @@ bool TCPSocket::Accept(TCPSocket * socket, std::string * ip, int * port) {
   } while (sock_client == -1 && errno == EINTR);
 
   if (sock_client < 0) {
-    LOG(ERROR) << "Failed accept connection on " << *ip << ":" << *port
-               << ", error: " << strerror(errno)
-               << (errno == EAGAIN ? " SO_RCVTIMEO timeout reached" : "");
+    // Let's suppress no connection present info for nonblocking socket.
+    if (errno != EAGAIN && errno != EWOULDBLOCK) {
+      LOG(ERROR) << "Failed accept connection on " << *ip << ":" << *port
+                 << ", error: " << strerror(errno);
+    }
     return false;
   }
 

--- a/src/rpc/rpc.cc
+++ b/src/rpc/rpc.cc
@@ -124,13 +124,14 @@ DGL_REGISTER_GLOBAL("distributed.rpc._CAPI_DGLRPCReceiverWait")
   std::string ip = args[0];
   int port = args[1];
   int num_sender = args[2];
+  bool blocking = args[3];
   std::string addr;
   if (RPCContext::ThreadLocal()->receiver->Type() == "socket") {
     addr = StringPrintf("socket://%s:%d", ip.c_str(), port);
   } else {
     LOG(FATAL) << "Unknown communicator type: " << RPCContext::ThreadLocal()->receiver->Type();
   }
-  if (RPCContext::ThreadLocal()->receiver->Wait(addr.c_str(), num_sender) == false) {
+  if (RPCContext::ThreadLocal()->receiver->Wait(addr.c_str(), num_sender, blocking) == false) {
     LOG(FATAL) << "Wait sender socket failed.";
   }
 });

--- a/tests/distributed/test_dist_graph_store.py
+++ b/tests/distributed/test_dist_graph_store.py
@@ -595,6 +595,10 @@ def test_server_client():
     check_server_client(True, 1, 1)
     check_server_client(False, 1, 1)
     check_server_client(True, 2, 2)
+    # handle many clients with a few working threads in receiver
+    os.environ['DGL_SOCKET_MAX_THREAD_COUNT'] = '2'
+    check_server_client(True, 2, os.cpu_count())
+    del(os.environ['DGL_SOCKET_MAX_THREAD_COUNT'])
 
 @unittest.skipIf(os.name == 'nt', reason='Do not support windows yet')
 @unittest.skipIf(dgl.backend.backend_name == "tensorflow", reason="TF doesn't support distributed DistEmbedding")

--- a/tests/distributed/test_dist_graph_store.py
+++ b/tests/distributed/test_dist_graph_store.py
@@ -595,10 +595,6 @@ def test_server_client():
     check_server_client(True, 1, 1)
     check_server_client(False, 1, 1)
     check_server_client(True, 2, 2)
-    # handle many clients with a few working threads in receiver
-    os.environ['DGL_SOCKET_MAX_THREAD_COUNT'] = '2'
-    check_server_client(True, 2, os.cpu_count())
-    del(os.environ['DGL_SOCKET_MAX_THREAD_COUNT'])
 
 @unittest.skipIf(os.name == 'nt', reason='Do not support windows yet')
 @unittest.skipIf(dgl.backend.backend_name == "tensorflow", reason="TF doesn't support distributed DistEmbedding")


### PR DESCRIPTION
improve receiver to wait in non-blocking way
other changes includes:
1. always use epoll on linux and dummy on windows
2. remove blocking waiting in SocketPool::GetActiveSocket

## Description
<!-- Brief description. Refer to the related issues if existed.
It'll be great if relevant reviewers can be assigned as well.-->
This is the 1st part of **support long live graph server in dist so that multiple client groups could join/leave freely**.
Basically, here's my schedule:
1. change C++_receiver to wait in non-blocking way and always be able to accept new connections from senders.
2. change C++_sender to be able to connect/disconnect to receiver one by one while the current one works in a blocking way.
3. attach group_id/client_id for each request msg in python level so that server could manage clients into groups.
4. change launch script to support long live server and multiple client groups.

## Checklist
Please feel free to remove inapplicable items for your PR.
- [ ] The PR title starts with [$CATEGORY] (such as [NN], [Model], [Doc], [Feature]])
- [ ] Changes are complete (i.e. I finished coding on this PR)
- [ ] All changes have test coverage
- [ ] Code is well-documented
- [ ] To the best of my knowledge, examples are either not affected by this change,
      or have been fixed to be compatible with this change
- [ ] Related issue is referred in this PR
- [ ] If the PR is for a new model/paper, I've updated the example index [here](../examples/README.md).

## Changes
<!-- You could use following template
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)
-->
