### PR TITLE
[Bug] Change include_dst_in_src to False in NeighborSampler

### DIFF
--- a/python/dgl/dataloading/neighbor_sampler.py
+++ b/python/dgl/dataloading/neighbor_sampler.py
@@ -112,7 +112,7 @@ class NeighborSampler(BlockSampler):
                 replace=self.replace, output_device=self.output_device,
                 exclude_edges=exclude_eids)
             eid = frontier.edata[EID]
-            block = to_block(frontier, seed_nodes)
+            block = to_block(frontier, seed_nodes, False)
             block.edata[EID] = eid
             seed_nodes = block.srcdata[NID]
             blocks.insert(0, block)


### PR DESCRIPTION
Including dst vertices in src causes the recursive sampling procedure to do unnecessary sampling for dst vertices who are not originally src vertices. This causes the sampled neighborhood to grow faster than it should resulting into wasted work. With this simple change, the number of vertices sampled goes from [176k, 84.3k 14.1k, 1k] to [167k, 77.1k, 13.1k, 1k] on reddit for batch size 1000, fanout 10,10,15 with 3 layers.