### PR TITLE
[Deprecation] Dataset Attributes

### DIFF
--- a/examples/pytorch/dgi/train.py
+++ b/examples/pytorch/dgi/train.py
@@ -23,18 +23,18 @@ def main(args):
     # load and preprocess dataset
     data = load_data(args)
     g = data[0]
-    features = torch.FloatTensor(data.features)
-    labels = torch.LongTensor(data.labels)
+    features = torch.FloatTensor(g.ndata['feat'])
+    labels = torch.LongTensor(g.ndata['labels'])
     if hasattr(torch, 'BoolTensor'):
-        train_mask = torch.BoolTensor(data.train_mask)
-        val_mask = torch.BoolTensor(data.val_mask)
-        test_mask = torch.BoolTensor(data.test_mask)
+        train_mask = torch.BoolTensor(g.ndata['train_mask'])
+        val_mask = torch.BoolTensor(g.ndata['val_mask'])
+        test_mask = torch.BoolTensor(g.ndata['test_mask'])
     else:
-        train_mask = torch.ByteTensor(data.train_mask)
-        val_mask = torch.ByteTensor(data.val_mask)
-        test_mask = torch.ByteTensor(data.test_mask)
+        train_mask = torch.ByteTensor(g.ndata['train_mask'])
+        val_mask = torch.ByteTensor(g.ndata['val_mask'])
+        test_mask = torch.ByteTensor(g.ndata['test_mask'])
     in_feats = features.shape[1]
-    n_classes = data.num_labels
+    n_classes = data.num_classes
     n_edges = g.number_of_edges()
 
     if args.gpu < 0:
@@ -130,7 +130,7 @@ def main(args):
         loss = F.nll_loss(preds[train_mask], labels[train_mask])
         loss.backward()
         classifier_optimizer.step()
-        
+
         if epoch >= 3:
             dur.append(time.time() - t0)
 
@@ -171,5 +171,5 @@ if __name__ == '__main__':
     parser.set_defaults(self_loop=False)
     args = parser.parse_args()
     print(args)
-    
+
     main(args)

--- a/python/dgl/data/citation_graph.py
+++ b/python/dgl/data/citation_graph.py
@@ -252,31 +252,6 @@ class CitationGraphDataset(DGLBuiltinDataset):
     """
 
     @property
-    def train_mask(self):
-        deprecate_property('dataset.train_mask', 'g.ndata[\'train_mask\']')
-        return F.asnumpy(self._g.ndata['train_mask'])
-
-    @property
-    def val_mask(self):
-        deprecate_property('dataset.val_mask', 'g.ndata[\'val_mask\']')
-        return F.asnumpy(self._g.ndata['val_mask'])
-
-    @property
-    def test_mask(self):
-        deprecate_property('dataset.test_mask', 'g.ndata[\'test_mask\']')
-        return F.asnumpy(self._g.ndata['test_mask'])
-
-    @property
-    def labels(self):
-        deprecate_property('dataset.label', 'g.ndata[\'label\']')
-        return F.asnumpy(self._g.ndata['label'])
-
-    @property
-    def features(self):
-        deprecate_property('dataset.feat', 'g.ndata[\'feat\']')
-        return self._g.ndata['feat']
-
-    @property
     def reverse_edge(self):
         return self._reverse_edge
 
@@ -305,43 +280,6 @@ def _sample_mask(idx, l):
 
 class CoraGraphDataset(CitationGraphDataset):
     r""" Cora citation network dataset.
