### PR TITLE
[Feature] Limited Edge Dataloader (Part of auto inference).

### DIFF
--- a/python/dgl/dataloading/limited_edge.py
+++ b/python/dgl/dataloading/limited_edge.py
@@ -1,0 +1,113 @@
+from typing import Generic
+import functools
+
+import torch
+import dgl
+from dgl.dataloading.dataloader import _TensorizedDatasetIter
+
+
+class LimitedEdgeDataloader(dgl.dataloading.NodeDataLoader):
+    """Limited Edge Dataloader class.
+
+    For the normal dataloader, each batch have a same batch size, which may cause the workload unbanlance
+    problem when some batches contains high degree nodes. The limited edge dataloader can support different
+    batch sizes among different batches. Users can parse two configures: max_node and max_edge, which means
+    the maximum number of nodes in a batch and the maximum number of edges in a batch. The limited edge 
+    dataloader can provide the largest batch which follows the rule.
+    """
+    def __init__(self, g, nids, sampler, max_node, max_edge, prefix_sum_in_degrees=None, \
+        device='cpu', shuffle=False, use_uva=False, drop_last=False, num_workers=0):
+
+        dataset = LimitedEdgeDataset(max_node, max_edge, g, nids, prefix_sum_in_degrees)
+        super().__init__(g,
+                         dataset,
+                         sampler,
+                         device=device,
+                         use_uva=use_uva,
+                         shuffle=shuffle,
+                         drop_last=drop_last,
+                         use_prefetch_thread=False,
+                         num_workers=num_workers)
+
+    def modify_max_edge(self, max_edge):
+        self.dataset.max_edge = max_edge
+        if self.dataset.curr_iter is not None:
+            self.dataset.curr_iter.max_edge = max_edge
+
+    def modify_max_node(self, max_node):
+        self.dataset.max_node = max_node
+        if self.dataset.curr_iter is not None:
+            self.dataset.curr_iter.max_node = max_node
+
+    def reset_batch_node(self, node_count):
+        if self.dataset.curr_iter is not None:
+            self.dataset.curr_iter.index -= node_count
+
+    def __setattr__(self, __name, __value) -> None:
+        return super(Generic, self).__setattr__(__name, __value)
+
+
+class LimitedEdgeDataset(dgl.dataloading.TensorizedDataset):
+    def __init__(self, max_node, max_edge, g, train_nids, prefix_sum_in_degrees=None):
+        super().__init__(train_nids, max_node, False)
+        self.device = train_nids.device
+        self.max_node = max_node
+        self.max_edge = max_edge
+        # move __iter__ to here
+        # TODO: support multi processing
+        id_tensor = self._id_tensor[train_nids.to(self._device)]
+
+        self.prefix_sum_in_degrees = prefix_sum_in_degrees
+        # Compute the prefix sum in degrees for the graph.
+        if self.prefix_sum_in_degrees is None:
+            in_degrees = g.in_degrees(train_nids.to(g.device))
+            self.prefix_sum_in_degrees = [0]
+            self.prefix_sum_in_degrees.extend(in_degrees.tolist())
+            for i in range(1, len(self.in_degrees)):
+                self.prefix_sum_in_degrees[i] += self.prefix_sum_in_degrees[i - 1]
+            self.prefix_sum_in_degrees.append(2e18)
+
+        self.curr_iter = CustomDatasetIter(
+            id_tensor, self.max_node, self.max_edge, self.prefix_sum_in_degrees, self.drop_last, self._mapping_keys)
+
+    def __getattr__(self, attribute_name):
+        if attribute_name in CustomDataset.functions:
+            function = functools.partial(CustomDataset.functions[attribute_name], self)
+            return function
+        else:
+            return super(Generic, self).__getattr__(attribute_name)
+
+    def __iter__(self):
+        return self.curr_iter
+
+
+class LimitedEdgeDatasetIter(_TensorizedDatasetIter):
+    def __init__(self, dataset, max_node, max_edge, prefix_sum_in_degrees, drop_last, mapping_keys):
+        super().__init__(dataset, max_node, drop_last, mapping_keys)
+        self.max_node = max_node
+        self.max_edge = max_edge
+        self.prefix_sum_in_degrees = prefix_sum_in_degrees
+        self.num_item = self.dataset.shape[0]
+
+    def get_end_idx(self):
+        # binary search
+        binary_start = self.index + 1
+        binary_end = min(self.index + self.max_node, self.num_item)
+        if self.prefix_sum_in_degrees[binary_end] - self.prefix_sum_in_degrees[self.index] < self.max_edge:
+            return binary_end
+        binary_middle = 0
+        while binary_end - binary_start > 5:
+            binary_middle = (binary_start + binary_end) // 2
+            if self.prefix_sum_in_degrees[binary_middle] - self.prefix_sum_in_degrees[self.index] < self.max_edge:
+                binary_start = binary_middle
+            else:
+                binary_end = binary_middle - 1
+        return binary_middle
+
+    def _next_indices(self):
+        if self.index >= self.num_item:
+            raise StopIteration
+        end_idx = self.get_end_idx()
+        batch = self.dataset[self.index:end_idx]
+        self.index = end_idx
+        return batch


