### PR TITLE
[Example][Refactor] Initial effort on refactoring graphsage examples

### DIFF
--- a/examples/pytorch/graphsage/README.md
+++ b/examples/pytorch/graphsage/README.md
@@ -33,8 +33,8 @@ python3 train_full.py --dataset cora --gpu 0    # full graph
 Train w/ mini-batch sampling for node classification on OGB-products:
 
 ```bash
-python3 node_classification.py
-python3 multi_gpu_node_classification.py
+python3 node_classification.py --gpu 0 --pure-gpu
+python3 multi_gpu_node_classification.py --gpu 0,1,2,3 --graph-device uva
 ```
 
 ### PyTorch Lightning for node classification

--- a/examples/pytorch/graphsage/link_pred.py
+++ b/examples/pytorch/graphsage/link_pred.py
@@ -135,7 +135,7 @@ edge_split = dataset.get_edge_split()
 model = SAGE(graph.ndata['feat'].shape[1], 256).to(device)
 opt = torch.optim.Adam(model.parameters(), lr=0.001, weight_decay=5e-4)
 
-sampler = dgl.dataloading.NeighborSampler([15, 10, 5], prefetch_node_feats=['feat'])
+sampler = dgl.dataloading.NeighborSampler([5, 10, 15], prefetch_node_feats=['feat'])
 sampler = dgl.dataloading.as_edge_prediction_sampler(
         sampler, exclude='reverse_id', reverse_eids=reverse_eids,
         negative_sampler=dgl.dataloading.negative_sampler.Uniform(1))

--- a/examples/pytorch/graphsage/model.py
+++ b/examples/pytorch/graphsage/model.py
@@ -1,35 +1,36 @@
 import torch
 import torch.nn as nn
 import dgl
-from dgl import DGLGraph
 from dgl.nn.pytorch.conv import SAGEConv
+import torch.nn.functional as F
 import tqdm
-
+# below import for distributed/multi-gpu training examples
 from dgl.multiprocessing import shared_tensor
-from dgl.utils import pin_memory_inplace, unpin_memory_inplace
 import torch.distributed as dist
+
+# parameters can be tuned as below, or as keyword arguments when create the model
+activation = F.relu
+dropout = 0.5
 
 class GraphSAGE(nn.Module):
     def __init__(self,
                  in_feats,
-                 n_hidden,
                  n_classes,
+                 n_hidden,
                  n_layers,
-                 activation,
-                 dropout,
                  aggregator_type):
         super().__init__()
         self.layers = nn.ModuleList()
         self.dropout = nn.Dropout(dropout)
         self.activation = activation
-
+        
         # input layer
         self.layers.append(SAGEConv(in_feats, n_hidden, aggregator_type))
         # hidden layers
         for i in range(n_layers):
             self.layers.append(SAGEConv(n_hidden, n_hidden, aggregator_type))
             # output layer
-        self.layers.append(SAGEConv(n_hidden, n_classes, aggregator_type)) # activation None
+        self.layers.append(SAGEConv(n_hidden, n_classes, aggregator_type))
 
     def forward(self, graph, inputs):
         h = self.dropout(inputs)
@@ -43,13 +44,11 @@ class GraphSAGE(nn.Module):
 class GraphSAGEBatch(GraphSAGE):
     def __init__(self,
                  in_feats,
-                 n_hidden,
                  n_classes,
+                 n_hidden,
                  n_layers,
-                 activation,
-                 dropout,
                  aggregator_type):
-        super().__init__(in_feats, n_hidden, n_classes, n_layers, activation, dropout, aggregator_type)
+        super().__init__(in_feats, n_classes, n_hidden, n_layers, aggregator_type)
         self.n_hidden = n_hidden
         self.n_classes = n_classes
         
@@ -62,33 +61,6 @@ class GraphSAGEBatch(GraphSAGE):
                 h = self.dropout(h)
         return h
 
-    def inference(self, g, device, batch_size):
-        feat = g.ndata['feat']
-        sampler = dgl.dataloading.MultiLayerFullNeighborSampler(1, prefetch_node_feats=['feat'])
-        dataloader = dgl.dataloading.DataLoader(
-                g, torch.arange(g.num_nodes()).to(g.device), sampler, device=device,
-                batch_size=batch_size, shuffle=False, drop_last=False,
-                num_workers=0)
-
-        for l, layer in enumerate(self.layers):
-            y = torch.empty(
-                g.num_nodes(), self.n_hidden if l != len(self.layers) - 1 else self.n_classes,
-                device='cpu', pin_memory=True)
-            feat = feat.to(device)
-            for input_nodes, output_nodes, blocks in tqdm.tqdm(dataloader):
-                # use an explicitly contiguous slice
-                x = feat[input_nodes]
-                h = layer(blocks[0], x)
-                if l != len(self.layers) - 1:
-                    h = self.activation(h)
-                    h = self.dropout(h)
-                # be design, our output nodes are contiguous so we can take
-                # advantage of that here
-                y[output_nodes[0]:output_nodes[-1]+1] = h.to('cpu')
-            feat = y
-        return y
-
-class GraphSAGEBatchMultiGPU(GraphSAGEBatch):
     def inference(self, g, device, batch_size):
         """
         Perform inference in layer-major order rather than batch-major order.
@@ -113,20 +85,53 @@ class GraphSAGEBatchMultiGPU(GraphSAGEBatch):
             tensor
                 The predictions for all nodes in the graph.
         """
-        g.ndata['h'] = g.ndata['feat']
-        sampler = dgl.dataloading.MultiLayerFullNeighborSampler(1, prefetch_node_feats=['h'])
+        feat = g.ndata['feat']
+        sampler = dgl.dataloading.MultiLayerFullNeighborSampler(1, prefetch_node_feats=['feat'])
         dataloader = dgl.dataloading.DataLoader(
-                g, torch.arange(g.num_nodes(), device=device), sampler, device=device,
+                g, torch.arange(g.num_nodes()).to(g.device), sampler, device=device,
                 batch_size=batch_size, shuffle=False, drop_last=False,
-                num_workers=0, use_ddp=True, use_uva=True)
+                num_workers=0)
 
         for l, layer in enumerate(self.layers):
+            y = torch.empty(
+                g.num_nodes(), self.n_hidden if l != len(self.layers) - 1 else self.n_classes,
+                device='cpu', pin_memory=True)
+            feat = feat.to(device)
+            for input_nodes, output_nodes, blocks in tqdm.tqdm(dataloader):
+                # use an explicitly contiguous slice
+                x = feat[input_nodes]
+                h = layer(blocks[0], x)
+                if l != len(self.layers) - 1:
+                    h = self.activation(h)
+                    h = self.dropout(h)
+                # by design, our output nodes are contiguous so we can take
+                # advantage of that here
+                y[output_nodes[0]:output_nodes[-1]+1] = h.to('cpu')
+            feat = y
+        return y
+
+class GraphSAGEBatchMultiGPU(GraphSAGEBatch):
+     """
+        Perform inference in layer-major order rather than batch-major order within the context of multi-gpu training.
+     """
+     def inference(self, g, device, batch_size):
+        g.ndata['h'] = g.ndata['feat']
+        sampler = dgl.dataloading.MultiLayerFullNeighborSampler(1, prefetch_node_feats=['h'])
+        use_uva = (g.device != device)
+
+        for l, layer in enumerate(self.layers):
+            """
+               Have to re-initialize dataloader for every layer to allow tensor pinned by DGL being automatically unpinned
+            """
+            dataloader = dgl.dataloading.DataLoader(
+                g, torch.arange(g.num_nodes(), device=device), sampler, device=device,
+                batch_size=batch_size, shuffle=False, drop_last=False,
+                num_workers=0, use_ddp=True, use_uva=use_uva)
+             
             # in order to prevent running out of GPU memory, we allocate a
-            # shared output tensor 'y' in host memory, pin it to allow UVA
-            # access from each GPU during forward propagation.
+            # shared output tensor 'y' in host memory
             y = shared_tensor(
-                    (g.num_nodes(), self.n_hidden if l != len(self.layers) - 1 else self.n_classes))
-            pin_memory_inplace(y)
+                (g.num_nodes(), self.n_hidden if l != len(self.layers) - 1 else self.n_classes))
 
             for input_nodes, output_nodes, blocks in tqdm.tqdm(dataloader) \
                     if dist.get_rank() == 0 else dataloader:
@@ -138,12 +143,13 @@ class GraphSAGEBatchMultiGPU(GraphSAGEBatch):
                 y[output_nodes] = h.to(y.device)
             # make sure all GPUs are done writing to 'y'
             dist.barrier()
-            if l > 0:
-                unpin_memory_inplace(g.ndata['h'])
             if l + 1 < len(self.layers):
                 # assign the output features of this layer as the new input
                 # features for the next layer
-                g.ndata['h'] = y
+                if use_uva:
+                    g.ndata['h'] = y
+                else:
+                    g.ndata['h'] = y.to(g.device)
             else:
                 # remove the intermediate data from the graph
                 g.ndata.pop('h')

