### PR TITLE
[Feature] Compatibility to DLPack 0.6 in tensoradapter

### DIFF
--- a/tensoradapter/include/tensoradapter.h
+++ b/tensoradapter/include/tensoradapter.h
@@ -10,32 +10,10 @@
 #ifndef TENSORADAPTER_H_
 #define TENSORADAPTER_H_
 
-#include <dlpack/dlpack.h>
-#include <vector>
-
 #if defined(WIN32) || defined(_WIN32)
 #define TA_EXPORTS __declspec(dllexport)
 #else
 #define TA_EXPORTS
 #endif
-
-namespace tensoradapter {
-
-extern "C" {
-
-/*!
- * \brief Allocate an empty tensor
- *
- * \param shape The shape
- * \param dtype The data type
- * \param ctx The device
- * \return The allocated tensor
- */
-TA_EXPORTS DLManagedTensor* TAempty(
-    std::vector<int64_t> shape, DLDataType dtype, DLContext ctx);
-
-}
-
-};  // namespace tensoradapter
 
 #endif  // TENSORADAPTER_H_

--- a/tensoradapter/pytorch/torch.cpp
+++ b/tensoradapter/pytorch/torch.cpp
@@ -10,6 +10,12 @@
 #include <vector>
 #include <iostream>
 
+#if DLPACK_VERSION > 040
+// Compatibility across DLPack - note that this assumes that the ABI stays the same.
+#define kDLGPU kDLCUDA
+#define DLContext DLDevice
+#endif
+
 namespace tensoradapter {
 
 static at::Device get_device(DLContext ctx) {
@@ -29,7 +35,7 @@ static at::Device get_device(DLContext ctx) {
 
 extern "C" {
 
-DLManagedTensor* TAempty(
+TA_EXPORTS DLManagedTensor* TAempty(
     std::vector<int64_t> shape,
     DLDataType dtype,
     DLContext ctx) {


### PR DESCRIPTION
This is to make tensoradapter compilable against PyTorch 1.11, which upgrades DLPack to 0.6.0 that renamed a bunch of stuff.