### PR TITLE
[Performance]Fused Edge Softmax GPU Ops

### DIFF
--- a/python/dgl/backend/pytorch/sparse.py
+++ b/python/dgl/backend/pytorch/sparse.py
@@ -473,15 +473,7 @@ class EdgeSoftmax(th.autograd.Function):
             gidx = gidx.edge_subgraph([eids], True).graph
         if norm_by == 'src':
             gidx = gidx.reverse()
-        #Note: Now _edge_softmax_forward op only supports CPU
-        #TODO(Zhejiang): We will support GPU in the future
-        if(score.is_cuda):
-            score_max = _gspmm(gidx, 'copy_rhs', 'max', None, score)[0]
-            score = th.exp(_gsddmm(gidx, 'sub', score, score_max, 'e', 'v'))
-            score_sum = _gspmm(gidx, 'copy_rhs', 'sum', None, score)[0]
-            out = _gsddmm(gidx, 'div', score, score_sum, 'e', 'v')
-        else:
-            out = _edge_softmax_forward(gidx, score, 'copy_rhs')
+        out = _edge_softmax_forward(gidx, score, 'copy_rhs')
         ctx.backward_cache = gidx
         ctx.save_for_backward(out)
         return out
@@ -509,13 +501,8 @@ class EdgeSoftmax(th.autograd.Function):
         out, = ctx.saved_tensors
         sds = out * grad_out
         #Note: Now _edge_softmax_backward op only supports CPU
-        #TODO(Zhejiang): We will support GPU in the future
-        if(out.is_cuda):
-            accum = gspmm(gidx, 'copy_rhs', 'sum', None, sds)
+        grad_score = _edge_softmax_backward(gidx, out, sds)
 
-            grad_score = sds - gsddmm(gidx, 'mul', out, accum, 'e', 'v')
-        else:
-            grad_score = _edge_softmax_backward(gidx, out, sds)
         return None, grad_score, None, None
 
 

--- a/src/array/cuda/spmm.cu
+++ b/src/array/cuda/spmm.cu
@@ -148,6 +148,36 @@ void SpMMCoo(const std::string& op, const std::string& reduce,
   }
 }
 
+/*! \brief Edge_softmax_csr forward op on Csr format. */
+template <int XPU, typename IdType, int bits>
+void Edge_softmax_csr_forward(const std::string& op,
+             const BcastOff& bcast,
+             const CSRMatrix& csr,
+             NDArray ufeat,
+             NDArray efeat,
+             NDArray out) {
+  SWITCH_BITS(bits, DType, {
+      SWITCH_OP(op, Op, {
+        cuda::Edge_softmax_csr_forward<IdType, DType, Op>(bcast, csr, ufeat, efeat, out);
+      });
+    });
+}
+
+/*! \brief Edge_softmax_csr backward op on Csr format. */
+template <int XPU, typename IdType, int bits>
+void Edge_softmax_csr_backward(const std::string& op,
+             const BcastOff& bcast,
+             const CSRMatrix& csr,
+             NDArray out,
+             NDArray sds,
+             NDArray back_out) {
+  SWITCH_BITS(bits, DType, {
+      SWITCH_OP(op, Op, {
+        cuda::Edge_softmax_csr_backward<IdType, DType, Op>(bcast, csr, out, sds, back_out);
+      });
+    });
+}
+
 template void SpMMCsr<kDLGPU, int32_t, 16>(
     const std::string& op, const std::string& reduce,
     const BcastOff& bcast, const CSRMatrix& csr,
@@ -199,6 +229,55 @@ template void SpMMCoo<kDLGPU, int64_t, 64>(
     const BcastOff& bcast, const COOMatrix& coo,
     NDArray ufeat, NDArray efeat, NDArray out, std::vector<NDArray> out_aux);
 
+template void Edge_softmax_csr_forward<kDLGPU, int32_t, 16>(
+    const std::string& op,
+    const BcastOff& bcast, const CSRMatrix& csr,
+    NDArray ufeat, NDArray efeat, NDArray out);
+template void Edge_softmax_csr_forward<kDLGPU, int64_t, 16>(
+    const std::string& op,
+    const BcastOff& bcast, const CSRMatrix& csr,
+    NDArray ufeat, NDArray efeat, NDArray out);
+template void Edge_softmax_csr_forward<kDLGPU, int32_t, 32>(
+    const std::string& op,
+    const BcastOff& bcast, const CSRMatrix& csr,
+    NDArray ufeat, NDArray efeat, NDArray out);
+template void Edge_softmax_csr_forward<kDLGPU, int64_t, 32>(
+    const std::string& op,
+    const BcastOff& bcast, const CSRMatrix& csr,
+    NDArray ufeat, NDArray efeat, NDArray out);
+template void Edge_softmax_csr_forward<kDLGPU, int32_t, 64>(
+    const std::string& op,
+    const BcastOff& bcast, const CSRMatrix& csr,
+    NDArray ufeat, NDArray efeat, NDArray out);
+template void Edge_softmax_csr_forward<kDLGPU, int64_t, 64>(
+    const std::string& op,
+    const BcastOff& bcast, const CSRMatrix& csr,
+    NDArray ufeat, NDArray efeat, NDArray out);
+
+template void Edge_softmax_csr_backward<kDLGPU, int32_t, 16>(
+    const std::string& op,
+    const BcastOff& bcast, const CSRMatrix& csr,
+    NDArray out, NDArray sds, NDArray back_out);
+template void Edge_softmax_csr_backward<kDLGPU, int64_t, 16>(
+    const std::string& op,
+    const BcastOff& bcast, const CSRMatrix& csr,
+    NDArray out, NDArray sds, NDArray back_out);
+template void Edge_softmax_csr_backward<kDLGPU, int32_t, 32>(
+    const std::string& op,
+    const BcastOff& bcast, const CSRMatrix& csr,
+    NDArray out, NDArray sds, NDArray back_out);
+template void Edge_softmax_csr_backward<kDLGPU, int64_t, 32>(
+    const std::string& op,
+    const BcastOff& bcast, const CSRMatrix& csr,
+    NDArray out, NDArray sds, NDArray back_out);
+template void Edge_softmax_csr_backward<kDLGPU, int32_t, 64>(
+    const std::string& op,
+    const BcastOff& bcast, const CSRMatrix& csr,
+    NDArray out, NDArray sds, NDArray back_out);
+template void Edge_softmax_csr_backward<kDLGPU, int64_t, 64>(
+    const std::string& op,
+    const BcastOff& bcast, const CSRMatrix& csr,
+    NDArray out, NDArray sds, NDArray back_out);
 
 }  // namespace aten
 }  // namespace dgl

