### PR TITLE
[Doc] Add gtrick in DGL-powered projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,7 @@ Take the survey [here](https://forms.gle/Ej3jHCocACmb49Gp8) and leave any feedba
 * RNAGlib: A package to facilitate construction, analysis, visualization and machine learning on RNA 2.5D Graphs. Includes a pre-built dataset: https://rnaglib.cs.mcgill.ca
 * OpenHGNN: Model zoo and benchmarks for Heterogeneous Graph Neural Networks. https://github.com/BUPT-GAMMA/OpenHGNN
 * TGL: A graph learning framework for large-scale temporal graphs. https://github.com/amazon-research/tgl
+* gtrick: Bag of Tricks for Graph Neural Networks. https://github.com/sangyx/gtrick
 
 ### Awesome Papers Using DGL
 


### PR DESCRIPTION
## Description
<!-- Brief description. Refer to the related issues if existed.
It'll be great if relevant reviewers can be assigned as well.-->
Hi, I have create a Python package called gtrick (https://github.com/sangyx/gtrick) to collect and test tricks for Graph Neural Networks. It is built on DGL and PyG and I want to add this repo in DGL-powered projects to let others know it.

## Checklist
Please feel free to remove inapplicable items for your PR.
- [x] The PR title starts with [$CATEGORY] (such as [NN], [Model], [Doc], [Feature]])
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] Code is well-documented
- [x] To the best of my knowledge, examples are either not affected by this change,
      or have been fixed to be compatible with this change

## Changes
<!-- You could use following template
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)
-->
- [x] Add gtrick in DGL-powered projects