### PR TITLE
[Distributed] use alltoall fix to bypass gloo - alltoallv bug in distributed partitioning

### DIFF
--- a/tools/distpartitioning/data_shuffle.py
+++ b/tools/distpartitioning/data_shuffle.py
@@ -16,7 +16,8 @@ from utils import read_ntype_partition_files, read_json, get_node_types, \
                     write_dgl_objects, write_metadata_json, get_ntype_featnames, \
                     get_idranges
 from gloo_wrapper import alltoall_cpu_object_lst, alltoallv_cpu, \
-                    alltoall_cpu, allgather_sizes, gather_metadata_json
+                    alltoall_cpu, allgather_sizes, gather_metadata_json,\
+                    alltoallv_cpu_data
 from globalids import assign_shuffle_global_nids_nodes, \
                     assign_shuffle_global_nids_edges, \
                     get_shuffle_global_nids_edges
@@ -140,8 +141,6 @@ def exchange_edge_data(rank, world_size, edge_data):
     """
 
     input_list = []
-    send_sizes = []
-    recv_sizes = []
     start = timer()
     for i in np.arange(world_size):
         send_idx = (edge_data[constants.OWNER_PROCESS] == i)
@@ -152,23 +151,13 @@ def exchange_edge_data(rank, world_size, edge_data):
                                     edge_data[constants.ETYPE_ID][send_idx == 1], \
                                     edge_data[constants.GLOBAL_EID][send_idx == 1]))
         if(filt_data.shape[0] <= 0):
-            input_list.append(torch.empty((0,), dtype=torch.int64))
-            send_sizes.append(torch.empty((0,), dtype=torch.int64))
+            input_list.append(torch.empty((0,5), dtype=torch.int64))
         else:
             input_list.append(torch.from_numpy(filt_data))
-            send_sizes.append(torch.tensor(filt_data.shape, dtype=torch.int64))
-        recv_sizes.append(torch.zeros((2,), dtype=torch.int64))
     end = timer()
     
     dist.barrier ()
-    start = timer()
-    alltoall_cpu(rank, world_size, recv_sizes, send_sizes)
-    output_list = []
-    for s in recv_sizes: 
-        output_list.append(torch.zeros(s.tolist(), dtype=torch.int64))
-
-    dist.barrier ()
-    alltoallv_cpu(rank, world_size, output_list, input_list)
+    output_list = alltoallv_cpu_data(rank, world_size, input_list,torch.int64)
     end = timer()
     print('[Rank: ', rank, '] Time to send/rcv edge data: ', timedelta(seconds=end-start))
 
@@ -246,6 +235,7 @@ def exchange_node_features(rank, world_size, node_feature_tids, ntype_gnid_map, 
             global_nid_per_rank = []
             feat_name = feat_info[0]
             feat_key = ntype_name+'/'+feat_name
+            print('[Rank: ', rank, '] processing node feature: ', feat_key)
 
             #compute the global_nid range for this node features
             type_nid_start = int(feat_info[1])
@@ -273,29 +263,25 @@ def exchange_node_features(rank, world_size, node_feature_tids, ntype_gnid_map, 
                 local_idx_partid = local_idx[cond]
 
                 if (gnids_per_partid.shape[0] == 0):
-                    node_feats_per_rank.append({feat_key : torch.empty((0,), dtype=torch.float)})
-                    global_nid_per_rank.append({feat_key : torch.empty((0,), dtype=torch.int64)})
+                    node_feats_per_rank.append(torch.empty((0,1), dtype=torch.float))
+                    global_nid_per_rank.append(np.empty((0,1), dtype=np.int64))
                 else:
-                    node_feats_per_rank.append({feat_key : node_feats[local_idx_partid]})
-                    global_nid_per_rank.append({feat_key : gnids_per_partid})
+                    if (len(list(node_feats[local_idx_partid].size())) == 1):
+                        node_feats_per_rank.append(node_feats[local_idx_partid])
+                    else:
+                        node_feats_per_rank.append(node_feats[local_idx_partid])
+                    global_nid_per_rank.append(torch.from_numpy(gnids_per_partid).type(torch.int64))
 
             #features (and global nids) per rank to be sent out are ready
             #for transmission, perform alltoallv here.
-            output_feat_list = alltoall_cpu_object_lst(rank, world_size, node_feats_per_rank)
-            output_feat_list[rank] = node_feats_per_rank[rank]
+            output_feat_list = alltoallv_cpu_data(rank, world_size, node_feats_per_rank, node_feats.dtype)
 
-            output_nid_list = alltoall_cpu_object_lst(rank, world_size, global_nid_per_rank)
-            output_nid_list[rank] = global_nid_per_rank[rank]
+            #output_nid_list = alltoall_cpu_object_lst(rank, world_size, global_nid_per_rank)
+            output_nid_list = alltoallv_cpu_data(rank, world_size, global_nid_per_rank, torch.int64)
 
             #stitch node_features together to form one large feature tensor
-            own_node_features[feat_key] = []
-            own_global_nids[feat_key] = []
-            for idx, x in enumerate(output_feat_list):
-                own_node_features[feat_key].append(x[feat_key])
-                own_global_nids[feat_key].append(output_nid_list[idx][feat_key])
-            for k in own_node_features.keys(): 
-                own_node_features[k] = torch.cat(own_node_features[k])
-                own_global_nids[k] = np.concatenate(own_global_nids[k])
+            own_node_features[feat_key] = torch.cat(output_feat_list)
+            own_global_nids[feat_key] = torch.cat(output_nid_list).numpy()
 
     end = timer()
     print('[Rank: ', rank, '] Total time for node feature exchange: ', timedelta(seconds = end - start))

--- a/tools/distpartitioning/data_shuffle.py
+++ b/tools/distpartitioning/data_shuffle.py
@@ -15,7 +15,7 @@ from utils import read_ntype_partition_files, read_json, get_node_types, \
                     augment_edge_data, get_gnid_range_map, \
                     write_dgl_objects, write_metadata_json, get_ntype_featnames, \
                     get_idranges
-from gloo_wrapper import alltoall_cpu, allgather_sizes, gather_metadata_json,\
+from gloo_wrapper import allgather_sizes, gather_metadata_json,\
                     alltoallv_cpu
 from globalids import assign_shuffle_global_nids_nodes, \
                     assign_shuffle_global_nids_edges, \

--- a/tools/distpartitioning/data_shuffle.py
+++ b/tools/distpartitioning/data_shuffle.py
@@ -185,6 +185,9 @@ def exchange_node_features(rank, world_size, node_feature_tids, ntype_gnid_map, 
         retrieved. 
     d. After receiving the corresponding shuffle_global_nids these ids are added to the 
         node_data and edge_data dictionaries
+    
+    This pipeline assumes all the input data in numpy format, except node/edge features which
+    are maintained as tensors throughout the various stages of the pipeline execution.
 
     Parameters: 
     -----------

--- a/tools/distpartitioning/data_shuffle.py
+++ b/tools/distpartitioning/data_shuffle.py
@@ -16,7 +16,7 @@ from utils import read_ntype_partition_files, read_json, get_node_types, \
                     write_dgl_objects, write_metadata_json, get_ntype_featnames, \
                     get_idranges
 from gloo_wrapper import alltoall_cpu, allgather_sizes, gather_metadata_json,\
-                    alltoallv_cpu_data
+                    alltoallv_cpu
 from globalids import assign_shuffle_global_nids_nodes, \
                     assign_shuffle_global_nids_edges, \
                     get_shuffle_global_nids_edges
@@ -156,7 +156,7 @@ def exchange_edge_data(rank, world_size, edge_data):
     end = timer()
     
     dist.barrier ()
-    output_list = alltoallv_cpu_data(rank, world_size, input_list)
+    output_list = alltoallv_cpu(rank, world_size, input_list)
     end = timer()
     print('[Rank: ', rank, '] Time to send/rcv edge data: ', timedelta(seconds=end-start))
 
@@ -270,8 +270,8 @@ def exchange_node_features(rank, world_size, node_feature_tids, ntype_gnid_map, 
 
             #features (and global nids) per rank to be sent out are ready
             #for transmission, perform alltoallv here.
-            output_feat_list = alltoallv_cpu_data(rank, world_size, node_feats_per_rank)
-            output_nid_list = alltoallv_cpu_data(rank, world_size, global_nid_per_rank)
+            output_feat_list = alltoallv_cpu(rank, world_size, node_feats_per_rank)
+            output_nid_list = alltoallv_cpu(rank, world_size, global_nid_per_rank)
 
             #stitch node_features together to form one large feature tensor
             own_node_features[feat_key] = torch.cat(output_feat_list)

--- a/tools/distpartitioning/globalids.py
+++ b/tools/distpartitioning/globalids.py
@@ -3,7 +3,7 @@ import torch
 import operator
 import itertools
 import constants
-from gloo_wrapper import allgather_sizes, alltoall_cpu, alltoallv_cpu_data
+from gloo_wrapper import allgather_sizes, alltoallv_cpu
 
 def get_shuffle_global_nids(rank, world_size, global_nids_ranks, node_data):
     """ 
