### PR TITLE
[Example][Bugfix] graphsage node classification example

### DIFF
--- a/examples/pytorch/graphsage/node_classification.py
+++ b/examples/pytorch/graphsage/node_classification.py
@@ -97,7 +97,7 @@ def train(args, device, g, dataset, model):
 
     opt = torch.optim.Adam(model.parameters(), lr=1e-3, weight_decay=5e-4)
     
-    for epoch in range(3):
+    for epoch in range(10):
         model.train()
         total_loss = 0
         for it, (input_nodes, output_nodes, blocks) in enumerate(train_dataloader):

--- a/examples/pytorch/graphsage/node_classification.py
+++ b/examples/pytorch/graphsage/node_classification.py
@@ -72,9 +72,9 @@ def evaluate(model, graph, dataloader):
 def layerwise_infer(device, graph, nid, model, batch_size):
     model.eval()
     with torch.no_grad():
-        pred = model.inference(graph, device, batch_size).to(device)
+        pred = model.inference(graph, device, batch_size) # pred in buffer_device
         pred = pred[nid]
-        label = graph.ndata['label'][nid]
+        label = graph.ndata['label'][nid].to(pred.device)
         return MF.accuracy(pred, label)
 
 def train(args, device, g, dataset, model):
@@ -97,7 +97,7 @@ def train(args, device, g, dataset, model):
 
     opt = torch.optim.Adam(model.parameters(), lr=1e-3, weight_decay=5e-4)
     
-    for epoch in range(10):
+    for epoch in range(3):
         model.train()
         total_loss = 0
         for it, (input_nodes, output_nodes, blocks) in enumerate(train_dataloader):
@@ -141,5 +141,5 @@ if __name__ == '__main__':
 
     # test the model
     print('Testing...')
-    acc = layerwise_infer(device, g, dataset.test_idx.to(device), model, batch_size=4096)
+    acc = layerwise_infer(device, g, dataset.test_idx, model, batch_size=4096)
     print("Test Accuracy {:.4f}".format(acc.item()))


### PR DESCRIPTION
## Description

node_classification.py still fails due to the same issue https://github.com/dmlc/dgl/issues/4234.
This PR fixes node_classification.py runs under all modes (--mode = `cpu`, `mixed`, `puregpu`)
 
## Checklist
Please feel free to remove inapplicable items for your PR.
- [x] The PR title starts with [$CATEGORY] (such as [NN], [Model], [Doc], [Feature]])
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage
- [ ] Code is well-documented
- [ ] To the best of my knowledge, examples are either not affected by this change,
      or have been fixed to be compatible with this change
- [x] Related issue is referred in this PR
- [ ] If the PR is for a new model/paper, I've updated the example index [here](../examples/README.md).

## Changes

- test_idx always on cpu
- Accuracy calculation `MF.accuracy` always on cpu
