### PR TITLE
[Doc] Fix typo in nn-tensorflow.rst

### DIFF
--- a/docs/source/api/python/nn-tensorflow.rst
+++ b/docs/source/api/python/nn-tensorflow.rst
@@ -42,4 +42,4 @@ Heterogeneous Learning Modules
     :nosignatures:
     :template: classtemplate.rst
 
-    ~dgl.nn.tensorflow.glob.HeteroGraphConv
+    ~dgl.nn.tensorflow.hetero.HeteroGraphConv


### PR DESCRIPTION
Fixed typo in the link to the HeteroGraphConv module

## Description
<!-- Brief description. Refer to the related issues if existed.
It'll be great if relevant reviewers can be assigned as well.-->

## Checklist
Please feel free to remove inapplicable items for your PR.
- [x] The PR title starts with [$CATEGORY] (such as [NN], [Model], [Doc], [Feature]])
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage
- [x] To the best of my knowledge, examples are either not affected by this change,
      or have been fixed to be compatible with this change
- [ ] Related issue is referred in this PR

## Changes
<!-- You could use following template
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)
-->