--- a/examples/pytorch/graphsage/model.py
+++ b/examples/pytorch/graphsage/model.py
@@ -1,0 +1,150 @@
+import torch
+import torch.nn as nn
+import dgl
+from dgl import DGLGraph
+from dgl.nn.pytorch.conv import SAGEConv
+import tqdm
+
+from dgl.multiprocessing import shared_tensor
+from dgl.utils import pin_memory_inplace, unpin_memory_inplace
+import torch.distributed as dist
+
+class GraphSAGE(nn.Module):
+    def __init__(self,
+                 in_feats,
+                 n_hidden,
+                 n_classes,
+                 n_layers,
+                 activation,
+                 dropout,
+                 aggregator_type):
+        super().__init__()
+        self.layers = nn.ModuleList()
+        self.dropout = nn.Dropout(dropout)
+        self.activation = activation
+
+        # input layer
+        self.layers.append(SAGEConv(in_feats, n_hidden, aggregator_type))
+        # hidden layers
+        for i in range(n_layers):
+            self.layers.append(SAGEConv(n_hidden, n_hidden, aggregator_type))
+            # output layer
+        self.layers.append(SAGEConv(n_hidden, n_classes, aggregator_type)) # activation None
+
+    def forward(self, graph, inputs):
+        h = self.dropout(inputs)
+        for l, layer in enumerate(self.layers):
+            h = layer(graph, h)
+            if l != len(self.layers) - 1:
+                h = self.activation(h)
+                h = self.dropout(h)
+        return h
+
+class GraphSAGEBatch(GraphSAGE):
+    def __init__(self,
+                 in_feats,
+                 n_hidden,
+                 n_classes,
+                 n_layers,
+                 activation,
+                 dropout,
+                 aggregator_type):
+        super().__init__(in_feats, n_hidden, n_classes, n_layers, activation, dropout, aggregator_type)
+        self.n_hidden = n_hidden
+        self.n_classes = n_classes
+        
+    def forward(self, blocks, x):
+        h = x
+        for l, (layer, block) in enumerate(zip(self.layers, blocks)):
+            h = layer(block, h)
+            if l != len(self.layers) - 1:
+                h = self.activation(h)
+                h = self.dropout(h)
+        return h
+
+    def inference(self, g, device, batch_size):
+        feat = g.ndata['feat']
+        sampler = dgl.dataloading.MultiLayerFullNeighborSampler(1, prefetch_node_feats=['feat'])
+        dataloader = dgl.dataloading.DataLoader(
+                g, torch.arange(g.num_nodes()).to(g.device), sampler, device=device,
+                batch_size=batch_size, shuffle=False, drop_last=False,
+                num_workers=0)
+
+        for l, layer in enumerate(self.layers):
+            y = torch.empty(
+                g.num_nodes(), self.n_hidden if l != len(self.layers) - 1 else self.n_classes,
+                device='cpu', pin_memory=True)
+            feat = feat.to(device)
+            for input_nodes, output_nodes, blocks in tqdm.tqdm(dataloader):
+                # use an explicitly contiguous slice
+                x = feat[input_nodes]
+                h = layer(blocks[0], x)
+                if l != len(self.layers) - 1:
+                    h = self.activation(h)
+                    h = self.dropout(h)
+                # be design, our output nodes are contiguous so we can take
+                # advantage of that here
+                y[output_nodes[0]:output_nodes[-1]+1] = h.to('cpu')
+            feat = y
+        return y
+
+class GraphSAGEBatchMultiGPU(GraphSAGEBatch):
+    def inference(self, g, device, batch_size):
+        """
+        Perform inference in layer-major order rather than batch-major order.
+        That is, infer the first layer for the entire graph, and store the
+        intermediate values h_0, before infering the second layer to generate
+        h_1. This is done for two reasons: 1) it limits the effect of node
+        degree on the amount of memory used as it only proccesses 1-hop
+        neighbors at a time, and 2) it reduces the total amount of computation
+        required as each node is only processed once per layer.
+
+        Parameters
+        ----------
+            g : DGLGraph
+                The graph to perform inference on.
+            device : context
+                The device this process should use for inference
+            batch_size : int
+                The number of items to collect in a batch.
+
+        Returns
+        -------
+            tensor
+                The predictions for all nodes in the graph.
+        """
+        g.ndata['h'] = g.ndata['feat']
+        sampler = dgl.dataloading.MultiLayerFullNeighborSampler(1, prefetch_node_feats=['h'])
+        dataloader = dgl.dataloading.DataLoader(
+                g, torch.arange(g.num_nodes(), device=device), sampler, device=device,
+                batch_size=batch_size, shuffle=False, drop_last=False,
+                num_workers=0, use_ddp=True, use_uva=True)
+
+        for l, layer in enumerate(self.layers):
+            # in order to prevent running out of GPU memory, we allocate a
+            # shared output tensor 'y' in host memory, pin it to allow UVA
+            # access from each GPU during forward propagation.
+            y = shared_tensor(
+                    (g.num_nodes(), self.n_hidden if l != len(self.layers) - 1 else self.n_classes))
+            pin_memory_inplace(y)
+
+            for input_nodes, output_nodes, blocks in tqdm.tqdm(dataloader) \
+                    if dist.get_rank() == 0 else dataloader:
+                x = blocks[0].srcdata['h']
+                h = layer(blocks[0], x)
+                if l != len(self.layers) - 1:
+                    h = self.activation(h)
+                    h = self.dropout(h)
+                y[output_nodes] = h.to(y.device)
+            # make sure all GPUs are done writing to 'y'
+            dist.barrier()
+            if l > 0:
+                unpin_memory_inplace(g.ndata['h'])
+            if l + 1 < len(self.layers):
+                # assign the output features of this layer as the new input
+                # features for the next layer
+                g.ndata['h'] = y
+            else:
+                # remove the intermediate data from the graph
+                g.ndata.pop('h')
+        return y

--- a/examples/pytorch/graphsage/multi_gpu_node_classification.py
+++ b/examples/pytorch/graphsage/multi_gpu_node_classification.py
@@ -6,111 +6,36 @@ import torch.distributed.optim
 import torchmetrics.functional as MF
 import dgl
 import dgl.nn as dglnn
-from dgl.utils import pin_memory_inplace, unpin_memory_inplace
-from dgl.multiprocessing import shared_tensor
 import time
 import numpy as np
 from ogb.nodeproppred import DglNodePropPredDataset
-import tqdm
+import argparse
+from dgl.data import register_data_args, load_data
+from model import GraphSAGEBatchMultiGPU,GraphSAGEBatch
+from node_classification import batch_evaluate, evaluate
 
+def train(rank, world_size, args, graph, devices, data):
+    in_feats, num_classes, train_idx, valid_idx, test_idx = data
+    device = torch.device(devices[rank])
+    if world_size > 0:
+        torch.cuda.set_device(device)
+    else:
+        world_size = 1
+        
+    if world_size > 1:
+        dist.init_process_group('nccl', 'tcp://127.0.0.1:12347', world_size=world_size, rank=rank)
+        model = GraphSAGEBatchMultiGPU(in_feats, args.n_hidden, num_classes, args.n_layers, F.relu, args.dropout, args.aggregator_type).to(device)
+        model = nn.parallel.DistributedDataParallel(model, device_ids=[rank], output_device=rank)
+        model = model.module
+    else:
+        model = GraphSAGEBatch(in_feats, args.n_hidden, num_classes, args.n_layers, F.relu, args.dropout, args.aggregator_type).to(device)
 
