### PR TITLE
Add links to RNAGlib in the DGL Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,7 @@ Take the survey [here](https://forms.gle/Ej3jHCocACmb49Gp8) and leave any feedba
 * GNN-RecSys: https://github.com/je-dbl/GNN-RecSys
 * Amazon Neptune ML: a new capability of Neptune that uses Graph Neural Networks (GNNs), a machine learning technique purpose-built for graphs, to make easy, fast, and more accurate predictions using graph data. https://aws.amazon.com/cn/neptune/machine-learning/
 * GNNLens2: Visualization tool for Graph Neural Networks. https://github.com/dmlc/GNNLens2
+* RNAGlib: A package to facilitate construction, analysis, visualization and machine learning on RNA 2.5D Graphs. Includes a pre-built dataset: rnaglib.cs.mcgill.ca 
 
 ### Awesome Papers Using DGL
 

--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ Take the survey [here](https://forms.gle/Ej3jHCocACmb49Gp8) and leave any feedba
 * GNN-RecSys: https://github.com/je-dbl/GNN-RecSys
 * Amazon Neptune ML: a new capability of Neptune that uses Graph Neural Networks (GNNs), a machine learning technique purpose-built for graphs, to make easy, fast, and more accurate predictions using graph data. https://aws.amazon.com/cn/neptune/machine-learning/
 * GNNLens2: Visualization tool for Graph Neural Networks. https://github.com/dmlc/GNNLens2
-* RNAGlib: A package to facilitate construction, analysis, visualization and machine learning on RNA 2.5D Graphs. Includes a pre-built dataset: rnaglib.cs.mcgill.ca 
+* RNAGlib: A package to facilitate construction, analysis, visualization and machine learning on RNA 2.5D Graphs. Includes a pre-built dataset: https://rnaglib.cs.mcgill.ca 
 
 ### Awesome Papers Using DGL
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -7,7 +7,9 @@ The folder contains example implementations of selected research papers related 
 To quickly locate the examples of your interest, search for the tagged keywords or use the search tool on [dgl.ai](https://www.dgl.ai/).
 
 ## 2021
-
+- <a name="rnaglib"></a> Oliver et al. Learning Protein and Small Molecule binding sites in RNA molecules with 2.5D graphs. [Paper link](https://academic.oup.com/bioinformatics/article/38/5/1458/6462185?login=true)
+    - Example code: [PyTorch](https://jwgitlab.cs.mcgill.ca/cgoliver/rnaglib)
+    - Tags: semi-supervised node classification
 - <a name="hilander"></a> Xing et al. Learning Hierarchical Graph Neural Networks for Image Clustering.
     - Example code: [PyTorch](../examples/pytorch/hilander)
     - Tags: clustering

--- a/examples/README.md
+++ b/examples/README.md
@@ -7,7 +7,7 @@ The folder contains example implementations of selected research papers related 
 To quickly locate the examples of your interest, search for the tagged keywords or use the search tool on [dgl.ai](https://www.dgl.ai/).
 
 ## 2021
-- <a name="rnaglib"></a> Oliver et al. Learning Protein and Small Molecule binding sites in RNA molecules with 2.5D graphs. [Paper link](https://academic.oup.com/bioinformatics/article/38/5/1458/6462185?login=true)
+- <a name="rnaglib"></a> Mallet et al. Learning Protein and Small Molecule binding sites in RNA molecules with 2.5D graphs. [Paper link](https://academic.oup.com/bioinformatics/article/38/5/1458/6462185?login=true)
     - Example code: [PyTorch](https://jwgitlab.cs.mcgill.ca/cgoliver/rnaglib)
     - Tags: semi-supervised node classification
 - <a name="hilander"></a> Xing et al. Learning Hierarchical Graph Neural Networks for Image Clustering.


### PR DESCRIPTION
## Description
Added a link to the RNAglib homepage in the _DGL-powered-projects_ section of the main `README.md`

Added a link to our repository in the 2021 examples section of the `examples/README.md`