### PR TITLE
[bugfix] Remove repeats in DDPTensorizedDataset (fix #3893)

### DIFF
--- a/python/dgl/dataloading/dataloader.py
+++ b/python/dgl/dataloading/dataloader.py
@@ -48,7 +48,7 @@ class _TensorizedDatasetIter(object):
             if drop_last:
                 num_batches = len(dataset) / batch_size
             else:
-                num_batches = math.ceil(len(dataset), batch_size)
+                num_batches = math.ceil(len(dataset) / batch_size)
         self.num_batches = num_batches
         self.sample = 0
 


### PR DESCRIPTION
## Description
This changes the behavior of DDPTensorizedDataset to trim the size of the second to last batch to achieve the same number of batches across processes rather than adding duplicates to the training set. This fixes the issue of having multiple of the same item in batch (#3893).

## Checklist
Please feel free to remove inapplicable items for your PR.
- [x] The PR title starts with [$CATEGORY] (such as [NN], [Model], [Doc], [Feature]])
- [x] Changes are complete (i.e. I finished coding on this PR)
- [ ] All changes have test coverage
- [x] Code is well-documented
- [x] To the best of my knowledge, examples are either not affected by this change,
      or have been fixed to be compatible with this change
- [x] Related issue is referred in this PR
