### PR TITLE
[Examples] Update graphsage multi-gpu example to use mutliple GPUs for validation and testing.

### DIFF
--- a/examples/pytorch/graphsage/multi_gpu_node_classification.py
+++ b/examples/pytorch/graphsage/multi_gpu_node_classification.py
@@ -6,10 +6,27 @@ import torch.distributed.optim
 import torchmetrics.functional as MF
 import dgl
 import dgl.nn as dglnn
+from dgl.utils import pin_memory_inplace, unpin_memory_inplace, gather_pinned_tensor_rows
 import time
 import numpy as np
 from ogb.nodeproppred import DglNodePropPredDataset
 import tqdm
+
+
+def shared_tensor(*shape, device, q):
+    rank = dist.get_rank()
+    world_size = dist.get_world_size()
+    if rank == 0:
+        y = torch.zeros(
+            *shape, device=device)
+        for i in range(1, world_size):
+            q.put(y)
+    else:
+        y = q.get()
+    dist.barrier()
+    pin_memory_inplace(y)
+    return y
+
 
 class SAGE(nn.Module):
     def __init__(self, in_feats, n_hidden, n_classes):
@@ -31,34 +48,37 @@ class SAGE(nn.Module):
                 h = self.dropout(h)
         return h
 
-    def inference(self, g, device, batch_size, num_workers, buffer_device=None):
-        # The difference between this inference function and the one in the official
-        # example is that the intermediate results can also benefit from prefetching.
-        g.ndata['h'] = g.ndata['feat']
-        sampler = dgl.dataloading.MultiLayerFullNeighborSampler(1, prefetch_node_feats=['h'])
-        dataloader = dgl.dataloading.DataLoader(
-                g, torch.arange(g.num_nodes()).to(g.device), sampler, device=device,
-                batch_size=1000, shuffle=False, drop_last=False, num_workers=num_workers,
-                persistent_workers=(num_workers > 0))
-        if buffer_device is None:
-            buffer_device = device
+    def inference(self, g, device, batch_size,
+                  buffer_device, q):
+        sampler = dgl.dataloading.MultiLayerFullNeighborSampler(1)
+        dataloader = dgl.dataloading.NodeDataLoader(
+                g, torch.arange(g.num_nodes(), device=device), sampler, device=device,
+                batch_size=batch_size, shuffle=False, drop_last=False,
+                num_workers=0, use_ddp=True, use_uva=True)
 
+        feat = g.ndata['feat']
         for l, layer in enumerate(self.layers):
-            y = torch.zeros(
-                g.num_nodes(), self.n_hidden if l != len(self.layers) - 1 else self.n_classes,
-                device=buffer_device)
-            for input_nodes, output_nodes, blocks in tqdm.tqdm(dataloader):
-                x = blocks[0].srcdata['h']
+            y = shared_tensor(
+                    g.num_nodes(), self.n_hidden if l != len(self.layers) - 1 else self.n_classes,
+                    device=buffer_device, q=q)
+
+            for input_nodes, output_nodes, blocks in tqdm.tqdm(dataloader) \
+                    if dist.get_rank() == 0 else dataloader:
+                x = gather_pinned_tensor_rows(feat, input_nodes)
                 h = layer(blocks[0], x)
                 if l != len(self.layers) - 1:
                     h = F.relu(h)
                     h = self.dropout(h)
                 y[output_nodes] = h.to(buffer_device)
-            g.ndata['h'] = y
+            # make sure all GPUs are done writing to 'y'
+            dist.barrier()
+            if l > 0:
+                unpin_memory_inplace(feat)
+            feat = y
         return y
 
 
-def train(rank, world_size, graph, num_classes, split_idx):
+def train(rank, world_size, graph, num_classes, split_idx, q):
     torch.cuda.set_device(rank)
     dist.init_process_group('nccl', 'tcp://127.0.0.1:12347', world_size=world_size, rank=rank)
 
@@ -68,18 +88,21 @@ def train(rank, world_size, graph, num_classes, split_idx):
 
     train_idx, valid_idx, test_idx = split_idx['train'], split_idx['valid'], split_idx['test']
 
+    # move ids to GPU
     train_idx = train_idx.to('cuda')
     valid_idx = valid_idx.to('cuda')
+    test_idx = test_idx.to('cuda')
 
     sampler = dgl.dataloading.NeighborSampler(
             [15, 10, 5], prefetch_node_feats=['feat'], prefetch_labels=['label'])
     train_dataloader = dgl.dataloading.DataLoader(
             graph, train_idx, sampler,
-            device='cuda', batch_size=1000, shuffle=True, drop_last=False,
+            device='cuda', batch_size=1024, shuffle=True, drop_last=False,
             num_workers=0, use_ddp=True, use_uva=True)
