### PR TITLE
[Bug] Fix NN modules crashing with FP16 inputs

### DIFF
--- a/examples/pytorch/gcn/train_fp16.py
+++ b/examples/pytorch/gcn/train_fp16.py
@@ -1,0 +1,99 @@
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+import dgl
+import dgl.nn as dglnn
+from dgl.data import CoraGraphDataset, CiteseerGraphDataset, PubmedGraphDataset
+from dgl import AddSelfLoop
+import argparse
+
+class GCN(nn.Module):
+    def __init__(self, in_size, hid_size, out_size):
+        super().__init__()
+        self.layers = nn.ModuleList()
+        # two-layer GCN
+        self.layers.append(dglnn.GraphConv(in_size, hid_size, activation=F.relu))
+        self.layers.append(dglnn.GraphConv(hid_size, out_size))
+        self.dropout = nn.Dropout(0.5)
+
+    def forward(self, g, features):
+        h = features
+        for i, layer in enumerate(self.layers):
+            if i != 0:
+                h = self.dropout(h)
+            h = layer(g, h)
+        return h
+    
+def evaluate(g, features, labels, mask, model):
+    model.eval()
+    with torch.no_grad():
+        logits = model(g, features)
+        logits = logits[mask]
+        labels = labels[mask]
+        _, indices = torch.max(logits, dim=1)
+        correct = torch.sum(indices == labels)
+        return correct.item() * 1.0 / len(labels)
+
+
+def train(g, features, labels, masks, model):
+    # define train/val samples, loss function and optimizer
+    train_mask = masks[0]
+    val_mask = masks[1]
+    loss_fcn = nn.CrossEntropyLoss()
+    optimizer = torch.optim.Adam(model.parameters(), lr=1e-2, weight_decay=5e-4)
+
+    # training loop
+    for epoch in range(200):
+        model.train()
+        logits = model(g, features)
+        loss = loss_fcn(logits[train_mask], labels[train_mask])
+        optimizer.zero_grad()
+        loss.backward()
+        optimizer.step()
+        acc = evaluate(g, features, labels, val_mask, model)
+        print("Epoch {:05d} | Loss {:.4f} | Accuracy {:.4f} "
+              . format(epoch, loss.item(), acc))
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--dataset", type=str, default="cora",
+                        help="Dataset name ('cora', 'citeseer', 'pubmed').")
+    args = parser.parse_args()
+    print(f'Training with DGL built-in GraphConv module.')
+ 
+    # load and preprocess dataset
+    transform = AddSelfLoop()  # by default, it will first remove self-loops to prevent duplication
+    if args.dataset == 'cora':
+        data = CoraGraphDataset(transform=transform)
+    elif args.dataset == 'citeseer':
+        data = CiteseerGraphDataset(transform=transform)
+    elif args.dataset == 'pubmed':
+        data = PubmedGraphDataset(transform=transform)
+    else:
+        raise ValueError('Unknown dataset: {}'.format(args.dataset))
+    g = data[0]
+    device = torch.device('cuda' if torch.cuda.is_available() else 'cpu')
+    g = g.int().to(device)
+    features = g.ndata['feat'].half()
+    labels = g.ndata['label']
+    masks = g.ndata['train_mask'], g.ndata['val_mask'], g.ndata['test_mask']
+        
+    # normalization
+    degs = g.in_degrees().float()
+    norm = torch.pow(degs, -0.5).to(device)
+    norm[torch.isinf(norm)] = 0
+    g.ndata['norm'] = norm.unsqueeze(1).half()
+
+    # create GCN model    
+    in_size = features.shape[1]
+    out_size = data.num_classes
+    model = GCN(in_size, 16, out_size).to(device).half()
+
+    # model training
+    print('Training...')
+    train(g, features, labels, masks, model)
+    
+    # test the model
+    print('Testing...')
+    acc = evaluate(g, features, labels, masks[2], model)
+    print("Test accuracy {:.4f}".format(acc))