-class SAGE(nn.Module):
-    def __init__(self, in_feats, n_hidden, n_classes):
-        super().__init__()
-        self.layers = nn.ModuleList()
-        self.layers.append(dglnn.SAGEConv(in_feats, n_hidden, 'mean'))
-        self.layers.append(dglnn.SAGEConv(n_hidden, n_hidden, 'mean'))
-        self.layers.append(dglnn.SAGEConv(n_hidden, n_classes, 'mean'))
-        self.dropout = nn.Dropout(0.5)
-        self.n_hidden = n_hidden
-        self.n_classes = n_classes
-
-    def _forward_layer(self, l, block, x):
-        h = self.layers[l](block, x)
-        if l != len(self.layers) - 1:
-            h = F.relu(h)
-            h = self.dropout(h)
-        return h
-
-    def forward(self, blocks, x):
-        h = x
-        for l, (layer, block) in enumerate(zip(self.layers, blocks)):
-            h = self._forward_layer(l, blocks[l], h)
-        return h
-
-    def inference(self, g, device, batch_size):
-        """
-        Perform inference in layer-major order rather than batch-major order.
-        That is, infer the first layer for the entire graph, and store the
-        intermediate values h_0, before infering the second layer to generate
-        h_1. This is done for two reasons: 1) it limits the effect of node
-        degree on the amount of memory used as it only proccesses 1-hop
-        neighbors at a time, and 2) it reduces the total amount of computation
-        required as each node is only processed once per layer.
-
-        Parameters
-        ----------
-            g : DGLGraph
-                The graph to perform inference on.
-            device : context
-                The device this process should use for inference
-            batch_size : int
-                The number of items to collect in a batch.
-
-        Returns
-        -------
-            tensor
-                The predictions for all nodes in the graph.
-        """
-        g.ndata['h'] = g.ndata['feat']
-        sampler = dgl.dataloading.MultiLayerFullNeighborSampler(1, prefetch_node_feats=['h'])
-        dataloader = dgl.dataloading.DataLoader(
-                g, torch.arange(g.num_nodes(), device=device), sampler, device=device,
-                batch_size=batch_size, shuffle=False, drop_last=False,
-                num_workers=0, use_ddp=True, use_uva=True)
-
-        for l, layer in enumerate(self.layers):
-            # in order to prevent running out of GPU memory, we allocate a
-            # shared output tensor 'y' in host memory, pin it to allow UVA
-            # access from each GPU during forward propagation.
-            y = shared_tensor(
-                    (g.num_nodes(), self.n_hidden if l != len(self.layers) - 1 else self.n_classes))
-            pin_memory_inplace(y)
-
-            for input_nodes, output_nodes, blocks in tqdm.tqdm(dataloader) \
-                    if dist.get_rank() == 0 else dataloader:
-                x = blocks[0].srcdata['h']
-                h = self._forward_layer(l, blocks[0], x)
-                y[output_nodes] = h.to(y.device)
-            # make sure all GPUs are done writing to 'y'
-            dist.barrier()
-            if l > 0:
-                unpin_memory_inplace(g.ndata['h'])
-            if l + 1 < len(self.layers):
-                # assign the output features of this layer as the new input
-                # features for the next layer
-                g.ndata['h'] = y
-            else:
-                # remove the intermediate data from the graph
-                g.ndata.pop('h')
-        return y
-
-
-def train(rank, world_size, graph, num_classes, split_idx):
-    torch.cuda.set_device(rank)
-    dist.init_process_group('nccl', 'tcp://127.0.0.1:12347', world_size=world_size, rank=rank)
-
-    model = SAGE(graph.ndata['feat'].shape[1], 256, num_classes).cuda()
-    model = nn.parallel.DistributedDataParallel(model, device_ids=[rank], output_device=rank)
     opt = torch.optim.Adam(model.parameters(), lr=0.001, weight_decay=5e-4)
 
-    train_idx, valid_idx, test_idx = split_idx['train'], split_idx['valid'], split_idx['test']
-
     # move ids to GPU
-    train_idx = train_idx.to('cuda')
-    valid_idx = valid_idx.to('cuda')
-    test_idx = test_idx.to('cuda')
-
+    train_idx = train_idx.to(device)
+    valid_idx = valid_idx.to(device)
+    
     # For training, each process/GPU will get a subset of the
     # train_idx/valid_idx, and generate mini-batches indepednetly. This allows
     # the only communication neccessary in training to be the all-reduce for
@@ -119,17 +44,19 @@ def train(rank, world_size, graph, num_classes, split_idx):
             [15, 10, 5], prefetch_node_feats=['feat'], prefetch_labels=['label'])
     train_dataloader = dgl.dataloading.DataLoader(
             graph, train_idx, sampler,
-            device='cuda', batch_size=1024, shuffle=True, drop_last=False,
-            num_workers=0, use_ddp=True, use_uva=True)
+            device=device, batch_size=args.batch_size, shuffle=True, drop_last=False,
+            num_workers=0, use_ddp=world_size > 1, use_uva=True)
     valid_dataloader = dgl.dataloading.DataLoader(
-            graph, valid_idx, sampler, device='cuda', batch_size=1024, shuffle=True,
-            drop_last=False, num_workers=0, use_ddp=True,
+            graph, valid_idx, sampler, device=device, batch_size=args.batch_size, shuffle=True,
+            drop_last=False, num_workers=0, use_ddp=world_size > 1,
             use_uva=True)
 
-    durations = []
-    for _ in range(10):
+    dur = []
+
+    for epoch in range(args.n_epochs):
         model.train()
         t0 = time.time()
+        total_loss = torch.tensor(0.0).to(device)
         for it, (input_nodes, output_nodes, blocks) in enumerate(train_dataloader):
             x = blocks[0].srcdata['feat']
             y = blocks[-1].dstdata['label'][:, 0]
@@ -138,51 +65,76 @@ def train(rank, world_size, graph, num_classes, split_idx):
             opt.zero_grad()
             loss.backward()
             opt.step()
-            if it % 20 == 0 and rank == 0:
-                acc = MF.accuracy(y_hat, y)
-                mem = torch.cuda.max_memory_allocated() / 1000000
-                print('Loss', loss.item(), 'Acc', acc.item(), 'GPU Mem', mem, 'MB')
+            total_loss += loss
         tt = time.time()
-
+        dur.append(tt - t0)
+        acc = batch_evaluate(model, graph, valid_dataloader) / world_size
+        if world_size > 1: dist.reduce(acc, 0)
         if rank == 0:
-            print(tt - t0)
-        durations.append(tt - t0)
+            mem = torch.cuda.max_memory_allocated() / 1000000
+            print("Epoch {:05d} | Avg. Time(s) {:.4f} | Loss {:.4f} | Accuracy {:.4f} | "
+                  "GPU Mem(MB) {:.2f}".format(epoch, np.mean(dur), total_loss.item() / (it+1),
+                                              acc.item(), mem))
+        if world_size > 1: dist.barrier()
 
-        model.eval()
-        ys = []
-        y_hats = []
-        for it, (input_nodes, output_nodes, blocks) in enumerate(valid_dataloader):
-            with torch.no_grad():
-                x = blocks[0].srcdata['feat']
-                ys.append(blocks[-1].dstdata['label'])
-                y_hats.append(model.module(blocks, x))
-        acc = MF.accuracy(torch.cat(y_hats), torch.cat(ys)) / world_size
-        dist.reduce(acc, 0)
-        if rank == 0:
-            print('Validation acc:', acc.item())
-        dist.barrier()
-
-    if rank == 0:
-        print(np.mean(durations[4:]), np.std(durations[4:]))
-    model.eval()
-    with torch.no_grad():
-        # since we do 1-layer at a time, use a very large batch size
-        pred = model.module.inference(graph, device='cuda', batch_size=2**16)
-        if rank == 0:
-            acc = MF.accuracy(pred[test_idx], graph.ndata['label'][test_idx])
-            print('Test acc:', acc.item())
+    acc = evaluate(model, graph, device, test_idx, 2**16)
+    if rank==0:
+        print("Test Accuracy on Master {:.4f}".format(acc.item()))
 
 if __name__ == '__main__':
+    parser = argparse.ArgumentParser(description='GraphSAGE')
+    register_data_args(parser)
+    parser.add_argument("--dropout", type=float, default=0.5,
+                        help="dropout probability")
+    parser.add_argument("--gpu", type=str, default='-1',
+                        help="GPU, can be a list of gpus for multi-gpu training,"
+                                " e.g., 0,1,2,3; -1 for CPU")
+    parser.add_argument("--lr", type=float, default=1e-3,
+                        help="learning rate")
+    parser.add_argument("--n-epochs", type=int, default=10,
+                        help="number of training epochs")
+    parser.add_argument("--n-hidden", type=int, default=256,
+                        help="number of hidden gcn units")
+    parser.add_argument("--n-layers", type=int, default=1,
+                        help="number of hidden gcn layers")
+    parser.add_argument("--batch-size", type=int, default=1024,
+                        help="batch size")
+    parser.add_argument("--weight-decay", type=float, default=5e-4,
+                        help="Weight for L2 loss")
+    parser.add_argument("--aggregator-type", type=str, default="mean",
+                        help="Aggregator type: mean/gcn/pool/lstm")
+    parser.add_argument('--pure-gpu', action='store_true',
+                    help='Perform both sampling and training on GPU.')
+    args = parser.parse_args()
+    
     dataset = DglNodePropPredDataset('ogbn-products')
-    graph, labels = dataset[0]
-    graph.ndata['label'] = labels
-    graph.create_formats_()     # must be called before mp.spawn().
+    devices = list(map(int, args.gpu.split(',')))
+    n_gpus = len(devices)
+    g, labels = dataset[0]
+    g.ndata['label'] = labels
+    features = g.ndata['feat']
+    g.create_formats_()     # must be called before mp.spawn().
     split_idx = dataset.get_idx_split()
-    num_classes = dataset.num_classes
-    # use all available GPUs
-    n_procs = torch.cuda.device_count()
+    n_classes = dataset.num_classes
+    n_edges = g.number_of_edges()
+    train_idx, valid_idx, test_idx = split_idx['train'], split_idx['valid'], split_idx['test']
+    data = features.shape[1], n_classes, train_idx, valid_idx, test_idx
 
+    print("""----Data statistics------'
+    #Edges %d
+    #Classes %d
+    #Train samples %d
+    #Val samples %d
+    #Test samples %d""" %
+    (n_edges, n_classes,
+     len(train_idx), len(valid_idx), len(test_idx)))
+     
     # Tested with mp.spawn and fork.  Both worked and got 4s per epoch with 4 GPUs
     # and 3.86s per epoch with 8 GPUs on p2.8x, compared to 5.2s from official examples.
     import torch.multiprocessing as mp
