### PR TITLE
[Dist] avoid busy ssh connection

### DIFF
--- a/tools/launch.py
+++ b/tools/launch.py
@@ -111,6 +111,8 @@ def execute_remote(
     thread = Thread(target=run, args=(ssh_cmd,))
     thread.setDaemon(True)
     thread.start()
+    # sleep for a while in case of ssh is rejected by peer due to busy connection
+    time.sleep(0.2)
     return thread
 
 def get_remote_pids(ip, port, cmd_regex):


### PR DESCRIPTION
## Description
<!-- Brief description. Refer to the related issues if existed.
It'll be great if relevant reviewers can be assigned as well.-->
I find if `num_servers=64`, launch server job will fail: `kex_exchange_identification: Connection closed by remote host`. I guess it's caused by ssh connection is issued too fast. This is kind of protection? Sleep for a while works in my side.
## Checklist
Please feel free to remove inapplicable items for your PR.
- [ ] The PR title starts with [$CATEGORY] (such as [NN], [Model], [Doc], [Feature]])
- [ ] Changes are complete (i.e. I finished coding on this PR)
- [ ] All changes have test coverage
- [ ] Code is well-documented
- [ ] To the best of my knowledge, examples are either not affected by this change,
      or have been fixed to be compatible with this change
- [ ] Related issue is referred in this PR
- [ ] If the PR is for a new model/paper, I've updated the example index [here](../examples/README.md).

## Changes
<!-- You could use following template
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)
-->