-
-    .. deprecated:: 0.5.0
-
-        - ``graph`` is deprecated, it is replaced by:
-
-            >>> dataset = CoraGraphDataset()
-            >>> graph = dataset[0]
-
-        - ``train_mask`` is deprecated, it is replaced by:
-
-            >>> dataset = CoraGraphDataset()
-            >>> graph = dataset[0]
-            >>> train_mask = graph.ndata['train_mask']
-
-        - ``val_mask`` is deprecated, it is replaced by:
-
-            >>> dataset = CoraGraphDataset()
-            >>> graph = dataset[0]
-            >>> val_mask = graph.ndata['val_mask']
-
-        - ``test_mask`` is deprecated, it is replaced by:
-
-            >>> dataset = CoraGraphDataset()
-            >>> graph = dataset[0]
-            >>> test_mask = graph.ndata['test_mask']
-
-        - ``labels`` is deprecated, it is replaced by:
-
-            >>> dataset = CoraGraphDataset()
-            >>> graph = dataset[0]
-            >>> labels = graph.ndata['label']
-
-        - ``feat`` is deprecated, it is replaced by:
-
-            >>> dataset = CoraGraphDataset()
-            >>> graph = dataset[0]
-            >>> feat = graph.ndata['feat']
 
     Nodes mean paper and edges mean citation
     relationships. Each node has a predefined
@@ -383,18 +321,6 @@ class CoraGraphDataset(CitationGraphDataset):
     ----------
     num_classes: int
         Number of label classes
-    graph: networkx.DiGraph
-        Graph structure
-    train_mask: numpy.ndarray
-        Mask of training nodes
-    val_mask: numpy.ndarray
-        Mask of validation nodes
-    test_mask: numpy.ndarray
-        Mask of test nodes
-    labels: numpy.ndarray
-        Ground truth labels of each node
-    features: Tensor
-        Node features
 
     Notes
     -----
@@ -454,43 +380,6 @@ class CoraGraphDataset(CitationGraphDataset):
 class CiteseerGraphDataset(CitationGraphDataset):
     r""" Citeseer citation network dataset.
 
-    .. deprecated:: 0.5.0
-
-        - ``graph`` is deprecated, it is replaced by:
-
-            >>> dataset = CiteseerGraphDataset()
-            >>> graph = dataset[0]
-
-        - ``train_mask`` is deprecated, it is replaced by:
-
-            >>> dataset = CiteseerGraphDataset()
-            >>> graph = dataset[0]
-            >>> train_mask = graph.ndata['train_mask']
-
-        - ``val_mask`` is deprecated, it is replaced by:
-
-            >>> dataset = CiteseerGraphDataset()
-            >>> graph = dataset[0]
-            >>> val_mask = graph.ndata['val_mask']
-
-        - ``test_mask`` is deprecated, it is replaced by:
-
-            >>> dataset = CiteseerGraphDataset()
-            >>> graph = dataset[0]
-            >>> test_mask = graph.ndata['test_mask']
-
-        - ``labels`` is deprecated, it is replaced by:
-
-            >>> dataset = CiteseerGraphDataset()
-            >>> graph = dataset[0]
-            >>> labels = graph.ndata['label']
-
-        - ``feat`` is deprecated, it is replaced by:
-
-            >>> dataset = CiteseerGraphDataset()
-            >>> graph = dataset[0]
-            >>> feat = graph.ndata['feat']
-
     Nodes mean scientific publications and edges
     mean citation relationships. Each node has a
     predefined feature with 3703 dimensions. The
@@ -531,18 +420,6 @@ class CiteseerGraphDataset(CitationGraphDataset):
     ----------
     num_classes: int
         Number of label classes
-    graph: networkx.DiGraph
-        Graph structure
-    train_mask: numpy.ndarray
-        Mask of training nodes
-    val_mask: numpy.ndarray
-        Mask of validation nodes
-    test_mask: numpy.ndarray
-        Mask of test nodes
-    labels: numpy.ndarray
-        Ground truth labels of each node
-    features: Tensor
-        Node features
 
     Notes
     -----
@@ -605,43 +482,6 @@ class CiteseerGraphDataset(CitationGraphDataset):
 class PubmedGraphDataset(CitationGraphDataset):
     r""" Pubmed citation network dataset.
 
