### PR TITLE
[bugfix] Make source build work for systems where the default is python2

### DIFF
--- a/tensoradapter/pytorch/CMakeLists.txt
+++ b/tensoradapter/pytorch/CMakeLists.txt
@@ -5,7 +5,7 @@ project(tensoradapter_pytorch C CXX)
 # (or "python" if empty)
 file(TO_NATIVE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/find_cmake.py FIND_CMAKE_PY)
 if(NOT PYTHON_INTERP)
-  set(PYTHON_INTERP python)
+  set(PYTHON_INTERP python3)
 endif()
 message(STATUS "Using Python interpreter: ${PYTHON_INTERP}")
 execute_process(

--- a/tensoradapter/pytorch/CMakeLists.txt
+++ b/tensoradapter/pytorch/CMakeLists.txt
@@ -3,11 +3,16 @@ project(tensoradapter_pytorch C CXX)
 
 # Find PyTorch cmake files and PyTorch versions with the python interpreter $PYTHON_INTERP
 # (or "python" if empty)
-file(TO_NATIVE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/find_cmake.py FIND_CMAKE_PY)
+find_package(Python 3 REQUIRED COMPONENTS Interpreter)
+if (Python_FOUND)
+  set(PYTHON_INTERP "${Python_EXECUTABLE}")
+endif()
 if(NOT PYTHON_INTERP)
-  set(PYTHON_INTERP python3)
+  # if we didn't find python via the package, try the basic executable
+  set(PYTHON_INTERP python)
 endif()
 message(STATUS "Using Python interpreter: ${PYTHON_INTERP}")
+file(TO_NATIVE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/find_cmake.py FIND_CMAKE_PY)
 execute_process(
   COMMAND ${PYTHON_INTERP} ${FIND_CMAKE_PY}
   OUTPUT_VARIABLE TORCH_PREFIX_VER

--- a/tensoradapter/pytorch/CMakeLists.txt
+++ b/tensoradapter/pytorch/CMakeLists.txt
@@ -2,14 +2,9 @@ cmake_minimum_required(VERSION 3.5)
 project(tensoradapter_pytorch C CXX)
 
 # Find PyTorch cmake files and PyTorch versions with the python interpreter $PYTHON_INTERP
-# (or "python" if empty)
-find_package(Python 3 REQUIRED COMPONENTS Interpreter)
-if (Python_FOUND)
-  set(PYTHON_INTERP "${Python_EXECUTABLE}")
-endif()
+# ("python3" or "python" if empty)
 if(NOT PYTHON_INTERP)
-  # if we didn't find python via the package, try the basic executable
-  set(PYTHON_INTERP python)
+  find_program(PYTHON_INTERP NAMES python3 python)
 endif()
 message(STATUS "Using Python interpreter: ${PYTHON_INTERP}")
 file(TO_NATIVE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/find_cmake.py FIND_CMAKE_PY)


### PR DESCRIPTION
## Description
On systems where `python` refers to `python2`, it breaks building DGL from source with `-DBUILD_TORCH=ON`. This PR makes it so `python3` is explicitly called in finding the pytorch to build the memory pool allocator against.

## Checklist
Please feel free to remove inapplicable items for your PR.
- [x] The PR title starts with [$CATEGORY] (such as [NN], [Model], [Doc], [Feature]])
- [x] Changes are complete (i.e. I finished coding on this PR)


