### PR TITLE
[Bug][Feature] Added more missing FP16 specializations

### DIFF
--- a/include/dgl/runtime/ndarray.h
+++ b/include/dgl/runtime/ndarray.h
@@ -18,6 +18,10 @@
 #include "serializer.h"
 #include "shared_mem.h"
 
+#ifdef DGL_USE_CUDA
+#include <cuda_fp16.h>
+#endif
+
 // forward declaration
 inline std::ostream& operator << (std::ostream& os, DGLType t);
 
@@ -46,6 +50,11 @@ GEN_DLDATATYPETRAITS_FOR(int64_t, kDLInt, 64);
 // converting uints to signed DTypes.
 GEN_DLDATATYPETRAITS_FOR(uint32_t, kDLInt, 32);
 GEN_DLDATATYPETRAITS_FOR(uint64_t, kDLInt, 64);
+#ifdef DGL_USE_CUDA
+#ifdef USE_FP16
+GEN_DLDATATYPETRAITS_FOR(__half, kDLFloat, 16);
+#endif
+#endif
 GEN_DLDATATYPETRAITS_FOR(float, kDLFloat, 32);
 GEN_DLDATATYPETRAITS_FOR(double, kDLFloat, 64);
 #undef GEN_DLDATATYPETRAITS_FOR