-    .. deprecated:: 0.5.0
-
-        - ``graph`` is deprecated, it is replaced by:
-
-            >>> dataset = PubmedGraphDataset()
-            >>> graph = dataset[0]
-
-        - ``train_mask`` is deprecated, it is replaced by:
-
-            >>> dataset = PubmedGraphDataset()
-            >>> graph = dataset[0]
-            >>> train_mask = graph.ndata['train_mask']
-
-        - ``val_mask`` is deprecated, it is replaced by:
-
-            >>> dataset = PubmedGraphDataset()
-            >>> graph = dataset[0]
-            >>> val_mask = graph.ndata['val_mask']
-
-        - ``test_mask`` is deprecated, it is replaced by:
-
-            >>> dataset = PubmedGraphDataset()
-            >>> graph = dataset[0]
-            >>> test_mask = graph.ndata['test_mask']
-
-        - ``labels`` is deprecated, it is replaced by:
-
-            >>> dataset = PubmedGraphDataset()
-            >>> graph = dataset[0]
-            >>> labels = graph.ndata['label']
-
-        - ``feat`` is deprecated, it is replaced by:
-
-            >>> dataset = PubmedGraphDataset()
-            >>> graph = dataset[0]
-            >>> feat = graph.ndata['feat']
-
     Nodes mean scientific publications and edges
     mean citation relationships. Each node has a
     predefined feature with 500 dimensions. The
@@ -682,18 +522,6 @@ class PubmedGraphDataset(CitationGraphDataset):
     ----------
     num_classes: int
         Number of label classes
-    graph: networkx.DiGraph
-        Graph structure
-    train_mask: numpy.ndarray
-        Mask of training nodes
-    val_mask: numpy.ndarray
-        Mask of validation nodes
-    test_mask: numpy.ndarray
-        Mask of test nodes
-    labels: numpy.ndarray
-        Ground truth labels of each node
-    features: Tensor
-        Node features
 
     Notes
     -----

--- a/python/dgl/data/gnn_benchmark.py
+++ b/python/dgl/data/gnn_benchmark.py
@@ -106,11 +106,6 @@ class GNNBenchmarkDataset(DGLBuiltinDataset):
         """Number of classes."""
         raise NotImplementedError
 
-    @property
-    def data(self):
-        deprecate_property('dataset.data', 'dataset[0]')
-        return self._data
-
     def __getitem__(self, idx):
         r""" Get graph by index
 
@@ -142,13 +137,6 @@ class GNNBenchmarkDataset(DGLBuiltinDataset):
 class CoraFullDataset(GNNBenchmarkDataset):
     r"""CORA-Full dataset for node classification task.
 
-    .. deprecated:: 0.5.0
-
-        - ``data`` is deprecated, it is repalced by:
-
-        >>> dataset = CoraFullDataset()
-        >>> graph = dataset[0]
-
     Extended Cora dataset. Nodes represent paper and edges represent citations.
 
     Reference: `<https://github.com/shchur/gnn-benchmark#datasets>`_
@@ -179,8 +167,6 @@ class CoraFullDataset(GNNBenchmarkDataset):
     ----------
     num_classes : int
         Number of classes for each node.
-    data : list
-        A list of DGLGraph objects
 
     Examples
     --------
@@ -210,13 +196,6 @@ class CoraFullDataset(GNNBenchmarkDataset):
 
 class CoauthorCSDataset(GNNBenchmarkDataset):
     r""" 'Computer Science (CS)' part of the Coauthor dataset for node classification task.
-
-    .. deprecated:: 0.5.0
-
-        - ``data`` is deprecated, it is repalced by:
-
-        >>> dataset = CoauthorCSDataset()
-        >>> graph = dataset[0]
 
     Coauthor CS and Coauthor Physics are co-authorship graphs based on the Microsoft Academic Graph
     from the KDD Cup 2016 challenge. Here, nodes are authors, that are connected by an edge if they
@@ -251,8 +230,6 @@ class CoauthorCSDataset(GNNBenchmarkDataset):
     ----------
     num_classes : int
         Number of classes for each node.
-    data : list
-        A list of DGLGraph objects
 
     Examples
     --------
@@ -282,13 +259,6 @@ class CoauthorCSDataset(GNNBenchmarkDataset):
 
 class CoauthorPhysicsDataset(GNNBenchmarkDataset):
     r""" 'Physics' part of the Coauthor dataset for node classification task.
