### PR TITLE
Fix CopyVectorToNDArray in src/c_api_common.h

### DIFF
--- a/src/c_api_common.h
+++ b/src/c_api_common.h
@@ -41,7 +41,8 @@ dgl::runtime::NDArray CopyVectorToNDArray(
     const std::vector<DType>& vec) {
   using dgl::runtime::NDArray;
   const int64_t len = vec.size();
-  NDArray a = NDArray::Empty({len}, DLDataType{kDLInt, sizeof(IdType) * 8, 1}, DLContext{kDLCPU, 0});
+  NDArray a = NDArray::Empty({len}, DLDataType{kDLInt, sizeof(IdType) * 8, 1},
+                             DLContext{kDLCPU, 0});
   std::copy(vec.begin(), vec.end(), static_cast<IdType*>(a->data));
   return a;
 }

--- a/src/c_api_common.h
+++ b/src/c_api_common.h
@@ -31,16 +31,17 @@ dgl::runtime::PackedFunc ConvertNDArrayVectorToPackedFunc(
     const std::vector<dgl::runtime::NDArray>& vec);
 
 /*!
- * \brief Copy a vector to an int64_t NDArray.
+ * \brief Copy a vector to an NDArray.
  *
- * The element type of the vector must be convertible to int64_t.
+ * The data type of the NDArray will be IdType, which must be an integer type.
+ * The element type (DType) of the vector must be convertible to IdType.
  */
 template<typename IdType, typename DType>
 dgl::runtime::NDArray CopyVectorToNDArray(
     const std::vector<DType>& vec) {
   using dgl::runtime::NDArray;
   const int64_t len = vec.size();
-  NDArray a = NDArray::Empty({len}, DLDataType{kDLInt, sizeof(IdType), 1}, DLContext{kDLCPU, 0});
+  NDArray a = NDArray::Empty({len}, DLDataType{kDLInt, sizeof(IdType) * 8, 1}, DLContext{kDLCPU, 0});
   std::copy(vec.begin(), vec.end(), static_cast<IdType*>(a->data));
   return a;
 }


### PR DESCRIPTION
## Description
<!-- Brief description. Refer to the related issues if existed.
It'll be great if relevant reviewers can be assigned as well.-->
Minor updates to the implementation and doc of `CopyVectorToNDArray` so that it works for any DType that is convertible to IdType. Relevant post [here](https://discuss.dgl.ai/t/copyvectortondarray-in-src-c-api-common-h/2570?u=hiracatus).

## Checklist
- [x] Changes are complete (i.e. I finished coding on this PR)
- [ ] All changes have test coverage
- [x] Code is well-documented
- [x] To the best of my knowledge, examples are either not affected by this change,
      or have been fixed to be compatible with this change
- [x] Related issue is referred in this PR

## Changes
<!-- You could use following template
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)
-->
