### PR TITLE
[Sampling] Separate DistNodeDataLoader from NodeDataLoader

### DIFF
--- a/docs/source/api/python/dgl.dataloading.rst
+++ b/docs/source/api/python/dgl.dataloading.rst
@@ -17,6 +17,8 @@ and an ``EdgeDataLoader`` for edge/link prediction task.
 .. autoclass:: NodeDataLoader
 .. autoclass:: EdgeDataLoader
 .. autoclass:: GraphDataLoader
+.. autoclass:: DistNodeDataLoader
+.. autoclass:: DistEdgeDataLoader
 
 .. _api-dataloading-neighbor-sampling:
 

--- a/docs/source/guide/distributed-apis.rst
+++ b/docs/source/guide/distributed-apis.rst
@@ -202,20 +202,20 @@ DGL provides two levels of APIs for sampling nodes and edges to generate mini-ba
 (see the section of mini-batch training). The low-level APIs require users to write code
 to explicitly define how a layer of nodes are sampled (e.g., using :func:`dgl.sampling.sample_neighbors` ).
 The high-level sampling APIs implement a few popular sampling algorithms for node classification
-and link prediction tasks (e.g., :class:`~dgl.dataloading.pytorch.NodeDataloader` and
-:class:`~dgl.dataloading.pytorch.EdgeDataloader` ).
+and link prediction tasks (e.g., :class:`~dgl.dataloading.pytorch.NodeDataLoader` and
+:class:`~dgl.dataloading.pytorch.EdgeDataLoader` ).
 
 The distributed sampling module follows the same design and provides two levels of sampling APIs.
 For the lower-level sampling API, it provides :func:`~dgl.distributed.sample_neighbors` for
 distributed neighborhood sampling on :class:`~dgl.distributed.DistGraph`. In addition, DGL provides
-a distributed Dataloader (:class:`~dgl.distributed.DistDataLoader` ) for distributed sampling.
-The distributed Dataloader has the same interface as Pytorch DataLoader except that users cannot
+a distributed DataLoader (:class:`~dgl.distributed.DistDataLoader` ) for distributed sampling.
+The distributed DataLoader has the same interface as Pytorch DataLoader except that users cannot
 specify the number of worker processes when creating a dataloader. The worker processes are created
 in :func:`dgl.distributed.initialize`.
 
 **Note**: When running :func:`dgl.distributed.sample_neighbors` on :class:`~dgl.distributed.DistGraph`,
-the sampler cannot run in Pytorch Dataloader with multiple worker processes. The main reason is that
-Pytorch Dataloader creates new sampling worker processes in every epoch, which leads to creating and
+the sampler cannot run in Pytorch DataLoader with multiple worker processes. The main reason is that
+Pytorch DataLoader creates new sampling worker processes in every epoch, which leads to creating and
 destroying :class:`~dgl.distributed.DistGraph` objects many times.
 
 When using the low-level API, the sampling code is similar to single-process sampling. The only
@@ -240,17 +240,17 @@ difference is that users need to use :func:`dgl.distributed.sample_neighbors` an
         for batch in dataloader:
             ...
 
-The same high-level sampling APIs (:class:`~dgl.dataloading.pytorch.NodeDataloader` and
-:class:`~dgl.dataloading.pytorch.EdgeDataloader` ) work for both :class:`~dgl.DGLGraph`
-and :class:`~dgl.distributed.DistGraph`. When using :class:`~dgl.dataloading.pytorch.NodeDataloader`
-and :class:`~dgl.dataloading.pytorch.EdgeDataloader`, the distributed sampling code is exactly
-the same as single-process sampling.
+The high-level sampling APIs (:class:`~dgl.dataloading.pytorch.NodeDataLoader` and
+:class:`~dgl.dataloading.pytorch.EdgeDataLoader` ) has distributed counterparts
+(:class:`~dgl.dataloading.pytorch.DistNodeDataLoader` and
+:class:`~dgl.dataloading.pytorch.DistEdgeDataLoader`).  The code is exactly the
+same as single-process sampling otherwise.
 
 .. code:: python
 
     sampler = dgl.sampling.MultiLayerNeighborSampler([10, 25])
-    dataloader = dgl.sampling.NodeDataLoader(g, train_nid, sampler,
-                                             batch_size=batch_size, shuffle=True)
+    dataloader = dgl.sampling.DistNodeDataLoader(g, train_nid, sampler,
+                                                 batch_size=batch_size, shuffle=True)
     for batch in dataloader:
         ...
 

--- a/docs/source/guide_cn/distributed-apis.rst
+++ b/docs/source/guide_cn/distributed-apis.rst
@@ -214,19 +214,19 @@ DGL提供了两个级别的API，用于对节点和边进行采样以生成小�
         for batch in dataloader:
             ...
 
-:class:`~dgl.DGLGraph` 和 :class:`~dgl.distributed.DistGraph` 都可以使用相同的高级采样API(
 :class:`~dgl.dataloading.pytorch.NodeDataloader`
 和
-:class:`~dgl.dataloading.pytorch.EdgeDataloader`)。使用
-:class:`~dgl.dataloading.pytorch.NodeDataloader`
+:class:`~dgl.dataloading.pytorch.EdgeDataloader` 有分布式的版本
+:class:`~dgl.dataloading.pytorch.DistNodeDataloader`
 和
-:class:`~dgl.dataloading.pytorch.EdgeDataloader` 时，分布式采样代码与单进程采样完全相同。
+:class:`~dgl.dataloading.pytorch.DistEdgeDataloader` 。使用
+时分布式采样代码与单进程采样几乎完全相同。
 
 .. code:: python
 
     sampler = dgl.sampling.MultiLayerNeighborSampler([10, 25])
-    dataloader = dgl.sampling.NodeDataLoader(g, train_nid, sampler,
-                                             batch_size=batch_size, shuffle=True)
+    dataloader = dgl.sampling.DistNodeDataLoader(g, train_nid, sampler,
+                                                 batch_size=batch_size, shuffle=True)
     for batch in dataloader:
         ...
 

