### PR TITLE
[Test] Relax Threshold for AllClose in Testing SIGN Diffusion (#4163)

### DIFF
--- a/tests/compute/test_transform.py
+++ b/tests/compute/test_transform.py
@@ -2356,6 +2356,8 @@ def test_module_laplacian_pe(idtype):
 @pytest.mark.parametrize('g', get_cases(['has_scalar_e_feature']))
 def test_module_sign(g):
     import torch
+    
+    atol = 1e-06
 
     ctx = F.ctx()
     g = g.to(ctx)
@@ -2372,25 +2374,25 @@ def test_module_sign(g):
     transform = dgl.SIGNDiffusion(k=1, in_feat_name='h', diffuse_op='raw')
     g = transform(g)
     target = torch.matmul(adj, g.ndata['h'])
-    assert torch.allclose(g.ndata['out_feat_1'], target)
+    assert torch.allclose(g.ndata['out_feat_1'], target, atol=atol)
 
     transform = dgl.SIGNDiffusion(k=1, in_feat_name='h', eweight_name='scalar_w', diffuse_op='raw')
     g = transform(g)
     target = torch.matmul(weight_adj, g.ndata['h'])
-    assert torch.allclose(g.ndata['out_feat_1'], target)
+    assert torch.allclose(g.ndata['out_feat_1'], target, atol=atol)
 
     # rw
     adj_rw = torch.matmul(torch.diag(1 / adj.sum(dim=1)), adj)
     transform = dgl.SIGNDiffusion(k=1, in_feat_name='h', diffuse_op='rw')
     g = transform(g)
     target = torch.matmul(adj_rw, g.ndata['h'])
-    assert torch.allclose(g.ndata['out_feat_1'], target)
+    assert torch.allclose(g.ndata['out_feat_1'], target, atol=atol)
 
     weight_adj_rw = torch.matmul(torch.diag(1 / weight_adj.sum(dim=1)), weight_adj)
     transform = dgl.SIGNDiffusion(k=1, in_feat_name='h', eweight_name='scalar_w', diffuse_op='rw')
     g = transform(g)
     target = torch.matmul(weight_adj_rw, g.ndata['h'])
-    assert torch.allclose(g.ndata['out_feat_1'], target)
+    assert torch.allclose(g.ndata['out_feat_1'], target, atol=atol)
 
     # gcn
     raw_eweight = g.edata['scalar_w']
@@ -2401,7 +2403,7 @@ def test_module_sign(g):
     transform = dgl.SIGNDiffusion(k=1, in_feat_name='h', diffuse_op='gcn')
     g = transform(g)
     target = torch.matmul(adj_gcn, g.ndata['h'])
-    assert torch.allclose(g.ndata['out_feat_1'], target)
+    assert torch.allclose(g.ndata['out_feat_1'], target, atol=atol)
 
     gcn_norm = dgl.GCNNorm('scalar_w')
     g = gcn_norm(g)
@@ -2412,20 +2414,20 @@ def test_module_sign(g):
                                   eweight_name='scalar_w', diffuse_op='gcn')
     g = transform(g)
     target = torch.matmul(weight_adj_gcn, g.ndata['h'])
-    assert torch.allclose(g.ndata['out_feat_1'], target)
+    assert torch.allclose(g.ndata['out_feat_1'], target, atol=atol)
 
     # ppr
     alpha = 0.2
     transform = dgl.SIGNDiffusion(k=1, in_feat_name='h', diffuse_op='ppr', alpha=alpha)
     g = transform(g)
     target = (1 - alpha) * torch.matmul(adj_gcn, g.ndata['h']) + alpha * g.ndata['h']
-    assert torch.allclose(g.ndata['out_feat_1'], target)
+    assert torch.allclose(g.ndata['out_feat_1'], target, atol=atol)
 
     transform = dgl.SIGNDiffusion(k=1, in_feat_name='h', eweight_name='scalar_w',
                                   diffuse_op='ppr', alpha=alpha)
     g = transform(g)
     target = (1 - alpha) * torch.matmul(weight_adj_gcn, g.ndata['h']) + alpha * g.ndata['h']
-    assert torch.allclose(g.ndata['out_feat_1'], target)
+    assert torch.allclose(g.ndata['out_feat_1'], target, atol=atol)
 
 @unittest.skipIf(dgl.backend.backend_name != 'pytorch', reason='Only support PyTorch for now')
 @parametrize_idtype


### PR DESCRIPTION
## Description
Originally `torch.allclose` uses `1e-08` for `atol`, which fails about every 10 times I invoke the unit test locally. I've changed it to `1e-06`, which passed the unit test locally for 10000 times. See also issue #4163 .

## Checklist
Please feel free to remove inapplicable items for your PR.
- [x] The PR title starts with [$CATEGORY] (such as [NN], [Model], [Doc], [Feature]])
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage
- [ ] Code is well-documented
- [x] To the best of my knowledge, examples are either not affected by this change,
      or have been fixed to be compatible with this change
- [ ] Related issue is referred in this PR
- [ ] If the PR is for a new model/paper, I've updated the example index [here](../examples/README.md).