--- a/src/array/cuda/spmm.cuh
+++ b/src/array/cuda/spmm.cuh
@@ -630,6 +630,106 @@ __global__ void SpMMCmpCsrHeteroKernel(
 }
 
 /*!
+ * \brief CUDA kernel of Edge Softmax Forward on Csr format.
+ * \note 
+ */
+
+template <typename Idx, typename DType,
+          typename Op,
+          bool UseBcast = false, bool UseIdx = false>
+__global__ void EdgeSoftmaxCsrForwardKernel(
+    const DType* __restrict__ ufeat,
+    const DType* __restrict__ efeat,
+    DType* __restrict__ out,
+    const Idx* __restrict__ indptr,
+    const Idx* __restrict__ indices,
+    const Idx* __restrict__ edge_map,
+    int64_t num_rows, int64_t num_cols,
+    const int64_t* __restrict__ ubcast_off,
+    const int64_t* __restrict__ ebcast_off,
+    int64_t ufeat_len, int64_t efeat_len, int64_t out_len) {
+  int ty = blockIdx.y * blockDim.y + threadIdx.y;
+  const Idx stride_y = blockDim.y * gridDim.y;
+  const int stride_x = blockDim.x * gridDim.x;
+  while (ty < num_rows) {
+    int tx = blockIdx.x * blockDim.x + threadIdx.x;
+    const Idx row_start = indptr[ty], row_end = indptr[ty+1];
+    while (tx < out_len) {
+      const int64_t rhs_add = UseBcast ? ebcast_off[tx] : tx;
+      DType max_v = -std::numeric_limits<DType>::infinity();
+      for (Idx i = row_start; i < row_end; ++i) {
+        const Idx eid = UseIdx ? _ldg(edge_map + i) : i;
+        const DType * eoff = Op::use_rhs ? 
+                          (efeat + eid * efeat_len + rhs_add) : nullptr;
+        max_v = _FindMax<DType>(max_v, _ldg(eoff));
+      }
+      DType exp_sum = 0;
+      for (Idx i = row_start; i < row_end; ++i) {
+        const Idx eid = UseIdx ? _ldg(edge_map + i) : i;
+        const DType * eoff = Op::use_rhs ? 
+                          (efeat + eid * efeat_len + rhs_add) : nullptr; 
+        DType ele = _CalExp<DType>(_ldg(eoff) - max_v);
+        exp_sum += ele;
+        out[eid*out_len + tx] = ele;
+      }
+
+      for (Idx i = row_start; i < row_end; ++i) {
+        const Idx eid = UseIdx ? _ldg(edge_map + i) : i;
+        DType val = out[eid*out_len + tx] / exp_sum;
+        out[eid*out_len + tx] = val;
+      }
+      tx += stride_x;
+    }
+    ty += stride_y;
+  }
+}
+
+/*!
+ * \brief CUDA kernel of Edge Softmax Backward on Csr format.
+ * \note 
+ */
+
+template <typename Idx, typename DType,
+          typename Op,
+          bool UseBcast = false, bool UseIdx = false>
+__global__ void EdgeSoftmaxCsrBackwardKernel(
+    const DType* __restrict__ out,
+    const DType* __restrict__ sds,
+    DType* __restrict__ back_out,
+    const Idx* __restrict__ indptr,
+    const Idx* __restrict__ indices,
+    const Idx* __restrict__ edge_map,
+    int64_t num_rows, int64_t num_cols,
+    const int64_t* __restrict__ lhs_off,
+    const int64_t* __restrict__ rhs_off,
+    int64_t out_len, int64_t sds_len, int64_t back_out_len) {
+  int ty = blockIdx.y * blockDim.y + threadIdx.y;
+  const Idx stride_y = blockDim.y * gridDim.y;
+  const int stride_x = blockDim.x * gridDim.x;
+  while (ty < num_rows) {
+    int tx = blockIdx.x * blockDim.x + threadIdx.x;    
+    const Idx row_start = indptr[ty], row_end = indptr[ty+1];
+    while (tx < out_len) {
+      DType sum_sds = 0.;
+      const int64_t rhs_add = UseBcast ? rhs_off[tx] : tx;
+      for (Idx i = row_start; i < row_end; ++i) {
+        const Idx eid = UseIdx ? edge_map[i] : i;
+        const DType * sds_off = Op::use_rhs ? sds + eid*sds_len + rhs_add : nullptr;
+        sum_sds += _ldg(sds_off);
+      }
+      for (Idx i = row_start; i < row_end; ++i) {
+        const Idx eid = UseIdx ? edge_map[i] : i;
+        const DType * out_off = Op::use_rhs ? out + eid*out_len + rhs_add : nullptr;
+        const DType * sds_off = Op::use_rhs ? sds + eid*sds_len + rhs_add : nullptr;
+        back_out[eid*back_out_len + tx] = _ldg(sds_off) - sum_sds * _ldg(out_off);
+      }
+      tx += stride_x;
+    }
+    ty += stride_y;
+  }
+}
+
+/*!
  * \brief CUDA implementation of g-SpMM on Coo format.
  * \param bcast Broadcast information.
  * \param coo The Coo matrix.
@@ -830,6 +930,93 @@ void SpMMCmpCsrHetero(
   });
 }
 
+/*!
+ * \brief CUDA implementation of Edge_softmax_csr_forward on Csr format.
+ * \param bcast Broadcast information.
+ * \param coo The Csr matrix.
+ * \param ufeat The feature on source nodes.
+ * \param efeat The feature on edges.
+ * \param out The result feature.
+ */
+template <typename Idx, typename DType, typename Op>
+void Edge_softmax_csr_forward(const BcastOff& bcast, const CSRMatrix& csr, NDArray ufeat,
+                NDArray efeat, NDArray out) {
+  const Idx *indptr = csr.indptr.Ptr<Idx>();
+  const Idx *indices = csr.indices.Ptr<Idx>();
+  const Idx *edge_map = csr.data.Ptr<Idx>();
+  const DType *ufeat_data = ufeat.Ptr<DType>();
+  const DType *efeat_data = efeat.Ptr<DType>();
+  DType *out_data = out.Ptr<DType>();
+
+  auto* thr_entry = runtime::CUDAThreadEntry::ThreadLocal();
+
+  int64_t *ubcast_off = nullptr, *ebcast_off = nullptr;
+  int64_t out_len = bcast.out_len,
+          ufeat_len = bcast.lhs_len,
+          efeat_len = bcast.rhs_len;
+  const int ntx = FindNumThreads(out_len);
+  const int nty = CUDA_MAX_NUM_THREADS / ntx;
+  const int nbx = (out_len + ntx - 1) / ntx;
+  const int nby = FindNumBlocks<'y'>((csr.num_rows + nty - 1)/nty);
+  const dim3 nblks(nbx, nby);
+  const dim3 nthrs(ntx, nty);
+  const bool use_idx = !IsNullArray(csr.data);
+
+  BCAST_IDX_CTX_SWITCH(bcast, use_idx, efeat->ctx, ubcast_off, ebcast_off, {
+    CUDA_KERNEL_CALL(
+      (EdgeSoftmaxCsrForwardKernel<Idx, DType, Op, UseBcast, UseIdx>),
+      nblks, nthrs, 0, thr_entry->stream,
+      ufeat_data, efeat_data, out_data,
+      indptr, indices, edge_map,
+      csr.num_rows, csr.num_cols,
+      ubcast_off, ebcast_off,
+      ufeat_len, efeat_len, out_len)
+  });
+} 
+
+/*!
+ * \brief GPU kernel of Edge_softmax_csr_backward on Csr format.
+ * \param bcast Broadcast information.
+ * \param csr The Csr matrix.
+ * \param out The result of forward.
+ * \param sds The result of gradiet * out.
+ * \param back_out The result of edge_softmax_backward.
+ */
+template <typename Idx, typename DType, typename Op>
+void Edge_softmax_csr_backward(const BcastOff& bcast, const CSRMatrix& csr, NDArray out,
+                NDArray sds, NDArray back_out) {
+  const Idx *indptr = csr.indptr.Ptr<Idx>();
+  const Idx *indices = csr.indices.Ptr<Idx>();
+  const Idx *edge_map = csr.data.Ptr<Idx>();
+  const DType *out_data = out.Ptr<DType>();
+  const DType *sds_data = sds.Ptr<DType>();
+  DType *back_out_data = back_out.Ptr<DType>();
+
+  auto* thr_entry = runtime::CUDAThreadEntry::ThreadLocal();
+
+  int64_t *lhs_off = nullptr, *rhs_off = nullptr;
+  int64_t back_out_len = bcast.out_len,
+          out_len = bcast.rhs_len,
+          sds_len = bcast.rhs_len; 
+  const int ntx = FindNumThreads(back_out_len);
+  const int nty = CUDA_MAX_NUM_THREADS / ntx;
+  const int nbx = (back_out_len + ntx - 1) / ntx;
+  const int nby = FindNumBlocks<'y'>((csr.num_rows + nty - 1)/nty);
+  const dim3 nblks(nbx, nby);
+  const dim3 nthrs(ntx, nty);
+  const bool use_idx = !IsNullArray(csr.data);
+
+  BCAST_IDX_CTX_SWITCH(bcast, use_idx, out->ctx, lhs_off, rhs_off, {
+    CUDA_KERNEL_CALL(
+      (EdgeSoftmaxCsrBackwardKernel<Idx, DType, Op, UseBcast, UseIdx>),
+      nblks, nthrs, 0, thr_entry->stream,
+      out_data, sds_data, back_out_data,
+      indptr, indices, edge_map,
+      csr.num_rows, csr.num_cols,
+      lhs_off, rhs_off,
+      out_len, sds_len, back_out_len)
+  });
+}
 
 }  // namespace cuda
 }  // namespace aten

