### PR TITLE
[Doc] default value typo fix in GlobalUniform negative sampler

### DIFF
--- a/python/dgl/dataloading/negative_sampler.py
+++ b/python/dgl/dataloading/negative_sampler.py
@@ -88,7 +88,7 @@ class GlobalUniform(_BaseNegativeSampler):
         Whether to exclude self-loops from negative samples.  (Default: True)
     replace : bool, optional
         Whether to sample with replacement.  Setting it to True will make things
-        faster.  (Default: True)
+        faster.  (Default: False)
 
     Notes
     -----


### PR DESCRIPTION
## Description
<!-- Brief description. Refer to the related issues if existed.
It'll be great if relevant reviewers can be assigned as well.-->

## Checklist
Please feel free to remove inapplicable items for your PR.
- [x] The PR title starts with [$CATEGORY] (such as [NN], [Model], [Doc], [Feature]])
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage
- [x] Code is well-documented
- [x] To the best of my knowledge, examples are either not affected by this change,
      or have been fixed to be compatible with this change
- [ ] Related issue is referred in this PR
- [ ] If the PR is for a new model/paper, I've updated the example index [here](../examples/README.md).
