### PR TITLE
Fixes the bug when total_nnz is > integer limit

### DIFF
--- a/src/array/cpu/spmm_blocking_libxsmm.h
+++ b/src/array/cpu/spmm_blocking_libxsmm.h
@@ -454,7 +454,7 @@ void SpMMRedopCsrOpt(
   const IdType K = csr.num_cols;
   const IdType* indptr = csr.indptr.Ptr<IdType>();
   CHECK_NOTNULL(indptr);
-  const int total_nnz = indptr[M];
+  const IdType total_nnz = indptr[M];
   if (M <= 0 || K <= 0 || N <= 0 || total_nnz <= 0) return;
 
   const double avg_degree = total_nnz * 1.0 / M;


### PR DESCRIPTION
## Description
This was a bug in the optimized spmm code that only manifests when number of edges of a graph are greater than integer limit. In that case since total_nnz is declared as an "int", it would be negative and the function would return without performing spmm.

## Checklist
Please feel free to remove inapplicable items for your PR.
- [x] Changes are complete (i.e. I finished coding on this PR)
- [ ] All changes have test coverage
- [x] Code is well-documented
- [x] To the best of my knowledge, examples are either not affected by this change,
      or have been fixed to be compatible with this change
