### PR TITLE
Disable tensoradapter and "using backend: xxx" log by default

### DIFF
--- a/docs/source/env_var.rst
+++ b/docs/source/env_var.rst
@@ -7,6 +7,10 @@ Global Configurations
     * Values: String (default=``"${HOME}/.dgl"``)
     * The directory to save the DGL configuration files.
 
+* ``DGL_LOG_DEBUG``:
+    * Values: Set to ``"1"`` to enable debug level logging for DGL
+    * Enable debug level logging for DGL
+
 Backend Options
 ---------------
 * ``DGLBACKEND``:

--- a/python/dgl/__init__.py
+++ b/python/dgl/__init__.py
@@ -9,6 +9,9 @@ and transforming graphs.
 # This initializes Winsock and performs cleanup at termination as required
 import socket
 
+# setup logging before everything
+from .logging import enable_verbose_logging
+
 # Should import backend before importing anything else
 from .backend import load_backend, backend_name
 

--- a/python/dgl/_ffi/base.py
+++ b/python/dgl/_ffi/base.py
@@ -7,6 +7,7 @@ import sys
 import os
 import ctypes
 import numpy as np
+import logging
 from . import libinfo
 
 #----------------------------
@@ -136,3 +137,6 @@ def load_tensor_adapter(backend, version):
         raise NotImplementedError('Unsupported system: %s' % sys.platform)
     path = os.path.join(_DIR_NAME, 'tensoradapter', backend, basename)
     tensor_adapter_loaded = (_LIB.DGLLoadTensorAdapter(path.encode('utf-8')) == 0)
+    if not tensor_adapter_loaded:
+        logger = logging.getLogger("dgl-core")
+        logger.warning("Memory optimization with PyTorch is not enabled.")

--- a/python/dgl/_ffi/base.py
+++ b/python/dgl/_ffi/base.py
@@ -6,8 +6,8 @@ from __future__ import absolute_import
 import sys
 import os
 import ctypes
-import numpy as np
 import logging
+import numpy as np
 from . import libinfo
 
 #----------------------------

--- a/python/dgl/backend/__init__.py
+++ b/python/dgl/backend/__init__.py
@@ -4,12 +4,14 @@ import sys
 import os
 import json
 import importlib
+import logging
 
 from . import backend
 from .set_default_backend import set_default_backend
 
 _enabled_apis = set()
 
+logger = logging.getLogger("dgl-core")
 
 def _gen_missing_api(api, mod_name):
     def _missing_api(*args, **kwargs):
@@ -42,7 +44,7 @@ def load_backend(mod_name):
     version = mod.__version__
     load_tensor_adapter(mod_name, version)
 
-    print('Using backend: %s' % mod_name, file=sys.stderr)
+    logger.debug('Using backend: %s' % mod_name)
     mod = importlib.import_module('.%s' % mod_name, __name__)
     thismod = sys.modules[__name__]
     for api in backend.__dict__.keys():

--- a/python/dgl/logging.py
+++ b/python/dgl/logging.py
@@ -6,25 +6,27 @@ def enable_verbose_logging():
     """
     Enable debug level logging for DGL
     """
-    import os
-    import logging
     os.environ["DMLC_LOG_DEBUG"] = "1"
     logger = logging.getLogger("dgl-core")
     logger.setLevel(logging.DEBUG)
     logging.info("DGL's logging level is set to DEBUG")
 
 
-logger = logging.getLogger("dgl-core")
-console = logging.StreamHandler()
-formatter = logging.Formatter(
-    "%(asctime)s %(filename)s:%(lineno)s %(levelname)s p:%(processName)s t:%(threadName)s: %(message)s"
-)
-console.setFormatter(formatter)
-console.setLevel(logging.DEBUG)
-# add the handlers to the logger
-logger.addHandler(console)
-logger.propagate = False
+def _setup_logger():
+    """setup logger"""
+    logger = logging.getLogger("dgl-core")
+    console = logging.StreamHandler()
+    formatter = logging.Formatter(
+        "%(asctime)s %(filename)s:%(lineno)s %(levelname)s p:%(processName)s \
+        t:%(threadName)s: %(message)s"
+    )
+    console.setFormatter(formatter)
+    console.setLevel(logging.DEBUG)
+    logger.addHandler(console)
+    logger.propagate = False
 
+
+_setup_logger()
 if "DGL_LOG_DEBUG" in os.environ and os.environ["DGL_LOG_DEBUG"] == "1":
     enable_verbose_logging()
 else:

--- a/python/dgl/logging.py
+++ b/python/dgl/logging.py
@@ -1,3 +1,4 @@
+"""logging module for DGL"""
 import logging
 import os
 
@@ -24,11 +25,10 @@ def _setup_logger():
     console.setLevel(logging.DEBUG)
     logger.addHandler(console)
     logger.propagate = False
+    logger.setLevel(logging.INFO)
 
 
 _setup_logger()
+
 if "DGL_LOG_DEBUG" in os.environ and os.environ["DGL_LOG_DEBUG"] == "1":
     enable_verbose_logging()
-else:
-    logger = logging.getLogger("dgl-core")
-    logger.setLevel(logging.INFO)

--- a/python/dgl/logging.py
+++ b/python/dgl/logging.py
@@ -30,5 +30,5 @@ def _setup_logger():
 
 _setup_logger()
 
-if "DGL_LOG_DEBUG" in os.environ and os.environ["DGL_LOG_DEBUG"] == "1":
+if os.environ.get("DGL_LOG_DEBUG", None) == "1":
     enable_verbose_logging()

--- a/python/dgl/logging.py
+++ b/python/dgl/logging.py
@@ -1,0 +1,32 @@
+import logging
+import os
+
+
+def enable_verbose_logging():
+    """
+    Enable debug level logging for DGL
+    """
+    import os
+    import logging
+    os.environ["DMLC_LOG_DEBUG"] = "1"
+    logger = logging.getLogger("dgl-core")
+    logger.setLevel(logging.DEBUG)
+    logging.info("DGL's logging level is set to DEBUG")
+
+
+logger = logging.getLogger("dgl-core")
+console = logging.StreamHandler()
+formatter = logging.Formatter(
+    "%(asctime)s %(filename)s:%(lineno)s %(levelname)s p:%(processName)s t:%(threadName)s: %(message)s"
+)
+console.setFormatter(formatter)
+console.setLevel(logging.DEBUG)
+# add the handlers to the logger
+logger.addHandler(console)
+logger.propagate = False
+
+if "DGL_LOG_DEBUG" in os.environ and os.environ["DGL_LOG_DEBUG"] == "1":
+    enable_verbose_logging()
+else:
+    logger = logging.getLogger("dgl-core")
+    logger.setLevel(logging.INFO)


### PR DESCRIPTION
## Description
Now the logging info when `import dgl` is disabled by default. User can set 'DGL_LOG_DEBUG=1' to enable it if needed.

This makes dgl-enter's log clearer

## Checklist
Please feel free to remove inapplicable items for your PR.
- [ ] The PR title starts with [$CATEGORY] (such as [NN], [Model], [Doc], [Feature]])
- [ ] Changes are complete (i.e. I finished coding on this PR)
- [ ] All changes have test coverage
- [ ] Code is well-documented
- [ ] To the best of my knowledge, examples are either not affected by this change,
      or have been fixed to be compatible with this change
- [ ] Related issue is referred in this PR
- [ ] If the PR is for a new model/paper, I've updated the example index [here](../examples/README.md).

## Changes
<!-- You could use following template
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)
-->