-
-    .. deprecated:: 0.5.0
-
-        - ``data`` is deprecated, it is repalced by:
-
-        >>> dataset = CoauthorPhysicsDataset()
-        >>> graph = dataset[0]
 
     Coauthor CS and Coauthor Physics are co-authorship graphs based on the Microsoft Academic Graph
     from the KDD Cup 2016 challenge. Here, nodes are authors, that are connected by an edge if they
@@ -323,8 +293,6 @@ class CoauthorPhysicsDataset(GNNBenchmarkDataset):
     ----------
     num_classes : int
         Number of classes for each node.
-    data : list
-        A list of DGLGraph objects
 
     Examples
     --------
@@ -354,13 +322,6 @@ class CoauthorPhysicsDataset(GNNBenchmarkDataset):
 
 class AmazonCoBuyComputerDataset(GNNBenchmarkDataset):
     r""" 'Computer' part of the AmazonCoBuy dataset for node classification task.
-
-    .. deprecated:: 0.5.0
-
-        - ``data`` is deprecated, it is repalced by:
-
-        >>> dataset = AmazonCoBuyComputerDataset()
-        >>> graph = dataset[0]
 
     Amazon Computers and Amazon Photo are segments of the Amazon co-purchase graph [McAuley et al., 2015],
     where nodes represent goods, edges indicate that two goods are frequently bought together, node
@@ -394,8 +355,6 @@ class AmazonCoBuyComputerDataset(GNNBenchmarkDataset):
     ----------
     num_classes : int
         Number of classes for each node.
-    data : list
-        A list of DGLGraph objects
 
     Examples
     --------
@@ -425,13 +384,6 @@ class AmazonCoBuyComputerDataset(GNNBenchmarkDataset):
 
 class AmazonCoBuyPhotoDataset(GNNBenchmarkDataset):
     r"""AmazonCoBuy dataset for node classification task.
-
-    .. deprecated:: 0.5.0
-
-        - ``data`` is deprecated, it is repalced by:
-
-        >>> dataset = AmazonCoBuyPhotoDataset()
-        >>> graph = dataset[0]
 
     Amazon Computers and Amazon Photo are segments of the Amazon co-purchase graph [McAuley et al., 2015],
     where nodes represent goods, edges indicate that two goods are frequently bought together, node
@@ -465,8 +417,6 @@ class AmazonCoBuyPhotoDataset(GNNBenchmarkDataset):
     ----------
     num_classes : int
         Number of classes for each node.
-    data : list
-        A list of DGLGraph objects
 
     Examples
     --------

--- a/python/dgl/data/karate.py
+++ b/python/dgl/data/karate.py
@@ -14,13 +14,6 @@ __all__ = ['KarateClubDataset', 'KarateClub']
 class KarateClubDataset(DGLDataset):
     r""" Karate Club dataset for Node Classification
 
-    .. deprecated:: 0.5.0
-
-        - ``data`` is deprecated, it is replaced by:
-
-            >>> dataset = KarateClubDataset()
-            >>> g = dataset[0]
-
     Zachary's karate club is a social network of a university
     karate club, described in the paper "An Information Flow
     Model for Conflict and Fission in Small Groups" by Wayne W. Zachary.
@@ -45,8 +38,6 @@ class KarateClubDataset(DGLDataset):
     ----------
     num_classes : int
         Number of node classes
-    data : list
-        A list of :class:`dgl.DGLGraph` objects
 
     Examples
     --------
@@ -72,11 +63,6 @@ class KarateClubDataset(DGLDataset):
     def num_classes(self):
         """Number of classes."""
         return 2
-
-    @property
-    def data(self):
-        deprecate_property('dataset.data', 'dataset[0]')
-        return self._data
 
     def __getitem__(self, idx):
         r""" Get graph object