--- a/src/array/cuda/array_index_select.cu
+++ b/src/array/cuda/array_index_select.cu
@@ -71,7 +71,8 @@ DType IndexSelect(NDArray array, int64_t index) {
   // The initialization constructor for __half is apparently a device-
   // only function in some setups, but the current function isn't run
   // on the device.
-  using SafeDType = typename std::conditional<std::is_same<DType,__half>::value, uint16_t, DType>::type;
+  using SafeDType = typename std::conditional<
+      std::is_same<DType, __half>::value, uint16_t, DType>::type;
   SafeDType ret = 0;
 #else
   DType ret = 0;

--- a/src/array/cuda/array_index_select.cu
+++ b/src/array/cuda/array_index_select.cu
@@ -69,8 +69,8 @@ DType IndexSelect(NDArray array, int64_t index) {
   auto device = runtime::DeviceAPI::Get(array->ctx);
 #ifdef USE_FP16
   // The initialization constructor for __half is apparently a device-
-  // only function in some setups, but the current function isn't run
-  // on the device.
+  // only function in some setups, but the current function, IndexSelect,
+  // isn't run on the device, so it doesn't have access to that constructor.
   using SafeDType = typename std::conditional<
       std::is_same<DType, __half>::value, uint16_t, DType>::type;
   SafeDType ret = 0;

--- a/src/array/cuda/array_index_select.cu
+++ b/src/array/cuda/array_index_select.cu
@@ -55,6 +55,10 @@ template NDArray IndexSelect<kDLGPU, int32_t, int32_t>(NDArray, IdArray);
 template NDArray IndexSelect<kDLGPU, int32_t, int64_t>(NDArray, IdArray);
 template NDArray IndexSelect<kDLGPU, int64_t, int32_t>(NDArray, IdArray);
 template NDArray IndexSelect<kDLGPU, int64_t, int64_t>(NDArray, IdArray);
+#ifdef USE_FP16
+template NDArray IndexSelect<kDLGPU, __half, int32_t>(NDArray, IdArray);
+template NDArray IndexSelect<kDLGPU, __half, int64_t>(NDArray, IdArray);
+#endif
 template NDArray IndexSelect<kDLGPU, float, int32_t>(NDArray, IdArray);
 template NDArray IndexSelect<kDLGPU, float, int64_t>(NDArray, IdArray);
 template NDArray IndexSelect<kDLGPU, double, int32_t>(NDArray, IdArray);
@@ -75,6 +79,9 @@ template int32_t IndexSelect<kDLGPU, int32_t>(NDArray array, int64_t index);
 template int64_t IndexSelect<kDLGPU, int64_t>(NDArray array, int64_t index);
 template uint32_t IndexSelect<kDLGPU, uint32_t>(NDArray array, int64_t index);
 template uint64_t IndexSelect<kDLGPU, uint64_t>(NDArray array, int64_t index);
+#ifdef USE_FP16
+template __half IndexSelect<kDLGPU, __half>(NDArray array, int64_t index);
+#endif
 template float IndexSelect<kDLGPU, float>(NDArray array, int64_t index);
 template double IndexSelect<kDLGPU, double>(NDArray array, int64_t index);
 

--- a/src/array/cuda/array_op_impl.cu
+++ b/src/array/cuda/array_op_impl.cu
@@ -224,6 +224,9 @@ NDArray Full(DType val, int64_t length, DLContext ctx) {
 
 template IdArray Full<kDLGPU, int32_t>(int32_t val, int64_t length, DLContext ctx);
 template IdArray Full<kDLGPU, int64_t>(int64_t val, int64_t length, DLContext ctx);
+#ifdef USE_FP16
+template IdArray Full<kDLGPU, __half>(__half val, int64_t length, DLContext ctx);
+#endif
 template IdArray Full<kDLGPU, float>(float val, int64_t length, DLContext ctx);
 template IdArray Full<kDLGPU, double>(double val, int64_t length, DLContext ctx);
 

--- a/src/array/cuda/array_scatter.cu
+++ b/src/array/cuda/array_scatter.cu
@@ -39,10 +39,16 @@ void Scatter_(IdArray index, NDArray value, NDArray out) {
 
 template void Scatter_<kDLGPU, int32_t, int32_t>(IdArray, NDArray, NDArray);
 template void Scatter_<kDLGPU, int64_t, int32_t>(IdArray, NDArray, NDArray);
+#ifdef USE_FP16
+template void Scatter_<kDLGPU, __half, int32_t>(IdArray, NDArray, NDArray);
+#endif
 template void Scatter_<kDLGPU, float, int32_t>(IdArray, NDArray, NDArray);
 template void Scatter_<kDLGPU, double, int32_t>(IdArray, NDArray, NDArray);
 template void Scatter_<kDLGPU, int32_t, int64_t>(IdArray, NDArray, NDArray);
 template void Scatter_<kDLGPU, int64_t, int64_t>(IdArray, NDArray, NDArray);
+#ifdef USE_FP16
+template void Scatter_<kDLGPU, __half, int64_t>(IdArray, NDArray, NDArray);
+#endif
 template void Scatter_<kDLGPU, float, int64_t>(IdArray, NDArray, NDArray);
 template void Scatter_<kDLGPU, double, int64_t>(IdArray, NDArray, NDArray);
 

--- a/src/array/cuda/csr_get_data.cu
+++ b/src/array/cuda/csr_get_data.cu
@@ -52,6 +52,12 @@ NDArray CSRGetData(
   return rst;
 }
 
+#ifdef USE_FP16
+template NDArray CSRGetData<kDLGPU, int32_t, __half>(
+    CSRMatrix csr, NDArray rows, NDArray cols, bool return_eids, NDArray weights, __half filler);
+template NDArray CSRGetData<kDLGPU, int64_t, __half>(
+    CSRMatrix csr, NDArray rows, NDArray cols, bool return_eids, NDArray weights, __half filler);
+#endif
 template NDArray CSRGetData<kDLGPU, int32_t, float>(
     CSRMatrix csr, NDArray rows, NDArray cols, bool return_eids, NDArray weights, float filler);
 template NDArray CSRGetData<kDLGPU, int64_t, float>(

--- a/src/array/cuda/csr_mm.cu
+++ b/src/array/cuda/csr_mm.cu
@@ -253,6 +253,12 @@ std::pair<CSRMatrix, NDArray> CSRMM(
   }
 }
 
+#ifdef USE_FP16
+template std::pair<CSRMatrix, NDArray> CSRMM<kDLGPU, int32_t, __half>(
+    const CSRMatrix&, NDArray, const CSRMatrix&, NDArray);
+template std::pair<CSRMatrix, NDArray> CSRMM<kDLGPU, int64_t, __half>(
+    const CSRMatrix&, NDArray, const CSRMatrix&, NDArray);
+#endif
 template std::pair<CSRMatrix, NDArray> CSRMM<kDLGPU, int32_t, float>(
     const CSRMatrix&, NDArray, const CSRMatrix&, NDArray);
 template std::pair<CSRMatrix, NDArray> CSRMM<kDLGPU, int64_t, float>(

--- a/src/array/cuda/csr_sum.cu
+++ b/src/array/cuda/csr_sum.cu
@@ -166,6 +166,12 @@ std::pair<CSRMatrix, NDArray> CSRSum(
   }
 }
 
+#ifdef USE_FP16
+template std::pair<CSRMatrix, NDArray> CSRSum<kDLGPU, int32_t, __half>(
+    const std::vector<CSRMatrix>&, const std::vector<NDArray>&);
+template std::pair<CSRMatrix, NDArray> CSRSum<kDLGPU, int64_t, __half>(
+    const std::vector<CSRMatrix>&, const std::vector<NDArray>&);
+#endif
 template std::pair<CSRMatrix, NDArray> CSRSum<kDLGPU, int32_t, float>(
     const std::vector<CSRMatrix>&, const std::vector<NDArray>&);
 template std::pair<CSRMatrix, NDArray> CSRSum<kDLGPU, int64_t, float>(

--- a/src/array/cuda/cusparse_dispatcher.cuh
+++ b/src/array/cuda/cusparse_dispatcher.cuh
@@ -41,7 +41,7 @@ struct CSRGEMM<__half> {
   static inline cusparseStatus_t bufferSizeExt(Args... args) {
     // TODO(ndickson): There is no cusparseHcsrgemm2_bufferSizeExt, so a different
     // implementation would be required.
-    BUG_IF_FAIL(false) << "CSRGEMM::bufferSizeExt does not support dtype half (FP16).";
+    LOG(FATAL) << "CSRGEMM::bufferSizeExt does not support dtype half (FP16).";
     return static_cast<cusparseStatus_t>(0);
   }
 
@@ -54,7 +54,7 @@ struct CSRGEMM<__half> {
   static inline cusparseStatus_t compute(Args... args) {
     // TODO(ndickson): There is no cusparseHcsrgemm2, so a different
     // implementation would be required.
-    BUG_IF_FAIL(false) << "CSRGEMM::compute does not support dtype half (FP16).";
+    LOG(FATAL) << "CSRGEMM::compute does not support dtype half (FP16).";
     return static_cast<cusparseStatus_t>(0);
   }
 };
@@ -124,7 +124,7 @@ struct CSRGEAM<__half> {
   static inline cusparseStatus_t bufferSizeExt(Args... args) {
     // TODO(ndickson): There is no cusparseHcsrgeam2_bufferSizeExt, so a different
     // implementation would be required.
-    BUG_IF_FAIL(false) << "CSRGEAM::bufferSizeExt does not support dtype half (FP16).";
+    LOG(FATAL) << "CSRGEAM::bufferSizeExt does not support dtype half (FP16).";
     return static_cast<cusparseStatus_t>(0);
   }
 
@@ -137,7 +137,7 @@ struct CSRGEAM<__half> {
   static inline cusparseStatus_t compute(Args... args) {
     // TODO(ndickson): There is no cusparseHcsrgeam2, so a different
     // implementation would be required.
-    BUG_IF_FAIL(false) << "CSRGEAM::compute does not support dtype half (FP16).";
+    LOG(FATAL) << "CSRGEAM::compute does not support dtype half (FP16).";
     return static_cast<cusparseStatus_t>(0);
   }
 };

--- a/src/array/cuda/cusparse_dispatcher.cuh
+++ b/src/array/cuda/cusparse_dispatcher.cuh
@@ -34,14 +34,15 @@ struct CSRGEMM {
   }
 };
 
-// NOTE: There is currently no cusparseHcsrgemm2_bufferSizeExt or cusparseHcsrgemm2.
-//ifdef USE_FP16
-#if 0
+#ifdef USE_FP16
 template <>
 struct CSRGEMM<__half> {
   template <typename... Args>
   static inline cusparseStatus_t bufferSizeExt(Args... args) {
-    return cusparseHcsrgemm2_bufferSizeExt(args...);
+    // There is no cusparseHcsrgemm2_bufferSizeExt, so a different implementation
+    // would be required.
+    BUG_IF_FAIL(false) << "CSRGEMM::bufferSizeExt does not support dtype half (FP16).";
+    return static_cast<cusparseStatus_t>(0);
   }
 
   template <typename... Args>
@@ -51,7 +52,10 @@ struct CSRGEMM<__half> {
 
   template <typename... Args>
   static inline cusparseStatus_t compute(Args... args) {
-    return cusparseHcsrgemm2(args...);
+    // There is no cusparseHcsrgemm2, so a different implementation
+    // would be required.
+    BUG_IF_FAIL(false) << "CSRGEMM::compute does not support dtype half (FP16).";
+    return static_cast<cusparseStatus_t>(0);
   }
 };
 #endif
@@ -113,14 +117,15 @@ struct CSRGEAM {
   }
 };
 
-// NOTE: There is currently no cusparseHcsrgeam2_bufferSizeExt or cusparseHcsrgeam2.
-//ifdef USE_FP16
-#if 0
+#ifdef USE_FP16
 template <>
 struct CSRGEAM<__half> {
   template <typename... Args>
   static inline cusparseStatus_t bufferSizeExt(Args... args) {
-    return cusparseHcsrgeam2_bufferSizeExt(args...);
+    // There is no cusparseHcsrgeam2_bufferSizeExt, so a different implementation
+    // would be required.
+    BUG_IF_FAIL(false) << "CSRGEAM::bufferSizeExt does not support dtype half (FP16).";
+    return static_cast<cusparseStatus_t>(0);
   }
 
   template <typename... Args>
@@ -130,7 +135,10 @@ struct CSRGEAM<__half> {
 
   template <typename... Args>
   static inline cusparseStatus_t compute(Args... args) {
-    return cusparseHcsrgeam2(args...);
+    // There is no cusparseHcsrgeam2, so a different implementation
+    // would be required.
+    BUG_IF_FAIL(false) << "CSRGEAM::compute does not support dtype half (FP16).";
+    return static_cast<cusparseStatus_t>(0);
   }
 };
 #endif

--- a/src/array/cuda/cusparse_dispatcher.cuh
+++ b/src/array/cuda/cusparse_dispatcher.cuh
@@ -39,8 +39,8 @@ template <>
 struct CSRGEMM<__half> {
   template <typename... Args>
   static inline cusparseStatus_t bufferSizeExt(Args... args) {
-    // There is no cusparseHcsrgemm2_bufferSizeExt, so a different implementation
-    // would be required.
+    // TODO(ndickson): There is no cusparseHcsrgemm2_bufferSizeExt, so a different
+    // implementation would be required.
     BUG_IF_FAIL(false) << "CSRGEMM::bufferSizeExt does not support dtype half (FP16).";
     return static_cast<cusparseStatus_t>(0);
   }
@@ -52,8 +52,8 @@ struct CSRGEMM<__half> {
 
   template <typename... Args>
   static inline cusparseStatus_t compute(Args... args) {
-    // There is no cusparseHcsrgemm2, so a different implementation
-    // would be required.
+    // TODO(ndickson): There is no cusparseHcsrgemm2, so a different
+    // implementation would be required.
     BUG_IF_FAIL(false) << "CSRGEMM::compute does not support dtype half (FP16).";
     return static_cast<cusparseStatus_t>(0);
   }
@@ -122,8 +122,8 @@ template <>
 struct CSRGEAM<__half> {
   template <typename... Args>
   static inline cusparseStatus_t bufferSizeExt(Args... args) {
-    // There is no cusparseHcsrgeam2_bufferSizeExt, so a different implementation
-    // would be required.
+    // TODO(ndickson): There is no cusparseHcsrgeam2_bufferSizeExt, so a different
+    // implementation would be required.
     BUG_IF_FAIL(false) << "CSRGEAM::bufferSizeExt does not support dtype half (FP16).";
     return static_cast<cusparseStatus_t>(0);
   }
@@ -135,8 +135,8 @@ struct CSRGEAM<__half> {
 
   template <typename... Args>
   static inline cusparseStatus_t compute(Args... args) {
-    // There is no cusparseHcsrgeam2, so a different implementation
-    // would be required.
+    // TODO(ndickson): There is no cusparseHcsrgeam2, so a different
+    // implementation would be required.
     BUG_IF_FAIL(false) << "CSRGEAM::compute does not support dtype half (FP16).";
     return static_cast<cusparseStatus_t>(0);
   }

--- a/src/array/cuda/cusparse_dispatcher.cuh
+++ b/src/array/cuda/cusparse_dispatcher.cuh
@@ -34,6 +34,28 @@ struct CSRGEMM {
   }
 };
 
+// NOTE: There is currently no cusparseHcsrgemm2_bufferSizeExt or cusparseHcsrgemm2.
+//ifdef USE_FP16
+#if 0
+template <>
+struct CSRGEMM<__half> {
+  template <typename... Args>
+  static inline cusparseStatus_t bufferSizeExt(Args... args) {
+    return cusparseHcsrgemm2_bufferSizeExt(args...);
+  }
+
+  template <typename... Args>
+  static inline cusparseStatus_t nnz(Args... args) {
+    return cusparseXcsrgemm2Nnz(args...);
+  }
+
+  template <typename... Args>
+  static inline cusparseStatus_t compute(Args... args) {
+    return cusparseHcsrgemm2(args...);
+  }
+};
+#endif
+
 template <>
 struct CSRGEMM<float> {
   template <typename... Args>
@@ -90,6 +112,28 @@ struct CSRGEAM {
     return static_cast<cusparseStatus_t>(0);
   }
 };
+
+// NOTE: There is currently no cusparseHcsrgeam2_bufferSizeExt or cusparseHcsrgeam2.
+//ifdef USE_FP16
+#if 0
+template <>
+struct CSRGEAM<__half> {
+  template <typename... Args>
+  static inline cusparseStatus_t bufferSizeExt(Args... args) {
+    return cusparseHcsrgeam2_bufferSizeExt(args...);
+  }
+
+  template <typename... Args>
+  static inline cusparseStatus_t nnz(Args... args) {
+    return cusparseXcsrgeam2Nnz(args...);
+  }
+
+  template <typename... Args>
+  static inline cusparseStatus_t compute(Args... args) {
+    return cusparseHcsrgeam2(args...);
+  }
+};
+#endif
 
 template <>
 struct CSRGEAM<float> {

--- a/src/array/cuda/spmm.cuh
+++ b/src/array/cuda/spmm.cuh
@@ -32,6 +32,20 @@ cublasStatus_t Xgeam(cublasHandle_t handle, cublasOperation_t transa,
   return CUBLAS_STATUS_EXECUTION_FAILED;
 }
 
+// NOTE: There is currently no cublasHgeam.
+//ifdef USE_FP16
+#if 0
+template <>
+cublasStatus_t Xgeam<__half>(cublasHandle_t handle, cublasOperation_t transa,
+    cublasOperation_t transb, int m, int n,
+    const __half* alpha, const __half* A, int lda,
+    const __half* beta, const __half* B, int ldb,
+    __half* C, int ldc) {
+  return cublasHgeam(handle, transa, transb, m, n, alpha, A, lda,
+      beta, B, ldb, C, ldc);
+}
+#endif
+
 template <>
 cublasStatus_t Xgeam<float>(cublasHandle_t handle, cublasOperation_t transa,
     cublasOperation_t transb, int m, int n,

--- a/src/array/cuda/spmm.cuh
+++ b/src/array/cuda/spmm.cuh
@@ -39,8 +39,8 @@ cublasStatus_t Xgeam<__half>(cublasHandle_t handle, cublasOperation_t transa,
     const __half* alpha, const __half* A, int lda,
     const __half* beta, const __half* B, int ldb,
     __half* C, int ldc) {
-  // There is no cublasHgeam, so a different implementation
-  // would be required.
+  // TODO(ndickson): There is no cublasHgeam, so a different
+  // implementation would be required.
   LOG(INFO) << "Xgeam does not support dtype half (FP16)";
   return CUBLAS_STATUS_EXECUTION_FAILED;
 }

--- a/src/array/cuda/spmm.cuh
+++ b/src/array/cuda/spmm.cuh
@@ -28,7 +28,7 @@ cublasStatus_t Xgeam(cublasHandle_t handle, cublasOperation_t transa,
     const DType* alpha, const DType* A, int lda,
     const DType* beta, const DType* B, int ldb,
     DType* C, int ldc) {
-  LOG(INFO) << "Not supported dtype";
+  LOG(FATAL) << "Not supported dtype";
   return CUBLAS_STATUS_EXECUTION_FAILED;
 }
 
@@ -41,7 +41,7 @@ cublasStatus_t Xgeam<__half>(cublasHandle_t handle, cublasOperation_t transa,
     __half* C, int ldc) {
   // TODO(ndickson): There is no cublasHgeam, so a different
   // implementation would be required.
-  LOG(INFO) << "Xgeam does not support dtype half (FP16)";
+  LOG(FATAL) << "Xgeam does not support dtype half (FP16)";
   return CUBLAS_STATUS_EXECUTION_FAILED;
 }
 #endif

--- a/src/array/cuda/spmm.cuh
+++ b/src/array/cuda/spmm.cuh
@@ -32,17 +32,17 @@ cublasStatus_t Xgeam(cublasHandle_t handle, cublasOperation_t transa,
   return CUBLAS_STATUS_EXECUTION_FAILED;
 }
 
-// NOTE: There is currently no cublasHgeam.
-//ifdef USE_FP16
-#if 0
+#ifdef USE_FP16
 template <>
 cublasStatus_t Xgeam<__half>(cublasHandle_t handle, cublasOperation_t transa,
     cublasOperation_t transb, int m, int n,
     const __half* alpha, const __half* A, int lda,
     const __half* beta, const __half* B, int ldb,
     __half* C, int ldc) {
-  return cublasHgeam(handle, transa, transb, m, n, alpha, A, lda,
-      beta, B, ldb, C, ldc);
+  // There is no cublasHgeam, so a different implementation
+  // would be required.
+  LOG(INFO) << "Xgeam does not support dtype half (FP16)";
+  return CUBLAS_STATUS_EXECUTION_FAILED;
 }
 #endif
 

--- a/src/array/cuda/utils.h
+++ b/src/array/cuda/utils.h
@@ -166,11 +166,18 @@ __global__ void _LinearSearchKernel(
         break;
       }
     }
-    if (v == -1)
+    if (v == -1) {
       out[tx] = filler;
-    else {
-      // The casts here are to be able to handle DType being __half
-      out[tx] = weights ? weights[v] : DType((long long)v);
+    } else {
+      // The casts here are to be able to handle DType being __half.
+      // GCC treats int64_t as a distinct type from long long, so
+      // without the explcit cast to long long, it errors out saying
+      // that the implicit cast results in an ambiguous choice of
+      // constructor for __half.
+      // The using statement is to avoid a linter error about using
+      // long or long long.
+      using LongLong = long long; // NOLINT
+      out[tx] = weights ? weights[v] : DType(LongLong(v));
     }
     tx += stride_x;
   }

--- a/src/array/cuda/utils.h
+++ b/src/array/cuda/utils.h
@@ -168,8 +168,10 @@ __global__ void _LinearSearchKernel(
     }
     if (v == -1)
       out[tx] = filler;
-    else
-      out[tx] = weights ? weights[v] : v;
+    else {
+      // The casts here are to be able to handle DType being __half
+      out[tx] = weights ? weights[v] : DType((long long)v);
+    }
     tx += stride_x;
   }
 }

--- a/src/runtime/ndarray.cc
+++ b/src/runtime/ndarray.cc
@@ -24,6 +24,9 @@ constexpr DLDataType DLDataTypeTraits<int32_t>::dtype;
 constexpr DLDataType DLDataTypeTraits<int64_t>::dtype;
 constexpr DLDataType DLDataTypeTraits<uint32_t>::dtype;
 constexpr DLDataType DLDataTypeTraits<uint64_t>::dtype;
+#ifdef USE_FP16
+constexpr DLDataType DLDataTypeTraits<__half>::dtype;
+#endif
 constexpr DLDataType DLDataTypeTraits<float>::dtype;
 constexpr DLDataType DLDataTypeTraits<double>::dtype;
 


### PR DESCRIPTION
## Description
* Continuation of adding more missing FP16 specializations after PR #4029 , which addressed the specific case from issue #3988
* Added missing specializations for `__half` of `DLDataTypeTraits`, `IndexSelect`, `Full`, `Scatter_`, `CSRGetData`, `CSRMM`, `CSRSum`
* Fixed casting issue in `_LinearSearchKernel` that was preventing it from supporting `__half`
* Added more specific error messages for unimplemented FP16 specializations of `Xgeam`, `CSRGEMM`, and `CSRGEAM`, which would require functions that aren't provided by cublas

## Checklist
- [x] The PR title starts with [$CATEGORY] (such as [NN], [Model], [Doc], [Feature]])
- [x] Changes are complete (i.e. I finished coding on this PR)
- [ ] All changes have test coverage
- [x] Code is well-documented
- [x] To the best of my knowledge, examples are either not affected by this change,
      or have been fixed to be compatible with this change
- [x] Related issue is referred in this PR

