### PR TITLE
[Bugfix] Fix multiple bugs and code refactor

### DIFF
--- a/include/dgl/aten/coo.h
+++ b/include/dgl/aten/coo.h
@@ -47,6 +47,8 @@ struct COOMatrix {
   bool row_sorted = false;
   /*! \brief whether the column indices per row are sorted */
   bool col_sorted = false;
+  /*! \brief whether the matrix is in pinned memory */
+  bool is_pinned = false;
   /*! \brief default constructor */
   COOMatrix() = default;
   /*! \brief constructor */
@@ -139,11 +141,14 @@ struct COOMatrix {
   *       The context check is deferred to pinning the NDArray.
   */
   inline void PinMemory_() {
+    if (is_pinned)
+      return;
     row.PinMemory_();
     col.PinMemory_();
     if (!aten::IsNullArray(data)) {
       data.PinMemory_();
     }
+    is_pinned = true;
   }
 
   /*!
@@ -154,11 +159,14 @@ struct COOMatrix {
   *       The context check is deferred to unpinning the NDArray.
   */
   inline void UnpinMemory_() {
+    if (!is_pinned)
+      return;
     row.UnpinMemory_();
     col.UnpinMemory_();
     if (!aten::IsNullArray(data)) {
       data.UnpinMemory_();
     }
+    is_pinned = false;
   }
 };
 

--- a/include/dgl/aten/csr.h
+++ b/include/dgl/aten/csr.h
@@ -44,6 +44,8 @@ struct CSRMatrix {
   IdArray data;
   /*! \brief whether the column indices per row are sorted */
   bool sorted = false;
+  /*! \brief whether the matrix is in pinned memory */
+  bool is_pinned = false;
   /*! \brief default constructor */
   CSRMatrix() = default;
   /*! \brief constructor */
@@ -132,11 +134,14 @@ struct CSRMatrix {
   *       The context check is deferred to pinning the NDArray.
   */
   inline void PinMemory_() {
+    if (is_pinned)
+      return;
     indptr.PinMemory_();
     indices.PinMemory_();
     if (!aten::IsNullArray(data)) {
       data.PinMemory_();
     }
+    is_pinned = true;
   }
 
   /*!
@@ -147,11 +152,14 @@ struct CSRMatrix {
   *       The context check is deferred to unpinning the NDArray.
   */
   inline void UnpinMemory_() {
+    if (!is_pinned)
+      return;
     indptr.UnpinMemory_();
     indices.UnpinMemory_();
     if (!aten::IsNullArray(data)) {
       data.UnpinMemory_();
     }
+    is_pinned = false;
   }
 };
 

--- a/include/dgl/base_heterograph.h
+++ b/include/dgl/base_heterograph.h
@@ -438,21 +438,6 @@ class BaseHeteroGraph : public runtime::Object {
   virtual aten::CSRMatrix GetCSCMatrix(dgl_type_t etype) const = 0;
 
   /*!
-   * \brief Set the COO matrix representation for a given edge type.
-   */
-  virtual void SetCOOMatrix(dgl_type_t etype, aten::COOMatrix coo) = 0;
-
-  /*!
-   * \brief Set the CSR matrix representation for a given edge type.
-   */
-  virtual void SetCSRMatrix(dgl_type_t etype, aten::CSRMatrix csr) = 0;
-
-  /*!
-   * \brief Set the CSC matrix representation for a given edge type.
-   */
-  virtual void SetCSCMatrix(dgl_type_t etype, aten::CSRMatrix csc) = 0;
-
-  /*!
    * \brief Extract the induced subgraph by the given vertices.
    *
    * The length of the given vector should be equal to the number of vertex types.

--- a/python/dgl/utils/checks.py
+++ b/python/dgl/utils/checks.py
@@ -30,7 +30,7 @@ def prepare_tensor(g, data, name):
         Data in tensor object.
     """
     if F.is_tensor(data):
-        if not g.is_pinned() and (F.dtype(data) != g.idtype or F.context(data) != g.device):
+        if (F.dtype(data) != g.idtype or F.context(data) != g.device) and not g.is_pinned():
             raise DGLError('Expect argument "{}" to have data type {} and device '
                            'context {}. But got {} and {}.'.format(
                                name, g.idtype, g.device, F.dtype(data), F.context(data)))

--- a/src/graph/heterograph.cc
+++ b/src/graph/heterograph.cc
@@ -309,6 +309,8 @@ HeteroGraphPtr HeteroGraph::CopyToSharedMem(
   std::vector<HeteroGraphPtr> relgraphs(g->NumEdgeTypes());
 
   for (dgl_type_t etype = 0 ; etype < g->NumEdgeTypes() ; ++etype) {
+    auto src_dst_type = g->GetEndpointTypes(etype);
+    int num_vtypes = (src_dst_type.first == src_dst_type.second ? 1 : 2);
     aten::COOMatrix coo;
     aten::CSRMatrix csr, csc;
     std::string prefix = name + "_" + std::to_string(etype);
@@ -321,7 +323,8 @@ HeteroGraphPtr HeteroGraph::CopyToSharedMem(
     if (has_csc) {
       csc = shm.CopyToSharedMem(hg->GetCSCMatrix(etype), prefix + "_csc");
     }
-    relgraphs[etype] = UnitGraph::CreateHomographFrom(csc, csr, coo, has_csc, has_csr, has_coo);
+    relgraphs[etype] = UnitGraph::CreateUnitGraphFrom(
+        num_vtypes, csc, csr, coo, has_csc, has_csr, has_coo);
   }
 
   auto ret = std::shared_ptr<HeteroGraph>(
@@ -361,6 +364,8 @@ std::tuple<HeteroGraphPtr, std::vector<std::string>, std::vector<std::string>>
 
   std::vector<HeteroGraphPtr> relgraphs(metagraph->NumEdges());
   for (dgl_type_t etype = 0 ; etype < metagraph->NumEdges() ; ++etype) {
+    auto src_dst = metagraph->FindEdge(etype);
+    int num_vtypes = (src_dst.first == src_dst.second) ? 1 : 2;
     aten::COOMatrix coo;
     aten::CSRMatrix csr, csc;
     std::string prefix = name + "_" + std::to_string(etype);
@@ -374,7 +379,8 @@ std::tuple<HeteroGraphPtr, std::vector<std::string>, std::vector<std::string>>
       shm.CreateFromSharedMem(&csc, prefix + "_csc");
     }
 
-    relgraphs[etype] = UnitGraph::CreateHomographFrom(csc, csr, coo, has_csc, has_csr, has_coo);
+    relgraphs[etype] = UnitGraph::CreateUnitGraphFrom(
+        num_vtypes, csc, csr, coo, has_csc, has_csr, has_coo);
   }
 
   auto ret = std::make_shared<HeteroGraph>(metagraph, relgraphs, num_verts_per_type);

--- a/src/graph/heterograph.h
+++ b/src/graph/heterograph.h
@@ -272,18 +272,6 @@ class HeteroGraph : public BaseHeteroGraph {
     return relation_graphs_;
   }
 
-  void SetCOOMatrix(dgl_type_t etype, aten::COOMatrix coo) override {
-    GetRelationGraph(etype)->SetCOOMatrix(0, coo);
-  }
-
-  void SetCSRMatrix(dgl_type_t etype, aten::CSRMatrix csr) override {
-    GetRelationGraph(etype)->SetCSRMatrix(0, csr);
-  }
-
-  void SetCSCMatrix(dgl_type_t etype, aten::CSRMatrix csc) override {
-    GetRelationGraph(etype)->SetCSCMatrix(0, csc);
-  }
-
  private:
   // To create empty class
   friend class Serializer;

--- a/src/graph/immutable_graph.cc
+++ b/src/graph/immutable_graph.cc
@@ -635,8 +635,8 @@ HeteroGraphPtr ImmutableGraph::AsHeteroGraph() const {
   if (coo_)
     coo = GetCOO()->ToCOOMatrix();
 
-  auto g = UnitGraph::CreateHomographFrom(
-      in_csr, out_csr, coo,
+  auto g = UnitGraph::CreateUnitGraphFrom(
+      1, in_csr, out_csr, coo,
       in_csr_ != nullptr,
       out_csr_ != nullptr,
       coo_ != nullptr);

--- a/src/graph/unit_graph.cc
+++ b/src/graph/unit_graph.cc
@@ -63,7 +63,7 @@ class UnitGraph::COO : public BaseHeteroGraph {
  public:
   COO(GraphPtr metagraph, int64_t num_src, int64_t num_dst, IdArray src,
       IdArray dst, bool row_sorted = false, bool col_sorted = false)
-    : BaseHeteroGraph(metagraph), is_pinned_(false) {
+    : BaseHeteroGraph(metagraph) {
     CHECK(aten::IsValidIdArray(src));
     CHECK(aten::IsValidIdArray(dst));
     CHECK_EQ(src->shape[0], dst->shape[0]) << "Input arrays should have the same length.";
@@ -73,7 +73,7 @@ class UnitGraph::COO : public BaseHeteroGraph {
   }
 
   COO(GraphPtr metagraph, const aten::COOMatrix& coo)
-    : BaseHeteroGraph(metagraph), adj_(coo), is_pinned_(false) {
+    : BaseHeteroGraph(metagraph), adj_(coo) {
     // Data index should not be inherited. Edges in COO format are always
     // assigned ids from 0 to num_edges - 1.
     CHECK(!COOHasData(coo)) << "[BUG] COO should not contain data.";
@@ -85,7 +85,6 @@ class UnitGraph::COO : public BaseHeteroGraph {
     // adj_.num_rows == 0 and adj_.num_cols == 0 means empty UnitGraph which is supported
     adj_.num_rows = -1;
     adj_.num_cols = -1;
-    is_pinned_ = false;
   };
 
   bool defined() const {
@@ -135,7 +134,7 @@ class UnitGraph::COO : public BaseHeteroGraph {
   }
 
   bool IsPinned() const override {
-    return is_pinned_;
+    return adj_.is_pinned;
   }
 
   uint8_t NumBits() const override {
@@ -165,13 +164,11 @@ class UnitGraph::COO : public BaseHeteroGraph {
   /*! \brief Pin the adj_: COOMatrix of the COO graph. */
   void PinMemory_() {
     adj_.PinMemory_();
-    is_pinned_ = true;
   }
 
   /*! \brief Unpin the adj_: COOMatrix of the COO graph. */
   void UnpinMemory_() {
     adj_.UnpinMemory_();
-    is_pinned_ = false;
   }
 
   bool IsMultigraph() const override {
@@ -456,8 +453,6 @@ class UnitGraph::COO : public BaseHeteroGraph {
 
   /*! \brief internal adjacency matrix. Data array is empty */
   aten::COOMatrix adj_;
-
-  bool is_pinned_;
 };
 
 //////////////////////////////////////////////////////////
@@ -471,7 +466,7 @@ class UnitGraph::CSR : public BaseHeteroGraph {
  public:
   CSR(GraphPtr metagraph, int64_t num_src, int64_t num_dst,
       IdArray indptr, IdArray indices, IdArray edge_ids)
-    : BaseHeteroGraph(metagraph), is_pinned_(false) {
+    : BaseHeteroGraph(metagraph) {
     CHECK(aten::IsValidIdArray(indptr));
     CHECK(aten::IsValidIdArray(indices));
     if (aten::IsValidIdArray(edge_ids))
@@ -484,7 +479,7 @@ class UnitGraph::CSR : public BaseHeteroGraph {
   }
 
   CSR(GraphPtr metagraph, const aten::CSRMatrix& csr)
-    : BaseHeteroGraph(metagraph), adj_(csr), is_pinned_(false) {
+    : BaseHeteroGraph(metagraph), adj_(csr) {
   }
 
   CSR() {
@@ -492,7 +487,6 @@ class UnitGraph::CSR : public BaseHeteroGraph {
     // adj_.num_rows == 0 and adj_.num_cols == 0 means empty UnitGraph which is supported
     adj_.num_rows = -1;
     adj_.num_cols = -1;
-    is_pinned_ = false;
   };
 
   bool defined() const {
@@ -542,7 +536,7 @@ class UnitGraph::CSR : public BaseHeteroGraph {
   }
 
   bool IsPinned() const override {
-    return is_pinned_;
+    return adj_.is_pinned;
   }
 
   uint8_t NumBits() const override {
@@ -575,13 +569,11 @@ class UnitGraph::CSR : public BaseHeteroGraph {
   /*! \brief Pin the adj_: CSRMatrix of the CSR graph. */
   void PinMemory_() {
     adj_.PinMemory_();
-    is_pinned_ = true;
   }
 
   /*! \brief Unpin the adj_: CSRMatrix of the CSR graph. */
   void UnpinMemory_() {
     adj_.UnpinMemory_();
-    is_pinned_ = false;
   }
 
   bool IsMultigraph() const override {
@@ -850,8 +842,6 @@ class UnitGraph::CSR : public BaseHeteroGraph {
 
   /*! \brief internal adjacency matrix. Data array stores edge ids */
   aten::CSRMatrix adj_;
-
-  bool is_pinned_ = false;
 };
 
 //////////////////////////////////////////////////////////

--- a/src/graph/unit_graph.cc
+++ b/src/graph/unit_graph.cc
@@ -362,18 +362,6 @@ class UnitGraph::COO : public BaseHeteroGraph {
     return aten::CSRMatrix();
   }
 
-  void SetCOOMatrix(dgl_type_t etype, aten::COOMatrix coo) override {
-    adj_ = coo;
-  }
-
-  void SetCSRMatrix(dgl_type_t etype, aten::CSRMatrix csr) override {
-    LOG(FATAL) << "Not enabled for COO graph";
-  }
-
-  void SetCSCMatrix(dgl_type_t etype, aten::CSRMatrix csc) override {
-    LOG(FATAL) << "Not enabled for COO graph";
-  }
-
   SparseFormat SelectFormat(dgl_type_t etype, dgl_format_code_t preferred_formats) const override {
     LOG(FATAL) << "Not enabled for COO graph";
     return SparseFormat::kCOO;
@@ -797,18 +785,6 @@ class UnitGraph::CSR : public BaseHeteroGraph {
 
   aten::CSRMatrix GetCSRMatrix(dgl_type_t etype) const override {
     return adj_;
-  }
-
-  void SetCOOMatrix(dgl_type_t etype, aten::COOMatrix coo) override {
-    LOG(FATAL) << "Not enabled for CSR graph";
-  }
-
-  void SetCSRMatrix(dgl_type_t etype, aten::CSRMatrix csr) override {
-    adj_ = csr;
-  }
-
-  void SetCSCMatrix(dgl_type_t etype, aten::CSRMatrix csc) override {
-    LOG(FATAL) << "Please use in_csr_->SetCSRMatrix(etype, csc) instead.";
   }
 
   SparseFormat SelectFormat(dgl_type_t etype, dgl_format_code_t preferred_formats) const override {
@@ -1521,54 +1497,6 @@ aten::CSRMatrix UnitGraph::GetCSRMatrix(dgl_type_t etype) const {
 
 aten::COOMatrix UnitGraph::GetCOOMatrix(dgl_type_t etype) const {
   return GetCOO()->adj();
-}
-
-void UnitGraph::SetCOOMatrix(dgl_type_t etype, COOMatrix coo) {
-  if (!(formats_ & COO_CODE)) {
-    LOG(FATAL) << "The graph have restricted sparse format " <<
-      CodeToStr(formats_) << ", cannot set COO matrix.";
-    return;
-  }
-  if (IsPinned()) {
-    LOG(FATAL) << "Cannot set COOMatrix if the graph is pinned, please unpin the graph.";
-    return;
-  }
-  if (!coo_->defined())
-    *(const_cast<UnitGraph*>(this)->coo_) = COO(meta_graph(), coo);
-  else
-    coo_->SetCOOMatrix(0, coo);
-}
-
-void UnitGraph::SetCSRMatrix(dgl_type_t etype, CSRMatrix csr) {
-  if (!(formats_ & CSR_CODE)) {
-    LOG(FATAL) << "The graph have restricted sparse format " <<
-      CodeToStr(formats_) << ", cannot set CSR matrix.";
-    return;
-  }
-  if (IsPinned()) {
-    LOG(FATAL) << "Cannot set CSRMatrix if the graph is pinned, please unpin the graph.";
-    return;
-  }
-  if (!out_csr_->defined())
-    *(const_cast<UnitGraph*>(this)->out_csr_) = CSR(meta_graph(), csr);
-  else
-    out_csr_->SetCSRMatrix(0, csr);
-}
-
-void UnitGraph::SetCSCMatrix(dgl_type_t etype, CSRMatrix csc) {
-  if (!(formats_ & CSC_CODE)) {
-    LOG(FATAL) << "The graph have restricted sparse format " <<
-      CodeToStr(formats_) << ", cannot set CSC matrix.";
-    return;
-  }
-  if (IsPinned()) {
-    LOG(FATAL) << "Cannot set CSCMatrix if the graph is pinned, please unpin the graph.";
-    return;
-  }
-  if (!in_csr_->defined())
-    *(const_cast<UnitGraph*>(this)->in_csr_) = CSR(meta_graph(), csc);
-  else
-    in_csr_->SetCSRMatrix(0, csc);
 }
 
 HeteroGraphPtr UnitGraph::GetAny() const {

--- a/src/graph/unit_graph.h
+++ b/src/graph/unit_graph.h
@@ -313,6 +313,7 @@ class UnitGraph : public BaseHeteroGraph {
   friend class Serializer;
   friend class HeteroGraph;
   friend class ImmutableGraph;
+  friend HeteroGraphPtr HeteroForkingUnpickle(const HeteroPickleStates& states);
 
   // private empty constructor
   UnitGraph() {}
@@ -329,6 +330,7 @@ class UnitGraph : public BaseHeteroGraph {
 
   /*!
    * \brief constructor
+   * \param num_vtypes number of vertex types (1 or 2)
    * \param metagraph metagraph
    * \param in_csr in edge csr
    * \param out_csr out edge csr
@@ -337,7 +339,8 @@ class UnitGraph : public BaseHeteroGraph {
    * \param has_out_csr whether out_csr is valid
    * \param has_coo whether coo is valid
    */
-  static HeteroGraphPtr CreateHomographFrom(
+  static HeteroGraphPtr CreateUnitGraphFrom(
+      int num_vtypes,
       const aten::CSRMatrix &in_csr,
       const aten::CSRMatrix &out_csr,
       const aten::COOMatrix &coo,

--- a/src/graph/unit_graph.h
+++ b/src/graph/unit_graph.h
@@ -305,10 +305,6 @@ class UnitGraph : public BaseHeteroGraph {
 
   void InvalidateCOO();
 
-  void SetCOOMatrix(dgl_type_t etype, aten::COOMatrix coo) override;
-  void SetCSRMatrix(dgl_type_t etype, aten::CSRMatrix csr) override;
-  void SetCSCMatrix(dgl_type_t etype, aten::CSRMatrix csc) override;
-
  private:
   friend class Serializer;
   friend class HeteroGraph;


### PR DESCRIPTION
* Removed `SetCOOMatrix` and similar methods since they are not necessary.
* Fix `CopyToSharedMem` assuming that all relation graphs are homogeneous.
* Fix #3802 by maintaining `is_pinned` flag in the GraphIndex rather than checking for the arrays' pinned memory status every time.