### PR TITLE
[Bug] Fix broken static_assert

### DIFF
--- a/src/array/cuda/rowwise_sampling_prob.cu
+++ b/src/array/cuda/rowwise_sampling_prob.cu
@@ -16,7 +16,7 @@
 #include "../../runtime/cuda/cuda_common.h"
 
 // require CUB 1.17 to use DeviceSegmentedSort
-static_assert(CUB_VERSION >= 101700);
+static_assert(CUB_VERSION >= 101700, "Require CUB >= 1.17 to use DeviceSegmentedSort");
 
 using namespace dgl::aten::cuda;
 


### PR DESCRIPTION
## Description

This is to fix that `static_assert` requires a second parameter - the error message - before C++17.