-    mp.spawn(train, args=(n_procs, graph, num_classes, split_idx), nprocs=n_procs)
+    if devices[0] == -1:
+        train(0, 0, args, g, ['cpu'], data)
+    elif n_gpus == 1:
+        train(0, 1, args, g, devices, data)
+    else:
+        mp.spawn(train, args=(n_gpus, args, g, devices, data), nprocs=n_gpus)

--- a/examples/pytorch/graphsage/multi_gpu_node_classification.py
+++ b/examples/pytorch/graphsage/multi_gpu_node_classification.py
@@ -10,7 +10,6 @@ import time
 import numpy as np
 from ogb.nodeproppred import DglNodePropPredDataset
 import argparse
-from dgl.data import register_data_args, load_data
 from model import GraphSAGEBatchMultiGPU,GraphSAGEBatch
 from node_classification import batch_evaluate, evaluate
 
@@ -18,23 +17,23 @@ def train(rank, world_size, args, graph, devices, data):
     in_feats, num_classes, train_idx, valid_idx, test_idx = data
     device = torch.device(devices[rank])
     use_uva = True
-    if world_size > 0: 
+    if world_size > 0:  # num. of running gpu >= 1
         torch.cuda.set_device(device)
-    else:  # no gpu, pure cpu run
+    else:  # no gpu specified or available
         world_size = 1
         use_uva = False
         
+    # create GraphSAGE model
     if world_size > 1:
         dist.init_process_group('nccl', 'tcp://127.0.0.1:12347', world_size=world_size, rank=rank)
-        model = GraphSAGEBatchMultiGPU(in_feats, args.n_hidden, num_classes, args.n_layers, F.relu, args.dropout, args.aggregator_type).to(device)
+        # parameters can be tuned here as keyword arguments
+        model = GraphSAGEBatchMultiGPU(in_feats, num_classes, n_hidden=256, n_layers=1, aggregator_type='mean').to(device)
         model = nn.parallel.DistributedDataParallel(model, device_ids=[rank], output_device=rank)
-        model = model.module
     else:
-        model = GraphSAGEBatch(in_feats, args.n_hidden, num_classes, args.n_layers, F.relu, args.dropout, args.aggregator_type).to(device)
+        model = GraphSAGEBatch(in_feats, n_classes, n_hidden=256, n_layers=1, aggregator_type = 'mean').to(device)
 
     opt = torch.optim.Adam(model.parameters(), lr=0.001, weight_decay=5e-4)
 
-    # move ids to GPU
     train_idx = train_idx.to(device)
     valid_idx = valid_idx.to(device)
 
@@ -43,14 +42,13 @@ def train(rank, world_size, args, graph, devices, data):
         use_uva = False
     elif args.graph_device == 'uva':
         graph.pin_memory_()
-
         
     # For training, each process/GPU will get a subset of the
     # train_idx/valid_idx, and generate mini-batches indepednetly. This allows
     # the only communication neccessary in training to be the all-reduce for
     # the gradients performed by the DDP wrapper (created above).
     sampler = dgl.dataloading.NeighborSampler(
-            [15, 10, 5], prefetch_node_feats=['feat'], prefetch_labels=['label'])
+            [5, 10, 15], prefetch_node_feats=['feat'], prefetch_labels=['label'])
     train_dataloader = dgl.dataloading.DataLoader(
             graph, train_idx, sampler,
             device=device, batch_size=args.batch_size, shuffle=True, drop_last=False,
@@ -60,8 +58,7 @@ def train(rank, world_size, args, graph, devices, data):
             drop_last=False, num_workers=0, use_ddp=world_size > 1,
             use_uva=use_uva)
 
-    dur = []
-
+    time_sta = time.time()
     for epoch in range(args.n_epochs):
         model.train()
         t0 = time.time()
@@ -76,42 +73,33 @@ def train(rank, world_size, args, graph, devices, data):
             opt.step()
             total_loss += loss
         tt = time.time()
-        dur.append(tt - t0)
+        dur = tt - t0
         acc = batch_evaluate(model, graph, valid_dataloader) / world_size
         if world_size > 1: dist.reduce(acc, 0)
         if rank == 0:
             mem = torch.cuda.max_memory_allocated() / 1000000
-            print("Epoch {:05d} | Avg. Time(s) {:.4f} | Loss {:.4f} | Accuracy {:.4f} | "
-                  "GPU Mem(MB) {:.2f}".format(epoch, np.mean(dur), total_loss.item() / (it+1),
+            print("Epoch {:05d} | Time(s) {:.4f} | Loss {:.4f} | Accuracy {:.4f} | "
+                  "GPU Mem(MB) {:.2f}".format(epoch, dur, total_loss.item() / (it+1),
                                               acc.item(), mem))
         if world_size > 1: dist.barrier()
 
+    if rank==0:
+        print("Training time(s) {:.4f}". format(time.time()-time_sta))
+        print()
+        
     acc = evaluate(model, graph, device, test_idx, 2**16) # 2**16: batch_size for evaluation
     if rank==0:
-        print("Test Accuracy on Master {:.4f}".format(acc.item()))
+        print("Test Accuracy {:.4f}".format(acc.item()))
 
 if __name__ == '__main__':
     parser = argparse.ArgumentParser(description='GraphSAGE')
-    register_data_args(parser)
-    parser.add_argument("--dropout", type=float, default=0.5,
-                        help="dropout probability")
     parser.add_argument("--gpu", type=str, default='-1',
                         help="GPU, can be a list of gpus for multi-gpu training,"
                                 " e.g., 0,1,2,3; -1 for CPU")
-    parser.add_argument("--lr", type=float, default=1e-3,
-                        help="learning rate")
     parser.add_argument("--n-epochs", type=int, default=10,
                         help="number of training epochs")
-    parser.add_argument("--n-hidden", type=int, default=256,
-                        help="number of hidden gcn units")
-    parser.add_argument("--n-layers", type=int, default=1,
-                        help="number of hidden gcn layers")
     parser.add_argument("--batch-size", type=int, default=1024,
-                        help="batch size")
-    parser.add_argument("--weight-decay", type=float, default=5e-4,
-                        help="Weight for L2 loss")
-    parser.add_argument("--aggregator-type", type=str, default="mean",
-                        help="Aggregator type: mean/gcn/pool/lstm")
+                        help="mini-batch sample size")
     parser.add_argument('--graph-device', choices=('cpu', 'gpu', 'uva'), default='cpu',
                            help="Device to perform the sampling. "
                            "Must have 0 workers for 'gpu' and 'uva'")
@@ -122,12 +110,12 @@ if __name__ == '__main__':
     devices = list(map(int, args.gpu.split(',')))
     n_gpus = len(devices)
     g, labels = dataset[0]
-    g.ndata['label'] = labels
+    g.ndata['label'] = labels.squeeze()
     features = g.ndata['feat']
     g.create_formats_()     # must be called before mp.spawn().
     split_idx = dataset.get_idx_split()
     n_classes = dataset.num_classes
-    n_edges = g.number_of_edges()
+    n_edges = g.num_edges()
     train_idx, valid_idx, test_idx = split_idx['train'], split_idx['valid'], split_idx['test']
     data = features.shape[1], n_classes, train_idx, valid_idx, test_idx
 
@@ -140,8 +128,6 @@ if __name__ == '__main__':
     (n_edges, n_classes,
      len(train_idx), len(valid_idx), len(test_idx)))
      
-    # Tested with mp.spawn and fork.  Both worked and got 4s per epoch with 4 GPUs
-    # and 3.86s per epoch with 8 GPUs on p2.8x, compared to 5.2s from official examples.
     import torch.multiprocessing as mp
     if devices[0] == -1:
         assert args.graph_device == 'cpu', \

--- a/examples/pytorch/graphsage/multi_gpu_node_classification.py
+++ b/examples/pytorch/graphsage/multi_gpu_node_classification.py
@@ -77,7 +77,7 @@ def train(rank, world_size, args, graph, devices, data):
                                               acc.item(), mem))
         if world_size > 1: dist.barrier()
 
-    acc = evaluate(model, graph, device, test_idx, 2**16)
+    acc = evaluate(model, graph, device, test_idx, 2**16) # 2**16: batch_size for evaluation
     if rank==0:
         print("Test Accuracy on Master {:.4f}".format(acc.item()))
 

--- a/examples/pytorch/graphsage/node_classification.py
+++ b/examples/pytorch/graphsage/node_classification.py
@@ -3,130 +3,127 @@ import torch.nn as nn
 import torch.nn.functional as F
 import torchmetrics.functional as MF
 import dgl
-import dgl.nn as dglnn
+from dgl.data import register_data_args, load_data
 import time
 import numpy as np
 from ogb.nodeproppred import DglNodePropPredDataset
-import tqdm
 import argparse
+from model import GraphSAGEBatch
 
