### PR TITLE
[Example][Bugfix] Fix various example crashes due to recent DGL API update

### DIFF
--- a/examples/pytorch/appnp/train.py
+++ b/examples/pytorch/appnp/train.py
@@ -45,7 +45,7 @@ def main(args):
     test_mask = g.ndata['test_mask']
     in_feats = features.shape[1]
     n_classes = data.num_labels
-    n_edges = data.graph.number_of_edges()
+    n_edges = g.number_of_edges()
     print("""----Data statistics------'
       #Edges %d
       #Classes %d

--- a/examples/pytorch/dgi/train.py
+++ b/examples/pytorch/dgi/train.py
@@ -21,6 +21,7 @@ def evaluate(model, features, labels, mask):
 def main(args):
     # load and preprocess dataset
     data = load_data(args)
+    g = data[0]
     features = torch.FloatTensor(data.features)
     labels = torch.LongTensor(data.labels)
     if hasattr(torch, 'BoolTensor'):
@@ -33,7 +34,7 @@ def main(args):
         test_mask = torch.ByteTensor(data.test_mask)
     in_feats = features.shape[1]
     n_classes = data.num_labels
-    n_edges = data.graph.number_of_edges()
+    n_edges = g.number_of_edges()
 
     if args.gpu < 0:
         cuda = False
@@ -46,13 +47,10 @@ def main(args):
         val_mask = val_mask.cuda()
         test_mask = test_mask.cuda()
 
-    # graph preprocess
-    g = data.graph
     # add self loop
     if args.self_loop:
         g.remove_edges_from(nx.selfloop_edges(g))
         g.add_edges_from(zip(g.nodes(), g.nodes()))
-    g = DGLGraph(g)
     n_edges = g.number_of_edges()
 
     if args.gpu >= 0:

--- a/examples/pytorch/gat/train.py
+++ b/examples/pytorch/gat/train.py
@@ -62,7 +62,7 @@ def main(args):
     test_mask = g.ndata['test_mask']
     num_feats = features.shape[1]
     n_classes = data.num_labels
-    n_edges = data.graph.number_of_edges()
+    n_edges = g.number_of_edges()
     print("""----Data statistics------'
       #Edges %d
       #Classes %d

--- a/examples/pytorch/gatv2/train.py
+++ b/examples/pytorch/gatv2/train.py
@@ -48,7 +48,7 @@ def accuracy(logits, labels):
     return correct.item() * 1.0 / len(labels)
 
 
-def evaluate(model, g, features, labels, mask):
+def evaluate(g, model, features, labels, mask):
     model.eval()
     with torch.no_grad():
         logits = model(g, features)
@@ -82,7 +82,7 @@ def main(args):
     test_mask = g.ndata['test_mask']
     num_feats = features.shape[1]
     n_classes = data.num_labels
-    n_edges = data.graph.number_of_edges()
+    n_edges = g.number_of_edges()
     print("""----Data statistics------'
       #Edges %d
       #Classes %d
@@ -156,7 +156,7 @@ def main(args):
     print()
     if args.early_stop:
         model.load_state_dict(torch.load('es_checkpoint.pt'))
-    acc = evaluate(model, features, labels, test_mask)
+    acc = evaluate(g, model, features, labels, test_mask)
     print("Test Accuracy {:.4f}".format(acc))
 
 

--- a/examples/pytorch/gcn/gcn_mp.py
+++ b/examples/pytorch/gcn/gcn_mp.py
@@ -140,7 +140,7 @@ def main(args):
     test_mask = g.ndata['test_mask']
     in_feats = features.shape[1]
     n_classes = data.num_labels
-    n_edges = data.graph.number_of_edges()
+    n_edges = g.number_of_edges()
     print("""----Data statistics------'
       #Edges %d
       #Classes %d

--- a/examples/pytorch/gcn/train.py
+++ b/examples/pytorch/gcn/train.py
@@ -47,7 +47,7 @@ def main(args):
     test_mask = g.ndata['test_mask']
     in_feats = features.shape[1]
     n_classes = data.num_labels
-    n_edges = data.graph.number_of_edges()
+    n_edges = g.number_of_edges()
     print("""----Data statistics------'
       #Edges %d
       #Classes %d

--- a/examples/pytorch/graphsage/train_full.py
+++ b/examples/pytorch/graphsage/train_full.py
@@ -70,7 +70,7 @@ def main(args):
     test_mask = g.ndata['test_mask']
     in_feats = features.shape[1]
     n_classes = data.num_classes
-    n_edges = data.graph.number_of_edges()
+    n_edges = g.number_of_edges()
     print("""----Data statistics------'
       #Edges %d
       #Classes %d

--- a/examples/pytorch/hardgat/train.py
+++ b/examples/pytorch/hardgat/train.py
@@ -60,7 +60,7 @@ def main(args):
     test_mask = g.ndata['test_mask']
     num_feats = features.shape[1]
     n_classes = data.num_labels
-    n_edges = data.graph.number_of_edges()
+    n_edges = g.number_of_edges()
     print("""----Data statistics------'
       #Edges %d
       #Classes %d

--- a/examples/pytorch/model_zoo/citation_network/run.py
+++ b/examples/pytorch/model_zoo/citation_network/run.py
@@ -57,7 +57,7 @@ def main(args):
     test_mask = g.ndata['test_mask']
     in_feats = features.shape[1]
     n_classes = data.num_labels
-    n_edges = data.graph.number_of_edges()
+    n_edges = g.number_of_edges()
     print("""----Data statistics------'
       #Edges %d
       #Classes %d

--- a/examples/pytorch/monet/citation.py
+++ b/examples/pytorch/monet/citation.py
@@ -78,7 +78,7 @@ def main(args):
     test_mask = g.ndata['test_mask']
     in_feats = features.shape[1]
     n_classes = data.num_labels
-    n_edges = data.graph.number_of_edges()
+    n_edges = g.number_of_edges()
     print("""----Data statistics------'
       #Edges %d
       #Classes %d

--- a/examples/pytorch/sgc/sgc.py
+++ b/examples/pytorch/sgc/sgc.py
@@ -51,7 +51,7 @@ def main(args):
     test_mask = g.ndata['test_mask']
     in_feats = features.shape[1]
     n_classes = data.num_labels
-    n_edges = data.graph.number_of_edges()
+    n_edges = g.number_of_edges()
     print("""----Data statistics------'
       #Edges %d
       #Classes %d

--- a/examples/pytorch/sgc/sgc_reddit.py
+++ b/examples/pytorch/sgc/sgc_reddit.py
@@ -31,7 +31,7 @@ def main(args):
     # load and preprocess dataset
     args.dataset = "reddit-self-loop"
     data = load_data(args)
-    g = data.graph
+    g = data[0]
     if args.gpu < 0:
         cuda = False
     else:
@@ -45,7 +45,7 @@ def main(args):
     test_mask = g.ndata['test_mask']
     in_feats = features.shape[1]
     n_classes = data.num_labels
-    n_edges = data.graph.number_of_edges()
+    n_edges = g.number_of_edges()
     print("""----Data statistics------'
       #Edges %d
       #Classes %d


### PR DESCRIPTION
## Description
Recently, DGL completely deprecated `data.graph`, yet many examples still use this out-dated API, which causes various crashes like, `AttributeError: 'CoraGraphDataset' object has no attribute 'graph'`. 

This PR fix crashes and make these cases (appnp, dgi, gat, gcn, gatv2, graphsage, hardgat, model_zoo, monet, sgc) run through. It also fixes a bug in gatv2 case due to mis-calling `evaluate` function

## Checklist
Please feel free to remove inapplicable items for your PR.
- [x] The PR title starts with [$CATEGORY] (such as [NN], [Model], [Doc], [Feature]])
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage
- [ ] Code is well-documented
- [ ] To the best of my knowledge, examples are either not affected by this change,
      or have been fixed to be compatible with this change
- [ ] Related issue is referred in this PR
- [ ] If the PR is for a new model/paper, I've updated the example index [here](../examples/README.md).

## Changes
- data.graph --> data[0]
- bugfix for gatv2 case (function argument misplacement)

