### PR TITLE
Add 'nccl' backend in train_dist.py and fix pad_data function cuda bug

### DIFF
--- a/examples/pytorch/graphsage/experimental/train_dist.py
+++ b/examples/pytorch/graphsage/experimental/train_dist.py
@@ -155,7 +155,7 @@ def evaluate(model, g, inputs, labels, val_nid, test_nid, batch_size, device):
     model.train()
     return compute_acc(pred[val_nid], labels[val_nid]), compute_acc(pred[test_nid], labels[test_nid])
 
-def pad_data(nids):
+def pad_data(nids, device):
     """
     In distributed traning scenario, we need to make sure that each worker has same number of
     batches. Otherwise the synchronization(barrier) is called diffirent times, which results in
@@ -165,7 +165,7 @@ def pad_data(nids):
     the maximum size among all workers.
     """
     import torch.distributed as dist
-    num_nodes = th.tensor(nids.numel())
+    num_nodes = th.tensor(nids.numel()).to(device)
     dist.all_reduce(num_nodes, dist.ReduceOp.MAX)
     max_num_nodes = int(num_nodes)
     nids_length = nids.shape[0]
@@ -183,7 +183,7 @@ def pad_data(nids):
 def run(args, device, data):
     # Unpack data
     train_nid, val_nid, test_nid, in_feats, n_classes, g = data
-    train_nid = pad_data(train_nid)
+    train_nid = pad_data(train_nid, device)
     # Create sampler
     sampler = NeighborSampler(g, [int(fanout) for fanout in args.fan_out.split(',')],
                               dgl.distributed.sample_neighbors, device)
@@ -281,7 +281,7 @@ def run(args, device, data):
 def main(args):
     dgl.distributed.initialize(args.ip_config)
     if not args.standalone:
-        th.distributed.init_process_group(backend='gloo')
+        th.distributed.init_process_group(backend=args.backend)
     g = dgl.distributed.DistGraph(args.graph_name, part_config=args.part_config)
     print('rank:', g.rank())
 
@@ -325,6 +325,7 @@ if __name__ == '__main__':
     parser.add_argument('--part_config', type=str, help='The path to the partition config file')
     parser.add_argument('--num_clients', type=int, help='The number of clients')
     parser.add_argument('--n_classes', type=int, help='the number of classes')
+    parser.add_argument('--backend', type=str, default='nccl', help='pytorch distributed backend')
     parser.add_argument('--num_gpus', type=int, default=-1,
                         help="the number of GPU device. Use -1 for CPU training")
     parser.add_argument('--num_epochs', type=int, default=20)

--- a/examples/pytorch/graphsage/experimental/train_dist.py
+++ b/examples/pytorch/graphsage/experimental/train_dist.py
@@ -326,7 +326,7 @@ if __name__ == '__main__':
     parser.add_argument('--part_config', type=str, help='The path to the partition config file')
     parser.add_argument('--num_clients', type=int, help='The number of clients')
     parser.add_argument('--n_classes', type=int, help='the number of classes')
-    parser.add_argument('--backend', type=str, default='nccl', help='pytorch distributed backend')
+    parser.add_argument('--backend', type=str, default='gloo', help='pytorch distributed backend')
     parser.add_argument('--num_gpus', type=int, default=-1,
                         help="the number of GPU device. Use -1 for CPU training")
     parser.add_argument('--num_epochs', type=int, default=20)

--- a/examples/pytorch/graphsage/experimental/train_dist.py
+++ b/examples/pytorch/graphsage/experimental/train_dist.py
@@ -165,6 +165,7 @@ def pad_data(nids, device):
     the maximum size among all workers.
     """
     import torch.distributed as dist
+    # NCCL backend only supports GPU tensors, thus here we need to allocate it to gpu
     num_nodes = th.tensor(nids.numel()).to(device)
     dist.all_reduce(num_nodes, dist.ReduceOp.MAX)
     max_num_nodes = int(num_nodes)


### PR DESCRIPTION
## Description
<!-- Brief description. Refer to the related issues if existed.
It'll be great if relevant reviewers can be assigned as well.-->

Current train_dist.py does not support 'nccl' backend. Add 'nccl' backend in arguments and fix `pad_data` function bug accordingly.

## Checklist
Please feel free to remove inapplicable items for your PR.
- [ Example ] The PR title starts with [$CATEGORY] (such as [NN], [Model], [Doc], [Feature]])
- [ Y ] Changes are complete (i.e. I finished coding on this PR)
- [ Y ] All changes have test coverage
- [ Y ] Code is well-documented

## Changes
<!-- You could use following template
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)
-->
Add 'nccl' backend in train_dist.py. After adding this backend, train_nid should be placed in GPU if using 'nccl' backend. Fix this bug as well.