--- a/python/dgl/nn/pytorch/conv/appnpconv.py
+++ b/python/dgl/nn/pytorch/conv/appnpconv.py
@@ -94,11 +94,11 @@ class APPNPConv(nn.Module):
         with graph.local_scope():
             if edge_weight is None:
                 src_norm = th.pow(
-                    graph.out_degrees().float().clamp(min=1), -0.5)
+                    graph.out_degrees().to(feat).clamp(min=1), -0.5)
                 shp = src_norm.shape + (1,) * (feat.dim() - 1)
                 src_norm = th.reshape(src_norm, shp).to(feat.device)
                 dst_norm = th.pow(
-                    graph.in_degrees().float().clamp(min=1), -0.5)
+                    graph.in_degrees().to(feat).clamp(min=1), -0.5)
                 shp = dst_norm.shape + (1,) * (feat.dim() - 1)
                 dst_norm = th.reshape(dst_norm, shp).to(feat.device)
             else:

--- a/python/dgl/nn/pytorch/conv/atomicconv.py
+++ b/python/dgl/nn/pytorch/conv/atomicconv.py
@@ -257,9 +257,9 @@ class AtomicConv(nn.Module):
             number of radial filters, and :math:`T` for the number of types of atomic numbers.
         """
         with graph.local_scope():
-            radial_pooled_values = self.radial_pooling(distances)                # (K, E, 1)
+            radial_pooled_values = self.radial_pooling(distances).to(feat)       # (K, E, 1)
             if self.features_to_use is not None:
-                feat = (feat == self.features_to_use).float()                    # (V, T)
+                feat = (feat == self.features_to_use).to(feat)                   # (V, T)
             graph.ndata['hv'] = feat
             graph.edata['he'] = radial_pooled_values.transpose(1, 0).squeeze(-1) # (E, K)
             graph.update_all(msg_func, reduce_func)

--- a/python/dgl/nn/pytorch/conv/chebconv.py
+++ b/python/dgl/nn/pytorch/conv/chebconv.py
@@ -104,8 +104,7 @@ class ChebConv(nn.Module):
             return graph.ndata.pop('h') * D_invsqrt
 
         with graph.local_scope():
-            D_invsqrt = th.pow(graph.in_degrees().float().clamp(
-                min=1), -0.5).unsqueeze(-1).to(feat.device)
+            D_invsqrt = th.pow(graph.in_degrees().to(feat).clamp(min=1), -0.5).unsqueeze(-1)
 
             if lambda_max is None:
                 dgl_warning(

--- a/python/dgl/nn/pytorch/conv/densegraphconv.py
+++ b/python/dgl/nn/pytorch/conv/densegraphconv.py
@@ -109,7 +109,7 @@ class DenseGraphConv(nn.Module):
             The output feature of shape :math:`(N, D_{out})` where :math:`D_{out}`
             is size of output feature.
         """
-        adj = adj.float().to(feat.device)
+        adj = adj.to(feat)
         src_degrees = adj.sum(dim=0).clamp(min=1)
         dst_degrees = adj.sum(dim=1).clamp(min=1)
         feat_src = feat

--- a/python/dgl/nn/pytorch/conv/densesageconv.py
+++ b/python/dgl/nn/pytorch/conv/densesageconv.py
@@ -120,7 +120,7 @@ class DenseSAGEConv(nn.Module):
             feat_dst = self.feat_drop(feat[1])
         else:
             feat_src = feat_dst = self.feat_drop(feat)
-        adj = adj.float().to(feat_src.device)
+        adj = adj.to(feat_src)
         in_degrees = adj.sum(dim=1, keepdim=True)
         h_neigh = (adj @ feat_src + feat_dst) / (in_degrees + 1)
         rst = self.fc(h_neigh)

--- a/python/dgl/nn/pytorch/conv/gcn2conv.py
+++ b/python/dgl/nn/pytorch/conv/gcn2conv.py
@@ -229,7 +229,7 @@ class GCN2Conv(nn.Module):
 
             # normalize  to get smoothed representation
             if edge_weight is None:
-                degs = graph.in_degrees().float().clamp(min=1)
+                degs = graph.in_degrees().to(feat).clamp(min=1)
                 norm = th.pow(degs, -0.5)
                 norm = norm.to(feat.device).unsqueeze(1)
             else:

