### PR TITLE
[Bugfix] Fixed fatal log output in COO class

### DIFF
--- a/include/dgl/immutable_graph.h
+++ b/include/dgl/immutable_graph.h
@@ -273,19 +273,19 @@ class COO : public GraphInterface {
   // TODO(da): add constructor for creating COO from shared memory
 
   void AddVertices(uint64_t num_vertices) override {
-    LOG(FATAL) << "CSR graph does not allow mutation.";
+    LOG(FATAL) << "COO graph does not allow mutation.";
   }
 
   void AddEdge(dgl_id_t src, dgl_id_t dst) override {
-    LOG(FATAL) << "CSR graph does not allow mutation.";
+    LOG(FATAL) << "COO graph does not allow mutation.";
   }
 
   void AddEdges(IdArray src_ids, IdArray dst_ids) override {
-    LOG(FATAL) << "CSR graph does not allow mutation.";
+    LOG(FATAL) << "COO graph does not allow mutation.";
   }
 
   void Clear() override {
-    LOG(FATAL) << "CSR graph does not allow mutation.";
+    LOG(FATAL) << "COO graph does not allow mutation.";
   }
 
   DLContext Context() const override {


### PR DESCRIPTION
## Description
Fix the fatal log output in COO class

## Checklist
- [x] The PR title starts with [$CATEGORY] (such as [NN], [Model], [Doc], [Feature]])
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverag
- [x] To the best of my knowledge, examples are either not affected by this change,
      or have been fixed to be compatible with this change