-parser = argparse.ArgumentParser()
-parser.add_argument('--pure-gpu', action='store_true',
-                    help='Perform both sampling and training on GPU.')
-args = parser.parse_args()
-
-class SAGE(nn.Module):
-    def __init__(self, in_feats, n_hidden, n_classes):
-        super().__init__()
-        self.layers = nn.ModuleList()
-        self.layers.append(dglnn.SAGEConv(in_feats, n_hidden, 'mean'))
-        self.layers.append(dglnn.SAGEConv(n_hidden, n_hidden, 'mean'))
-        self.layers.append(dglnn.SAGEConv(n_hidden, n_classes, 'mean'))
-        self.dropout = nn.Dropout(0.5)
-        self.n_hidden = n_hidden
-        self.n_classes = n_classes
-
-    def forward(self, blocks, x):
-        h = x
-        for l, (layer, block) in enumerate(zip(self.layers, blocks)):
-            h = layer(block, h)
-            if l != len(self.layers) - 1:
-                h = F.relu(h)
-                h = self.dropout(h)
-        return h
-
-    def inference(self, g, device, batch_size, num_workers, buffer_device=None):
-        feat = g.ndata['feat']
-        sampler = dgl.dataloading.MultiLayerFullNeighborSampler(1, prefetch_node_feats=['feat'])
-        dataloader = dgl.dataloading.DataLoader(
-                g, torch.arange(g.num_nodes()).to(g.device), sampler, device=device,
-                batch_size=batch_size, shuffle=False, drop_last=False,
-                num_workers=num_workers)
-
-        if buffer_device is None:
-            buffer_device = device
-
-        for l, layer in enumerate(self.layers):
-            y = torch.empty(
-                g.num_nodes(), self.n_hidden if l != len(self.layers) - 1 else self.n_classes,
-                device=buffer_device, pin_memory=True)
-            feat = feat.to(device)
-            for input_nodes, output_nodes, blocks in tqdm.tqdm(dataloader):
-                # use an explicitly contiguous slice
-                x = feat[input_nodes]
-                h = layer(blocks[0], x)
-                if l != len(self.layers) - 1:
-                    h = F.relu(h)
-                    h = self.dropout(h)
-                # be design, our output nodes are contiguous so we can take
-                # advantage of that here
-                y[output_nodes[0]:output_nodes[-1]+1] = h.to(buffer_device)
-            feat = y
-        return y
-
-dataset = DglNodePropPredDataset('ogbn-products')
-graph, labels = dataset[0]
-graph.ndata['label'] = labels.squeeze()
-split_idx = dataset.get_idx_split()
-train_idx, valid_idx, test_idx = split_idx['train'], split_idx['valid'], split_idx['test']
-
-device = 'cuda'
-train_idx = train_idx.to(device)
-valid_idx = valid_idx.to(device)
-test_idx = test_idx.to(device)
-
-graph = graph.to('cuda' if args.pure_gpu else 'cpu')
-
-model = SAGE(graph.ndata['feat'].shape[1], 256, dataset.num_classes).to(device)
-opt = torch.optim.Adam(model.parameters(), lr=0.001, weight_decay=5e-4)
-
-sampler = dgl.dataloading.NeighborSampler(
-        [15, 10, 5], prefetch_node_feats=['feat'], prefetch_labels=['label'])
-train_dataloader = dgl.dataloading.DataLoader(
-        graph, train_idx, sampler, device=device, batch_size=1024, shuffle=True,
-        drop_last=False, num_workers=0, use_uva=not args.pure_gpu)
-valid_dataloader = dgl.dataloading.DataLoader(
-        graph, valid_idx, sampler, device=device, batch_size=1024, shuffle=True,
-        drop_last=False, num_workers=0, use_uva=not args.pure_gpu)
-
-durations = []
-for _ in range(10):
-    model.train()
-    t0 = time.time()
-    for it, (input_nodes, output_nodes, blocks) in enumerate(train_dataloader):
-        x = blocks[0].srcdata['feat']
-        y = blocks[-1].dstdata['label']
-        y_hat = model(blocks, x)
-        loss = F.cross_entropy(y_hat, y)
-        opt.zero_grad()
-        loss.backward()
-        opt.step()
-        if it % 20 == 0:
-            acc = MF.accuracy(y_hat, y)
-            mem = torch.cuda.max_memory_allocated() / 1000000
-            print('Loss', loss.item(), 'Acc', acc.item(), 'GPU Mem', mem, 'MB')
-    tt = time.time()
-    print(tt - t0)
-    durations.append(tt - t0)
-
+def batch_evaluate(model, graph, dataloader):
     model.eval()
     ys = []
     y_hats = []
-    for it, (input_nodes, output_nodes, blocks) in enumerate(valid_dataloader):
+    for it, (input_nodes, output_nodes, blocks) in enumerate(dataloader):
         with torch.no_grad():
             x = blocks[0].srcdata['feat']
             ys.append(blocks[-1].dstdata['label'])
             y_hats.append(model(blocks, x))
-    acc = MF.accuracy(torch.cat(y_hats), torch.cat(ys))
-    print('Validation acc:', acc.item())
+    return MF.accuracy(torch.cat(y_hats), torch.cat(ys))
 
-print(np.mean(durations[4:]), np.std(durations[4:]))
+def evaluate(model, graph, device, nid, batch_size):
+    model.eval()
+    nid = nid.to(device)
+    with torch.no_grad():
+        pred = model.inference(graph, device, batch_size)
+        pred = pred[nid].to(device)
+        label = graph.ndata['label'][nid].to(device)
+        return MF.accuracy(pred, label)
 
-# Test accuracy and offline inference of all nodes
-model.eval()
-with torch.no_grad():
-    pred = model.inference(graph, device, 4096, 0, 'cpu')
-    pred = pred[test_idx].to(device)
-    label = graph.ndata['label'][test_idx].to(device)
-    acc = MF.accuracy(pred, label)
-    print('Test acc:', acc.item())
+def train(args, g, device, in_feats, n_classes, train_idx, valid_idx):
+    train_idx = train_idx.to(device)
+    valid_idx = valid_idx.to(device)
+
+    model = GraphSAGEBatch(in_feats, args.n_hidden, n_classes, args.n_layers, F.relu, args.dropout, args.aggregator_type).to(device)
+    opt = torch.optim.Adam(model.parameters(), lr=args.lr, weight_decay=args.weight_decay)
+
+    sampler = dgl.dataloading.NeighborSampler([15, 10, 5],
+                                              prefetch_node_feats=['feat'], prefetch_labels=['label'])
+    train_dataloader = dgl.dataloading.DataLoader(g, train_idx, sampler, device = device,
+                                                  batch_size=args.batch_size, shuffle=True,
+                                                  drop_last=False, num_workers=0,
+                                                  use_uva=not args.pure_gpu)
+
+    valid_dataloader = dgl.dataloading.DataLoader(g, valid_idx, sampler, device=device,
+                                                  batch_size=args.batch_size, shuffle=True,
+                                                  drop_last=False, num_workers=0,
+                                                  use_uva=not args.pure_gpu)
+    
+    dur = []
+    for epoch in range(args.n_epochs):
+        model.train()
+        t0 = time.time()
+        total_loss = torch.tensor(0.0).to(device)
+        for it, (input_nodes, output_nodes, blocks) in enumerate(train_dataloader):
+            x = blocks[0].srcdata['feat']
+            y = blocks[-1].dstdata['label']
+            y_hat = model(blocks, x)
+            loss = F.cross_entropy(y_hat, y)
+            opt.zero_grad()
+            loss.backward()
+            opt.step()
+            total_loss += loss
+        tt = time.time()
+        dur.append(tt-t0)
+        acc = batch_evaluate(model, g, valid_dataloader)
+        mem = torch.cuda.max_memory_allocated() / 1000000
+        print("Epoch {:05d} | Avg. Time(s) {:.4f} | Loss {:.4f} | Accuracy {:.4f} | "
+              "GPU Mem(MB) {:.2f}".format(epoch, np.mean(dur), total_loss.item() / (it+1),
+                                            acc.item(), mem))
+    return model
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser(description='GraphSAGE')
+    register_data_args(parser)
+    parser.add_argument("--dropout", type=float, default=0.5,
+                        help="dropout probability")
+    parser.add_argument("--gpu", type=int, default=-1,
+                        help="gpu")
+    parser.add_argument("--lr", type=float, default=1e-3,
+                        help="learning rate")
+    parser.add_argument("--n-epochs", type=int, default=10,
+                        help="number of training epochs")
+    parser.add_argument("--n-hidden", type=int, default=256,
+                        help="number of hidden gcn units")
+    parser.add_argument("--n-layers", type=int, default=1,
+                        help="number of hidden gcn layers")
+    parser.add_argument("--batch-size", type=int, default=1024,
+                        help="batch size")
+    parser.add_argument("--weight-decay", type=float, default=5e-4,
+                        help="Weight for L2 loss")
+    parser.add_argument("--aggregator-type", type=str, default="mean",
+                        help="Aggregator type: mean/gcn/pool/lstm")
+    parser.add_argument('--pure-gpu', action='store_true',
+                    help='Perform both sampling and training on GPU.')
+    args = parser.parse_args()
+    print(args)
+    dataset = DglNodePropPredDataset('ogbn-products')
+    g, labels = dataset[0]
+    g.ndata['label'] = labels.squeeze()
+    features = g.ndata['feat']
+    split_idx = dataset.get_idx_split()
+    in_feats = features.shape[1]
+    n_classes = dataset.num_classes
+    n_edges = g.number_of_edges()
+    if args.gpu < 0:
+        device = torch.device('cpu')
+        args.pure_gpu = False
+    else:
+        device = torch.device('cuda' if torch.cuda.is_available() else 'cpu')
+        g = g.to(device if args.pure_gpu else 'cpu')
+    train_idx, valid_idx, test_idx = split_idx['train'], split_idx['valid'], split_idx['test']
+    
+    print("""----Data statistics------'
+    #Edges %d
+    #Classes %d
+    #Train samples %d
+    #Val samples %d
+    #Test samples %d""" %
+    (n_edges, n_classes,
+     len(train_idx), len(valid_idx), len(test_idx)))
+     
+    model = train(args, g, device, in_feats, n_classes, train_idx, valid_idx)
+    # Test accuracy and offline inference of all nodes                           
+    acc = evaluate(model, g, device, test_idx, 4096)
+    print("Test Accuracy {:.4f}".format(acc.item()))
+    