--- a/python/dgl/nn/pytorch/conv/graphconv.py
+++ b/python/dgl/nn/pytorch/conv/graphconv.py
@@ -107,8 +107,10 @@ class EdgeWeightNorm(nn.Module):
                                'This leads to square root of zero or negative values.')
 
             dev = graph.device
-            graph.srcdata['_src_out_w'] = th.ones((graph.number_of_src_nodes())).float().to(dev)
-            graph.dstdata['_dst_in_w'] = th.ones((graph.number_of_dst_nodes())).float().to(dev)
+            graph.srcdata['_src_out_w'] = th.ones(
+                    graph.number_of_src_nodes(), dtype=edge_weight.dtype, device=dev)
+            graph.dstdata['_dst_in_w'] = th.ones(
+                    graph.number_of_dst_nodes(), dtype=edge_weight.dtype, device=dev)
             graph.edata['_edge_w'] = edge_weight
 
             if self._norm == 'both':
@@ -398,7 +400,7 @@ class GraphConv(nn.Module):
             # (BarclayII) For RGCN on heterogeneous graphs we need to support GCN on bipartite.
             feat_src, feat_dst = expand_as_pair(feat, graph)
             if self._norm in ['left', 'both']:
-                degs = graph.out_degrees().float().clamp(min=1)
+                degs = graph.out_degrees().to(feat_src).clamp(min=1)
                 if self._norm == 'both':
                     norm = th.pow(degs, -0.5)
                 else:
@@ -431,7 +433,7 @@ class GraphConv(nn.Module):
                     rst = th.matmul(rst, weight)
 
             if self._norm in ['right', 'both']:
-                degs = graph.in_degrees().float().clamp(min=1)
+                degs = graph.in_degrees().to(feat_dst).clamp(min=1)
                 if self._norm == 'both':
                     norm = th.pow(degs, -0.5)
                 else:

--- a/python/dgl/nn/pytorch/conv/sgconv.py
+++ b/python/dgl/nn/pytorch/conv/sgconv.py
@@ -191,7 +191,7 @@ class SGConv(nn.Module):
             else:
                 if edge_weight is None:
                     # compute normalization
-                    degs = graph.in_degrees().float().clamp(min=1)
+                    degs = graph.in_degrees().to(feat).clamp(min=1)
                     norm = th.pow(degs, -0.5)
                     norm = norm.to(feat.device).unsqueeze(1)
                 # compute (D^-1 A^k D)^k X

--- a/python/dgl/nn/pytorch/conv/tagconv.py
+++ b/python/dgl/nn/pytorch/conv/tagconv.py
@@ -116,7 +116,7 @@ class TAGConv(nn.Module):
         with graph.local_scope():
             assert graph.is_homogeneous, 'Graph is not homogeneous'
             if edge_weight is None:
-                norm = th.pow(graph.in_degrees().float().clamp(min=1), -0.5)
+                norm = th.pow(graph.in_degrees().to(feat).clamp(min=1), -0.5)
                 shp = norm.shape + (1,) * (feat.dim() - 1)
                 norm = th.reshape(norm, shp).to(feat.device)
 

--- a/python/dgl/nn/pytorch/conv/twirlsconv.py
+++ b/python/dgl/nn/pytorch/conv/twirlsconv.py
@@ -550,7 +550,7 @@ class TWIRLSUnfoldingAndAttention(nn.Module):
         Y = X
 
         g.edata["w"] = tc.ones(g.number_of_edges(), 1, device=g.device)
-        g.ndata["deg"] = g.in_degrees().float()
+        g.ndata["deg"] = g.in_degrees().to(X)
 
         if self.init_att:
             g = self.init_attn(g, Y, self.etas)


### PR DESCRIPTION
Some of the modules compute normalizers etc. as float32 vectors.  As we are going to support float16 inputs, this will result in math between float32 and float16, causing crashes.

Also I attached my GCN example with float16 (EDIT: for awareness only, won't go into actual example), which always return NaN losses.  Have we tested our examples (not necessarily all of them though) with FP16 inputs?  @chang-l @nv-dlasalle 

EDIT: AMP with autocast worked fine.