--- a/python/dgl/data/knowledge_graph.py
+++ b/python/dgl/data/knowledge_graph.py
@@ -191,21 +191,6 @@ class KnowledgeGraphDataset(DGLBuiltinDataset):
     def save_name(self):
         return self.name + '_dgl_graph'
 
-    @property
-    def train(self):
-        deprecate_property('dataset.train', 'g.edata[\'train_mask\']')
-        return self._train
-
-    @property
-    def valid(self):
-        deprecate_property('dataset.valid', 'g.edata[\'val_mask\']')
-        return self._valid
-
-    @property
-    def test(self):
-        deprecate_property('dataset.test', 'g.edata[\'test_mask\']')
-        return self._test
-
 def _read_dictionary(filename):
     d = {}
     with open(filename, 'r+') as f:
@@ -344,35 +329,6 @@ def build_knowledge_graph(num_nodes, num_rels, train, valid, test, reverse=True)
 class FB15k237Dataset(KnowledgeGraphDataset):
     r"""FB15k237 link prediction dataset.
 
-    .. deprecated:: 0.5.0
-
-        - ``train`` is deprecated, it is replaced by:
-
-            >>> dataset = FB15k237Dataset()
-            >>> graph = dataset[0]
-            >>> train_mask = graph.edata['train_mask']
-            >>> train_idx = th.nonzero(train_mask, as_tuple=False).squeeze()
-            >>> src, dst = graph.find_edges(train_idx)
-            >>> rel = graph.edata['etype'][train_idx]
-
-        - ``valid`` is deprecated, it is replaced by:
-
-            >>> dataset = FB15k237Dataset()
-            >>> graph = dataset[0]
-            >>> val_mask = graph.edata['val_mask']
-            >>> val_idx = th.nonzero(val_mask, as_tuple=False).squeeze()
-            >>> src, dst = graph.find_edges(val_idx)
-            >>> rel = graph.edata['etype'][val_idx]
-
-        - ``test`` is deprecated, it is replaced by:
-
-            >>> dataset = FB15k237Dataset()
-            >>> graph = dataset[0]
-            >>> test_mask = graph.edata['test_mask']
-            >>> test_idx = th.nonzero(test_mask, as_tuple=False).squeeze()
-            >>> src, dst = graph.find_edges(test_idx)
-            >>> rel = graph.edata['etype'][test_idx]
-
     FB15k-237 is a subset of FB15k where inverse
     relations are removed. When creating the dataset,
     a reverse edge with reversed relation types are
@@ -411,12 +367,6 @@ class FB15k237Dataset(KnowledgeGraphDataset):
         Number of nodes
     num_rels: int
         Number of relation types
-    train: numpy.ndarray
-        A numpy array of triplets (src, rel, dst) for the training graph
-    valid: numpy.ndarray
-        A numpy array of triplets (src, rel, dst) for the validation graph
-    test: numpy.ndarray
-        A numpy array of triplets (src, rel, dst) for the test graph
 
     Examples
     ----------
@@ -484,35 +434,6 @@ class FB15k237Dataset(KnowledgeGraphDataset):
 class FB15kDataset(KnowledgeGraphDataset):
     r"""FB15k link prediction dataset.
 