--- a/examples/pytorch/graphsage/node_classification.py
+++ b/examples/pytorch/graphsage/node_classification.py
@@ -30,7 +30,8 @@ def evaluate(model, graph, device, nid, batch_size):
         label = graph.ndata['label'][nid].to(device)
         return MF.accuracy(pred, label)
 
-def train(args, g, device, in_feats, n_classes, train_idx, valid_idx):
+def train(args, g, device, data):
+    in_feats, n_classes, train_idx, valid_idx = data
     train_idx = train_idx.to(device)
     valid_idx = valid_idx.to(device)
 
@@ -97,6 +98,8 @@ if __name__ == '__main__':
                     help='Perform both sampling and training on GPU.')
     args = parser.parse_args()
     print(args)
+    
+    # load and preprocess dataset
     dataset = DglNodePropPredDataset('ogbn-products')
     g, labels = dataset[0]
     g.ndata['label'] = labels.squeeze()
@@ -121,9 +124,10 @@ if __name__ == '__main__':
     #Test samples %d""" %
     (n_edges, n_classes,
      len(train_idx), len(valid_idx), len(test_idx)))
-     
-    model = train(args, g, device, in_feats, n_classes, train_idx, valid_idx)
+
+    data = in_feats, n_classes, train_idx, valid_idx
+    model = train(args, g, device, data)
     # Test accuracy and offline inference of all nodes                           
-    acc = evaluate(model, g, device, test_idx, 4096)
+    acc = evaluate(model, g, device, test_idx, 4096) # 4096: batch size for evaluation
     print("Test Accuracy {:.4f}".format(acc.item()))
     

--- a/examples/pytorch/graphsage/node_classification.py
+++ b/examples/pytorch/graphsage/node_classification.py
@@ -3,7 +3,6 @@ import torch.nn as nn
 import torch.nn.functional as F
 import torchmetrics.functional as MF
 import dgl
-from dgl.data import register_data_args, load_data
 import time
 import numpy as np
 from ogb.nodeproppred import DglNodePropPredDataset
@@ -25,7 +24,10 @@ def evaluate(model, graph, device, nid, batch_size):
     model.eval()
     nid = nid.to(device)
     with torch.no_grad():
-        pred = model.inference(graph, device, batch_size)
+        if isinstance(model, GraphSAGEBatch):
+            pred = model.inference(graph, device, batch_size)
+        else:
+            pred = model.module.inference(graph, device, batch_size)
         pred = pred[nid].to(device)
         label = graph.ndata['label'][nid].to(device)
         return MF.accuracy(pred, label)
@@ -35,10 +37,12 @@ def train(args, g, device, data):
     train_idx = train_idx.to(device)
     valid_idx = valid_idx.to(device)
 
-    model = GraphSAGEBatch(in_feats, args.n_hidden, n_classes, args.n_layers, F.relu, args.dropout, args.aggregator_type).to(device)
-    opt = torch.optim.Adam(model.parameters(), lr=args.lr, weight_decay=args.weight_decay)
+    # create GraphSAGE model
+    # parameters can be tuned here as keyword arguments
+    model = GraphSAGEBatch(in_feats, n_classes, n_hidden=256, n_layers=1, aggregator_type = 'mean').to(device)
+    opt = torch.optim.Adam(model.parameters(), lr=1e-3, weight_decay=5e-4)
 
