### PR TITLE
[Bugfix][Hotfix] Fix cugraph Pytorch CI failures 

### DIFF
--- a/tests/cugraph/test_basics.py
+++ b/tests/cugraph/test_basics.py
@@ -1,3 +1,5 @@
+# NOTE(vibwu): Currently cugraph must be imported before torch to avoid a resource cleanup issue.
+#    See https://github.com/rapidsai/cugraph/issues/2718
 import cugraph
 import backend as F
 import dgl

--- a/tests/cugraph/test_basics.py
+++ b/tests/cugraph/test_basics.py
@@ -1,10 +1,11 @@
+import cugraph
 import backend as F
 import dgl
 import numpy as np
 from dgl import DGLGraph
 import unittest
 import pytest
-import cugraph
+
 
 def test_dummy():
     cg = cugraph.Graph()

--- a/tests/scripts/cugraph_unit_test.sh
+++ b/tests/scripts/cugraph_unit_test.sh
@@ -13,6 +13,7 @@ export DGL_LIBRARY_PATH=${PWD}/build
 export PYTHONPATH=tests:${PWD}/python:$PYTHONPATH
 export DGL_DOWNLOAD_DIR=${PWD}
 export TF_FORCE_GPU_ALLOW_GROWTH=true
+
 export CUDA_VISIBLE_DEVICES=0
 
 python3 -m pip install pytest psutil pyyaml pydantic pandas rdflib ogb || fail "pip install"

--- a/tests/scripts/cugraph_unit_test.sh
+++ b/tests/scripts/cugraph_unit_test.sh
@@ -13,9 +13,8 @@ export DGL_LIBRARY_PATH=${PWD}/build
 export PYTHONPATH=tests:${PWD}/python:$PYTHONPATH
 export DGL_DOWNLOAD_DIR=${PWD}
 export TF_FORCE_GPU_ALLOW_GROWTH=true
-
 export CUDA_VISIBLE_DEVICES=0
 
 python3 -m pip install pytest psutil pyyaml pydantic pandas rdflib ogb || fail "pip install"
 
-python3 -m pytest -v --junitxml=pytest_cugraph.xml --durations=20 tests/cugraph || fail "cugraph"
+python3 -m pytest -v --junitxml=pytest_cugraph.xml --durations=20 tests/cugraph

--- a/tests/scripts/cugraph_unit_test.sh
+++ b/tests/scripts/cugraph_unit_test.sh
@@ -17,4 +17,4 @@ export CUDA_VISIBLE_DEVICES=0
 
 python3 -m pip install pytest psutil pyyaml pydantic pandas rdflib ogb || fail "pip install"
 
-python3 -m pytest -v --junitxml=pytest_cugraph.xml --durations=20 tests/cugraph
+python3 -m pytest -v --junitxml=pytest_cugraph.xml --durations=20 tests/cugraph || fail "cugraph"


### PR DESCRIPTION
## Description

What i think is happening is that after the Pytests are passed (see [logs](https://github.com/dmlc/dgl/issues/4324#issuecomment-1255212794) and all other logs (https://github.com/dmlc/dgl/pull/4597, https://github.com/dmlc/dgl/pull/4534)  during cleanup there seems to be an segfault occuring. 

On attaching GDB it seems to be stemming from libcugraph.so .

```
Thread 1 "python3.9" received signal SIGSEGV, Segmentation fault.
0x00007fe6d91b42fc in std::_Hashtable<std::thread::id, std::pair<std::thread::id const, std::weak_ptr<raft::interruptible> >, std::allocator<std::pair<std::thread::id const, std::weak_ptr<raft::interruptible> > >, std::__detail::_Select1st, std::equal_to<std::thread::id>, std::hash<std::thread::id>, std::__detail::_Mod_range_hashing, std::__detail::_Default_ranged_hash, std::__detail::_Prime_rehash_policy, std::__detail::_Hashtable_traits<false, false, true> >::find(std::thread::id const&) () from /opt/conda/lib/python3.9/site-packages/cugraph/community/../../../../libcugraph.so
```
The current guess is that this is happening because of some interaction on context cleanup b/w pytorch and cugraph. 

If we flip the import order around, I cant seem to repro the error locally or on the CI so far. I have run with this fix about 60 times locally now and see no errors.

For reproducing locally you can follow the instructions in this [gist](https://gist.github.com/VibhuJawa/e3ce253d55fba0072f70b154be18de5b).

## Checklist
Please feel free to remove inapplicable items for your PR.
- [ ] The PR title starts with [$CATEGORY] (such as [NN], [Model], [Doc], [Feature]])
- [ ] Changes are complete (i.e. I finished coding on this PR)
- [ ] All changes have test coverage
- [ ] Code is well-documented
- [ ] To the best of my knowledge, examples are either not affected by this change,
      or have been fixed to be compatible with this change
- [ ] Related issue is referred in this PR
- [ ] If the PR is for a new model/paper, I've updated the example index [here](../examples/README.md).

## Changes
<!-- You could use following template
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)
-->


Long Term Fix will be in  most probably in cugraph: https://github.com/rapidsai/cugraph/issues/2718