--- a/src/array/cuda/utils.h
+++ b/src/array/cuda/utils.h
@@ -244,6 +244,65 @@ __device__ IdType _BinarySearch(const IdType *A, int64_t n, IdType x) {
   return n;  // not found
 }
 
+/*!
+ * \brief Find the maximum one of two input values.
+ * Specialized for half, float and double types to use cuda math function.
+ * 
+ * @param a: The first value to be compared
+ * @param b: The second value to be compared.
+ * @return the maximum value. 
+ */
+
+template <typename DType>
+__device__ inline DType _FindMax(DType a, DType b) {
+  return a > b ? a : b;
+}
+
+#ifdef USE_FP16
+template <>
+__device__ inline half _FindMax(half a, half b) {
+  return __hmax(a, b);
+}
+#endif
+
+template <>
+__device__ inline float _FindMax(float a, float b) {
+  return fmaxf(a, b);
+}
+
+template <>
+__device__ inline double _FindMax(double a, double b) {
+  return fmax(a, b);
+}
+
+/*!
+ * \brief Calculate the exp of a floating point value.
+ * Specilaized for half, float and double types to use cuda math function.
+ * 
+ * @param f: Input floating point value.
+ * @return The exp(f).
+ */
+
+template <typename DType>
+__device__ inline DType _CalExp(DType f);
+
+#ifdef USE_FP16
+template <>
+__device__ inline half _CalExp(half f) {
+  return hexp(f);
+}
+#endif
+
+template <>
+__device__ inline float _CalExp(float f) {
+  return expf(f);
+}
+
+template <>
+__device__ inline double _CalExp(double f) {
+  return exp(f);
+}
+
 }  // namespace cuda
 }  // namespace dgl
 

