### PR TITLE
[NN] Add bias argument to HeteroLinear

### DIFF
--- a/python/dgl/nn/pytorch/hetero.py
+++ b/python/dgl/nn/pytorch/hetero.py
@@ -260,6 +260,8 @@ class HeteroLinear(nn.Module):
         Input feature size for heterogeneous inputs. A key can be a string or a tuple of strings.
     out_size : int
         Output feature size.
+    bias : bool, optional
+        If True, learns a bias term. Defaults: ``True``.
 
     Examples
     --------
@@ -276,12 +278,12 @@ class HeteroLinear(nn.Module):
     >>> print(out_feats[('user', 'follows', 'user')].shape)
     torch.Size([3, 3])
     """
-    def __init__(self, in_size, out_size):
+    def __init__(self, in_size, out_size, bias=True):
         super(HeteroLinear, self).__init__()
 
         self.linears = nn.ModuleDict()
         for typ, typ_in_size in in_size.items():
-            self.linears[str(typ)] = nn.Linear(typ_in_size, out_size)
+            self.linears[str(typ)] = nn.Linear(typ_in_size, out_size, bias=bias)
 
     def forward(self, feat):
         """Forward function


### PR DESCRIPTION
## Description
Added ability to use `torch.nn.Linear` without `bias`. This can be useful for residual connections and linear projections.

## Checklist
Please feel free to remove inapplicable items for your PR.
- [x] The PR title starts with [$CATEGORY] (such as [NN], [Model], [Doc], [Feature]])
- [x] Changes are complete (i.e. I finished coding on this PR)
- [ ] All changes have test coverage
- [x] Code is well-documented
- [x] To the best of my knowledge, examples are either not affected by this change,
      or have been fixed to be compatible with this change

## Changes
- Added `bias` argument to HeteroLinear constructor
