### PR TITLE
[Feature] Add an optional argument to always exclude given edge IDs in as_edge_prediction_sampler

### DIFF
--- a/python/dgl/dataloading/base.py
+++ b/python/dgl/dataloading/base.py
@@ -245,7 +245,7 @@ class BlockSampler(Sampler):
         return self.assign_lazy_features(result)
 
 
-def _find_exclude_eids_with_reverse_id(g, eids, reverse_eid_map):
+def _find_exclude_eids_with_reverse_id(eids, reverse_eid_map):
     if isinstance(eids, Mapping):
         assert_canonical_etype_keys(eids)
         exclude_eids = {
@@ -276,7 +276,7 @@ def _find_exclude_eids(g, exclude_mode, eids, **kwargs):
     elif exclude_mode == 'self':
         return eids
     elif exclude_mode == 'reverse_id':
-        return _find_exclude_eids_with_reverse_id(g, eids, kwargs['reverse_eid_map'])
+        return _find_exclude_eids_with_reverse_id(eids, kwargs['reverse_eid_map'])
     elif exclude_mode == 'reverse_types':
         return _find_exclude_eids_with_reverse_types(g, eids, kwargs['reverse_etype_map'])
     else:

--- a/python/dgl/dataloading/base.py
+++ b/python/dgl/dataloading/base.py
@@ -486,7 +486,9 @@ def as_edge_prediction_sampler(
         The edge IDs to always exclude during neighborhood sampling.
 
         Note that if :attr:`exclude` argument is ``reverse_id`` or ``reverse_types``,
-        the reverse edges of this argument will also be excluded.
+        the reverse edges of this argument will also be excluded.  If :attr:`exclude`
+        is a callable, then its argument will be the union of the seed edges in the
+        minibatch and :attr:`exclude_eids`.
     reverse_eids : Tensor or dict[etype, Tensor], optional
         A tensor of reverse edge ID mapping.  The i-th element indicates the ID of
         the i-th edge's reverse edge.

--- a/python/dgl/dataloading/base.py
+++ b/python/dgl/dataloading/base.py
@@ -483,7 +483,7 @@ def as_edge_prediction_sampler(
         * User-defined exclusion rule. It is a callable with edges in the current
           minibatch as a single argument and should return the edges to be excluded.
     exclude_eids : Tensor or dict[etype, Tensor], optional
-        The edge IDs to always exclude from during neighborhood sampling.
+        The edge IDs to always exclude during neighborhood sampling.
 
         Note that if :attr:`exclude` argument is ``reverse_id`` or ``reverse_types``,
         the reverse edges of this argument will also be excluded.

--- a/python/dgl/dataloading/dataloader.py
+++ b/python/dgl/dataloading/dataloader.py
@@ -937,8 +937,8 @@ class EdgeDataLoader(DataLoader):
                  ddp_seed=0, batch_size=1, drop_last=False, shuffle=False,
                  use_prefetch_thread=False, use_alternate_streams=True,
                  pin_prefetcher=False,
-                 exclude=None, reverse_eids=None, reverse_etypes=None, negative_sampler=None,
-                 use_uva=False, **kwargs):
+                 exclude=None, exclude_eids=None, reverse_eids=None, reverse_etypes=None,
+                 negative_sampler=None, use_uva=False, **kwargs):
 
         if device is None:
             if use_uva:
@@ -961,7 +961,8 @@ class EdgeDataLoader(DataLoader):
                     if indices_device != reverse_eids_device:
                         raise ValueError('Expect the same device for indices and reverse_eids')
             graph_sampler = as_edge_prediction_sampler(
-                graph_sampler, exclude=exclude, reverse_eids=reverse_eids,
+                graph_sampler, exclude=exclude, exclude_eids=exclude_eids,
+                reverse_eids=reverse_eids,
                 reverse_etypes=reverse_etypes, negative_sampler=negative_sampler)
 
         super().__init__(

--- a/python/dgl/utils/internal.py
+++ b/python/dgl/utils/internal.py
@@ -1023,4 +1023,21 @@ def dtype_of(data):
     """Return the dtype of the data which can be either a tensor or a dict of tensors."""
     return F.dtype(next(iter(data.values())) if isinstance(data, Mapping) else data)
 
+def union(data1, data2):
+    """Return the union of two tensors or two dictionaries of tensors."""
+    ismap1 = isinstance(data1, Mapping)
+    ismap2 = isinstance(data2, Mapping)
+    if ismap1 and ismap2:
+        result = data1.copy()
+        for k, v in data2.items():
+            if k in result:
+                result[k] = F.unique(F.cat([result[k], v], 0))
+            else:
+                result[k] = v
+        return result
+    elif ismap1 or ismap2:
+        raise TypeError('Expect arguments to be both tensors or both dictionaries.')
+    else:
+        return F.unique(F.cat([data1, data2]))
+
 _init_api("dgl.utils.internal")

--- a/python/dgl/utils/internal.py
+++ b/python/dgl/utils/internal.py
@@ -1049,6 +1049,7 @@ def to_canonical_etype_keys(g, data):
     return {g.to_canonical_etype(k): v for k, v in data.items()}
 
 def assert_canonical_etype_keys(data):
+    """Asserts that if the keys of the given dictionaries are already canonical edge types."""
     assert all(isinstance(k, tuple) for k in data.keys())
 
 _init_api("dgl.utils.internal")

--- a/python/dgl/utils/internal.py
+++ b/python/dgl/utils/internal.py
@@ -1038,6 +1038,17 @@ def union(data1, data2):
     elif ismap1 or ismap2:
         raise TypeError('Expect arguments to be both tensors or both dictionaries.')
     else:
-        return F.unique(F.cat([data1, data2]))
+        return F.unique(F.cat([data1, data2], 0))
+
+def to_canonical_etype_keys(g, data):
+    """Convert the keys of data dictionary to canonical edge types if necessary, or
+    return the data itself if it is not a dictionary.
+    """
+    if not isinstance(data, Mapping):
+        return data
+    return {g.to_canonical_etype(k): v for k, v in data.items()}
+
+def assert_canonical_etype_keys(data):
+    assert all(isinstance(k, tuple) for k in data.keys())
 
 _init_api("dgl.utils.internal")

--- a/tests/pytorch/test_dataloader.py
+++ b/tests/pytorch/test_dataloader.py
@@ -364,7 +364,7 @@ def test_edge_dataloader_excludes(exclude, always_exclude_flag):
     kwargs['exclude_eids'] = always_exclude
 
     dataloader = dgl.dataloading.EdgeDataLoader(
-        g, seed_edges, sampler, batch_size=50, device=F.ctx(), use_prefetch_thread=False, num_workers=0, **kwargs)
+        g, seed_edges, sampler, batch_size=50, device=F.ctx(), **kwargs)
     for input_nodes, pair_graph, blocks in dataloader:
         block = blocks[0]
         pair_eids = pair_graph.edata[dgl.EID]

--- a/tests/pytorch/test_dataloader.py
+++ b/tests/pytorch/test_dataloader.py
@@ -361,8 +361,9 @@ def test_edge_dataloader_excludes(exclude, always_exclude_flag):
         else exclude)
     kwargs['reverse_eids'] = reverse_eids if exclude == 'reverse_id' else None
     kwargs['reverse_etypes'] = reverse_etypes if exclude == 'reverse_types' else None
