### PR TITLE
[Example] Fix multi-GPU RGCN example

### DIFF
--- a/examples/pytorch/rgcn/entity_sample_multi_gpu.py
+++ b/examples/pytorch/rgcn/entity_sample_multi_gpu.py
@@ -31,12 +31,13 @@ def collect_eval(n_gpus, queue, labels):
 
 def run(proc_id, n_gpus, n_cpus, args, devices, dataset, queue=None):
     dev_id = devices[proc_id]
+    th.cuda.set_device(dev_id)
     g, num_rels, num_classes, labels, train_idx, test_idx,\
         target_idx, inv_target = dataset
 
     dist_init_method = 'tcp://{master_ip}:{master_port}'.format(
         master_ip='127.0.0.1', master_port='12345')
-    backend = 'gloo'
+    backend = 'nccl'
     if proc_id == 0:
         print("backend using {}".format(backend))
     th.distributed.init_process_group(backend=backend,
@@ -101,6 +102,7 @@ def main(args, devices):
     g.create_formats_()
 
     n_gpus = len(devices)
+    mp.set_start_method('spawn')
     n_cpus = mp.cpu_count()
     queue = mp.Queue(n_gpus)
     mp.spawn(run, args=(n_gpus, n_cpus // n_gpus, args, devices, data, queue),

--- a/tutorials/multi/2_node_classification.py
+++ b/tutorials/multi/2_node_classification.py
@@ -206,19 +206,6 @@ def run(proc_id, devices):
 # 
 # A typical scenario for multi-GPU training with DDP is to replicate the
 # model once per GPU, and spawn one trainer process per GPU.
-# 
-# PyTorch tutorials recommend using ``multiprocessing.spawn`` to spawn
-# multiple processes. This however is undesirable for training node
-# classification or link prediction models on a single large graph,
-# especially on Linux. The reason is that a single large graph itself may
-# take a lot of memory, and ``mp.spawn`` will duplicate all objects in the
-# program, including the large graph. Consequently, the large graph will
-# be duplicated as many times as the number of GPUs.
-# 
-# To alleviate the problem we recommend using ``multiprocessing.Process``,
-# which *forks* from the main process and allows sharing the same graph
-# object to trainer processes via *copy-on-write*. This can greatly reduce
-# the memory consumption.
 #
 # Normally, DGL maintains only one sparse matrix representation (usually COO)
 # for each graph, and will create new formats when some APIs are called for
@@ -238,12 +225,6 @@ graph.create_formats_()
 ######################################################################
 # Then you can spawn the subprocesses to train with multiple GPUs.
 # 
-# .. note::
-# 
-#    You will need to use ``dgl.multiprocessing`` instead of the Python
-#    ``multiprocessing`` package. ``dgl.multiprocessing`` is identical to
-#    Python’s built-in ``multiprocessing`` except that it handles the
-#    subtleties between forking and multithreading in Python.
 # 
 # .. code:: python
 #


### PR DESCRIPTION
## Description

Previously when we change the multiprocessing start method to `spawn`, we leave out this `mp.Queue()`, which could cause an error.

This also sets CUDA device explicitly in each training process and uses the NCCL backend.

Remove `dgl.multiprocessing` and the recommendation for `fork` in tutorials.

## Checklist
Please feel free to remove inapplicable items for your PR.
- [x] The PR title starts with [$CATEGORY] (such as [NN], [Model], [Doc], [Feature]])
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] To the best of my knowledge, examples are either not affected by this change,
      or have been fixed to be compatible with this change
