### PR TITLE
[Examples] fix path for load_graph

### DIFF
--- a/examples/pytorch/graphsage/advanced/train_lightning.py
+++ b/examples/pytorch/graphsage/advanced/train_lightning.py
@@ -11,7 +11,7 @@ import tqdm
 import glob
 import os
 import sys
-sys.path.append('../')
+sys.path.append(os.path.join(os.path.dirname(__file__), '..'))
 from load_graph import load_reddit, inductive_split, load_ogb
 
 from torchmetrics import Accuracy

--- a/examples/pytorch/graphsage/advanced/train_lightning_unsupervised.py
+++ b/examples/pytorch/graphsage/advanced/train_lightning_unsupervised.py
@@ -18,7 +18,7 @@ from pytorch_lightning.callbacks import ModelCheckpoint, Callback
 from pytorch_lightning import LightningDataModule, LightningModule, Trainer
 from model import SAGE, compute_acc_unsupervised as compute_acc
 import sys
-sys.path.append('../')
+sys.path.append(os.path.join(os.path.dirname(__file__), '..'))
 from load_graph import load_reddit, inductive_split, load_ogb
 
 class CrossEntropyLoss(nn.Module):

--- a/examples/pytorch/graphsage/advanced/train_sampling_unsupervised.py
+++ b/examples/pytorch/graphsage/advanced/train_sampling_unsupervised.py
@@ -15,7 +15,7 @@ from torch.nn.parallel import DistributedDataParallel
 from model import SAGE, compute_acc_unsupervised as compute_acc
 from negative_sampler import NegativeSampler
 import sys
-sys.path.append('../')
+sys.path.append(os.path.join(os.path.dirname(__file__), '..'))
 from load_graph import load_reddit, load_ogb
 
 class CrossEntropyLoss(nn.Module):

--- a/examples/pytorch/graphsage/dist/partition_graph.py
+++ b/examples/pytorch/graphsage/dist/partition_graph.py
@@ -4,7 +4,8 @@ import torch as th
 import argparse
 import time
 import sys
-sys.path.append('../')
+import os
+sys.path.append(os.path.join(os.path.dirname(__file__), '..'))
 from load_graph import load_reddit, load_ogb
 
 if __name__ == '__main__':

--- a/examples/pytorch/graphsage/distgnn/partition_graph.py
+++ b/examples/pytorch/graphsage/distgnn/partition_graph.py
@@ -19,7 +19,7 @@ from statistics import mean
 import random
 import time
 import argparse
-sys.path.append('../')
+sys.path.append(os.path.join(os.path.dirname(__file__), '..'))
 from load_graph import load_ogb
 import dgl
 from dgl.data import load_data


### PR DESCRIPTION
## Description
<!-- Brief description. Refer to the related issues if existed.
It'll be great if relevant reviewers can be assigned as well.-->
enable to run `train.py` under any path such as `//dgl/` : `python3 examples/pytorch/graphsage/advanced/train_sampling_unsupervised.py`
## Checklist
Please feel free to remove inapplicable items for your PR.
- [ ] The PR title starts with [$CATEGORY] (such as [NN], [Model], [Doc], [Feature]])
- [ ] Changes are complete (i.e. I finished coding on this PR)
- [ ] All changes have test coverage
- [ ] Code is well-documented
- [ ] To the best of my knowledge, examples are either not affected by this change,
      or have been fixed to be compatible with this change
- [ ] Related issue is referred in this PR
- [ ] If the PR is for a new model/paper, I've updated the example index [here](../examples/README.md).

## Changes
<!-- You could use following template
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)
-->
