### PR TITLE
[Performance] Workaround CSR conversion barrier stalls

### DIFF
--- a/src/array/cpu/spmat_op_impl_coo.cc
+++ b/src/array/cpu/spmat_op_impl_coo.cc
@@ -532,7 +532,7 @@ template <class IdType> CSRMatrix UnSortedDenseCOOToCSR(const COOMatrix &coo) {
   std::vector<std::vector<IdType>> local_ptrs;
   std::vector<int64_t> thread_prefixsum;
 
-#pragma omp parallel
+#pragma omp parallel if (NNZ >= 1024)
   {
     const int num_threads = omp_get_num_threads();
     const int thread_id = omp_get_thread_num();


### PR DESCRIPTION
This PR works around OpenMP barrier stalls observed on multiple workloads with 2+ dataloader workers.

If merged, OpenMP will be disabled for small sparse matrix (<1024 non-zero elements) CSR conversion
The change has no negative performance impact outside of barrier stalls issue since overhead on thread management exceeds the gain from parallelizing the computation.