### PR TITLE
[BUGFIX] Heterograph CopyToSharedMem method bugfix

### DIFF
--- a/src/graph/heterograph.cc
+++ b/src/graph/heterograph.cc
@@ -302,6 +302,7 @@ HeteroGraphPtr HeteroGraph::CopyToSharedMem(
     aten::COOMatrix coo;
     aten::CSRMatrix csr, csc;
     std::string prefix = name + "_" + std::to_string(etype);
+    auto relgraph = g->GetRelationGraph(etype);
     if (has_coo) {
       coo = shm.CopyToSharedMem(hg->GetCOOMatrix(etype), prefix + "_coo");
     }
@@ -311,7 +312,8 @@ HeteroGraphPtr HeteroGraph::CopyToSharedMem(
     if (has_csc) {
       csc = shm.CopyToSharedMem(hg->GetCSCMatrix(etype), prefix + "_csc");
     }
-    relgraphs[etype] = UnitGraph::CreateHomographFrom(csc, csr, coo, has_csc, has_csr, has_coo);
+    relgraphs[etype] = UnitGraph::CreateHeterographFrom(csc, csr, coo, has_csc, has_csr, has_coo,
+            (int)relgraph->NumVertexTypes());
   }
 
   auto ret = std::shared_ptr<HeteroGraph>(

--- a/src/graph/unit_graph.cc
+++ b/src/graph/unit_graph.cc
@@ -1325,6 +1325,36 @@ HeteroGraphPtr UnitGraph::CreateHomographFrom(
   return HeteroGraphPtr(new UnitGraph(mg, in_csr_ptr, out_csr_ptr, coo_ptr, formats));
 }
 
+HeteroGraphPtr UnitGraph::CreateHeterographFrom(
+        const aten::CSRMatrix &in_csr,
+        const aten::CSRMatrix &out_csr,
+        const aten::COOMatrix &coo,
+        bool has_in_csr,
+        bool has_out_csr,
+        bool has_coo,
+        int num_vtypes,
+        dgl_format_code_t formats) {
+  auto mg = CreateUnitGraphMetaGraph(num_vtypes);
+
+  CSRPtr in_csr_ptr = nullptr;
+  CSRPtr out_csr_ptr = nullptr;
+  COOPtr coo_ptr = nullptr;
+
+  if (has_in_csr)
+      in_csr_ptr = CSRPtr(new CSR(mg, in_csr));
+  else
+      in_csr_ptr = CSRPtr(new CSR());
+  if (has_out_csr)
+      out_csr_ptr = CSRPtr(new CSR(mg, out_csr));
+  else
+      out_csr_ptr = CSRPtr(new CSR());
+  if (has_coo)
+      coo_ptr = COOPtr(new COO(mg, coo));
+  else
+      coo_ptr = COOPtr(new COO());
+  return HeteroGraphPtr(new UnitGraph(mg, in_csr_ptr, out_csr_ptr, coo_ptr, formats));
+}
+
 UnitGraph::CSRPtr UnitGraph::GetInCSR(bool inplace) const {
   if (inplace)
     if (!(formats_ & CSC_CODE))

--- a/src/graph/unit_graph.h
+++ b/src/graph/unit_graph.h
@@ -321,6 +321,28 @@ class UnitGraph : public BaseHeteroGraph {
       bool has_coo,
       dgl_format_code_t formats = ALL_CODE);
 
+
+/*!
+   * \brief constructor
+   * \param metagraph metagraph
+   * \param in_csr in edge csr
+   * \param out_csr out edge csr
+   * \param coo coo
+   * \param has_in_csr whether in_csr is valid
+   * \param has_out_csr whether out_csr is valid
+   * \param has_coo whether coo is valid
+   * \param number of vertex types
+ */
+  static HeteroGraphPtr CreateHeterographFrom(
+      const aten::CSRMatrix &in_csr,
+      const aten::CSRMatrix &out_csr,
+      const aten::COOMatrix &coo,
+      bool has_in_csr,
+      bool has_out_csr,
+      bool has_coo,
+      int num_vtypes,
+      dgl_format_code_t formats = ALL_CODE);
+
   /*! \return Return any existing format. */
   HeteroGraphPtr GetAny() const;
 


### PR DESCRIPTION
## Description
when Heterograph copy to shared mem , the size of graph will change  , and later use this shared-graph  in sampling will occur a error as follow and coredump:
<img width="1031" alt="屏幕快照 2022-03-25 下午2 46 03" src="https://user-images.githubusercontent.com/5078316/160069365-d149c7d3-b479-42ff-a205-e1e6b215a4c0.png">
compare the Heterograph graph in shared memory and common use  , the data size exist diff , you will see the next pic 
g1 was common use ,  g2 was g1's copy to share mem, but the size was changed
<img width="518" alt="屏幕快照 2022-03-25 下午2 48 54" src="https://user-images.githubusercontent.com/5078316/160069407-1642f071-aa61-46b4-b7ff-00ae4b5339f0.png">
the coredump because of  the unitgraph number of types was change. you will see as follow:
![image](https://user-images.githubusercontent.com/5078316/160069930-d789cafc-2714-4c1c-9e64-5a00d33fa917.png)

so fix it