-    sampler = dgl.dataloading.NeighborSampler([15, 10, 5],
+    sampler = dgl.dataloading.NeighborSampler([5, 10, 15],
                                               prefetch_node_feats=['feat'], prefetch_labels=['label'])
     train_dataloader = dgl.dataloading.DataLoader(g, train_idx, sampler, device = device,
                                                   batch_size=args.batch_size, shuffle=True,
@@ -50,7 +54,7 @@ def train(args, g, device, data):
                                                   drop_last=False, num_workers=0,
                                                   use_uva=not args.pure_gpu)
     
-    dur = []
+    time_sta = time.time()
     for epoch in range(args.n_epochs):
         model.train()
         t0 = time.time()
@@ -65,35 +69,25 @@ def train(args, g, device, data):
             opt.step()
             total_loss += loss
         tt = time.time()
-        dur.append(tt-t0)
+        dur = tt-t0
         acc = batch_evaluate(model, g, valid_dataloader)
         mem = torch.cuda.max_memory_allocated() / 1000000
-        print("Epoch {:05d} | Avg. Time(s) {:.4f} | Loss {:.4f} | Accuracy {:.4f} | "
-              "GPU Mem(MB) {:.2f}".format(epoch, np.mean(dur), total_loss.item() / (it+1),
+        print("Epoch {:05d} | Time(s) {:.4f} | Loss {:.4f} | Accuracy {:.4f} | "
+              "GPU Mem(MB) {:.2f}".format(epoch, dur, total_loss.item() / (it+1),
                                             acc.item(), mem))
+    print("Training time(s) {:.4f}". format(time.time() - time_sta))
+    print()
     return model
 
 if __name__ == '__main__':
     parser = argparse.ArgumentParser(description='GraphSAGE')
-    register_data_args(parser)
-    parser.add_argument("--dropout", type=float, default=0.5,
-                        help="dropout probability")
     parser.add_argument("--gpu", type=int, default=-1,
                         help="gpu")
-    parser.add_argument("--lr", type=float, default=1e-3,
-                        help="learning rate")
     parser.add_argument("--n-epochs", type=int, default=10,
                         help="number of training epochs")
-    parser.add_argument("--n-hidden", type=int, default=256,
-                        help="number of hidden gcn units")
-    parser.add_argument("--n-layers", type=int, default=1,
-                        help="number of hidden gcn layers")
     parser.add_argument("--batch-size", type=int, default=1024,
-                        help="batch size")
-    parser.add_argument("--weight-decay", type=float, default=5e-4,
-                        help="Weight for L2 loss")
-    parser.add_argument("--aggregator-type", type=str, default="mean",
-                        help="Aggregator type: mean/gcn/pool/lstm")
+                        help="mini-batch sample size")
+    # need to switch to --graph-device, in line with multi-gpu-node-classification
     parser.add_argument('--pure-gpu', action='store_true',
                     help='Perform both sampling and training on GPU.')
     args = parser.parse_args()
@@ -102,18 +96,19 @@ if __name__ == '__main__':
     # load and preprocess dataset
     dataset = DglNodePropPredDataset('ogbn-products')
     g, labels = dataset[0]
-    g.ndata['label'] = labels.squeeze()
-    features = g.ndata['feat']
-    split_idx = dataset.get_idx_split()
-    in_feats = features.shape[1]
-    n_classes = dataset.num_classes
-    n_edges = g.number_of_edges()
     if args.gpu < 0:
         device = torch.device('cpu')
         args.pure_gpu = False
     else:
         device = torch.device('cuda' if torch.cuda.is_available() else 'cpu')
         g = g.to(device if args.pure_gpu else 'cpu')
+        
+    g.ndata['label'] = labels.squeeze().to(g.device)
+    features = g.ndata['feat']
+    split_idx = dataset.get_idx_split()
+    in_feats = features.shape[1]
+    n_classes = dataset.num_classes
+    n_edges = g.num_edges()
     train_idx, valid_idx, test_idx = split_idx['train'], split_idx['valid'], split_idx['test']
     
     print("""----Data statistics------'

--- a/examples/pytorch/graphsage/train_full.py
+++ b/examples/pytorch/graphsage/train_full.py
@@ -26,7 +26,8 @@ def evaluate(model, graph, features, labels, nid):
         correct = torch.sum(indices == labels)
         return correct.item() * 1.0 / len(labels)
     
-def train(args, g, device, features, labels, train_nid, val_nid):
+def train(args, g, device, data):
+    features, labels, train_nid, val_nid = data
     # graph preprocess and calculate normalization factor
     n_edges = g.number_of_edges()
 
@@ -117,6 +118,7 @@ if __name__ == '__main__':
     val_nid = val_mask.nonzero().squeeze().to(device)
     test_nid = test_mask.nonzero().squeeze().to(device)
     g = dgl.remove_self_loop(g)
-    model = train(args, g, device, features, labels, train_nid, val_nid)
+    data = features, labels, train_nid, val_nid
+    model = train(args, g, device, data)
     acc = evaluate(model, g, features, labels, test_nid)
     print("Test Accuracy {:.4f}".format(acc))

--- a/examples/pytorch/graphsage/train_full.py
+++ b/examples/pytorch/graphsage/train_full.py
@@ -7,13 +7,10 @@ Simple reference implementation of GraphSAGE.
 import argparse
 import time
 import numpy as np
-import networkx as nx
 import torch
-import torch.nn as nn
 import torch.nn.functional as F
 import dgl
-from dgl import DGLGraph
-from dgl.data import register_data_args, load_data
+from dgl.data import CoraGraphDataset, CiteseerGraphDataset, PubmedGraphDataset
 from model import GraphSAGE
 
 def evaluate(model, graph, features, labels, nid):
@@ -28,65 +25,62 @@ def evaluate(model, graph, features, labels, nid):
     
 def train(args, g, device, data):
     features, labels, train_nid, val_nid = data
-    # graph preprocess and calculate normalization factor
-    n_edges = g.number_of_edges()
+    n_edges = g.num_edges()
 
     # create GraphSAGE model
-    model = GraphSAGE(in_feats,
-                      args.n_hidden,
-                      n_classes,
-                      args.n_layers,
-                      F.relu,
-                      args.dropout,
-                      args.aggregator_type).to(device)
+    # parameters can be tuned here as keyword arguments
+    model = GraphSAGE(in_feats, n_classes, n_hidden=256, n_layers=1, aggregator_type='gcn').to(device)
+
     # use optimizer
-    optimizer = torch.optim.Adam(model.parameters(), lr=args.lr, weight_decay=args.weight_decay)
+    optimizer = torch.optim.Adam(model.parameters(), lr=1e-2, weight_decay=5e-4)
 
     # initialize graph
-    dur = []
+    time_sta = time.time()
     for epoch in range(args.n_epochs):
         model.train()
         t0 = time.time()
         # forward
         logits = model(g, features)
         loss = F.cross_entropy(logits[train_nid], labels[train_nid])
-
         optimizer.zero_grad()
         loss.backward()
         optimizer.step()
-        
-        dur.append(time.time() - t0)
+        dur = time.time() - t0
         acc = evaluate(model, g, features, labels, val_nid)
-        print("Epoch {:05d} | Avg. Time(s) {:.4f} | Loss {:.4f} | Accuracy {:.4f} | "
-              "ETputs(KTEPS) {:.2f}".format(epoch, np.mean(dur), loss.item(),
-                                            acc, n_edges / np.mean(dur) / 1000))
+        print("Epoch {:05d} | Time(s) {:.4f} | Loss {:.4f} | Accuracy {:.4f} | "
+              "ETputs(KTEPS) {:.2f}".format(epoch, dur, loss.item(),
+                                            acc, n_edges / dur / 1000))
+    print("Training time(s) {:.4f}". format(time.time() - time_sta))
+    print()
     return model
 
 if __name__ == '__main__':
     parser = argparse.ArgumentParser(description='GraphSAGE')
-    register_data_args(parser)
-    parser.add_argument("--dropout", type=float, default=0.5,
-                        help="dropout probability")
+    parser.add_argument("--dataset", type=str, default="cora",
+                        help="Dataset name ('cora', 'citeseer', 'pubmed').")
     parser.add_argument("--gpu", type=int, default=-1,
                         help="gpu")
-    parser.add_argument("--lr", type=float, default=1e-2,
-                        help="learning rate")
     parser.add_argument("--n-epochs", type=int, default=200,
                         help="number of training epochs")
-    parser.add_argument("--n-hidden", type=int, default=16,
-                        help="number of hidden gcn units")
-    parser.add_argument("--n-layers", type=int, default=1,
-                        help="number of hidden gcn layers")
-    parser.add_argument("--weight-decay", type=float, default=5e-4,
-                        help="Weight for L2 loss")
-    parser.add_argument("--aggregator-type", type=str, default="gcn",
-                        help="Aggregator type: mean/gcn/pool/lstm")
     args = parser.parse_args()
     print(args)
     
     # load and preprocess dataset
-    data = load_data(args)
+    if args.dataset == 'cora':
+        data = CoraGraphDataset()
+    elif args.dataset == 'citeseer':
+        data = CiteseerGraphDataset()
+    elif args.dataset == 'pubmed':
+        data = PubmedGraphDataset()
+    else:
+        raise ValueError('Unknown dataset: {}'.format(args.dataset))
     g = data[0]
+    if args.gpu < 0:
+        device = torch.device('cpu')
+    else:
+        device = torch.device('cuda' if torch.cuda.is_available() else 'cpu')
+        g = g.to(device)
+
     features = g.ndata['feat']
     labels = g.ndata['label']
     train_mask = g.ndata['train_mask']
@@ -94,31 +88,14 @@ if __name__ == '__main__':
     test_mask = g.ndata['test_mask']
     in_feats = features.shape[1]
     n_classes = data.num_classes
-    n_edges = g.number_of_edges()
-    print("""----Data statistics------'
-      #Edges %d
-      #Classes %d
-      #Train samples %d
-      #Val samples %d
-      #Test samples %d""" %
-          (n_edges, n_classes,
-           train_mask.int().sum().item(),
-           val_mask.int().sum().item(),
-           test_mask.int().sum().item()))
 
-    if args.gpu < 0:
-        device = torch.device('cpu')
-    else:
-        device = torch.device('cuda' if torch.cuda.is_available() else 'cpu')
-        features = features.to(device)
-        labels = labels.to(device)
-        g = g.to(device)
-        
-    train_nid = train_mask.nonzero().squeeze().to(device)
-    val_nid = val_mask.nonzero().squeeze().to(device)
-    test_nid = test_mask.nonzero().squeeze().to(device)
+    train_nid = train_mask.nonzero().squeeze()
+    val_nid = val_mask.nonzero().squeeze()
+    test_nid = test_mask.nonzero().squeeze()
+    
     g = dgl.remove_self_loop(g)
     data = features, labels, train_nid, val_nid
     model = train(args, g, device, data)
+
     acc = evaluate(model, g, features, labels, test_nid)
     print("Test Accuracy {:.4f}".format(acc))

--- a/examples/pytorch/graphsage/train_full.py
+++ b/examples/pytorch/graphsage/train_full.py
@@ -14,40 +14,7 @@ import torch.nn.functional as F
 import dgl
 from dgl import DGLGraph
 from dgl.data import register_data_args, load_data
-from dgl.nn.pytorch.conv import SAGEConv
-
-
-class GraphSAGE(nn.Module):
-    def __init__(self,
-                 in_feats,
-                 n_hidden,
-                 n_classes,
-                 n_layers,
-                 activation,
-                 dropout,
-                 aggregator_type):
-        super(GraphSAGE, self).__init__()
-        self.layers = nn.ModuleList()
-        self.dropout = nn.Dropout(dropout)
-        self.activation = activation
-
-        # input layer
-        self.layers.append(SAGEConv(in_feats, n_hidden, aggregator_type))
-        # hidden layers
-        for i in range(n_layers - 1):
-            self.layers.append(SAGEConv(n_hidden, n_hidden, aggregator_type))
-        # output layer
-        self.layers.append(SAGEConv(n_hidden, n_classes, aggregator_type)) # activation None
-
-    def forward(self, graph, inputs):
-        h = self.dropout(inputs)
-        for l, layer in enumerate(self.layers):
-            h = layer(graph, h)
-            if l != len(self.layers) - 1:
-                h = self.activation(h)
-                h = self.dropout(h)
-        return h
-
+from model import GraphSAGE
 
 def evaluate(model, graph, features, labels, nid):
     model.eval()
@@ -58,51 +25,10 @@ def evaluate(model, graph, features, labels, nid):
         _, indices = torch.max(logits, dim=1)
         correct = torch.sum(indices == labels)
         return correct.item() * 1.0 / len(labels)
-
-def main(args):
-    # load and preprocess dataset
-    data = load_data(args)
-    g = data[0]
-    features = g.ndata['feat']
-    labels = g.ndata['label']
-    train_mask = g.ndata['train_mask']
-    val_mask = g.ndata['val_mask']
-    test_mask = g.ndata['test_mask']
-    in_feats = features.shape[1]
-    n_classes = data.num_classes
-    n_edges = data.graph.number_of_edges()
-    print("""----Data statistics------'
-      #Edges %d
-      #Classes %d
-      #Train samples %d
-      #Val samples %d
-      #Test samples %d""" %
-          (n_edges, n_classes,
-           train_mask.int().sum().item(),
-           val_mask.int().sum().item(),
-           test_mask.int().sum().item()))
-
-    if args.gpu < 0:
-        cuda = False
-    else:
-        cuda = True
-        torch.cuda.set_device(args.gpu)
-        features = features.cuda()
-        labels = labels.cuda()
-        train_mask = train_mask.cuda()
-        val_mask = val_mask.cuda()
-        test_mask = test_mask.cuda()
-        print("use cuda:", args.gpu)
-
-    train_nid = train_mask.nonzero().squeeze()
-    val_nid = val_mask.nonzero().squeeze()
-    test_nid = test_mask.nonzero().squeeze()
-
+    
+def train(args, g, device, features, labels, train_nid, val_nid):
     # graph preprocess and calculate normalization factor
-    g = dgl.remove_self_loop(g)
     n_edges = g.number_of_edges()
-    if cuda:
-        g = g.int().to(args.gpu)
 
     # create GraphSAGE model
     model = GraphSAGE(in_feats,
@@ -111,11 +37,7 @@ def main(args):
                       args.n_layers,
                       F.relu,
                       args.dropout,
-                      args.aggregator_type)
-
-    if cuda:
-        model.cuda()
-
+                      args.aggregator_type).to(device)
     # use optimizer
     optimizer = torch.optim.Adam(model.parameters(), lr=args.lr, weight_decay=args.weight_decay)
 
@@ -123,8 +45,7 @@ def main(args):
     dur = []
     for epoch in range(args.n_epochs):
         model.train()
-        if epoch >= 3:
-            t0 = time.time()
+        t0 = time.time()
         # forward
         logits = model(g, features)
         loss = F.cross_entropy(logits[train_nid], labels[train_nid])
@@ -132,19 +53,13 @@ def main(args):
         optimizer.zero_grad()
         loss.backward()
         optimizer.step()
-
-        if epoch >= 3:
-            dur.append(time.time() - t0)
-
+        
+        dur.append(time.time() - t0)
         acc = evaluate(model, g, features, labels, val_nid)
-        print("Epoch {:05d} | Time(s) {:.4f} | Loss {:.4f} | Accuracy {:.4f} | "
+        print("Epoch {:05d} | Avg. Time(s) {:.4f} | Loss {:.4f} | Accuracy {:.4f} | "
               "ETputs(KTEPS) {:.2f}".format(epoch, np.mean(dur), loss.item(),
                                             acc, n_edges / np.mean(dur) / 1000))
-
-    print()
-    acc = evaluate(model, g, features, labels, test_nid)
-    print("Test Accuracy {:.4f}".format(acc))
-
+    return model
 
 if __name__ == '__main__':
     parser = argparse.ArgumentParser(description='GraphSAGE')
@@ -167,5 +82,41 @@ if __name__ == '__main__':
                         help="Aggregator type: mean/gcn/pool/lstm")
     args = parser.parse_args()
     print(args)
+    
+    # load and preprocess dataset
+    data = load_data(args)
+    g = data[0]
+    features = g.ndata['feat']
+    labels = g.ndata['label']
+    train_mask = g.ndata['train_mask']
+    val_mask = g.ndata['val_mask']
+    test_mask = g.ndata['test_mask']
+    in_feats = features.shape[1]
+    n_classes = data.num_classes
+    n_edges = g.number_of_edges()
+    print("""----Data statistics------'
+      #Edges %d
+      #Classes %d
+      #Train samples %d
+      #Val samples %d
+      #Test samples %d""" %
+          (n_edges, n_classes,
+           train_mask.int().sum().item(),
+           val_mask.int().sum().item(),
+           test_mask.int().sum().item()))
 
-    main(args)
+    if args.gpu < 0:
+        device = torch.device('cpu')
+    else:
+        device = torch.device('cuda' if torch.cuda.is_available() else 'cpu')
+        features = features.to(device)
+        labels = labels.to(device)
+        g = g.to(device)
+        
+    train_nid = train_mask.nonzero().squeeze().to(device)
+    val_nid = val_mask.nonzero().squeeze().to(device)
+    test_nid = test_mask.nonzero().squeeze().to(device)
+    g = dgl.remove_self_loop(g)
+    model = train(args, g, device, features, labels, train_nid, val_nid)
+    acc = evaluate(model, g, features, labels, test_nid)
+    print("Test Accuracy {:.4f}".format(acc))


### PR DESCRIPTION
Updates on 06/24:

## Major changes since last revision
- Reduced the number of cmd line options, and re-positioned all parameters to make users easy and convenient to change
- Removed load_data() and register_data_arg() functions, due to the limitation of available datasets and lack of documentation.
- Deprecated manually pin_memory_inplace()/unpin_memory_inplace functions, thanks to @yaox12 's latest PR. And, these two functions are not documented as well...
- Slight change on output format, i.e., now report timing w.r.t per epoch and report total train time in the end (What is ETputs? is it a well-accepted quantity?)
```
Epoch xxx | Time(s) 0.0058 | Loss 0.0875 | Accuracy 0.6480 | ETputs(KTEPS) 1579.65
Training time(s) 2.5515

Test Accuracy 0.6760
```
- Fanout is corrected from [15,10,5]-->[5,10,15]
- Support --graph-device cpu/gpu/uva for multi-gpu mini-batch training

## Issues:
- File naming convention. Current file naming is not consistent and confusing, e.g., train_full vs. node_classification.py. Any suggestions?
- File consolidation. Do we need to keep multi-gpu and single-gpu implementations as two sperate files?

---
Graphsage seems one of the most up-to-date example case, and also one of most comprehensive example including single/multi-GPU/multi-node implementations and many other advanced usages. Apparently, these implementations/script files have been developed by different contributors or within different time periods. It might be a good idea to start our example refactoring on this case because of its (1) comprehensiveness, so we can easily extend to other examples; and (2) (relative) up-to-date scripts, i.e., less effort to refactor.

In general, the goals are:
1. Consistency: configurations (definition of input arguments), output format, general code structure, etc.
2. Succinct: avoid redundant code and main script should be succinct. 
3. Maintainability: Modularize the code to ease reusing and future extension

Currently, I have only refactored the basic examples (not touching all `adv.` folders) with full/mini-batch training using CPU/GPU/multi-GPU. Affected files are: `train_full.py`, `node_classification.py` and `multi_gpu_node_classification.py`.

## Checklist
Please feel free to remove inapplicable items for your PR.
- [x] The PR title starts with [$CATEGORY] (such as [NN], [Model], [Doc], [Feature]])
- [ ] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage
- [x] Code is well-documented
- [x] To the best of my knowledge, examples are either not affected by this change,
      or have been fixed to be compatible with this change