-    .. deprecated:: 0.5.0
-
-        - ``train`` is deprecated, it is replaced by:
-
-            >>> dataset = FB15kDataset()
-            >>> graph = dataset[0]
-            >>> train_mask = graph.edata['train_mask']
-            >>> train_idx = th.nonzero(train_mask, as_tuple=False).squeeze()
-            >>> src, dst = graph.edges(train_idx)
-            >>> rel = graph.edata['etype'][train_idx]
-
-        - ``valid`` is deprecated, it is replaced by:
-
-            >>> dataset = FB15kDataset()
-            >>> graph = dataset[0]
-            >>> val_mask = graph.edata['val_mask']
-            >>> val_idx = th.nonzero(val_mask, as_tuple=False).squeeze()
-            >>> src, dst = graph.edges(val_idx)
-            >>> rel = graph.edata['etype'][val_idx]
-
-        - ``test`` is deprecated, it is replaced by:
-
-            >>> dataset = FB15kDataset()
-            >>> graph = dataset[0]
-            >>> test_mask = graph.edata['test_mask']
-            >>> test_idx = th.nonzero(test_mask, as_tuple=False).squeeze()
-            >>> src, dst = graph.edges(test_idx)
-            >>> rel = graph.edata['etype'][test_idx]
-
     The FB15K dataset was introduced in `Translating Embeddings for Modeling
     Multi-relational Data <http://papers.nips.cc/paper/5071-translating-embeddings-for-modeling-multi-relational-data.pdf>`_.
     It is a subset of Freebase which contains about
@@ -554,12 +475,6 @@ class FB15kDataset(KnowledgeGraphDataset):
         Number of nodes
     num_rels: int
         Number of relation types
-    train: numpy.ndarray
-        A numpy array of triplets (src, rel, dst) for the training graph
-    valid: numpy.ndarray
-        A numpy array of triplets (src, rel, dst) for the validation graph
-    test: numpy.ndarray
-        A numpy array of triplets (src, rel, dst) for the test graph
 
     Examples
     ----------
@@ -627,35 +542,6 @@ class FB15kDataset(KnowledgeGraphDataset):
 class WN18Dataset(KnowledgeGraphDataset):
     r""" WN18 link prediction dataset.
 
-    .. deprecated:: 0.5.0
-
-        - ``train`` is deprecated, it is replaced by:
-
-            >>> dataset = WN18Dataset()
-            >>> graph = dataset[0]
-            >>> train_mask = graph.edata['train_mask']
-            >>> train_idx = th.nonzero(train_mask, as_tuple=False).squeeze()
-            >>> src, dst = graph.edges(train_idx)
-            >>> rel = graph.edata['etype'][train_idx]
-
-        - ``valid`` is deprecated, it is replaced by:
-
-            >>> dataset = WN18Dataset()
-            >>> graph = dataset[0]
-            >>> val_mask = graph.edata['val_mask']
-            >>> val_idx = th.nonzero(val_mask, as_tuple=False).squeeze()
-            >>> src, dst = graph.edges(val_idx)
-            >>> rel = graph.edata['etype'][val_idx]
-
-        - ``test`` is deprecated, it is replaced by:
-
-            >>> dataset = WN18Dataset()
-            >>> graph = dataset[0]
-            >>> test_mask = graph.edata['test_mask']
-            >>> test_idx = th.nonzero(test_mask, as_tuple=False).squeeze()
-            >>> src, dst = graph.edges(test_idx)
-            >>> rel = graph.edata['etype'][test_idx]
-
     The WN18 dataset was introduced in `Translating Embeddings for Modeling
     Multi-relational Data <http://papers.nips.cc/paper/5071-translating-embeddings-for-modeling-multi-relational-data.pdf>`_.
     It included the full 18 relations scraped from
@@ -696,12 +582,6 @@ class WN18Dataset(KnowledgeGraphDataset):
         Number of nodes
     num_rels: int
         Number of relation types
-    train: numpy.ndarray
-        A numpy array of triplets (src, rel, dst) for the training graph
-    valid: numpy.ndarray
-        A numpy array of triplets (src, rel, dst) for the validation graph
-    test: numpy.ndarray
-        A numpy array of triplets (src, rel, dst) for the test graph
 
     Examples
     ----------

--- a/python/dgl/data/reddit.py
+++ b/python/dgl/data/reddit.py
@@ -15,48 +15,6 @@ from ..transforms import reorder_graph
 class RedditDataset(DGLBuiltinDataset):
     r""" Reddit dataset for community detection (node classification)
 
