### PR TITLE
[bugfix] Change standard to c++14 to be compatible to tensorpipe's dependencies

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -92,11 +92,10 @@ if(MSVC)
   endif()
 else(MSVC)
   include(CheckCXXCompilerFlag)
-  check_cxx_compiler_flag("-std=c++11"    SUPPORT_CXX11)
+  # tensorpipe's dependencies require C++14
+  check_cxx_compiler_flag("-std=c++14"    SUPPORT_CXX14)
   set(CMAKE_C_FLAGS "-O2 -Wall -fPIC ${CMAKE_C_FLAGS}")
-  # We still use c++11 flag in CPU build because gcc5.4 (our default compiler) is
-  # not fully compatible with c++14 feature.
-  set(CMAKE_CXX_FLAGS "-O2 -Wall -fPIC -std=c++11 ${CMAKE_CXX_FLAGS}")
+  set(CMAKE_CXX_FLAGS "-O2 -Wall -fPIC -std=c++14 ${CMAKE_CXX_FLAGS}")
   if(NOT APPLE)
     set(CMAKE_SHARED_LINKER_FLAGS "-Wl,--warn-common ${CMAKE_SHARED_LINKER_FLAGS}")
   endif(NOT APPLE)


### PR DESCRIPTION
## Description

libnop depends on the helper type `decay_t` that was only introduced in C++14 (https://en.cppreference.com/w/cpp/types/decay). When building with gcc 9.3.0:
```
[ 13%] Building CXX object third_party/tensorpipe/tensorpipe/CMakeFiles/tensorpipe.dir/channel/helpers.cc.o
cd /workspace/dgl/build/third_party/tensorpipe/tensorpipe && /usr/bin/c++ -DDGL_USE_CUDA -DENABLE_PARTIAL_FRONTIER=0 -I/usr/local/cuda/include -I/workspace/dgl/third_party/METIS/GKlib -I/workspace/dgl/third_party/METIS/include -I/workspace/dgl/third_party/tensorpipe -I/workspace/dgl/build/third_party/tensorpipe -I/workspace/dgl/third_party/tensorpipe/third_party/libnop/include -I/workspace/dgl/third_party/tensorpipe/third_party/libuv/include -fopenmp -O2 -Wall -fPIC -std=c++11  -DUSE_AVX -DUSE_LIBXSMM -DDGL_CPU_LLC_SIZE=40000000 -DIDXTYPEWIDTH=64 -DREALTYPEWIDTH=32 -O3 -DNDEBUG -MD -MT third_party/tensorpipe/tensorpipe/CMakeFiles/tensorpipe.dir/channel/helpers.cc.o -MF CMakeFiles/tensorpipe.dir/channel/helpers.cc.o.d -o CMakeFiles/tensorpipe.dir/channel/helpers.cc.o -c /workspace/dgl/third_party/tensorpipe/tensorpipe/channel/helpers.cc
In file included from /workspace/dgl/third_party/tensorpipe/third_party/libnop/include/nop/status.h:22,
                 from /workspace/dgl/third_party/tensorpipe/third_party/libnop/include/nop/base/encoding.h:30,
                 from /workspace/dgl/third_party/tensorpipe/third_party/libnop/include/nop/base/array.h:22,
                 from /workspace/dgl/third_party/tensorpipe/third_party/libnop/include/nop/serializer.h:20,
                 from /workspace/dgl/third_party/tensorpipe/tensorpipe/common/nop.h:11,
                 from /workspace/dgl/third_party/tensorpipe/tensorpipe/channel/helpers.h:15,
                 from /workspace/dgl/third_party/tensorpipe/tensorpipe/channel/helpers.cc:9:
/workspace/dgl/third_party/tensorpipe/third_party/libnop/include/nop/types/result.h:68:36: error: 'decay_t' is not a member of 'std'; did you mean 'decay'?
   68 |   static_assert(!std::is_same<std::decay_t<ErrorEnum>, std::decay_t<T>>::value,
      |                                    ^~~~~~~
      |                                    decay
/workspace/dgl/third_party/tensorpipe/third_party/libnop/include/nop/types/result.h:68:36: error: 'decay_t' is not a member of 'std'; did you mean 'decay'?
   68 |   static_assert(!std::is_same<std::decay_t<ErrorEnum>, std::decay_t<T>>::value,
      |                                    ^~~~~~~
      |                                    decay
/workspace/dgl/third_party/tensorpipe/third_party/libnop/include/nop/types/result.h:68:53: error: wrong number of template arguments (1, should be 2)
   68 |   static_assert(!std::is_same<std::decay_t<ErrorEnum>, std::decay_t<T>>::value,
      |                                                     ^
```
Not all versions of GCC seemed to be effected by this, as one system with gcc 7.5.0, it compiles fine with the -std=c++11.

This may fix #3685, but it's not clear if the cause is the same.

## Checklist
Please feel free to remove inapplicable items for your PR.
- [x] The PR title starts with [$CATEGORY] (such as [NN], [Model], [Doc], [Feature]])
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] To the best of my knowledge, examples are either not affected by this change,
      or have been fixed to be compatible with this change
- [x] Related issue is referred in this PR


