### PR TITLE
[Bug] Fixed missing dgl.transforms.functional `__all__` entries

### DIFF
--- a/python/dgl/transforms/functional.py
+++ b/python/dgl/transforms/functional.py
@@ -79,7 +79,10 @@ __all__ = [
     'norm_by_dst',
     'radius_graph',
     'random_walk_pe',
-    'laplacian_pe'
+    'laplacian_pe',
+    'to_half',
+    'to_float',
+    'to_double'
     ]
 
 


### PR DESCRIPTION
## Description
Added `to_half`, `to_float`, and `to_double` to `__all__`, from which they were mistakenly missing for dgl.transforms.functional, so that they can be imported properly, as mentioned in https://github.com/dmlc/dgl/issues/4087

## Checklist
- [x] The PR title starts with [$CATEGORY] (such as [NN], [Model], [Doc], [Feature]])
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] To the best of my knowledge, examples are either not affected by this change,
      or have been fixed to be compatible with this change
- [x] Related issue is referred in this PR