+    kwargs['exclude_eids'] = always_exclude
 
-    dataloader = dgl.dataloading.EdgeDataLoader(
+    dataloader = dgl.dataloading.DataLoader(
         g, seed_edges, sampler, batch_size=50, device=F.ctx(), **kwargs)
     for input_nodes, pair_graph, blocks in dataloader:
         block = blocks[0]

--- a/tests/pytorch/test_dataloader.py
+++ b/tests/pytorch/test_dataloader.py
@@ -363,8 +363,8 @@ def test_edge_dataloader_excludes(exclude, always_exclude_flag):
     kwargs['reverse_etypes'] = reverse_etypes if exclude == 'reverse_types' else None
     kwargs['exclude_eids'] = always_exclude
 
-    dataloader = dgl.dataloading.DataLoader(
-        g, seed_edges, sampler, batch_size=50, device=F.ctx(), **kwargs)
+    dataloader = dgl.dataloading.EdgeDataLoader(
+        g, seed_edges, sampler, batch_size=50, device=F.ctx(), use_prefetch_thread=False, num_workers=0, **kwargs)
     for input_nodes, pair_graph, blocks in dataloader:
         block = blocks[0]
         pair_eids = pair_graph.edata[dgl.EID]
@@ -384,3 +384,4 @@ def test_edge_dataloader_excludes(exclude, always_exclude_flag):
 
 if __name__ == '__main__':
     test_node_dataloader(F.int32, 'neighbor', None)
+    test_edge_dataloader_excludes('reverse_types', True)


### PR DESCRIPTION
Fixes #4072 by adding an `exclude_eids` argument in `as_edge_prediction_sampler` (and `EdgeDataLoader`).

@alexpod1000 I think this should address your concern.  Please let me know your thoughts.  Thanks!