-    .. deprecated:: 0.5.0
-
-        - ``graph`` is deprecated, it is replaced by:
-
-            >>> dataset = RedditDataset()
-            >>> graph = dataset[0]
-
-        - ``num_labels`` is deprecated, it is replaced by:
-
-            >>> dataset = RedditDataset()
-            >>> num_classes = dataset.num_classes
-
-        - ``train_mask`` is deprecated, it is replaced by:
-
-            >>> dataset = RedditDataset()
-            >>> graph = dataset[0]
-            >>> train_mask = graph.ndata['train_mask']
-
-        - ``val_mask`` is deprecated, it is replaced by:
-
-            >>> dataset = RedditDataset()
-            >>> graph = dataset[0]
-            >>> val_mask = graph.ndata['val_mask']
-
-        - ``test_mask`` is deprecated, it is replaced by:
-
-            >>> dataset = RedditDataset()
-            >>> graph = dataset[0]
-            >>> test_mask = graph.ndata['test_mask']
-
-        - ``features`` is deprecated, it is replaced by:
-
-            >>> dataset = RedditDataset()
-            >>> graph = dataset[0]
-            >>> features = graph.ndata['feat']
-
-        - ``labels`` is deprecated, it is replaced by:
-
-            >>> dataset = RedditDataset()
-            >>> graph = dataset[0]
-            >>> labels = graph.ndata['label']
-
     This is a graph dataset from Reddit posts made in the month of September, 2014.
     The node label in this case is the community, or “subreddit”, that a post belongs to.
     The authors sampled 50 large communities and built a post-to-post graph, connecting
@@ -95,20 +53,6 @@ class RedditDataset(DGLBuiltinDataset):
     ----------
     num_classes : int
         Number of classes for each node
-    graph : :class:`dgl.DGLGraph`
-        Graph of the dataset
-    num_labels : int
-        Number of classes for each node
-    train_mask: numpy.ndarray
-        Mask of training nodes
-    val_mask: numpy.ndarray
-        Mask of validation nodes
-    test_mask: numpy.ndarray
-        Mask of test nodes
-    features : Tensor
-        Node features
-    labels :  Tensor
-        Node labels
 
     Examples
     --------
@@ -201,41 +145,6 @@ class RedditDataset(DGLBuiltinDataset):
     def num_classes(self):
         r"""Number of classes for each node."""
         return 41
-
-    @property
-    def num_labels(self):
-        deprecate_property('dataset.num_labels', 'dataset.num_classes')
-        return self.num_classes
-
-    @property
-    def graph(self):
-        deprecate_property('dataset.graph', 'dataset[0]')
-        return self._graph
-
-    @property
-    def train_mask(self):
-        deprecate_property('dataset.train_mask', 'graph.ndata[\'train_mask\']')
-        return F.asnumpy(self._graph.ndata['train_mask'])
-
-    @property
-    def val_mask(self):
-        deprecate_property('dataset.val_mask', 'graph.ndata[\'val_mask\']')
-        return F.asnumpy(self._graph.ndata['val_mask'])
-
-    @property
-    def test_mask(self):
-        deprecate_property('dataset.test_mask', 'graph.ndata[\'test_mask\']')
-        return F.asnumpy(self._graph.ndata['test_mask'])
-
-    @property
-    def features(self):
-        deprecate_property('dataset.features', 'graph.ndata[\'feat\']')
-        return self._graph.ndata['feat']
-
-    @property
-    def labels(self):
-        deprecate_property('dataset.labels', 'graph.ndata[\'label\']')
-        return self._graph.ndata['label']
 
     def __getitem__(self, idx):
         r""" Get graph by index

--- a/python/dgl/data/tree.py
+++ b/python/dgl/data/tree.py
@@ -22,16 +22,6 @@ __all__ = ['SST', 'SSTDataset']
 class SSTDataset(DGLBuiltinDataset):
     r"""Stanford Sentiment Treebank dataset.
 
