### PR TITLE
[BugFix] involve indices_devices for other dataset object.

### DIFF
--- a/python/dgl/dataloading/dataloader.py
+++ b/python/dgl/dataloading/dataloader.py
@@ -697,19 +697,23 @@ class DataLoader(torch.utils.data.DataLoader):
         self.indices = indices      # For PyTorch-Lightning
         num_workers = kwargs.get('num_workers', 0)
 
+        indices_device = None
         try:
             if isinstance(indices, Mapping):
                 indices = {k: (torch.tensor(v) if not torch.is_tensor(v) else v)
                            for k, v in indices.items()}
                 indices_device = next(iter(indices.values())).device
             else:
-                if hasattr(indices, "device"):
-                    indices_device = indices.device
                 indices = torch.tensor(indices) if not torch.is_tensor(indices) else indices
                 indices_device = indices.device
         except:     # pylint: disable=bare-except
             # ignore when it fails to convert to torch Tensors.
             pass
+        if indices_device is None:
+            if not hasattr(indices, 'device'):
+                raise AttributeError('Custom indices dataset requires a \"device\" attribute indicating where the indices is.')
+            indices_device = indices.device
+
 
         self.device = _get_device(device)
 

--- a/python/dgl/dataloading/dataloader.py
+++ b/python/dgl/dataloading/dataloader.py
@@ -711,7 +711,8 @@ class DataLoader(torch.utils.data.DataLoader):
             pass
         if indices_device is None:
             if not hasattr(indices, 'device'):
-                raise AttributeError('Custom indices dataset requires a \"device\" attribute indicating where the indices is.')
+                raise AttributeError('Custom indices dataset requires a \"device\" \
+                attribute indicating where the indices is.')
             indices_device = indices.device
         self.device = _get_device(device)
 

--- a/python/dgl/dataloading/dataloader.py
+++ b/python/dgl/dataloading/dataloader.py
@@ -713,8 +713,6 @@ class DataLoader(torch.utils.data.DataLoader):
             if not hasattr(indices, 'device'):
                 raise AttributeError('Custom indices dataset requires a \"device\" attribute indicating where the indices is.')
             indices_device = indices.device
-
-
         self.device = _get_device(device)
 
         # Sanity check - we only check for DGLGraphs.

--- a/python/dgl/dataloading/dataloader.py
+++ b/python/dgl/dataloading/dataloader.py
@@ -703,6 +703,8 @@ class DataLoader(torch.utils.data.DataLoader):
                            for k, v in indices.items()}
                 indices_device = next(iter(indices.values())).device
             else:
+                if hasattr(indices, "device"):
+                    indices_device = indices.device
                 indices = torch.tensor(indices) if not torch.is_tensor(indices) else indices
                 indices_device = indices.device
         except:     # pylint: disable=bare-except


### PR DESCRIPTION
## Description
<!-- Brief description. Refer to the related issues if existed.
It'll be great if relevant reviewers can be assigned as well.-->
DGL 0.8 support custom dataset and we can parse a customize "TensorizedDataset" in the indices field. However here cause an error that indices_device will not be created if a customize dataset is parsed. @BarclayII 

## Checklist
Please feel free to remove inapplicable items for your PR.
- [ ] The PR title starts with [$CATEGORY] (such as [NN], [Model], [Doc], [Feature]])
- [ ] Changes are complete (i.e. I finished coding on this PR)
- [ ] All changes have test coverage
- [ ] Code is well-documented
- [ ] To the best of my knowledge, examples are either not affected by this change,
      or have been fixed to be compatible with this change
- [ ] Related issue is referred in this PR
- [ ] If the PR is for a new model/paper, I've updated the example index [here](../examples/README.md).

## Changes
<!-- You could use following template
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)
-->
