### PR TITLE
[Example] Fixed device type in GraphSAGE inference

### DIFF
--- a/examples/pytorch/graphsage/node_classification.py
+++ b/examples/pytorch/graphsage/node_classification.py
@@ -39,7 +39,7 @@ class SAGE(nn.Module):
                 g, torch.arange(g.num_nodes()).to(g.device), sampler, device=device,
                 batch_size=batch_size, shuffle=False, drop_last=False,
                 num_workers=0)
-        buffer_device = 'cpu'
+        buffer_device = torch.device('cpu')
         pin_memory = (buffer_device != device)
 
         for l, layer in enumerate(self.layers):
@@ -141,5 +141,5 @@ if __name__ == '__main__':
 
     # test the model
     print('Testing...')
-    acc = layerwise_infer(device.type, g, dataset.test_idx, model, batch_size=4096)
+    acc = layerwise_infer(device, g, dataset.test_idx, model, batch_size=4096)
     print("Test Accuracy {:.4f}".format(acc.item()))

--- a/examples/pytorch/graphsage/node_classification.py
+++ b/examples/pytorch/graphsage/node_classification.py
@@ -141,5 +141,5 @@ if __name__ == '__main__':
 
     # test the model
     print('Testing...')
-    acc = layerwise_infer(device, g, dataset.test_idx, model, batch_size=4096)
+    acc = layerwise_infer(device.type, g, dataset.test_idx, model, batch_size=4096)
     print("Test Accuracy {:.4f}".format(acc.item()))


### PR DESCRIPTION
## Description

The device here was typed in the string, which ended up pin_memory being false anyway to lead to issues in the CPU device case.

https://github.com/dmlc/dgl/blob/2cf05c53420546443a267d91ec624887d0078278/examples/pytorch/graphsage/node_classification.py#L42-L43

## Checklist

- [x] The PR title starts with [$CATEGORY] (such as [NN], [Model], [Doc], [Feature]])
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] To the best of my knowledge, examples are either not affected by this change,
      or have been fixed to be compatible with this change
- [x] If the PR is for a new model/paper, I've updated the example index [here](../examples/README.md).

## Changes

Fixed the example code for torch-GraphSAGE
