### PR TITLE
[Bug Fix] Make modules using reducers like GINConv pickleable

### DIFF
--- a/python/dgl/function/reducer.py
+++ b/python/dgl/function/reducer.py
@@ -77,7 +77,8 @@ def _gen_reduce_builtin(reducer):
 
     def func(msg, out):
         return SimpleReduceFunction(reducer, msg, out)
-    func.__name__ = reducer
+    func.__name__ = str(reducer)
+    func.__qualname__ = str(reducer)
     func.__doc__ = docstring
     return func
 


### PR DESCRIPTION
## Description
#2278
Some modules like GINConv are not pickleable and thus, cannot be saved as a whole model, because their `__qualname__` is still the original ones (i.e., `_gen_reduce_builtin.<locals>.func`).
 

## Checklist
Please feel free to remove inapplicable items for your PR.
- [x] The PR title starts with [$CATEGORY] (such as [NN], [Model], [Doc], [Feature]])
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] To the best of my knowledge, examples are either not affected by this change,
      or have been fixed to be compatible with this change
- [x] Related issue is referred in this PR

## Changes
- [x] To make the reduce functions generated in `dgl.function` pickleable, I set the` __name__` and `__qualname__` attributes for them.
