### PR TITLE
[BugFix] fix unstable sort when using dataloader with HeteroGraph

### DIFF
--- a/python/dgl/dataloading/dataloader.py
+++ b/python/dgl/dataloading/dataloader.py
@@ -72,7 +72,7 @@ class _TensorizedDatasetIter(object):
         # convert the type-ID pairs to dictionary
         type_ids = batch[:, 0]
         indices = batch[:, 1]
-        type_ids_sortidx = torch.argsort(type_ids)
+        _, type_ids_sortidx = torch.sort(type_ids, stable=True)
         type_ids = type_ids[type_ids_sortidx]
         indices = indices[type_ids_sortidx]
         type_id_uniq, type_id_count = torch.unique_consecutive(type_ids, return_counts=True)


### PR DESCRIPTION
## Description
When using Dataloader on a HeteroGraph and setting shuffle to False, the output_nodes are out of order because of the unstable sort. related issue:https://github.com/dmlc/dgl/issues/4125

## Checklist
Please feel free to remove inapplicable items for your PR.
- [x] The PR title starts with [$CATEGORY] (such as [NN], [Model], [Doc], [Feature]])
- [x] Changes are complete (i.e. I finished coding on this PR)
- [ ] All changes have test coverage
- [ ] Code is well-documented
- [x] To the best of my knowledge, examples are either not affected by this change,
      or have been fixed to be compatible with this change
- [x] Related issue is referred in this PR
- [ ] If the PR is for a new model/paper, I've updated the example index [here](../examples/README.md).

## relevant information
related pytorch stable sort issue: https://github.com/pytorch/pytorch/issues/38681
pytorch `torch.sort` doc: https://pytorch.org/docs/stable/generated/torch.argsort.html?highlight=argsort#torch.argsort
pytorch `torch.argsort` doc: https://pytorch.org/docs/stable/generated/torch.argsort.html?highlight=argsort#torch.argsort

## may need attention
According the pytorch doc, the cpu version of `stable torch.sort` was introduced in version 1.9, and the cuda version of `stable torch.sort` was introduced in 1.10.

