### PR TITLE
[Bugfix] Fix dataloader pytorch cuda indexing 

### DIFF
--- a/examples/pytorch/rgcn-hetero-ogbn-mag/main.py
+++ b/examples/pytorch/rgcn-hetero-ogbn-mag/main.py
@@ -7,7 +7,6 @@ import dgl
 import torch
 import torch.nn as nn
 import torch.nn.functional as F
-import torch.distributed as dist
 
 import utils
 from model import EntityClassify, RelGraphEmbedding
@@ -157,7 +156,6 @@ def validate(
 
 
 def run(args: argparse.ArgumentParser) -> None:
-    dist.init_process_group('nccl', 'tcp://127.0.0.1:12347', world_size=1, rank=0)
     torch.manual_seed(args.seed)
 
     dataset, hg, train_idx, valid_idx, test_idx = utils.process_dataset(
@@ -174,7 +172,6 @@ def run(args: argparse.ArgumentParser) -> None:
 
     fanouts = [int(fanout) for fanout in args.fanouts.split(',')]
 
-    train_idx = train_idx.to('cuda:0')
     train_sampler = dgl.dataloading.MultiLayerNeighborSampler(fanouts)
     train_dataloader = dgl.dataloading.DataLoader(
         hg,
@@ -184,8 +181,6 @@ def run(args: argparse.ArgumentParser) -> None:
         shuffle=True,
         drop_last=False,
         num_workers=args.num_workers,
-        use_uva = True,
-        use_ddp = True
     )
 
     if inferfence_mode == 'neighbor_sampler':

--- a/python/dgl/dataloading/dataloader.py
+++ b/python/dgl/dataloading/dataloader.py
@@ -157,7 +157,7 @@ class TensorizedDataset(torch.utils.data.IterableDataset):
 
     def __iter__(self):
         indices = _divide_by_worker(self._indices, self.batch_size, self.drop_last)
-        id_tensor = self._id_tensor[indices.to(self._device)]
+        id_tensor = self._id_tensor[indices]
         return _TensorizedDatasetIter(
             id_tensor, self.batch_size, self.drop_last, self._mapping_keys, self._shuffle)
 
@@ -223,12 +223,7 @@ class DDPTensorizedDataset(torch.utils.data.IterableDataset):
         """Shuffles the dataset."""
         # Only rank 0 does the actual shuffling.  The other ranks wait for it.
         if self.rank == 0:
-            if self._device == torch.device('cpu'):
-                np.random.shuffle(self._indices[:self.num_indices].numpy())
-            else:
-                self._indices[:self.num_indices] = self._indices[
-                    torch.randperm(self.num_indices, device=self._indices.device)]
-
+            np.random.shuffle(self._indices[:self.num_indices].numpy())
             if not self.drop_last:
                 # pad extra
                 self._indices[self.num_indices:] = \
@@ -239,7 +234,7 @@ class DDPTensorizedDataset(torch.utils.data.IterableDataset):
         start = self.num_samples * self.rank
         end = self.num_samples * (self.rank + 1)
         indices = _divide_by_worker(self._indices[start:end], self.batch_size, self.drop_last)
-        id_tensor = self._id_tensor[indices.to(self._id_tensor.device)]
+        id_tensor = self._id_tensor[indices]
         return _TensorizedDatasetIter(
             id_tensor, self.batch_size, self.drop_last, self._mapping_keys, self._shuffle)
 

--- a/python/dgl/dataloading/dataloader.py
+++ b/python/dgl/dataloading/dataloader.py
@@ -240,6 +240,7 @@ class DDPTensorizedDataset(torch.utils.data.IterableDataset):
         end = self.num_samples * (self.rank + 1)
         indices = _divide_by_worker(self._indices[start:end], self.batch_size, self.drop_last)
         id_tensor = self._id_tensor[indices.to(self._device)]
+        #id_tensor = self._id_tensor[indices.to(self._id_tensor.device)]
         return _TensorizedDatasetIter(
             id_tensor, self.batch_size, self.drop_last, self._mapping_keys, self._shuffle)
 

--- a/python/dgl/dataloading/dataloader.py
+++ b/python/dgl/dataloading/dataloader.py
@@ -239,8 +239,7 @@ class DDPTensorizedDataset(torch.utils.data.IterableDataset):
         start = self.num_samples * self.rank
         end = self.num_samples * (self.rank + 1)
         indices = _divide_by_worker(self._indices[start:end], self.batch_size, self.drop_last)
-        id_tensor = self._id_tensor[indices.to(self._device)]
-        #id_tensor = self._id_tensor[indices.to(self._id_tensor.device)]
+        id_tensor = self._id_tensor[indices.to(self._id_tensor.device)]
         return _TensorizedDatasetIter(
             id_tensor, self.batch_size, self.drop_last, self._mapping_keys, self._shuffle)
 


### PR DESCRIPTION
## Description
To fix https://github.com/dmlc/dgl/issues/4296, the problem is `_id_tensor` always copied back to master process to allow the access from every device through UVA, as the result of calling `call_once_and_share()`. Thus, `_id_tensor` will then be in a different device (CPU) as `indices` and `self._device` (GPU), and in L242, `id_tensor = self._id_tensor[indices.to(self._device)]` triggers the crash.


## Checklist
Please feel free to remove inapplicable items for your PR.
- [x] The PR title starts with [$CATEGORY] (such as [NN], [Model], [Doc], [Feature]])
- [x] Changes are complete (i.e. I finished coding on this PR)
- [ ] All changes have test coverage
- [ ] Code is well-documented
- [x] To the best of my knowledge, examples are either not affected by this change,
      or have been fixed to be compatible with this change
- [x] Related issue is referred in this PR
- [ ] If the PR is for a new model/paper, I've updated the example index [here](../examples/README.md).

## Changes
1. Bugfix in the training script, i.e., `out_nodes` should be in same device as labels
2. `self._id_tensor[indices.to(self._device)]`  --> `self._id_tensor[indices.to(self._id_tensor.device)]` 

## Results
1. In the example `example/pytorch/rgcn-hetero-ogbn-mag/main.py`, enable `use_ddp`, `use_uva`, etc.,  as [here](https://github.com/chang-l/dgl/commit/68473a99533f863ddc2017dbe29a57374db45637#diff-fa2c05a9e9897aeccaf2877e028e098d9b6c1e31cbf17efd9fbdf36cc9d2116c)

2. Run `python  main.py  --gpu-training --num-epochs 2 --num-workers 0` 

Before this PR (crash):
```
RuntimeError: indices should be either on cpu or on the same device as the indexed tensor (cpu)
```

With this PR:
```
## Training started ##
Epoch: 001 Train Loss: 2.54 Valid Loss: 1.99 Train Accuracy: 0.3718 Valid Accuracy: 0.4681 Train Epoch Time: 24.40 Valid Epoch Time: 3.19
Epoch: 002 Train Loss: 1.78 Valid Loss: 1.87 Train Accuracy: 0.5188 Valid Accuracy: 0.4952 Train Epoch Time: 23.44 Valid Epoch Time: 3.06
## Training finished ##
Best Epoch: 2 Train Loss: 1.78 Valid Loss: 1.87 Train Accuracy: 0.5188 Valid Accuracy: 0.4952
## Test data validation ##
Test Loss: 1.92 Test Accuracy: 0.4805 Test Epoch Time: 2.18
```
