### PR TITLE
[BugFix] send rpc messages blockingly in case of congestion

### DIFF
--- a/tests/distributed/test_rpc.py
+++ b/tests/distributed/test_rpc.py
@@ -16,7 +16,7 @@ if os.name != 'nt':
 INTEGER = 2
 STR = 'hello world!'
 HELLO_SERVICE_ID = 901231
-TENSOR = F.zeros((10, 10), F.int64, F.cpu())
+TENSOR = F.zeros((1000, 1000), F.int64, F.cpu())
 
 def foo(x, y):
     assert x == 123
@@ -188,15 +188,16 @@ def test_multi_client():
     os.environ['DGL_DIST_MODE'] = 'distributed'
     generate_ip_config("rpc_ip_config_mul_client.txt", 1, 1)
     ctx = mp.get_context('spawn')
-    pserver = ctx.Process(target=start_server, args=(10, "rpc_ip_config_mul_client.txt"))
+    num_clients = 20
+    pserver = ctx.Process(target=start_server, args=(num_clients, "rpc_ip_config_mul_client.txt"))
     pclient_list = []
-    for i in range(10):
+    for i in range(num_clients):
         pclient = ctx.Process(target=start_client, args=("rpc_ip_config_mul_client.txt",))
         pclient_list.append(pclient)
     pserver.start()
-    for i in range(10):
+    for i in range(num_clients):
         pclient_list[i].start()
-    for i in range(10):
+    for i in range(num_clients):
         pclient_list[i].join()
     pserver.join()
 


### PR DESCRIPTION
## Description
<!-- Brief description. Refer to the related issues if existed.
It'll be great if relevant reviewers can be assigned as well.-->
dist training may hang in DistGraph.__init__() when many trainers are booted. The direct cause seems to be that some rpc messages from clients fail to arrive at servers.

needs more confirmations.
## Checklist
Please feel free to remove inapplicable items for your PR.
- [ ] The PR title starts with [$CATEGORY] (such as [NN], [Model], [Doc], [Feature]])
- [ ] Changes are complete (i.e. I finished coding on this PR)
- [ ] All changes have test coverage
- [ ] Code is well-documented
- [ ] To the best of my knowledge, examples are either not affected by this change,
      or have been fixed to be compatible with this change
- [ ] Related issue is referred in this PR
- [ ] If the PR is for a new model/paper, I've updated the example index [here](../examples/README.md).

## Changes
<!-- You could use following template
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)
-->
