### PR TITLE
[Doc] Fix the doc for the partition_graph function

### DIFF
--- a/python/dgl/distributed/partition.py
+++ b/python/dgl/distributed/partition.py
@@ -569,8 +569,9 @@ def partition_graph(g, graph_name, num_parts, out_path, num_hops=1, part_method=
     ...                                 out_path='output/', reshuffle=True,
     ...                                 balance_ntypes=g.ndata['train_mask'],
     ...                                 balance_edges=True)
-    >>> g, node_feats, edge_feats, gpb, graph_name, ntypes_list, etypes_list =
-    ...     dgl.distributed.load_partition('output/test.json', 0)
+    >>> (
+    ...     g, node_feats, edge_feats, gpb, graph_name, ntypes_list, etypes_list,
+    ... ) = dgl.distributed.load_partition('output/test.json', 0)
     '''
     def get_homogeneous(g, balance_ntypes):
         if g.is_homogeneous:

--- a/python/dgl/distributed/partition.py
+++ b/python/dgl/distributed/partition.py
@@ -532,7 +532,7 @@ def partition_graph(g, graph_name, num_parts, out_path, num_hops=1, part_method=
     ...                                 out_path='output/', reshuffle=True,
     ...                                 balance_ntypes=g.ndata['train_mask'],
     ...                                 balance_edges=True)
-    >>> g, node_feats, edge_feats, gpb, graph_name = dgl.distributed.load_partition(
+    >>> g, node_feats, edge_feats, gpb, graph_name, ntypes_list, etypes_list = dgl.distributed.load_partition(
     ...                                 'output/test.json', 0)
     '''
     def get_homogeneous(g, balance_ntypes):

--- a/python/dgl/distributed/partition.py
+++ b/python/dgl/distributed/partition.py
@@ -569,8 +569,8 @@ def partition_graph(g, graph_name, num_parts, out_path, num_hops=1, part_method=
     ...                                 out_path='output/', reshuffle=True,
     ...                                 balance_ntypes=g.ndata['train_mask'],
     ...                                 balance_edges=True)
-    >>> g, node_feats, edge_feats, gpb, graph_name, ntypes_list, etypes_list = dgl.distributed.load_partition(
-    ...                                 'output/test.json', 0)
+    >>> g, node_feats, edge_feats, gpb, graph_name, ntypes_list, etypes_list =
+    ...     dgl.distributed.load_partition('output/test.json', 0)
     '''
     def get_homogeneous(g, balance_ntypes):
         if g.is_homogeneous:


### PR DESCRIPTION
## Description
<!-- The example in the partition_graph omits two return parameters (ntypes_list and etypes_list) for the load_partition function 
-->

## Checklist
Please feel free to remove inapplicable items for your PR.
- [x] The PR title starts with [$CATEGORY] (such as [NN], [Model], [Doc], [Feature]])
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage
- [x] Code is well-documented
- [x] To the best of my knowledge, examples are either not affected by this change,
      or have been fixed to be compatible with this change
- [ ] Related issue is referred in this PR
- [ ] If the PR is for a new model/paper, I've updated the example index [here](../examples/README.md).

## Changes

