### PR TITLE
[NN] Fix GATv2Conv residual for mini-batch

### DIFF
--- a/python/dgl/nn/pytorch/conv/gatv2conv.py
+++ b/python/dgl/nn/pytorch/conv/gatv2conv.py
@@ -287,6 +287,7 @@ class GATv2Conv(nn.Module):
                         -1, self._num_heads, self._out_feats)
                 if graph.is_block:
                     feat_dst = feat_src[:graph.number_of_dst_nodes()]
+                    h_dst = h_dst[:graph.number_of_dst_nodes()]
             graph.srcdata.update({'el': feat_src})# (num_src_edge, num_heads, out_dim)
             graph.dstdata.update({'er': feat_dst})
             graph.apply_edges(fn.u_add_v('el', 'er', 'e'))


### PR DESCRIPTION
## Description
Added inputs slicing to choose destination node feats from mini-batch. This fix error with wrong size of `resval` tensor when residual connections are used in mini-batch training.

## Checklist
Please feel free to remove inapplicable items for your PR.
- [x] The PR title starts with [$CATEGORY] (such as [NN], [Model], [Doc], [Feature]])
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] To the best of my knowledge, examples are either not affected by this change,
      or have been fixed to be compatible with this change
