### PR TITLE
[Bug] Fix multi-GPU edge classification crashing with pure GPU sampling

### DIFF
--- a/python/dgl/dataloading/dataloader.py
+++ b/python/dgl/dataloading/dataloader.py
@@ -513,8 +513,9 @@ class CollateWrapper(object):
         self.device = device
 
     def __call__(self, items):
-        if self.use_uva:
-            # Only copy the indices to the given device if in UVA mode.
+        if self.use_uva or self.g.device != 'cpu':
+            # Only copy the indices to the given device if in UVA mode or the graph is not on
+            # CPU.
             items = recursive_apply(items, lambda x: x.to(self.device))
         batch = self.sample_func(self.g, items)
         return recursive_apply(batch, remove_parent_storage_columns, self.g)

--- a/python/dgl/dataloading/dataloader.py
+++ b/python/dgl/dataloading/dataloader.py
@@ -513,7 +513,7 @@ class CollateWrapper(object):
         self.device = device
 
     def __call__(self, items):
-        if self.use_uva or self.g.device != 'cpu':
+        if self.use_uva or (self.g.device != torch.device('cpu')):
             # Only copy the indices to the given device if in UVA mode or the graph is not on
             # CPU.
             items = recursive_apply(items, lambda x: x.to(self.device))


### PR DESCRIPTION
The situation is described in slack channel (with the same OP of https://discuss.dgl.ai/t/heterogenous-graph-edge-sampling-on-gpu/2892).  Basically when doing edge classification with multi-GPU pure GPU sampling it crashes with a device mismatch error.  This is caused by the indices not being copied to GPU in the collate wrapper.