### PR DESCRIPTION
## Description
<!-- Brief description. Refer to the related issues if existed.
It'll be great if relevant reviewers can be assigned as well.-->
This is the limited edge dataloader. (For automatic inference helper).
For the normal node dataloader, the memory consumption of each batch is unbalance. We only fixed the number of target nodes in a batch, while the number of edges are different among different batches. Since we may encounter the cases that many high degree nodes in the same batch, and it become the bottleneck of training/inference. We develop a limited edge dataloader, which user first define two configures: `max_node` and `max_edge`. These two parameters define the maximum number of nodes and the maximum number of edges in the same batch. This dataloader mainly consider the workload of GNN inference.

The limited edge dataloader also support modify `max_node` and `max_edge` during training/inference. (The support for automatic inference).

Here we display an example of using the LimitedEdgeDataloader:
```python
import torch
import dgl
from dgl.dataloading.limited_edge import LimitedEdgeDataloader
from dgl.data import RedditDataset

if __name__ == '__main__':
    data = RedditDataset(self_loop=True)
    g = data[0].to("cuda")
    nids = torch.arange(g.number_of_nodes()).to(g.device)
    sampler = dgl.dataloading.MultiLayerFullNeighborSampler(1)
    dataloader = LimitedEdgeDataloader(
        g, nids, sampler, max_node=5000, max_edge=500000,
        shuffle=False, drop_last=False, device="cuda", num_workers=0)
    for input_nodes, output_nodes, blocks in dataloader:
        print(blocks)
```
Here I limited maximum number of nodes=5000, maximum number of edges=500000, and part of the result likes:
```
[Block(num_src_nodes=24686, num_dst_nodes=5000, num_edges=85203)]
[Block(num_src_nodes=29197, num_dst_nodes=5000, num_edges=329521)]
[Block(num_src_nodes=29056, num_dst_nodes=4775, num_edges=499702)]
[Block(num_src_nodes=43231, num_dst_nodes=5000, num_edges=477514)]
[Block(num_src_nodes=49092, num_dst_nodes=4407, num_edges=499802)]
[Block(num_src_nodes=63065, num_dst_nodes=5000, num_edges=473265)]
[Block(num_src_nodes=37184, num_dst_nodes=2961, num_edges=499686)]
[Block(num_src_nodes=72631, num_dst_nodes=4771, num_edges=498843)]
[Block(num_src_nodes=48633, num_dst_nodes=2741, num_edges=499758)]
[Block(num_src_nodes=68416, num_dst_nodes=3529, num_edges=499993)]
[Block(num_src_nodes=80186, num_dst_nodes=4128, num_edges=499989)]
[Block(num_src_nodes=78550, num_dst_nodes=3458, num_edges=499995)]
[Block(num_src_nodes=87168, num_dst_nodes=3383, num_edges=499872)]
...
```

## Checklist
Please feel free to remove inapplicable items for your PR.
- [x] The PR title starts with [$CATEGORY] (such as [NN], [Model], [Doc], [Feature]])
- [x] Changes are complete (i.e. I finished coding on this PR)
- [ ] All changes have test coverage
- [ ] Code is well-documented
- [ ] To the best of my knowledge, examples are either not affected by this change,
      or have been fixed to be compatible with this change
- [ ] Related issue is referred in this PR
- [ ] If the PR is for a new model/paper, I've updated the example index [here](../examples/README.md).

## Changes
<!-- You could use following template
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)
-->