--- a/docs/source/guide_cn/distributed-apis.rst
+++ b/docs/source/guide_cn/distributed-apis.rst
@@ -177,9 +177,9 @@ DGL提供了一个稀疏的Adagrad优化器 :class:`~dgl.distributed.SparseAdagr
 DGL提供了两个级别的API，用于对节点和边进行采样以生成小批次训练数据(请参阅小批次训练的章节)。
 底层API要求用户编写代码以明确定义如何对节点层进行采样(例如，使用 :func:`dgl.sampling.sample_neighbors` )。
 高层采样API为节点分类和链接预测任务实现了一些流行的采样算法（例如
-:class:`~dgl.dataloading.pytorch.NodeDataloader`
+:class:`~dgl.dataloading.pytorch.NodeDataLoader`
 和
-:class:`~dgl.dataloading.pytorch.EdgeDataloader` )。
+:class:`~dgl.dataloading.pytorch.EdgeDataLoader` )。
 
 分布式采样模块遵循相同的设计，也提供两个级别的采样API。对于底层的采样API，它为
 :class:`~dgl.distributed.DistGraph` 上的分布式邻居采样提供了
@@ -188,7 +188,7 @@ DGL提供了两个级别的API，用于对节点和边进行采样以生成小�
 分布式数据加载器具有与PyTorch DataLoader相同的接口。其中的工作进程(worker)在 :func:`dgl.distributed.initialize` 中创建。
 
 **Note**: 在 :class:`~dgl.distributed.DistGraph` 上运行 :func:`dgl.distributed.sample_neighbors` 时，
-采样器无法在具有多个工作进程的PyTorch Dataloader中运行。主要原因是PyTorch Dataloader在每个训练周期都会创建新的采样工作进程，
+采样器无法在具有多个工作进程的PyTorch DataLoader中运行。主要原因是PyTorch DataLoader在每个训练周期都会创建新的采样工作进程，
 从而导致多次创建和删除 :class:`~dgl.distributed.DistGraph` 对象。
 
 使用底层API时，采样代码类似于单进程采样。唯一的区别是用户需要使用
@@ -214,12 +214,12 @@ DGL提供了两个级别的API，用于对节点和边进行采样以生成小�
         for batch in dataloader:
             ...
 
-:class:`~dgl.dataloading.pytorch.NodeDataloader`
+:class:`~dgl.dataloading.pytorch.NodeDataLoader`
 和
-:class:`~dgl.dataloading.pytorch.EdgeDataloader` 有分布式的版本
-:class:`~dgl.dataloading.pytorch.DistNodeDataloader`
+:class:`~dgl.dataloading.pytorch.EdgeDataLoader` 有分布式的版本
+:class:`~dgl.dataloading.pytorch.DistNodeDataLoader`
 和
-:class:`~dgl.dataloading.pytorch.DistEdgeDataloader` 。使用
+:class:`~dgl.dataloading.pytorch.DistEdgeDataLoader` 。使用
 时分布式采样代码与单进程采样几乎完全相同。
 
 .. code:: python

--- a/docs/source/guide_ko/distributed-apis.rst
+++ b/docs/source/guide_ko/distributed-apis.rst
@@ -132,8 +132,8 @@ DGL은 노드 임베딩들을 필요로 하는 변환 모델(transductive models
 분산 샘플링
 ~~~~~~~~
 
-DGL은 미니-배치를 생성하기 위해 노드 및 에지 샘플링을 하는 두 수준의 API를 제공한다 (미니-배치 학습 섹션 참조). Low-level API는 노드들의 레이어가 어떻게 샘플링될지를 명시적으로 정의하는 코드를 직접 작성해야한다 (예를 들면, :func:`dgl.sampling.sample_neighbors` 사용해서). High-level API는 노드 분류 및 링크 예측(예, :class:`~dgl.dataloading.pytorch.NodeDataloader` 와
-:class:`~dgl.dataloading.pytorch.EdgeDataloader`) 에 사용되는 몇 가지 유명한 샘플링 알고리즘을 구현하고 있다.
+DGL은 미니-배치를 생성하기 위해 노드 및 에지 샘플링을 하는 두 수준의 API를 제공한다 (미니-배치 학습 섹션 참조). Low-level API는 노드들의 레이어가 어떻게 샘플링될지를 명시적으로 정의하는 코드를 직접 작성해야한다 (예를 들면, :func:`dgl.sampling.sample_neighbors` 사용해서). High-level API는 노드 분류 및 링크 예측(예, :class:`~dgl.dataloading.pytorch.NodeDataLoader` 와
+:class:`~dgl.dataloading.pytorch.EdgeDataLoader`) 에 사용되는 몇 가지 유명한 샘플링 알고리즘을 구현하고 있다.
 
 분산 샘플링 모듈도 같은 디자인을 따르고 있고, 두 level의 샘플링 API를 제공한다. Low-level 샘플링 API의 경우, :class:`~dgl.distributed.DistGraph` 에 대한 분산 이웃 샘플링을 위해 :func:`~dgl.distributed.sample_neighbors` 가 있다. 또한, DGL은 분산 샘플링을 위해 분산 데이터 로더, :class:`~dgl.distributed.DistDataLoader` 를 제공한다. 분산 DataLoader는 PyTorch DataLoader와 같은 인터페이스를 갖는데, 다른 점은 사용자가 데이터 로더를 생성할 때 worker 프로세스의 개수를 지정할 수 없다는 점이다. Worker 프로세스들은 :func:`dgl.distributed.initialize` 에서 만들어진다.
 
@@ -159,7 +159,7 @@ Low-level API를 사용할 때, 샘플링 코드는 단일 프로세스 샘플�
         for batch in dataloader:
             ...
 
-동일한 high-level 샘플링 API들(:class:`~dgl.dataloading.pytorch.NodeDataloader` 와 :class:`~dgl.dataloading.pytorch.EdgeDataloader` )이 :class:`~dgl.DGLGraph` 와 :class:`~dgl.distributed.DistGraph` 에 대해서 동작한다. :class:`~dgl.dataloading.pytorch.NodeDataloader` 과 :class:`~dgl.dataloading.pytorch.EdgeDataloader` 를 사용할 때, 분산 샘플링 코드는 싱글-프로세스 샘플링 코드와 정확하게 같다.
+동일한 high-level 샘플링 API들(:class:`~dgl.dataloading.pytorch.NodeDataLoader` 와 :class:`~dgl.dataloading.pytorch.EdgeDataLoader` )이 :class:`~dgl.DGLGraph` 와 :class:`~dgl.distributed.DistGraph` 에 대해서 동작한다. :class:`~dgl.dataloading.pytorch.NodeDataLoader` 과 :class:`~dgl.dataloading.pytorch.EdgeDataLoader` 를 사용할 때, 분산 샘플링 코드는 싱글-프로세스 샘플링 코드와 정확하게 같다.
 
 .. code:: python
 

--- a/docs/source/guide_ko/distributed-apis.rst
+++ b/docs/source/guide_ko/distributed-apis.rst
@@ -164,8 +164,8 @@ Low-level API를 사용할 때, 샘플링 코드는 단일 프로세스 샘플�
 .. code:: python
 
     sampler = dgl.sampling.MultiLayerNeighborSampler([10, 25])
-    dataloader = dgl.sampling.NodeDataLoader(g, train_nid, sampler,
-                                             batch_size=batch_size, shuffle=True)
+    dataloader = dgl.sampling.DistNodeDataLoader(g, train_nid, sampler,
+                                                 batch_size=batch_size, shuffle=True)
     for batch in dataloader:
         ...
 

--- a/examples/pytorch/graphsage/experimental/train_dist_unsupervised.py
+++ b/examples/pytorch/graphsage/experimental/train_dist_unsupervised.py
@@ -69,7 +69,7 @@ class SAGE(nn.Module):
             y = th.zeros(g.number_of_nodes(), self.n_hidden if l != len(self.layers) - 1 else self.n_classes)
 
             sampler = dgl.dataloading.MultiLayerNeighborSampler([None])
-            dataloader = dgl.dataloading.NodeDataLoader(
+            dataloader = dgl.dataloading.DistNodeDataLoader(
                 g,
                 th.arange(g.number_of_nodes()),
                 sampler,

--- a/examples/pytorch/rgcn/experimental/entity_classify_dist.py
+++ b/examples/pytorch/rgcn/experimental/entity_classify_dist.py
@@ -366,7 +366,7 @@ def run(args, device, data):
     val_fanouts = [int(fanout) for fanout in args.validation_fanout.split(',')]
 
     sampler = dgl.dataloading.MultiLayerNeighborSampler(fanouts)
-    dataloader = dgl.dataloading.NodeDataLoader(
+    dataloader = dgl.dataloading.DistNodeDataLoader(
         g,
         {'paper': train_nid},
         sampler,
@@ -375,7 +375,7 @@ def run(args, device, data):
         drop_last=False)
 
     valid_sampler = dgl.dataloading.MultiLayerNeighborSampler(val_fanouts)
-    valid_dataloader = dgl.dataloading.NodeDataLoader(
+    valid_dataloader = dgl.dataloading.DistNodeDataLoader(
         g,
         {'paper': val_nid},
         valid_sampler,
@@ -384,7 +384,7 @@ def run(args, device, data):
         drop_last=False)
 
     test_sampler = dgl.dataloading.MultiLayerNeighborSampler(val_fanouts)
-    test_dataloader = dgl.dataloading.NodeDataLoader(
+    test_dataloader = dgl.dataloading.DistNodeDataLoader(
         g,
         {'paper': test_nid},
         test_sampler,

--- a/examples/pytorch/tgn/dataloading.py
+++ b/examples/pytorch/tgn/dataloading.py
@@ -233,60 +233,6 @@ class TemporalEdgeCollator(EdgeCollator):
         _pop_storages(result[-1], self.g_sampling)
         return result
 
-
-class TemporalEdgeDataLoader(dgl.dataloading.EdgeDataLoader):
-    """ TemporalEdgeDataLoader is an iteratable object to generate blocks for temporal embedding
-    as well as pos and neg pair graph for memory update.
-
-    The batch generated will follow temporal order
-
-    Parameters
-    ----------
-    g : dgl.Heterograph
-        graph for batching the temporal edge id as well as generate negative subgraph
-
-    eids : torch.tensor() or numpy array
-        eids range which to be batched, it is useful to split training validation test dataset
-
-    graph_sampler : dgl.dataloading.BlockSampler
-        temporal neighbor sampler which sample temporal and computationally depend blocks for computation
-
-    device : str
-        'cpu' means load dataset on cpu
-        'cuda' means load dataset on gpu
-
-    collator : dgl.dataloading.EdgeCollator
-        Merge input eid from pytorch dataloader to graph
-
-    Example
-    ----------
-    Please refers to examples/pytorch/tgn/train.py
-
-    """
-
-    def __init__(self, g, eids, graph_sampler, device='cpu', collator=TemporalEdgeCollator, **kwargs):
-        super().__init__(g, eids, graph_sampler, device, **kwargs)
-        collator_kwargs = {}
-        dataloader_kwargs = {}
-        for k, v in kwargs.items():
-            if k in self.collator_arglist:
-                collator_kwargs[k] = v
-            else:
-                dataloader_kwargs[k] = v
-        self.collator = collator(g, eids, graph_sampler, **collator_kwargs)
-
-        assert not isinstance(g, dgl.distributed.DistGraph), \
-            'EdgeDataLoader does not support DistGraph for now. ' \
-            + 'Please use DistDataLoader directly.'
-        self.dataloader = torch.utils.data.DataLoader(
-            self.collator.dataset, collate_fn=self.collator.collate, **dataloader_kwargs)
-        self.device = device
-
-        # Precompute the CSR and CSC representations so each subprocess does not
-        # duplicate.
-        if dataloader_kwargs.get('num_workers', 0) > 0:
-            g.create_formats_()
-
 # ====== Fast Mode ======
 
 # Part of code in reservoir sampling comes from PyG library

--- a/examples/pytorch/tgn/train.py
+++ b/examples/pytorch/tgn/train.py
@@ -11,7 +11,8 @@ from tgn import TGN
 from data_preprocess import TemporalWikipediaDataset, TemporalRedditDataset, TemporalDataset
 from dataloading import (FastTemporalEdgeCollator, FastTemporalSampler,
                          SimpleTemporalEdgeCollator, SimpleTemporalSampler,
-                         TemporalEdgeDataLoader, TemporalSampler, TemporalEdgeCollator)
+                         TemporalSampler, TemporalEdgeCollator)
+from dgl.dataloading import EdgeDataLoader
 
 from sklearn.metrics import average_precision_score, roc_auc_score
 
@@ -197,49 +198,49 @@ if __name__ == "__main__":
         g_sampling.ndata[dgl.NID] = new_node_g_sampling.nodes()
 
     # we highly recommend that you always set the num_workers=0, otherwise the sampled subgraph may not be correct.
-    train_dataloader = TemporalEdgeDataLoader(graph_no_new_node,
-                                              train_seed,
-                                              sampler,
+    train_dataloader = EdgeDataLoader(graph_no_new_node,
+                                      train_seed,
+                                      sampler,
+                                      batch_size=args.batch_size,
+                                      negative_sampler=neg_sampler,
+                                      shuffle=False,
+                                      drop_last=False,
+                                      num_workers=0,
+                                      collator_cls=edge_collator,
+                                      g_sampling=g_sampling)
+
+    valid_dataloader = EdgeDataLoader(graph_no_new_node,
+                                      valid_seed,
+                                      sampler,
+                                      batch_size=args.batch_size,
+                                      negative_sampler=neg_sampler,
+                                      shuffle=False,
+                                      drop_last=False,
+                                      num_workers=0,
+                                      collator_cls=edge_collator,
+                                      g_sampling=g_sampling)
+
+    test_dataloader = EdgeDataLoader(graph_no_new_node,
+                                     test_seed,
+                                     sampler,
+                                     batch_size=args.batch_size,
+                                     negative_sampler=neg_sampler,
+                                     shuffle=False,
+                                     drop_last=False,
+                                     num_workers=0,
+                                     collator_cls=edge_collator,
+                                     g_sampling=g_sampling)
+
+    test_new_node_dataloader = EdgeDataLoader(graph_new_node,
+                                              test_new_node_seed,
+                                              new_node_sampler if args.fast_mode else sampler,
                                               batch_size=args.batch_size,
                                               negative_sampler=neg_sampler,
                                               shuffle=False,
                                               drop_last=False,
                                               num_workers=0,
-                                              collator=edge_collator,
-                                              g_sampling=g_sampling)
-
-    valid_dataloader = TemporalEdgeDataLoader(graph_no_new_node,
-                                              valid_seed,
-                                              sampler,
-                                              batch_size=args.batch_size,
-                                              negative_sampler=neg_sampler,
-                                              shuffle=False,
-                                              drop_last=False,
-                                              num_workers=0,
-                                              collator=edge_collator,
-                                              g_sampling=g_sampling)
-
-    test_dataloader = TemporalEdgeDataLoader(graph_no_new_node,
-                                             test_seed,
-                                             sampler,
-                                             batch_size=args.batch_size,
-                                             negative_sampler=neg_sampler,
-                                             shuffle=False,
-                                             drop_last=False,
-                                             num_workers=0,
-                                             collator=edge_collator,
-                                             g_sampling=g_sampling)
-
-    test_new_node_dataloader = TemporalEdgeDataLoader(graph_new_node,
-                                                      test_new_node_seed,
-                                                      new_node_sampler if args.fast_mode else sampler,
-                                                      batch_size=args.batch_size,
-                                                      negative_sampler=neg_sampler,
-                                                      shuffle=False,
-                                                      drop_last=False,
-                                                      num_workers=0,
-                                                      collator=edge_collator,
-                                                      g_sampling=new_node_g_sampling)
+                                              collator_cls=edge_collator,
+                                              g_sampling=new_node_g_sampling)
 
     edge_dim = data.edata['feats'].shape[1]
     num_node = data.num_nodes()

--- a/examples/pytorch/tgn/train.py
+++ b/examples/pytorch/tgn/train.py
@@ -11,8 +11,7 @@ from tgn import TGN
 from data_preprocess import TemporalWikipediaDataset, TemporalRedditDataset, TemporalDataset
 from dataloading import (FastTemporalEdgeCollator, FastTemporalSampler,
                          SimpleTemporalEdgeCollator, SimpleTemporalSampler,
-                         TemporalSampler, TemporalEdgeCollator)
-from dgl.dataloading import EdgeDataLoader
+                         TemporalEdgeDataLoader, TemporalSampler, TemporalEdgeCollator)
 
 from sklearn.metrics import average_precision_score, roc_auc_score
 
@@ -198,49 +197,49 @@ if __name__ == "__main__":
         g_sampling.ndata[dgl.NID] = new_node_g_sampling.nodes()
 
     # we highly recommend that you always set the num_workers=0, otherwise the sampled subgraph may not be correct.
-    train_dataloader = EdgeDataLoader(graph_no_new_node,
-                                      train_seed,
-                                      sampler,
-                                      batch_size=args.batch_size,
-                                      negative_sampler=neg_sampler,
-                                      shuffle=False,
-                                      drop_last=False,
-                                      num_workers=0,
-                                      collator_cls=edge_collator,
-                                      g_sampling=g_sampling)
-
-    valid_dataloader = EdgeDataLoader(graph_no_new_node,
-                                      valid_seed,
-                                      sampler,
-                                      batch_size=args.batch_size,
-                                      negative_sampler=neg_sampler,
-                                      shuffle=False,
-                                      drop_last=False,
-                                      num_workers=0,
-                                      collator_cls=edge_collator,
-                                      g_sampling=g_sampling)
-
-    test_dataloader = EdgeDataLoader(graph_no_new_node,
-                                     test_seed,
-                                     sampler,
-                                     batch_size=args.batch_size,
-                                     negative_sampler=neg_sampler,
-                                     shuffle=False,
-                                     drop_last=False,
-                                     num_workers=0,
-                                     collator_cls=edge_collator,
-                                     g_sampling=g_sampling)
-
-    test_new_node_dataloader = EdgeDataLoader(graph_new_node,
-                                              test_new_node_seed,
-                                              new_node_sampler if args.fast_mode else sampler,
+    train_dataloader = TemporalEdgeDataLoader(graph_no_new_node,
+                                              train_seed,
+                                              sampler,
                                               batch_size=args.batch_size,
                                               negative_sampler=neg_sampler,
                                               shuffle=False,
                                               drop_last=False,
                                               num_workers=0,
-                                              collator_cls=edge_collator,
-                                              g_sampling=new_node_g_sampling)
+                                              collator=edge_collator,
+                                              g_sampling=g_sampling)
+
+    valid_dataloader = TemporalEdgeDataLoader(graph_no_new_node,
+                                              valid_seed,
+                                              sampler,
+                                              batch_size=args.batch_size,
+                                              negative_sampler=neg_sampler,
+                                              shuffle=False,
+                                              drop_last=False,
+                                              num_workers=0,
+                                              collator=edge_collator,
+                                              g_sampling=g_sampling)
+
+    test_dataloader = TemporalEdgeDataLoader(graph_no_new_node,
+                                             test_seed,
+                                             sampler,
+                                             batch_size=args.batch_size,
+                                             negative_sampler=neg_sampler,
+                                             shuffle=False,
+                                             drop_last=False,
+                                             num_workers=0,
+                                             collator=edge_collator,
+                                             g_sampling=g_sampling)
+
+    test_new_node_dataloader = TemporalEdgeDataLoader(graph_new_node,
+                                                      test_new_node_seed,
+                                                      new_node_sampler if args.fast_mode else sampler,
+                                                      batch_size=args.batch_size,
+                                                      negative_sampler=neg_sampler,
+                                                      shuffle=False,
+                                                      drop_last=False,
+                                                      num_workers=0,
+                                                      collator=edge_collator,
+                                                      g_sampling=new_node_g_sampling)
 
     edge_dim = data.edata['feats'].shape[1]
     num_node = data.num_nodes()
@@ -293,7 +292,7 @@ if __name__ == "__main__":
             if i < args.epochs-1 and args.fast_mode:
                 sampler.reset()
             print(log_content[0], log_content[1], log_content[2])
-    except:
+    except KeyboardInterrupt:
         traceback.print_exc()
         error_content = "Training Interreputed!"
         f.writelines(error_content)

--- a/python/dgl/dataloading/pytorch/__init__.py
+++ b/python/dgl/dataloading/pytorch/__init__.py
@@ -1,2 +1,3 @@
 """DGL PyTorch DataLoader module."""
 from .dataloader import *
+from .dist_dataloader import *

--- a/python/dgl/dataloading/pytorch/dataloader.py
+++ b/python/dgl/dataloading/pytorch/dataloader.py
@@ -164,14 +164,6 @@ class _ScalarDataBatcher(th.utils.data.IterableDataset):
         """Set epoch number for distributed training."""
         self.epoch = epoch
 
-def _remove_kwargs_dist(kwargs):
-    if 'num_workers' in kwargs:
-        del kwargs['num_workers']
-    if 'pin_memory' in kwargs:
-        del kwargs['pin_memory']
-        print('Distributed DataLoader does not support pin_memory')
-    return kwargs
-
 # The following code is a fix to the PyTorch-specific issue in
 # https://github.com/dmlc/dgl/issues/2137
 #
@@ -287,28 +279,32 @@ def _restore_storages(subgs, g):
         else:
             _restore_subgraph_storage(subg, g)
 
-class _NodeCollator(NodeCollator):
-    def collate(self, items):
-        # input_nodes, output_nodes, blocks
-        result = super().collate(items)
-        _pop_storages(result[-1], self.g)
-        return result
+def _wrap_node_collator(cls):
+    class _NodeCollator(cls):
+        def collate(self, items):
+            # input_nodes, output_nodes, blocks
+            result = super().collate(items)
+            _pop_storages(result[-1], self.g)
+            return result
+    return _NodeCollator
 
-class _EdgeCollator(EdgeCollator):
-    def collate(self, items):
-        if self.negative_sampler is None:
-            # input_nodes, pair_graph, blocks
-            result = super().collate(items)
-            _pop_subgraph_storage(result[1], self.g)
-            _pop_storages(result[-1], self.g_sampling)
-            return result
-        else:
-            # input_nodes, pair_graph, neg_pair_graph, blocks
-            result = super().collate(items)
-            _pop_subgraph_storage(result[1], self.g)
-            _pop_subgraph_storage(result[2], self.g)
-            _pop_storages(result[-1], self.g_sampling)
-            return result
+def _wrap_edge_collator(cls):
+    class _EdgeCollator(cls):
+        def collate(self, items):
+            if self.negative_sampler is None:
+                # input_nodes, pair_graph, blocks
+                result = super().collate(items)
+                _pop_subgraph_storage(result[1], self.g)
+                _pop_storages(result[-1], self.g_sampling)
+                return result
+            else:
+                # input_nodes, pair_graph, neg_pair_graph, blocks
+                result = super().collate(items)
+                _pop_subgraph_storage(result[1], self.g)
+                _pop_subgraph_storage(result[2], self.g)
+                _pop_storages(result[-1], self.g_sampling)
+                return result
+    return _EdgeCollator
 
 class _GraphCollator(GraphCollator):
     def __init__(self, subgraph_iterator, **kwargs):
@@ -325,10 +321,10 @@ def _to_device(data, device):
     return recursive_apply(data, lambda x: x.to(device))
 
 class _NodeDataLoaderIter:
-    def __init__(self, node_dataloader):
+    def __init__(self, node_dataloader, iter_):
         self.device = node_dataloader.device
         self.node_dataloader = node_dataloader
-        self.iter_ = iter(node_dataloader.dataloader)
+        self.iter_ = iter_
         self.async_load = node_dataloader.async_load
         if self.async_load:
             if F.device_type(self.device) != 'cuda':
@@ -350,10 +346,10 @@ class _NodeDataLoaderIter:
         return result
 
 class _EdgeDataLoaderIter:
-    def __init__(self, edge_dataloader):
+    def __init__(self, edge_dataloader, iter_):
         self.device = edge_dataloader.device
         self.edge_dataloader = edge_dataloader
-        self.iter_ = iter(edge_dataloader.dataloader)
+        self.iter_ = iter_
 
     # Make this an iterator for PyTorch Lightning compatibility
     def __iter__(self):
@@ -373,9 +369,9 @@ class _EdgeDataLoaderIter:
         return result
 
 class _GraphDataLoaderIter:
-    def __init__(self, graph_dataloader):
+    def __init__(self, graph_dataloader, iter_):
         self.dataloader = graph_dataloader
-        self.iter_ = iter(graph_dataloader.dataloader)
+        self.iter_ = iter_
 
     def __iter__(self):
         return self
@@ -427,9 +423,9 @@ def _init_dataloader(collator, device, dataloader_kwargs, use_ddp, ddp_seed):
         collate_fn=collator.collate,
         **dataloader_kwargs)
 
-    return use_scalar_batcher, scalar_batcher, dataloader, dist_sampler
+    return use_scalar_batcher, scalar_batcher, dataset, collator, dist_sampler
 
-class NodeDataLoader:
+class NodeDataLoader(DataLoader):
     """PyTorch dataloader for batch-iterating over a set of nodes, generating the list
     of message flow graphs (MFGs) as computation dependency of the said minibatch.
 
@@ -479,6 +475,8 @@ class NodeDataLoader:
         to be transferred. As a disadvantage, underlying `to_block` on GPU
         becomes disabled and could lead to decreased performance. This is a
         trade-off which needs profiling to decide whether to enable it.
+    collator_cls : dgl.dataloading.Collator, optional
+        The collator class.  Default is :class:`dgl.dataloading.NodeCollator`.
     kwargs : dict
         Arguments being passed to :py:class:`torch.utils.data.DataLoader`.
 
@@ -558,7 +556,7 @@ class NodeDataLoader:
 
     def __init__(self, g, nids, graph_sampler, device=None, use_ddp=False, ddp_seed=0,
                  load_input=None, load_output=None, load_ndata=None, load_edata=None,
-                 async_load=False, **kwargs):
+                 async_load=False, collator_cls=NodeCollator, **kwargs):
         collator_kwargs = {}
         dataloader_kwargs = {}
         for k, v in kwargs.items():
@@ -567,75 +565,55 @@ class NodeDataLoader:
             else:
                 dataloader_kwargs[k] = v
 
-        if isinstance(g, DistGraph):
-            if device is None:
-                # for the distributed case default to the CPU
-                device = 'cpu'
-            assert device == 'cpu', 'Only cpu is supported in the case of a DistGraph.'
-            # Distributed DataLoader currently does not support heterogeneous graphs
-            # and does not copy features.  Fallback to normal solution
-            self.collator = NodeCollator(g, nids, graph_sampler, **collator_kwargs)
-            _remove_kwargs_dist(dataloader_kwargs)
-            self.dataloader = DistDataLoader(self.collator.dataset,
-                                             collate_fn=self.collator.collate,
-                                             **dataloader_kwargs)
-            self.is_distributed = True
+        if device is None:
+            # default to the same device the graph is on
+            device = th.device(g.device)
+
+        self.async_load = async_load
+        self.load_input = {} if load_input is None else load_input
+        self.load_output = {} if load_output is None else load_output
+        self.load_ndata = {} if load_ndata is None else load_ndata
+        # TODO(BarclayII): The samplers may not always return edge IDs due to
+        # efficiency concerns (see the comment in BlockSampler.__init__()).
+        # However, the async copy wrapper relies on EID in the returned subgraph
+        # to fetch edge features.  Therefore to make edge feature fetching work,
+        # return_eids must be True.  If we have a graph-level lazy index implemented
+        # we can potentially relax this constraint.
+        if (async_load and load_edata is not None and
+                not getattr(graph_sampler, "return_eids", True)):
+            raise DGLError("sampler's return_eids must be True if load_edata is not None")
+        self.load_edata = {} if load_edata is None else load_edata
+
+        # if the sampler supports it, tell it to output to the specified device.
+        # But if async_load is enabled, set_output_context should be skipped as
+        # we'd like to avoid any graph/data transfer graphs across devices in
+        # sampler. Such transfer will be handled in dataloader.
+        num_workers = dataloader_kwargs.get('num_workers', 0)
+        if ((not async_load) and
+                callable(getattr(graph_sampler, "set_output_context", None)) and
+                num_workers == 0):
+            graph_sampler.set_output_context(to_dgl_context(device))
         else:
-            if device is None:
-                # default to the same device the graph is on
-                device = th.device(g.device)
+            graph_sampler.set_output_context(to_dgl_context(th.device('cpu')))
 
-            self.async_load = async_load
-            self.load_input = {} if load_input is None else load_input
-            self.load_output = {} if load_output is None else load_output
-            self.load_ndata = {} if load_ndata is None else load_ndata
-            # TODO(BarclayII): The samplers may not always return edge IDs due to
-            # efficiency concerns (see the comment in BlockSampler.__init__()).
-            # However, the async copy wrapper relies on EID in the returned subgraph
-            # to fetch edge features.  Therefore to make edge feature fetching work,
-            # return_eids must be True.  If we have a graph-level lazy index implemented
-            # we can potentially relax this constraint.
-            if (async_load and load_edata is not None and
-                    not getattr(graph_sampler, "return_eids", True)):
-                raise DGLError("sampler's return_eids must be True if load_edata is not None")
-            self.load_edata = {} if load_edata is None else load_edata
+        self.collator = _wrap_node_collator(collator_cls)(
+            g, nids, graph_sampler, **collator_kwargs)
+        self.use_scalar_batcher, self.scalar_batcher, dataset, collator, self.dist_sampler = \
+            _init_dataloader(self.collator, device, dataloader_kwargs, use_ddp, ddp_seed)
+        super().__init__(dataset, collate_fn=collator.collate, **dataloader_kwargs)
 
-            # if the sampler supports it, tell it to output to the specified device.
-            # But if async_load is enabled, set_output_context should be skipped as
-            # we'd like to avoid any graph/data transfer graphs across devices in
-            # sampler. Such transfer will be handled in dataloader.
-            num_workers = dataloader_kwargs.get('num_workers', 0)
-            if ((not async_load) and
-                    callable(getattr(graph_sampler, "set_output_context", None)) and
-                    num_workers == 0):
-                graph_sampler.set_output_context(to_dgl_context(device))
-            else:
-                graph_sampler.set_output_context(to_dgl_context(th.device('cpu')))
+        self.use_ddp = use_ddp
+        self.is_distributed = False
 
-            self.collator = _NodeCollator(g, nids, graph_sampler, **collator_kwargs)
-            self.use_scalar_batcher, self.scalar_batcher, self.dataloader, self.dist_sampler = \
-                _init_dataloader(self.collator, device, dataloader_kwargs, use_ddp, ddp_seed)
-
-            self.use_ddp = use_ddp
-            self.is_distributed = False
-
-            # Precompute the CSR and CSC representations so each subprocess does not
-            # duplicate.
-            if num_workers > 0:
-                g.create_formats_()
+        # Precompute the CSR and CSC representations so each subprocess does not
+        # duplicate.
+        if num_workers > 0:
+            g.create_formats_()
         self.device = device
 
     def __iter__(self):
         """Return the iterator of the data loader."""
-        if self.is_distributed:
-            # Directly use the iterator of DistDataLoader, which doesn't copy features anyway.
-            return iter(self.dataloader)
-        else:
-            return _NodeDataLoaderIter(self)
-
-    def __len__(self):
-        """Return the number of batches of the data loader."""
-        return len(self.dataloader)
+        return _NodeDataLoaderIter(self, super().__iter__())
 
     def set_epoch(self, epoch):
         """Sets the epoch number for the underlying sampler which ensures all replicas
@@ -658,7 +636,7 @@ class NodeDataLoader:
         else:
             raise DGLError('set_epoch is only available when use_ddp is True.')
 
-class EdgeDataLoader:
+class EdgeDataLoader(DataLoader):
     """PyTorch dataloader for batch-iterating over a set of edges, generating the list
     of message flow graphs (MFGs) as computation dependency of the said minibatch for
     edge classification, edge regression, and link prediction.
@@ -749,6 +727,8 @@ class EdgeDataLoader:
         :class:`torch.utils.data.distributed.DistributedSampler`.
 
         Only effective when :attr:`use_ddp` is True.
+    collator_cls : dgl.dataloading.Collator, optional
+        The collator class.  Default is :class:`dgl.dataloading.EdgeCollator`.
     kwargs : dict
         Arguments being passed to :py:class:`torch.utils.data.DataLoader`.
 
@@ -867,7 +847,8 @@ class EdgeDataLoader:
     """
     collator_arglist = inspect.getfullargspec(EdgeCollator).args
 
-    def __init__(self, g, eids, graph_sampler, device='cpu', use_ddp=False, ddp_seed=0, **kwargs):
+    def __init__(self, g, eids, graph_sampler, device='cpu', use_ddp=False, ddp_seed=0,
+                 collator_cls=EdgeCollator, **kwargs):
         collator_kwargs = {}
         dataloader_kwargs = {}
         for k, v in kwargs.items():
@@ -876,53 +857,31 @@ class EdgeDataLoader:
             else:
                 dataloader_kwargs[k] = v
 
-        if isinstance(g, DistGraph):
-            if device is None:
-                # for the distributed case default to the CPU
-                device = 'cpu'
-            assert device == 'cpu', 'Only cpu is supported in the case of a DistGraph.'
-            # Distributed DataLoader currently does not support heterogeneous graphs
-            # and does not copy features.  Fallback to normal solution
-            self.collator = EdgeCollator(g, eids, graph_sampler, **collator_kwargs)
-            _remove_kwargs_dist(dataloader_kwargs)
-            self.dataloader = DistDataLoader(self.collator.dataset,
-                                             collate_fn=self.collator.collate,
-                                             **dataloader_kwargs)
-            self.is_distributed = True
-        else:
             if device is None:
                 # default to the same device the graph is on
                 device = th.device(g.device)
 
-            # if the sampler supports it, tell it to output to the
-            # specified device
-            num_workers = dataloader_kwargs.get('num_workers', 0)
-            if callable(getattr(graph_sampler, "set_output_context", None)) and num_workers == 0:
-                graph_sampler.set_output_context(to_dgl_context(device))
+        # if the sampler supports it, tell it to output to the
+        # specified device
+        num_workers = dataloader_kwargs.get('num_workers', 0)
+        if callable(getattr(graph_sampler, "set_output_context", None)) and num_workers == 0:
+            graph_sampler.set_output_context(to_dgl_context(device))
 
-            self.collator = _EdgeCollator(g, eids, graph_sampler, **collator_kwargs)
-            self.use_scalar_batcher, self.scalar_batcher, self.dataloader, self.dist_sampler = \
-                    _init_dataloader(self.collator, device, dataloader_kwargs, use_ddp, ddp_seed)
-            self.use_ddp = use_ddp
-            self.is_distributed = False
+        self.collator = _wrap_edge_collator(collator_cls)(
+            g, eids, graph_sampler, **collator_kwargs)
+        self.use_scalar_batcher, self.scalar_batcher, dataset, collator, self.dist_sampler = \
+                _init_dataloader(self.collator, device, dataloader_kwargs, use_ddp, ddp_seed)
+        self.use_ddp = use_ddp
+        super().__init__(dataset, collate_fn=collator.collate, **dataloader_kwargs)
 
-            # Precompute the CSR and CSC representations so each subprocess does not duplicate.
-            if num_workers > 0:
-                g.create_formats_()
+        # Precompute the CSR and CSC representations so each subprocess does not duplicate.
+        if num_workers > 0:
+            g.create_formats_()
 
         self.device = device
 
     def __iter__(self):
-        """Return the iterator of the data loader."""
-        if self.is_distributed:
-            # Directly use the iterator of DistDataLoader, which doesn't copy features anyway.
-            return iter(self.dataloader)
-        else:
-            return _EdgeDataLoaderIter(self)
-
-    def __len__(self):
-        """Return the number of batches of the data loader."""
-        return len(self.dataloader)
+        return _EdgeDataLoaderIter(self, super().__iter__())
 
     def set_epoch(self, epoch):
         """Sets the epoch number for the underlying sampler which ensures all replicas
@@ -945,7 +904,7 @@ class EdgeDataLoader:
         else:
             raise DGLError('set_epoch is only available when use_ddp is True.')
 
-class GraphDataLoader:
+class GraphDataLoader(DataLoader):
     """PyTorch dataloader for batch-iterating over a set of graphs, generating the batched
     graph and corresponding label tensor (if provided) of the said minibatch.
 
@@ -1027,14 +986,11 @@ class GraphDataLoader:
         if use_ddp:
             self.dist_sampler = _create_dist_sampler(dataset, dataloader_kwargs, ddp_seed)
             dataloader_kwargs['sampler'] = self.dist_sampler
-
-        self.dataloader = DataLoader(dataset=dataset,
-                                     collate_fn=self.collate,
-                                     **dataloader_kwargs)
+        super().__init__(dataset, collate_fn=self.collate, **dataloader_kwargs)
 
     def __iter__(self):
         """Return the iterator of the data loader."""
-        return _GraphDataLoaderIter(self)
+        return _GraphDataLoaderIter(self, super().__iter__())
 
     def __len__(self):
         """Return the number of batches of the data loader."""

--- a/python/dgl/dataloading/pytorch/dist_dataloader.py
+++ b/python/dgl/dataloading/pytorch/dist_dataloader.py
@@ -1,0 +1,58 @@
+"""Distributed dataloaders.
+"""
+from ...distributed import DistDataLoader
+from ..dataloader import NodeCollator, EdgeCollator
+
+def _remove_kwargs_dist(kwargs):
+    if 'num_workers' in kwargs:
+        del kwargs['num_workers']
+    if 'pin_memory' in kwargs:
+        del kwargs['pin_memory']
+        print('Distributed DataLoaders do not support pin_memory.')
+    return kwargs
+
+class DistNodeDataLoader(DistDataLoader):
+    def __init__(self, g, nids, graph_sampler, device=None, **kwargs):
+        collator_kwargs = {}
+        dataloader_kwargs = {}
+        for k, v in kwargs.items():
+            if k in self.collator_arglist:
+                collator_kwargs[k] = v
+            else:
+                dataloader_kwargs[k] = v
+        if device is None:
+            # for the distributed case default to the CPU
+            device = 'cpu'
+        assert device == 'cpu', 'Only cpu is supported in the case of a DistGraph.'
+        # Distributed DataLoader currently does not support heterogeneous graphs
+        # and does not copy features.  Fallback to normal solution
+        self.collator = NodeCollator(g, nids, graph_sampler, **collator_kwargs)
+        _remove_kwargs_dist(dataloader_kwargs)
+        super().__init__(self.collator.dataset,
+                         collate_fn=self.collator.collate,
+                         **dataloader_kwargs)
+        self.device = device
+
+class DistEdgeDataLoader(DistDataLoader):
+    def __init__(self, g, eids, graph_sampler, device=None, **kwargs):
+        collator_kwargs = {}
+        dataloader_kwargs = {}
+        for k, v in kwargs.items():
+            if k in self.collator_arglist:
+                collator_kwargs[k] = v
+            else:
+                dataloader_kwargs[k] = v
+
+        if device is None:
+            # for the distributed case default to the CPU
+            device = 'cpu'
+        assert device == 'cpu', 'Only cpu is supported in the case of a DistGraph.'
+        # Distributed DataLoader currently does not support heterogeneous graphs
+        # and does not copy features.  Fallback to normal solution
+        self.collator = EdgeCollator(g, eids, graph_sampler, **collator_kwargs)
+        _remove_kwargs_dist(dataloader_kwargs)
+        self.dataloader = DistDataLoader(self.collator.dataset,
+                                         collate_fn=self.collator.collate,
+                                         **dataloader_kwargs)
+
+        self.device = device

--- a/python/dgl/dataloading/pytorch/dist_dataloader.py
+++ b/python/dgl/dataloading/pytorch/dist_dataloader.py
@@ -35,8 +35,9 @@ class DistNodeDataLoader(DistDataLoader):
     def __init__(self, g, nids, graph_sampler, device=None, **kwargs):
         collator_kwargs = {}
         dataloader_kwargs = {}
+        _collator_arglist = inspect.getfullargspec(NodeCollator).args
         for k, v in kwargs.items():
-            if k in self.collator_arglist:
+            if k in _collator_arglist:
                 collator_kwargs[k] = v
             else:
                 dataloader_kwargs[k] = v
@@ -78,8 +79,9 @@ class DistEdgeDataLoader(DistDataLoader):
     def __init__(self, g, eids, graph_sampler, device=None, **kwargs):
         collator_kwargs = {}
         dataloader_kwargs = {}
+        _collator_arglist = inspect.getfullargspec(EdgeCollator).args
         for k, v in kwargs.items():
-            if k in self.collator_arglist:
+            if k in _collator_arglist:
                 collator_kwargs[k] = v
             else:
                 dataloader_kwargs[k] = v
@@ -92,8 +94,8 @@ class DistEdgeDataLoader(DistDataLoader):
         # and does not copy features.  Fallback to normal solution
         self.collator = EdgeCollator(g, eids, graph_sampler, **collator_kwargs)
         _remove_kwargs_dist(dataloader_kwargs)
-        self.dataloader = DistDataLoader(self.collator.dataset,
-                                         collate_fn=self.collator.collate,
-                                         **dataloader_kwargs)
+        super().__init__(self.collator.dataset,
+                         collate_fn=self.collator.collate,
+                         **dataloader_kwargs)
 
         self.device = device

--- a/python/dgl/dataloading/pytorch/dist_dataloader.py
+++ b/python/dgl/dataloading/pytorch/dist_dataloader.py
@@ -12,6 +12,26 @@ def _remove_kwargs_dist(kwargs):
     return kwargs
 
 class DistNodeDataLoader(DistDataLoader):
+    """PyTorch dataloader for batch-iterating over a set of nodes, generating the list
+    of message flow graphs (MFGs) as computation dependency of the said minibatch, on
+    a distributed graph.
+
+    All the arguments have the same meaning as the single-machine counterpart
+    :class:`dgl.dataloading.pytorch.NodeDataLoader` except the first argument
+    :attr:`g` which must be a :class:`dgl.distributed.DistGraph`.
+
+    Parameters
+    ----------
+    g : DistGraph
+        The distributed graph.
+
+    nids, graph_sampler, device, kwargs :
+        See :class:`dgl.dataloading.pytorch.NodeDataLoader`.
+
+    See also
+    --------
+    dgl.dataloading.pytorch.NodeDataLoader
+    """
     def __init__(self, g, nids, graph_sampler, device=None, **kwargs):
         collator_kwargs = {}
         dataloader_kwargs = {}
@@ -34,6 +54,27 @@ class DistNodeDataLoader(DistDataLoader):
         self.device = device
 
 class DistEdgeDataLoader(DistDataLoader):
+    """PyTorch dataloader for batch-iterating over a set of edges, generating the list
+    of message flow graphs (MFGs) as computation dependency of the said minibatch for
+    edge classification, edge regression, and link prediction, on a distributed
+    graph.
+
+    All the arguments have the same meaning as the single-machine counterpart
+    :class:`dgl.dataloading.pytorch.EdgeDataLoader` except the first argument
+    :attr:`g` which must be a :class:`dgl.distributed.DistGraph`.
+
+    Parameters
+    ----------
+    g : DistGraph
+        The distributed graph.
+
+    eids, graph_sampler, device, kwargs :
+        See :class:`dgl.dataloading.pytorch.EdgeDataLoader`.
+
+    See also
+    --------
+    dgl.dataloading.pytorch.EdgeDataLoader
+    """
     def __init__(self, g, eids, graph_sampler, device=None, **kwargs):
         collator_kwargs = {}
         dataloader_kwargs = {}

--- a/python/dgl/dataloading/pytorch/dist_dataloader.py
+++ b/python/dgl/dataloading/pytorch/dist_dataloader.py
@@ -1,5 +1,6 @@
 """Distributed dataloaders.
 """
+import inspect
 from ...distributed import DistDataLoader
 from ..dataloader import NodeCollator, EdgeCollator
 

--- a/tests/distributed/test_mp_dataloader.py
+++ b/tests/distributed/test_mp_dataloader.py
@@ -148,14 +148,14 @@ def start_dist_neg_dataloader(rank, tmpdir, num_server, num_workers, orig_nid, g
     num_negs = 5
     sampler = dgl.dataloading.MultiLayerNeighborSampler([5,10])
     negative_sampler=dgl.dataloading.negative_sampler.Uniform(num_negs)
-    dataloader = dgl.dataloading.EdgeDataLoader(dist_graph,
-                                                train_eid,
-                                                sampler,
-                                                batch_size=batch_size,
-                                                negative_sampler=negative_sampler,
-                                                shuffle=True,
-                                                drop_last=False,
-                                                num_workers=num_workers)
+    dataloader = dgl.dataloading.DistEdgeDataLoader(dist_graph,
+                                                    train_eid,
+                                                    sampler,
+                                                    batch_size=batch_size,
+                                                    negative_sampler=negative_sampler,
+                                                    shuffle=True,
+                                                    drop_last=False,
+                                                    num_workers=num_workers)
     for _ in range(2):
         for _, (_, pos_graph, neg_graph, blocks) in zip(range(0, num_edges_to_sample, batch_size), dataloader):
             block = blocks[-1]
@@ -283,7 +283,7 @@ def start_node_dataloader(rank, tmpdir, num_server, num_workers, orig_nid, orig_
     # We need to test creating DistDataLoader multiple times.
     for i in range(2):
         # Create DataLoader for constructing blocks
-        dataloader = dgl.dataloading.NodeDataLoader(
+        dataloader = dgl.dataloading.DistNodeDataLoader(
             dist_graph,
             train_nid,
             sampler,
@@ -334,7 +334,7 @@ def start_edge_dataloader(rank, tmpdir, num_server, num_workers, orig_nid, orig_
     # We need to test creating DistDataLoader multiple times.
     for i in range(2):
         # Create DataLoader for constructing blocks
-        dataloader = dgl.dataloading.EdgeDataLoader(
+        dataloader = dgl.dataloading.DistEdgeDataLoader(
             dist_graph,
             train_eid,
             sampler,

--- a/tutorials/dist/1_node_classification.py
+++ b/tutorials/dist/1_node_classification.py
@@ -265,7 +265,8 @@ Pytorch's `DistributedDataParallel`.
 Distributed mini-batch sampler
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-We can use the same `NodeDataLoader` to create a distributed mini-batch sampler for
+We can use the same :class:`~dgl.dataloading.pytorch.DistNodeDataLoader`, the distributed counterpart
+of :class:`~dgl.dataloading.pytorch.NodeDataLoader`, to create a distributed mini-batch sampler for
 node classification.
 
 
@@ -274,10 +275,10 @@ node classification.
 .. code-block:: python
 
     sampler = dgl.dataloading.MultiLayerNeighborSampler([25,10])
-    train_dataloader = dgl.dataloading.NodeDataLoader(
+    train_dataloader = dgl.dataloading.DistNodeDataLoader(
                                  g, train_nid, sampler, batch_size=1024,
                                  shuffle=True, drop_last=False)
-    valid_dataloader = dgl.dataloading.NodeDataLoader(
+    valid_dataloader = dgl.dataloading.DistNodeDataLoader(
                                  g, valid_nid, sampler, batch_size=1024,
                                  shuffle=False, drop_last=False)
 


### PR DESCRIPTION
## Description
This PR is to split the logic for distributed graphs from `{Node,Edge}DataLoader` into a new class `Dist{Node,Edge}DataLoader`.

## Checklist
Please feel free to remove inapplicable items for your PR.
- [x] The PR title starts with [$CATEGORY] (such as [NN], [Model], [Doc], [Feature]])
- [ ] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage
- [ ] Code is well-documented
- [x] To the best of my knowledge, examples are either not affected by this change,
      or have been fixed to be compatible with this change