@@ -30,7 +30,7 @@ def get_shuffle_global_nids(rank, world_size, global_nids_ranks, node_data):
     """
     #build a list of sizes (lengths of lists)
     global_nids_ranks = [torch.from_numpy(x) for x in global_nids_ranks]
-    recv_nodes = alltoallv_cpu_data(rank, world_size, global_nids_ranks)
+    recv_nodes = alltoallv_cpu(rank, world_size, global_nids_ranks)
 
     # Use node_data to lookup global id to send over.
     send_nodes = []
@@ -48,7 +48,7 @@ def get_shuffle_global_nids(rank, world_size, global_nids_ranks, node_data):
             send_nodes.append(torch.empty((0), dtype=torch.int64))
 
     #send receive global-ids
-    recv_shuffle_global_nids = alltoallv_cpu_data(rank, world_size, send_nodes)
+    recv_shuffle_global_nids = alltoallv_cpu(rank, world_size, send_nodes)
     shuffle_global_nids = np.concatenate([x.numpy() if x != None else [] for x in recv_shuffle_global_nids])
     global_nids = np.concatenate([x for x in global_nids_ranks])
     ret_val = np.column_stack([global_nids, shuffle_global_nids])

--- a/tools/distpartitioning/globalids.py
+++ b/tools/distpartitioning/globalids.py
@@ -49,7 +49,7 @@ def get_shuffle_global_nids(rank, world_size, global_nids_ranks, node_data):
 
     #send receive global-ids
     recv_shuffle_global_nids = alltoallv_cpu(rank, world_size, send_nodes)
-    shuffle_global_nids = np.concatenate([x.numpy() if x != None else [] for x in recv_shuffle_global_nids])
+    shuffle_global_nids = np.concatenate([x.numpy() if x is not None else [] for x in recv_shuffle_global_nids])
     global_nids = np.concatenate([x for x in global_nids_ranks])
     ret_val = np.column_stack([global_nids, shuffle_global_nids])
     return ret_val

--- a/tools/distpartitioning/gloo_wrapper.py
+++ b/tools/distpartitioning/gloo_wrapper.py
@@ -59,7 +59,7 @@ def alltoall_cpu(rank, world_size, output_tensor_list, input_tensor_list):
     for i in range(world_size):
         dist.scatter(output_tensor_list[i], input_tensor_list if i == rank else [], src=i)
 
-def alltoallv_cpu_data(rank, world_size, input_tensor_list):
+def alltoallv_cpu(rank, world_size, input_tensor_list):
     """
     Wrapper function to providing the alltoallv functionality by using underlying alltoall
     messaging primitive. 


### PR DESCRIPTION
…er testing

1. Replaced alltoallv gloo wrapper call with alltoall message.
2. All the messages are padded to be of same length
3. Receiving side unpads the messages and continues processing.

## Description
<!-- Brief description. Refer to the related issues if existed.
It'll be great if relevant reviewers can be assigned as well.-->

## Checklist
Please feel free to remove inapplicable items for your PR.
- [ ] The PR title starts with [$CATEGORY] (such as [NN], [Model], [Doc], [Feature]])
- [X] Changes are complete (i.e. I finished coding on this PR)
- [X] All changes have test coverage
- [X] Code is well-documented
- [X] To the best of my knowledge, examples are either not affected by this change,
      or have been fixed to be compatible with this change
- [ ] Related issue is referred in this PR
- [ ] If the PR is for a new model/paper, I've updated the example index [here](../examples/README.md).

## Changes
<!-- You could use following template
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)
-->
