### PR TITLE
[Example][Bugfix] Bugfix for dgi example

### DIFF
--- a/examples/pytorch/dgi/train.py
+++ b/examples/pytorch/dgi/train.py
@@ -4,6 +4,7 @@ import networkx as nx
 import torch
 import torch.nn as nn
 import torch.nn.functional as F
+import dgl
 from dgl import DGLGraph
 from dgl.data import register_data_args, load_data
 from dgi import DGI, Classifier
@@ -49,8 +50,8 @@ def main(args):
 
     # add self loop
     if args.self_loop:
-        g.remove_edges_from(nx.selfloop_edges(g))
-        g.add_edges_from(zip(g.nodes(), g.nodes()))
+        g = dgl.remove_self_loop(g)
+        g = dgl.add_self_loop(g)
     n_edges = g.number_of_edges()
 
     if args.gpu >= 0:


### PR DESCRIPTION
## Description
Use DGL remove_self_loop()/add_self_loop() function, instead of remove_edges_from()/add_edges_from(), from networkx.graph module, to add self-loop for a given graph.

## Checklist
Please feel free to remove inapplicable items for your PR.
- [x] The PR title starts with [$CATEGORY] (such as [NN], [Model], [Doc], [Feature]])
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage
- [ ] Code is well-documented
- [ ] To the best of my knowledge, examples are either not affected by this change,
      or have been fixed to be compatible with this change
- [ ] Related issue is referred in this PR
- [ ] If the PR is for a new model/paper, I've updated the example index [here](../examples/README.md).

## Changes
- remove_edges_from/add_edges_from  --> remove_self_loop/add_self_loop

## Test

- `python3 train.py --dataset=cora --gpu=0 --self-loop`

```
Test Accuracy 0.8170
```