### PR TITLE
[Bugfix] Fix GCMC examples

### DIFF
--- a/examples/pytorch/gcmc/data.py
+++ b/examples/pytorch/gcmc/data.py
@@ -504,6 +504,7 @@ class MovieLens(object):
 
         """
         import torchtext
+        from torchtext.data.utils import get_tokenizer
 
         if self._name == 'ml-100k':
             GENRES = GENRES_ML_100K
@@ -514,7 +515,9 @@ class MovieLens(object):
         else:
             raise NotImplementedError
 
-        TEXT = torchtext.legacy.data.Field(tokenize='spacy', tokenizer_language='en_core_web_sm')
+        # Old torchtext-legacy API commented below
+        # TEXT = torchtext.legacy.data.Field(tokenize='spacy', tokenizer_language='en_core_web_sm')
+        tokenizer = get_tokenizer('spacy', language='en_core_web_sm') # new API (torchtext 0.9+)
         embedding = torchtext.vocab.GloVe(name='840B', dim=300)
 
         title_embedding = np.zeros(shape=(self.movie_info.shape[0], 300), dtype=np.float32)
@@ -528,7 +531,8 @@ class MovieLens(object):
             else:
                 title_context, year = match_res.groups()
             # We use average of glove
-            title_embedding[i, :] = embedding.get_vecs_by_tokens(TEXT.tokenize(title_context)).numpy().mean(axis=0)
+            # Upgraded torchtext API:  TEXT.tokenize(title_context) --> tokenizer(title_context)            
+            title_embedding[i, :] = embedding.get_vecs_by_tokens(tokenizer(title_context)).numpy().mean(axis=0)
             release_years[i] = float(year)
         movie_features = np.concatenate((title_embedding,
                                          (release_years - 1950.0) / 100.0,

--- a/examples/pytorch/gcmc/model.py
+++ b/examples/pytorch/gcmc/model.py
@@ -87,7 +87,7 @@ class GCMCGraphConv(nn.Module):
             if weight is not None:
                 feat = dot_or_identity(feat, weight, self.device)
 
-            feat = feat * self.dropout(cj).view(-1, 1)
+            feat = feat * self.dropout(cj)
             graph.srcdata['h'] = feat
             graph.update_all(fn.copy_src(src='h', out='m'),
                              fn.sum(msg='m', out='h'))
@@ -342,7 +342,7 @@ class BiDecoder(nn.Module):
                 graph.apply_edges(fn.u_dot_v('h', 'h', 'sr'))
                 basis_out.append(graph.edata['sr'])
             out = th.cat(basis_out, dim=1)
-            #out = self.combine_basis(out)
+            out = self.combine_basis(out)
         return out
 
 class DenseBiDecoder(nn.Module):


### PR DESCRIPTION
## Description
Duplicate from PR  #4020 
To fix https://github.com/dmlc/dgl/issues/4019
Updated the API of accessing tokenizer in the latest version of torchtext. Using module torchtext.legacy causes the crash with torchtext 0.13.
Revert the changes of model.py from 74f01405 