-    valid_dataloader = dgl.dataloading.DataLoader(
+    valid_dataloader = dgl.dataloading.NodeDataLoader(
             graph, valid_idx, sampler, device='cuda', batch_size=1024, shuffle=True,
-            drop_last=False, num_workers=0, use_uva=True)
+            drop_last=False, num_workers=0, use_ddp=True,
+            use_uva=True)
 
     durations = []
     for _ in range(10):
@@ -93,33 +116,39 @@ def train(rank, world_size, graph, num_classes, split_idx):
             opt.zero_grad()
             loss.backward()
             opt.step()
-            if it % 20 == 0:
-                acc = MF.accuracy(y_hat, y)
+            if it % 20 == 0 and rank == 0:
+                acc = MF.accuracy(torch.argmax(y_hat, dim=1), y)
                 mem = torch.cuda.max_memory_allocated() / 1000000
                 print('Loss', loss.item(), 'Acc', acc.item(), 'GPU Mem', mem, 'MB')
         tt = time.time()
+
         if rank == 0:
             print(tt - t0)
-            durations.append(tt - t0)
+        durations.append(tt - t0)
 
-            model.eval()
-            ys = []
-            y_hats = []
-            for it, (input_nodes, output_nodes, blocks) in enumerate(valid_dataloader):
-                with torch.no_grad():
-                    x = blocks[0].srcdata['feat']
-                    ys.append(blocks[-1].dstdata['label'])
-                    y_hats.append(model.module(blocks, x))
-            acc = MF.accuracy(torch.cat(y_hats), torch.cat(ys))
+        model.eval()
+        ys = []
+        y_hats = []
+        for it, (input_nodes, output_nodes, blocks) in enumerate(valid_dataloader):
+            with torch.no_grad():
+                x = blocks[0].srcdata['feat']
+                ys.append(blocks[-1].dstdata['label'])
+                y_hats.append(model.module(blocks, x))
+        acc = MF.accuracy(torch.argmax(torch.cat(y_hats), dim=1), torch.cat(ys)) / world_size
+        dist.reduce(acc, 0)
+        if rank == 0:
             print('Validation acc:', acc.item())
         dist.barrier()
 
     if rank == 0:
         print(np.mean(durations[4:]), np.std(durations[4:]))
-        model.eval()
-        with torch.no_grad():
-            pred = model.module.inference(graph, 'cuda', 1000, 12, graph.device)
-            acc = MF.accuracy(pred.to(graph.device), graph.ndata['label'])
+    model.eval()
+    with torch.no_grad():
+        # since we do 1-layer at a time, use a very large batch size
+        pred = model.module.inference(graph, device='cuda', batch_size=2**16,
+                                      buffer_device='cpu', q=q)
+        if rank == 0:
+            acc = MF.accuracy(torch.argmax(pred[test_idx], dim=1), graph.ndata['label'][test_idx])
             print('Test acc:', acc.item())
 
 if __name__ == '__main__':
@@ -129,9 +158,12 @@ if __name__ == '__main__':
     graph.create_formats_()     # must be called before mp.spawn().
     split_idx = dataset.get_idx_split()
     num_classes = dataset.num_classes
-    n_procs = 4
+    # use all available GPUs
+    n_procs = torch.cuda.device_count()
 
     # Tested with mp.spawn and fork.  Both worked and got 4s per epoch with 4 GPUs
     # and 3.86s per epoch with 8 GPUs on p2.8x, compared to 5.2s from official examples.
     import torch.multiprocessing as mp
-    mp.spawn(train, args=(n_procs, graph, num_classes, split_idx), nprocs=n_procs)
+    ctx = mp.get_context('spawn')
+    q = ctx.Queue()
+    mp.spawn(train, args=(n_procs, graph, num_classes, split_idx, q), nprocs=n_procs)


### PR DESCRIPTION
## Description
This PR enables multi-GPU validation and testing that also uses UVA in this example.
This results in significant end-to-end speedup on the script in my testing (assuming the dataset is already downloaded):

Current example using 4 GPUs:
```
real    3m21.090s
user    33m23.354s
sys     14m6.606s
```
This PR using 4 GPUs:
```
real    1m14.908s
user    4m32.907s
sys     2m40.365s
```
Which is a little more than 7 times faster, and a much better user experience, and showcases how to do multi-GPU validation and testing/inference.


## Checklist
Please feel free to remove inapplicable items for your PR.
- [x] The PR title starts with [$CATEGORY] (such as [NN], [Model], [Doc], [Feature]])
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage
- [x] Code is well-documented
- [x] To the best of my knowledge, examples are either not affected by this change,
      or have been fixed to be compatible with this change

## Changes
This changes how validation and testing/inference is done to use multiple GPUs and UVA.

This uses much larger batch sizes for inference, since we are only executing a single layer at a time.

This ensures only process 0 calls `tqdm` preventing multiple processes trying to write progress bars to the screen.

This restricts the test accuracy to include only the test set, rather than the entire graph.

This uses all available GPUs, rather than 4.
