### PR TITLE
[Bug] Fix unpinning when tensoradaptor is not available

### DIFF
--- a/src/runtime/ndarray.cc
+++ b/src/runtime/ndarray.cc
@@ -67,7 +67,8 @@ struct NDArray::Internal {
       ptr->mem = nullptr;
     } else if (ptr->dl_tensor.data != nullptr) {
       // if the array is still pinned before freeing, unpin it.
-      UnpinContainer(ptr);
+      if (ptr->pinned_by_dgl_)
+        UnpinContainer(ptr);
       dgl::runtime::DeviceAPI::Get(ptr->dl_tensor.ctx)->FreeDataSpace(
           ptr->dl_tensor.ctx, ptr->dl_tensor.data);
     }


### PR DESCRIPTION
## Description

Check the `pinned_by_dgl_` flag before unpinning to avoid CUDA calls.

I have tested it offline and it fixes https://github.com/dmlc/dgl/issues/4340. Not sure how to include it in the unit test because the dataloader (where the error occurs) is for the PyTorch backend only, for which we always enable the tensoradaptor.

## Checklist
Please feel free to remove inapplicable items for your PR.
- [x] The PR title starts with [$CATEGORY] (such as [NN], [Model], [Doc], [Feature]])
- [x] Changes are complete (i.e. I finished coding on this PR)
- [ ] All changes have test coverage
- [x] To the best of my knowledge, examples are either not affected by this change,
      or have been fixed to be compatible with this change
- [x] Related issue is referred in this PR

