### PR TITLE
[Bugfix] Disable non-atomic atomic operations

### DIFF
--- a/src/array/cuda/atomic.cuh
+++ b/src/array/cuda/atomic.cuh
@@ -80,12 +80,17 @@ static __device__ __forceinline__ unsigned short int atomicCASshort(
     unsigned short int *address,
     unsigned short int compare,
     unsigned short int val) {
-#if (defined(CUDART_VERSION) && (CUDART_VERSION > 10000))
+  static_assert(CUDART_VERSION >= 10000, "Requires at least CUDA 10");
 #if (defined(__CUDA_ARCH__) && (__CUDA_ARCH__) >= 700)
   return atomicCAS(address, compare, val);
-#endif  // (defined(__CUDA_ARCH__) && (__CUDA_ARCH__) >= 700)
-#endif  // (defined(CUDART_VERSION) && (CUDART_VERSION > 10000))
+#else
+  (void)address;
+  (void)compare;
+  (void)val;
+  printf("Atomic operations are not supported on this GPU.\n");
+  __trap();
   return val;
+#endif  // (defined(__CUDA_ARCH__) && (__CUDA_ARCH__) >= 700)
 }
 
 #define DEFINE_ATOMIC(NAME) \
@@ -260,9 +265,11 @@ __device__ __forceinline__ half AtomicAdd<half>(half* addr, half val) {
 #if __CUDA_ARCH__ >= 700
   return atomicAdd(addr, val);
 #else
-  half old = *addr;
-  *addr = half(float(old) + float(val));
-  return old;
+  (void)addr;
+  (void)val;
+  printf("Atomic operations are not supported on this GPU.\n");
+  __trap();
+  return val;
 #endif  // __CUDA_ARCH__ >= 700
 }
 #endif  // defined(CUDART_VERSION) && CUDART_VERSION >= 10000

--- a/src/array/cuda/atomic.cuh
+++ b/src/array/cuda/atomic.cuh
@@ -87,7 +87,8 @@ static __device__ __forceinline__ unsigned short int atomicCASshort(
   (void)address;
   (void)compare;
   (void)val;
-  printf("Atomic operations are not supported for FP16 on this GPU.\n");
+  printf("Atomic operations are not supported for half precision (FP16) "
+      "on this GPU.\n");
   __trap();
   return val;
 #endif  // (defined(__CUDA_ARCH__) && (__CUDA_ARCH__) >= 700)
@@ -267,7 +268,8 @@ __device__ __forceinline__ half AtomicAdd<half>(half* addr, half val) {
 #else
   (void)addr;
   (void)val;
-  printf("Atomic operations are not supported for FP16 on this GPU.\n");
+  printf("Atomic operations are not supported for half precision (FP16) "
+      "on this GPU.\n");
   __trap();
   return val;
 #endif  // __CUDA_ARCH__ >= 700

--- a/src/array/cuda/atomic.cuh
+++ b/src/array/cuda/atomic.cuh
@@ -87,7 +87,7 @@ static __device__ __forceinline__ unsigned short int atomicCASshort(
   (void)address;
   (void)compare;
   (void)val;
-  printf("Atomic operations are not supported on this GPU.\n");
+  printf("Atomic operations are not supported for FP16 on this GPU.\n");
   __trap();
   return val;
 #endif  // (defined(__CUDA_ARCH__) && (__CUDA_ARCH__) >= 700)
@@ -267,7 +267,7 @@ __device__ __forceinline__ half AtomicAdd<half>(half* addr, half val) {
 #else
   (void)addr;
   (void)val;
-  printf("Atomic operations are not supported on this GPU.\n");
+  printf("Atomic operations are not supported for FP16 on this GPU.\n");
   __trap();
   return val;
 #endif  // __CUDA_ARCH__ >= 700


### PR DESCRIPTION
## Description
This disable implementations of atomic functions that are not atomic.

Fixes #4031.

## Checklist
Please feel free to remove inapplicable items for your PR.
- [x] The PR title starts with [$CATEGORY] (such as [NN], [Model], [Doc], [Feature]])
- [x] Changes are complete (i.e. I finished coding on this PR)
- [ ] All changes have test coverage
- [x] Code is well-documented
- [x] To the best of my knowledge, examples are either not affected by this change,
      or have been fixed to be compatible with this change
- [x] Related issue is referred in this PR

