### PR TITLE
[bugfix] Fix EdgePredictionSampler for UVA sampling

### DIFF
--- a/python/dgl/dataloading/base.py
+++ b/python/dgl/dataloading/base.py
@@ -373,8 +373,12 @@ class EdgePredictionSampler(Sampler):
             neg_srcdst = {g.canonical_etypes[0]: neg_srcdst}
 
         dtype = F.dtype(list(neg_srcdst.values())[0][0])
+        ctx = F.context(list(seed_edges.values())[0][0]) if seed_edges \
+                                                         else g.device
         neg_edges = {
-            etype: neg_srcdst.get(etype, (F.tensor([], dtype), F.tensor([], dtype)))
+            etype: neg_srcdst.get(etype,
+                                  (F.copy_to(F.tensor([], dtype), ctx=ctx),
+                                   F.copy_to(F.tensor([], dtype), ctx=ctx)))
             for etype in g.canonical_etypes}
         neg_pair_graph = heterograph(
             neg_edges, {ntype: g.num_nodes(ntype) for ntype in g.ntypes})

--- a/tests/compute/test_dataloader.py
+++ b/tests/compute/test_dataloader.py
@@ -28,11 +28,11 @@ def create_test_graph(idtype):
 @parametrize_dtype
 def test_edge_prediction_sampler(idtype):
     g = create_test_graph(idtype)
-    sampler = NeighborSampler([{'follows':10}, {'follows':10}])
+    sampler = NeighborSampler([10,10])
     sampler = as_edge_prediction_sampler(
         sampler, negative_sampler=negative_sampler.Uniform(1))
 
-    seeds = F.copy_to(F.arange(0, 2, dtype=F.int64), ctx=F.ctx())
+    seeds = F.copy_to(F.arange(0, 2, dtype=idtype), ctx=F.ctx())
     # just a smoke test to make sure we don't fail internal assertions
     result = sampler.sample(g, {'follows': seeds})
 

--- a/tests/compute/test_dataloader.py
+++ b/tests/compute/test_dataloader.py
@@ -1,0 +1,41 @@
+import unittest
+import backend as F
+import dgl
+from dgl.dataloading import NeighborSampler, negative_sampler, \
+    as_edge_prediction_sampler
+from test_utils import parametrize_dtype
+
+def create_test_graph(idtype):
+    # test heterograph from the docstring, plus a user -- wishes -- game relation
+    # 3 users, 2 games, 2 developers
+    # metagraph:
+    #    ('user', 'follows', 'user'),
+    #    ('user', 'plays', 'game'),
+    #    ('user', 'wishes', 'game'),
+    #    ('developer', 'develops', 'game')])
+
+    g = dgl.heterograph({
+        ('user', 'follows', 'user'): ([0, 1], [1, 2]),
+        ('user', 'plays', 'game'): ([0, 1, 2, 1], [0, 0, 1, 1]),
+        ('user', 'wishes', 'game'): ([0, 2], [1, 0]),
+        ('developer', 'develops', 'game'): ([0, 1], [0, 1])
+    }, idtype=idtype, device=F.ctx())
+    assert g.idtype == idtype
+    assert g.device == F.ctx()
+    return g
+
+
+@parametrize_dtype
+def test_edge_prediction_sampler(idtype):
+    g = create_test_graph(idtype)
+    sampler = NeighborSampler([{'follows':10}, {'follows':10}])
+    sampler = as_edge_prediction_sampler(
+        sampler, negative_sampler=negative_sampler.Uniform(1))
+
+    seeds = F.copy_to(F.arange(0, 2, dtype=F.int64), ctx=F.ctx())
+    # just a smoke test to make sure we don't fail internal assertions
+    result = sampler.sample(g, {'follows': seeds})
+
+
+if __name__ == '__main__':
+    test_edge_prediction_sampler()


### PR DESCRIPTION
## Description
Empty relations for the negative graph in link prediction were being generated on the CPU, generating errors similar to #3873.
This adds a unit test, and fixes the issue by generating the empty relations on the same device as the input edges.

## Checklist
Please feel free to remove inapplicable items for your PR.
- [x] The PR title starts with [$CATEGORY] (such as [NN], [Model], [Doc], [Feature]])
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage
- [x] Code is well-documented
- [x] To the best of my knowledge, examples are either not affected by this change,
      or have been fixed to be compatible with this change
- [x] Related issue is referred in this PR



