### PR TITLE
[bugfix] Set `stacklevel=2` for `dgl_warning`

### DIFF
--- a/python/dgl/base.py
+++ b/python/dgl/base.py
@@ -40,9 +40,9 @@ def dgl_warning_format(message, category, filename, lineno, line=None):
     else:
         return _default_formatwarning(message, category, filename, lineno, line=None)
 
-def dgl_warning(message, category=DGLWarning, stacklevel=1):
+def dgl_warning(message, category=DGLWarning, stacklevel=2):
     """DGL warning wrapper that defaults to ``DGLWarning`` instead of ``UserWarning`` category."""
-    return warnings.warn(message, category=category, stacklevel=1)
+    return warnings.warn(message, category=category, stacklevel=stacklevel)
 
 warnings.formatwarning = dgl_warning_format
 


### PR DESCRIPTION
## Description
The current implementation of `dgl_warning` calls `warnings.warn` with `stacklevel=1`, which always returns the file `python/dgl/core.py`.

This PR sets `stacklevel=2`, such that it returns the location of the actual caller.

Reference: https://docs.python.org/3/library/warnings.html?highlight=stacklevel#warnings.warn

## Checklist
Please feel free to remove inapplicable items for your PR.
- [X] The PR title starts with [$CATEGORY] (such as [NN], [Model], [Doc], [Feature]])
- [X] Changes are complete (i.e. I finished coding on this PR)
- [ ] All changes have test coverage
- [ ] Code is well-documented
- [X] To the best of my knowledge, examples are either not affected by this change,
      or have been fixed to be compatible with this change
- [ ] Related issue is referred in this PR
- [ ] If the PR is for a new model/paper, I've updated the example index [here](../examples/README.md).
