### PR TITLE
[BugFix] Remove redundant reference of networkx package in pagerank.py

### DIFF
--- a/examples/pytorch/pagerank.py
+++ b/examples/pytorch/pagerank.py
@@ -4,7 +4,7 @@ import dgl
 import dgl.function as fn
 
 N = 100
-g = nx.nx.erdos_renyi_graph(N, 0.05)
+g = nx.erdos_renyi_graph(N, 0.05)
 g = dgl.DGLGraph(g)
 
 DAMP = 0.85


### PR DESCRIPTION
## Description
There is a redundant reference of `nx` (nextworkx) in `examples/pytorch/pagerank.py` which will produce the error: `AttributeError: module networkx has no attribute nx` .

## Checklist
Please feel free to remove inapplicable items for your PR.
- [x] The PR title starts with [$CATEGORY] (such as [NN], [Model], [Doc], [Feature]])
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage