### PR TITLE
[Bugfix?] Remove simple graph requirement for to_bidirected

### DIFF
--- a/python/dgl/transform.py
+++ b/python/dgl/transform.py
@@ -709,8 +709,6 @@ def to_bidirected(g, copy_ndata=False, readonly=None):
                 "unidirectional bipartite graphs" \
                 ", but {} is unidirectional bipartite".format(c_etype)
 
-    assert g.is_multigraph is False, "to_bidirected only support simple graph"
-
     g = add_reverse_edges(g, copy_ndata=copy_ndata, copy_edata=False)
     g = to_simple(g, return_counts=None, copy_ndata=copy_ndata, copy_edata=False)
     return g


### PR DESCRIPTION
Currently our `to_bidirected` semantics do not require the graph to be a simple graph in documentation, and the implementation uses `to_simple`.  However, in the code we still check for whether the graph is a multigraph.  This PR lifts this restriction.