### PR TITLE
[bugfix] Fix set_default_backend() keyword

### DIFF
--- a/python/dgl/backend/set_default_backend.py
+++ b/python/dgl/backend/set_default_backend.py
@@ -3,8 +3,7 @@ import os
 import json
 
 def set_default_backend(default_dir, backend_name):
-    # the exists_ok requires python >= 3.2
-    os.makedirs(default_dir, exists_ok=True)
+    os.makedirs(default_dir, exist_ok=True)
     config_path = os.path.join(default_dir, 'config.json')
     with open(config_path, "w") as config_file: 
         json.dump({'backend': backend_name.lower()}, config_file)

--- a/tests/compute/test_backend.py
+++ b/tests/compute/test_backend.py
@@ -1,0 +1,11 @@
+import backend as F
+import os
+import unittest
+
+
+def test_set_default_backend():
+    default_dir = os.path.join(os.path.expanduser('~'), '.dgl_unit_test')
+    F.set_default_backend(default_dir, 'pytorch')
+
+    # make sure the config file was created
+    assert os.path.exists(os.path.join(default_dir, 'config.json'))


### PR DESCRIPTION
## Description
The PR #3696 introduced a keyword for os.makedirs() with typo (I was testing it incorrectly, and none of our unit tests covered it). This PR adds a unit test for the function `set_default_backend()` and fixes the typo: `exists_ok=True` -> `exist_ok=True`.

## Checklist
Please feel free to remove inapplicable items for your PR.
- [x] The PR title starts with [$CATEGORY] (such as [NN], [Model], [Doc], [Feature]])
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage
- [x] Code is well-documented
- [x] To the best of my knowledge, examples are either not affected by this change,
      or have been fixed to be compatible with this change
- [x] Related issue is referred in this PR

