### PR TITLE
[CI] Migrate to Pylint 2.7.0

### DIFF
--- a/docker/Dockerfile.ci_lint
+++ b/docker/Dockerfile.ci_lint
@@ -1,7 +1,9 @@
 # CI docker for lint
 # Adapted from github.com/dmlc/tvm/docker/Dockerfile.ci_lint
 
-FROM ubuntu:16.04
+FROM ubuntu:18.04
+
+ENV DEBIAN_FRONTEND=noninteractive
 
 COPY install/ubuntu_install_core.sh /install/ubuntu_install_core.sh
 RUN bash /install/ubuntu_install_core.sh
@@ -11,4 +13,4 @@ RUN bash /install/ubuntu_install_python.sh
 
 RUN apt-get install -y doxygen graphviz
 
-RUN pip3 install cpplint==1.3.0 pylint==2.3.0 mypy
+RUN pip3 install cpplint==1.3.0 pylint==2.7.0 mypy

--- a/python/dgl/distributed/graph_partition_book.py
+++ b/python/dgl/distributed/graph_partition_book.py
@@ -661,12 +661,12 @@ class RangePartitionBook(GraphPartitionBook):
         for ntype in ntypes:
             ntype_id = ntypes[ntype]
             self._ntypes[ntype_id] = ntype
-        assert all([ntype is not None for ntype in self._ntypes]), \
+        assert all(ntype is not None for ntype in self._ntypes), \
                 "The node types have invalid IDs."
         for etype in etypes:
             etype_id = etypes[etype]
             self._etypes[etype_id] = etype
-        assert all([etype is not None for etype in self._etypes]), \
+        assert all(etype is not None for etype in self._etypes), \
                 "The edge types have invalid IDs."
 
         # This stores the node ID ranges for each node type in each partition.


### PR DESCRIPTION
Turns out that pylint 2.6.0 has a bug that will print the same error multiple times.  So I upgraded it to 2.7.0.