- [ ] Related issue is referred in this PR

## Detailed Changes
- Move all graphsage model definitions to a new file, `model.py`.
       Within `model.py`, inheritance/dependency list is:   `nn.Module` -> `GraphSage` --> `GraphSageBatch` --> `GraphSageBatchMultiGPU`, thus every implementation can import a corresp. SAGE module to avoid redundant code.
- Align all input/output format.
      Originaly, minibatch runs (`node_classificaiton.py` and `multi_gpu_node_classification.py`) have everything hard-coded and no "control knobs". For example, `multi_gpu_node_classification.py` can only take all available GPUs, and no `--gpu` to test the speed-up of different # GPUs. Also, minibatch runs' output are messy and lack of information.  
       Now, minibatch runs share the same set of inputs, e.g., `--n-epochs`, `--batch-size`, `--gpu`, etc. And they also share a similar set of output, where per-epoch stats is the finest reporting scale (disable per batch printing). Sample out:
```
	---Data Stats ---
	...	
        Epoch 00000 | Avg. Time(s) 6.6292 | Loss 1.3383 | Accuracy 0.8547 | GPU Mem(MB) 523.98
        ...
	Test Accuracy 0.8030
```
- Align code structures in scripts, and replace all `cuda()` --> `to(device)`
- Eliminate warning msgs in train_full.py by updating to the latest dgl API (deprecated `dataset.graph`)

## Remaining Issues
1. `link_pred.py`, `lighting/`, `advanced/`, `dist/`, and `distgnn/` are not updated at this point. Probably will keep tracking these when this PR is open.
2. `multi_gpu_node_classification.py` seems can cover `node_classification.py` (i.e., specifying `--gpu 0`). Do we really need to keep both files?
3. In `node_classification.py`, maybe break input option `--pure-gpu` into `--graph-device` and `--data-device`, similar to `advanced/train_sampling_upsupervised.py`?

## Tests:

- `python3 train_full.py --dataset cora --gpu 0`
```
...
Epoch 00002 | Avg. Time(s) 0.2767 | Loss 1.9332 | Accuracy 0.2120 | ETputs(KTEPS) 38.15
...
Test Accuracy 0.8090
```
- `python3 node_classification.py --n-epochs 5 --gpu 0 --pure-gpu`
```
...
Epoch 00002 | Avg. Time(s) 2.2549 | Loss 0.5173 | Accuracy 0.8833 | GPU Mem(MB) 6933.29
...
Test Accuracy 0.7401
```
- `python3 multi_gpu_node_classification.py --n-epochs 5 --gpu 0,1`
```
...
Epoch 00001 | Avg. Time(s) 2.5231 | Loss 0.8258 | Accuracy 0.8519 | GPU Mem(MB) 521.92
...
Test Accuracy on Master 0.6931
```