### PR TITLE
[Build or bug?] Fix VS2019 compilation error in randomwalk GPU kernel

### DIFF
--- a/src/graph/sampling/randomwalks/randomwalk_gpu.cu
+++ b/src/graph/sampling/randomwalks/randomwalk_gpu.cu
@@ -110,7 +110,7 @@ std::pair<IdArray, IdArray> RandomWalkUniform(
   IdType *traces_data = traces.Ptr<IdType>();
   IdType *eids_data = eids.Ptr<IdType>();
 
-  GraphKernelData<IdType> h_graphs[num_etypes];
+  std::vector<GraphKernelData<IdType>> h_graphs(num_etypes);
   DGLContext ctx;
   for (int64_t etype = 0; etype < num_etypes; ++etype) {
     const CSRMatrix &csr = hg->GetCSRMatrix(etype);

--- a/src/graph/sampling/randomwalks/randomwalk_gpu.cu
+++ b/src/graph/sampling/randomwalks/randomwalk_gpu.cu
@@ -127,7 +127,7 @@ std::pair<IdArray, IdArray> RandomWalkUniform(
       device->AllocWorkspace(ctx, (num_etypes) * sizeof(GraphKernelData<IdType>)));
   auto d_metapath_data = metapath_data;
   // copy graph metadata pointers to GPU
-  device->CopyDataFromTo(h_graphs, 0, d_graphs, 0,
+  device->CopyDataFromTo(h_graphs.data(), 0, d_graphs, 0,
       (num_etypes) * sizeof(GraphKernelData<IdType>),
       DGLContext{kDLCPU, 0},
       ctx,


### PR DESCRIPTION
There's some declaration like `T a[num_etypes]` which is not a good practice anyway.