### PR TITLE
[Fix] Wrap all CUDA kernel calls with macro

### DIFF
--- a/src/graph/transform/cuda/cuda_map_edges.cuh
+++ b/src/graph/transform/cuda/cuda_map_edges.cuh
@@ -239,11 +239,8 @@ MapEdges(
       const dim3 block(BLOCK_SIZE);
 
       // map the srcs
-      map_edge_ids<IdType, BLOCK_SIZE, TILE_SIZE><<<
-        grid,
-        block,
-        0,
-        stream>>>(
+      CUDA_KERNEL_CALL((map_edge_ids<IdType, BLOCK_SIZE, TILE_SIZE>),
+        grid, block, 0, stream,
         edges.src.Ptr<IdType>(),
         new_lhs.back().Ptr<IdType>(),
         edges.dst.Ptr<IdType>(),
@@ -251,7 +248,6 @@ MapEdges(
         num_edges,
         node_map.LhsHashTable(src_type).DeviceHandle(),
         node_map.RhsHashTable(dst_type).DeviceHandle());
-      CUDA_CALL(cudaGetLastError());
     } else {
       new_lhs.emplace_back(
           aten::NullArray(DLDataType{kDLInt, sizeof(IdType)*8, 1}, ctx));


### PR DESCRIPTION
## Description

This PR wraps all CUDA kernel calls with the `CUDA_KERNEL_CALL` macro, except for those in `src/array/cuda/rowwise_sampling.cu`, which are covered by #4064.

## Checklist
Please feel free to remove inapplicable items for your PR.
- [x] The PR title starts with [$CATEGORY] (such as [NN], [Model], [Doc], [Feature]])
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] To the best of my knowledge, examples are either not affected by this change,
      or have been fixed to be compatible with this change
