### PR TITLE
Address the edge feature support test case correctness.

### DIFF
--- a/tests/tools/test_dist_part.py
+++ b/tests/tools/test_dist_part.py
@@ -12,6 +12,7 @@ from dgl.data.utils import load_graphs, load_tensors
 
 from create_chunked_dataset import create_chunked_dataset
 
+
 @pytest.mark.parametrize("num_chunks", [1, 8])
 def test_chunk_graph(num_chunks):
 
@@ -260,12 +261,14 @@ def test_part_pipeline(num_chunks, num_parts):
                 tensor_dict = load_tensors(fname)
 
                 all_tensors = [
-                        'author:writes:paper/year',
-                        'paper:cites:paper/count',
-                        'paper:rev_writes:author/year',
+                    'author:writes:paper/year',
+                    'paper:cites:paper/count',
+                    'paper:rev_writes:author/year',
                 ]
 
-                assert tensor_dict.keys() == set([x.split(":")[1] for x in all_tensors])
+                assert tensor_dict.keys() == set(
+                    [x.split(":")[1] for x in all_tensors]
+                )
                 for key in all_tensors:
                     tokens = key.split(":")
                     assert isinstance(tensor_dict[tokens[1]], torch.Tensor)
@@ -277,6 +280,8 @@ def test_part_pipeline(num_chunks, num_parts):
                     assert len(tokens) == 3
 
                     part_data = tensor_dict[tokens[1]]
-                    gold_data = edge_data_gold[can_etype_feat][orig_eids[tokens[1]].numpy()]
+                    gold_data = edge_data_gold[can_etype_feat][
+                        orig_eids[tokens[1]].numpy()
+                    ]
 
                     assert np.all(gold_data == part_data.numpy())


### PR DESCRIPTION
After merging several times with the master branch and code restructuring (part of addressing ci comments) the original logic to test edge feature data was mis-placed and as a result the test case was rendered incorrect.

Now corrected the test_dist_part.py to correctly test the edge feature support. This depends on the save_orig_id feature which is needed to check the edge data from both the original graph as well as the partitioned graph.


## Description
<!-- Brief description. Refer to the related issues if existed.
It'll be great if relevant reviewers can be assigned as well.-->

## Checklist
Please feel free to remove inapplicable items for your PR.
- [ ] The PR title starts with [$CATEGORY] (such as [NN], [Model], [Doc], [Feature]])
- [X] Changes are complete (i.e. I finished coding on this PR)
- [X] All changes have test coverage
- [X] Code is well-documented
- [X] To the best of my knowledge, examples are either not affected by this change,
      or have been fixed to be compatible with this change
- [ ] Related issue is referred in this PR
- [ ] If the PR is for a new model/paper, I've updated the example index [here](../examples/README.md).

## Changes
<!-- You could use following template
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)
-->