--- a/src/array/kernel.cc
+++ b/src/array/kernel.cc
@@ -327,7 +327,6 @@ void Edge_softmax_forward(const std::string& op,
           NDArray ufeat,
           NDArray efeat,
           NDArray out) {
-  // TODO(zhejiang): add gpu op for edge_softmax
   SparseFormat format = graph->SelectFormat(0, CSC_CODE);
   const auto& bcast = CalcBcastOff(op, ufeat, efeat);
 
@@ -349,7 +348,6 @@ void Edge_softmax_backward(const std::string& op,
           NDArray sds,
           NDArray back_out,
           NDArray ufeat) {
-  // TODO(zhejiang): add gpu op for edge_softmax
   SparseFormat format = graph->SelectFormat(0, CSC_CODE);
   const auto& bcast = CalcBcastOff(op, ufeat, sds);
 

--- a/src/array/kernel.cc
+++ b/src/array/kernel.cc
@@ -331,7 +331,7 @@ void Edge_softmax_forward(const std::string& op,
   SparseFormat format = graph->SelectFormat(0, CSC_CODE);
   const auto& bcast = CalcBcastOff(op, ufeat, efeat);
 
-  ATEN_XPU_SWITCH(graph->Context().device_type, XPU, "edge_softmax", {
+  ATEN_XPU_SWITCH_CUDA(graph->Context().device_type, XPU, "edge_softmax", {
     ATEN_ID_TYPE_SWITCH(graph->DataType(), IdType, {
       ATEN_FLOAT_BITS_SWITCH(out->dtype, bits, "edge_softmax out data", {
         Edge_softmax_csr_forward<XPU, IdType, bits>(
@@ -353,7 +353,7 @@ void Edge_softmax_backward(const std::string& op,
   SparseFormat format = graph->SelectFormat(0, CSC_CODE);
   const auto& bcast = CalcBcastOff(op, ufeat, sds);
 
-  ATEN_XPU_SWITCH(graph->Context().device_type, XPU, "edge_softmax_back", {
+  ATEN_XPU_SWITCH_CUDA(graph->Context().device_type, XPU, "edge_softmax_back", {
     ATEN_ID_TYPE_SWITCH(graph->DataType(), IdType, {
       ATEN_FLOAT_BITS_SWITCH(out->dtype, bits, "edge_softmax out data_back", {
         Edge_softmax_csr_backward<XPU, IdType, bits>(


### PR DESCRIPTION
## Description
Hi,

I added fused EdgeSoftmax kernel support (forward and backward) in this PR.

The forward kernel and backward kernel both use vertex-centric parallelism.

The task mapping is the same as SpMM kernels: x-axis for feature dimension, y-axis for vertices.

The forward kernel consists of three loops over the edge list for each vertex. The first one finds the max value, the second one calculates the exp sum, the last one calculates the attention of each edge.

The backward kernel consists of two loops over the edge list.

## Performance Comparison (Nvidia V100 32GB)

### Cora

| #dim  | #Orginal forward | #New forward |
| ------------- | ------------- | ------- |
| 8  |  0.00051 | 0.000071 |
| 4  | 0.00060 | 0.0000705 |
| 1  | 0.00052 | 0.000082 |

### Pubmed

| #dim  | #Orginal forward | #New forward |
| ------------- | ------------- | ------- |
| 8  |  0.00053 | 0.000099 |
| 4  | 0.00052 |  0.000096 |
| 1  | 0.00053 | 0.000096 |

### Ogbn-arxiv

| #dim  | #Orginal forward | #New forward |
| ------------- | ------------- | ------- |
| 8  |  0.0070 | 0.0125 |
| 4  | 0.0063 |  0.0126 |
| 1  | 0.0040 | 0.0106 |

### Reddit

| #dim  | #Orginal forward | #New forward |
| ------------- | ------------- | ------- |
| 8  |  0.0922 | 0.0979 |
| 4  | 0.0582 |  0.0789 |
| 1  | 0.0586 | 0.1287 |

We can observe significant speedups over the first two small datasets, but slowdowns over larger datasets.

I guess the reason could be the workload imbalance in the large graph and the original implementation uses `sddmm`, which is edge parallelism.


