### PR TITLE
[Model] Fix output dimensions of residual connection for GATv2Conv

### DIFF
--- a/python/dgl/nn/pytorch/conv/gatv2conv.py
+++ b/python/dgl/nn/pytorch/conv/gatv2conv.py
@@ -174,7 +174,7 @@ class GATv2Conv(nn.Module):
         self.attn_drop = nn.Dropout(attn_drop)
         self.leaky_relu = nn.LeakyReLU(negative_slope)
         if residual:
-            if self._in_dst_feats != out_feats:
+            if self._in_dst_feats != out_feats * num_heads:
                 self.res_fc = nn.Linear(
                     self._in_dst_feats, num_heads * out_feats, bias=bias)
             else:


### PR DESCRIPTION
## Description
Number of heads needs to be considered for the transformation of the destination features. Otherwise this will crash if residual==True.

## Checklist
Please feel free to remove inapplicable items for your PR.
- [x] The PR title starts with [$CATEGORY] (such as [NN], [Model], [Doc], [Feature]])
- [x] Changes are complete (i.e. I finished coding on this PR)
- [ ] All changes have test coverage
- [x] Code is well-documented
- [x] To the best of my knowledge, examples are either not affected by this change,
      or have been fixed to be compatible with this change
- [ ] Related issue is referred in this PR
- [ ] If the PR is for a new model/paper, I've updated the example index [here](../examples/README.md).