-    .. deprecated:: 0.5.0
-
-        - ``trees`` is deprecated, it is replaced by:
-
-            >>> dataset = SSTDataset()
-            >>> for tree in dataset:
-            ....    # your code here
-
-        - ``num_vocabs`` is deprecated, it is replaced by ``vocab_size``.
-
     Each sample is the constituency tree of a sentence. The leaf nodes
     represent words. The word is a int value stored in the ``x`` feature field.
     The non-leaf node has a special value ``PAD_WORD`` in the ``x`` field.
@@ -74,15 +64,11 @@ class SSTDataset(DGLBuiltinDataset):
     ----------
     vocab : OrderedDict
         Vocabulary of the dataset
-    trees : list
-        A list of DGLGraph objects
     num_classes : int
         Number of classes for each node
     pretrained_emb: Tensor
         Pretrained glove embedding with respect the vocabulary.
     vocab_size : int
-        The size of the vocabulary
-    num_vocabs : int
         The size of the vocabulary
 
     Notes
@@ -225,11 +211,6 @@ class SSTDataset(DGLBuiltinDataset):
             self._pretrained_emb = load_info(emb_path)['embed']
 
     @property
-    def trees(self):
-        deprecate_property('dataset.trees', '[dataset[i] for i in len(dataset)]')
-        return self._trees
-
-    @property
     def vocab(self):
         r""" Vocabulary
 
@@ -269,11 +250,6 @@ class SSTDataset(DGLBuiltinDataset):
     def __len__(self):
         r"""Number of graphs in the dataset."""
         return len(self._trees)
-
-    @property
-    def num_vocabs(self):
-        deprecate_property('dataset.num_vocabs', 'dataset.vocab_size')
-        return self.vocab_size
 
     @property
     def vocab_size(self):

--- a/tutorials/models/1_gnn/6_line_graph.py
+++ b/tutorials/models/1_gnn/6_line_graph.py
@@ -97,7 +97,7 @@ from dgl.data import citation_graph as citegrh
 data = citegrh.load_cora()
 
 G = data[0]
-labels = th.tensor(data.labels)
+labels = th.tensor(G.ndata['label'])
 
 # find all the nodes labeled with class 0
 label0_nodes = th.nonzero(labels == 0, as_tuple=False).squeeze()

--- a/tutorials/models/1_gnn/9_gat.py
+++ b/tutorials/models/1_gnn/9_gat.py
@@ -303,11 +303,9 @@ import networkx as nx
 
 def load_cora_data():
     data = citegrh.load_cora()
-    features = torch.FloatTensor(data.features)
-    labels = torch.LongTensor(data.labels)
     g = data[0]
     mask = torch.BoolTensor(g.ndata['train_mask'])
-    return g, features, labels, mask
+    return g, g.ndata['feat'], g.ndata['label'], mask
 
 ##############################################################################
 # The training loop is exactly the same as in the GCN tutorial.

--- a/tutorials/models/1_gnn/9_gat.py
+++ b/tutorials/models/1_gnn/9_gat.py
@@ -305,8 +305,8 @@ def load_cora_data():
     data = citegrh.load_cora()
     features = torch.FloatTensor(data.features)
     labels = torch.LongTensor(data.labels)
-    mask = torch.BoolTensor(data.train_mask)
     g = data[0]
+    mask = torch.BoolTensor(g.ndata['train_mask'])
     return g, features, labels, mask
 
 ##############################################################################


### PR DESCRIPTION
## Description

Remove the dataset attributes deprecated in v0.5. I have not updated the deprecated examples that use these deprecated APIs.

## Checklist
Please feel free to remove inapplicable items for your PR.
- [x] The PR title starts with [$CATEGORY] (such as [NN], [Model], [Doc], [Feature]])
- [x] Changes are complete (i.e. I finished coding on this PR)
- [ ] All changes have test coverage
- [ ] Code is well-documented
- [x] To the best of my knowledge, examples are either not affected by this change,
      or have been fixed to be compatible with this change
- [ ] Related issue is referred in this PR
- [ ] If the PR is for a new model/paper, I've updated the example index [here](../examples/README.md).