### PR TITLE
[Subgraph] State in docstring that nodes cannot have any duplicate value when inducing a subgraph.

### DIFF
--- a/python/dgl/subgraph.py
+++ b/python/dgl/subgraph.py
@@ -34,7 +34,8 @@ def node_subgraph(graph, nodes, *, relabel_nodes=True, store_ids=True, output_de
     graph : DGLGraph
         The graph to extract subgraphs from.
     nodes : nodes or dict[str, nodes]
-        The nodes to form the subgraph. The allowed nodes formats are:
+        The nodes to form the subgraph, which cannot have any duplicate value. The result
+        will be undefined otherwise. The allowed nodes formats are:
 
         * Int Tensor: Each element is a node ID. The tensor must have the same device type
           and ID data type as the graph's.
@@ -333,7 +334,8 @@ def in_subgraph(graph, nodes, *, relabel_nodes=False, store_ids=True, output_dev
     graph : DGLGraph
         The input graph.
     nodes : nodes or dict[str, nodes]
-        The nodes to form the subgraph. The allowed nodes formats are:
+        The nodes to form the subgraph, which cannot have any duplicate value. The result
+        will be undefined otherwise. The allowed nodes formats are:
 
         * Int Tensor: Each element is a node ID. The tensor must have the same device type
           and ID data type as the graph's.
@@ -460,7 +462,8 @@ def out_subgraph(graph, nodes, *, relabel_nodes=False, store_ids=True, output_de
     graph : DGLGraph
         The input graph.
     nodes : nodes or dict[str, nodes]
-        The nodes to form the subgraph. The allowed nodes formats are:
+        The nodes to form the subgraph, which cannot have any duplicate value. The result
+        will be undefined otherwise. The allowed nodes formats are:
 
         * Int Tensor: Each element is a node ID. The tensor must have the same device type
           and ID data type as the graph's.
@@ -588,7 +591,8 @@ def khop_in_subgraph(graph, nodes, k, *, relabel_nodes=True, store_ids=True, out
     graph : DGLGraph
         The input graph.
     nodes : nodes or dict[str, nodes]
-        The starting node(s) to expand. The allowed formats are:
+        The starting node(s) to expand, which cannot have any duplicate value. The result
+        will be undefined otherwise. The allowed formats are:
 
         * Int: ID of a single node.
         * Int Tensor: Each element is a node ID. The tensor must have the same device
@@ -749,7 +753,8 @@ def khop_out_subgraph(graph, nodes, k, *, relabel_nodes=True, store_ids=True, ou
     graph : DGLGraph
         The input graph.
     nodes : nodes or dict[str, nodes]
-        The starting node(s) to expand. The allowed formats are:
+        The starting node(s) to expand, which cannot have any duplicate value. The result
+        will be undefined otherwise. The allowed formats are:
 
         * Int: ID of a single node.
         * Int Tensor: Each element is a node ID. The tensor must have the same device


### PR DESCRIPTION


## Description
Resolve #4109 

## Checklist
Please feel free to remove inapplicable items for your PR.
- [x] The PR title starts with [$CATEGORY] (such as [NN], [Model], [Doc], [Feature]])
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage
- [x] Code is well-documented
- [x] To the best of my knowledge, examples are either not affected by this change,
      or have been fixed to be compatible with this change
- [x] Related issue is referred in this PR
## Changes
<!-- You could use following template
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)
-->
