### PR TITLE
[bugfix] Fix edge_subgraph() with UVA (fixes #3873)

### DIFF
--- a/python/dgl/subgraph.py
+++ b/python/dgl/subgraph.py
@@ -144,8 +144,10 @@ def node_subgraph(graph, nodes, *, relabel_nodes=True, store_ids=True, output_de
             return utils.prepare_tensor(graph, v, 'nodes["{}"]'.format(ntype))
 
     induced_nodes = []
+    nodes_device = F.context(list(nodes.values())[0]) if len(nodes) > 0 \
+                                                      else g.device
     for ntype in graph.ntypes:
-        nids = nodes.get(ntype, F.copy_to(F.tensor([], graph.idtype), graph.device))
+        nids = nodes.get(ntype, F.copy_to(F.tensor([], graph.idtype), nodes_device))
         induced_nodes.append(_process_nodes(ntype, nids))
     device = context_of(induced_nodes)
     sgi = graph._graph.node_subgraph(induced_nodes, relabel_nodes)
@@ -303,7 +305,8 @@ def edge_subgraph(graph, edges, *, relabel_nodes=True, store_ids=True, output_de
             return utils.prepare_tensor(graph, e, 'edges["{}"]'.format(etype))
 
     edges = {graph.to_canonical_etype(etype): e for etype, e in edges.items()}
-    edges_device = F.context(list(edges.values())[0]) if len(edges) > 0 else g.device
+    edges_device = F.context(list(edges.values())[0]) if len(edges) > 0 \
+                                                      else g.device
     induced_edges = []
     for cetype in graph.canonical_etypes:
         eids = edges.get(cetype, F.copy_to(F.tensor([], graph.idtype), edges_device))
@@ -430,14 +433,16 @@ def in_subgraph(graph, nodes, *, relabel_nodes=False, store_ids=True, output_dev
             raise DGLError("Must specify node type when the graph is not homogeneous.")
         nodes = {graph.ntypes[0] : nodes}
     nodes = utils.prepare_tensor_dict(graph, nodes, 'nodes')
+    nodes_device = F.context(list(nodes.values())[0]) if len(nodes) > 0 \
+                                                      else g.device
     device = context_of(nodes)
     nodes_all_types = []
     for ntype in graph.ntypes:
         if ntype in nodes:
             nodes_all_types.append(F.to_dgl_nd(nodes[ntype]))
         else:
-            nodes_all_types.append(nd.NULL[graph._idtype_str])
-
+            nodes_all_types.append(F.to_dgl_nd( \
+                F.copy_to(F.tensor([], graph.idtype), nodes_device)))
     sgi = _CAPI_DGLInSubgraph(graph._graph, nodes_all_types, relabel_nodes)
     induced_nodes_or_device = sgi.induced_nodes if relabel_nodes else device
     induced_edges = sgi.induced_edges

--- a/python/dgl/subgraph.py
+++ b/python/dgl/subgraph.py
@@ -303,9 +303,10 @@ def edge_subgraph(graph, edges, *, relabel_nodes=True, store_ids=True, output_de
             return utils.prepare_tensor(graph, e, 'edges["{}"]'.format(etype))
 
     edges = {graph.to_canonical_etype(etype): e for etype, e in edges.items()}
+    edges_device = F.context(list(edges.values())[0]) if len(edges) > 0 else g.device
     induced_edges = []
     for cetype in graph.canonical_etypes:
-        eids = edges.get(cetype, F.copy_to(F.tensor([], graph.idtype), graph.device))
+        eids = edges.get(cetype, F.copy_to(F.tensor([], graph.idtype), edges_device))
         induced_edges.append(_process_edges(cetype, eids))
     device = context_of(induced_edges)
     sgi = graph._graph.edge_subgraph(induced_edges, not relabel_nodes)

--- a/tests/compute/test_heterograph.py
+++ b/tests/compute/test_heterograph.py
@@ -1312,7 +1312,8 @@ def test_subgraph_uva(idtype):
     g.pin_memory_()
 
     # just a smoke test to ensure the it doesn't fail checks
-    sg1 = g.edge_subgraph({'follows': F.copy_to(F.tensor([0,1], dtype=F.int64), ctx=F.ctx())})
+    sg1 = g.edge_subgraph({'follows': F.copy_to(F.tensor([0,1], dtype=idtype), \
+                                                ctx=F.ctx())})
 
 @parametrize_dtype
 def test_subgraph(idtype):

--- a/tests/compute/test_heterograph.py
+++ b/tests/compute/test_heterograph.py
@@ -1299,6 +1299,21 @@ def test_subgraph_mask(idtype):
                                'wishes': F.tensor([False, True], dtype=F.bool)})
         _check_subgraph(g, sg2)
 
+@unittest.skipIf(F._default_context_str == 'cpu', reason="GPU for uva testing.")
+@parametrize_dtype
+def test_subgraph_uva(idtype):
+    g = dgl.heterograph({
+        ('user', 'follows', 'user'): ([0, 1], [1, 2]),
+        ('user', 'plays', 'game'): ([0, 1, 2, 1], [0, 0, 1, 1]),
+        ('user', 'wishes', 'game'): ([0, 2], [1, 0]),
+        ('developer', 'develops', 'game'): ([0, 1], [0, 1])
+    }, idtype=idtype, device=F.cpu())
+
+    g.pin_memory_()
+
+    # just a smoke test to ensure the it doesn't fail checks
+    sg1 = g.edge_subgraph({'follows': F.copy_to(F.tensor([0,1], dtype=F.int64), ctx=F.ctx())})
+
 @parametrize_dtype
 def test_subgraph(idtype):
     g = create_test_heterograph(idtype)


### PR DESCRIPTION
## Description
Ensures empty relations are created on the appropriate device. Fixes #3873.

This does not fully fix node_subgraph and in_subgraph currently, as they require more complex fixes to how the CSR is generated.

## Checklist
Please feel free to remove inapplicable items for your PR.
- [x] The PR title starts with [$CATEGORY] (such as [NN], [Model], [Doc], [Feature]])
- [ ] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage
- [x] Code is well-documented
- [x] To the best of my knowledge, examples are either not affected by this change,
      or have been fixed to be compatible with this change
- [x] Related issue is referred in this PR
