### PR TITLE
[Transform] Fix graph structure corruption with transform

### DIFF
--- a/python/dgl/transforms/module.py
+++ b/python/dgl/transforms/module.py
@@ -1441,11 +1441,12 @@ class DropNode(BaseTransform):
         self.dist = Bernoulli(p)
 
     def __call__(self, g):
+        g = g.clone()
+
         # Fast path
         if self.p == 0:
             return g
 
-        g = g.clone()
         for ntype in g.ntypes:
             samples = self.dist.sample(torch.Size([g.num_nodes(ntype)]))
             nids_to_remove = g.nodes(ntype)[samples.bool().to(g.device)]
@@ -1487,11 +1488,12 @@ class DropEdge(BaseTransform):
         self.dist = Bernoulli(p)
 
     def __call__(self, g):
+        g = g.clone()
+
         # Fast path
         if self.p == 0:
             return g
 
-        g = g.clone()
         for c_etype in g.canonical_etypes:
             samples = self.dist.sample(torch.Size([g.num_edges(c_etype)]))
             eids_to_remove = g.edges(form='eid', etype=c_etype)[samples.bool().to(g.device)]

--- a/python/dgl/transforms/module.py
+++ b/python/dgl/transforms/module.py
@@ -1397,6 +1397,7 @@ class NodeShuffle(BaseTransform):
             [ 7.,  8.]])
     """
     def __call__(self, g):
+        g = g.clone()
         for ntype in g.ntypes:
             nids = F.astype(g.nodes(ntype), F.int64)
             perm = F.rand_shuffle(nids)
@@ -1444,6 +1445,7 @@ class DropNode(BaseTransform):
         if self.p == 0:
             return g
 
+        g = g.clone()
         for ntype in g.ntypes:
             samples = self.dist.sample(torch.Size([g.num_nodes(ntype)]))
             nids_to_remove = g.nodes(ntype)[samples.bool().to(g.device)]
@@ -1489,6 +1491,7 @@ class DropEdge(BaseTransform):
         if self.p == 0:
             return g
 
+        g = g.clone()
         for c_etype in g.canonical_etypes:
             samples = self.dist.sample(torch.Size([g.num_edges(c_etype)]))
             eids_to_remove = g.edges(form='eid', etype=c_etype)[samples.bool().to(g.device)]
@@ -1526,6 +1529,7 @@ class AddEdge(BaseTransform):
 
         device = g.device
         idtype = g.idtype
+        g = g.clone()
         for c_etype in g.canonical_etypes:
             utype, _, vtype = c_etype
             num_edges_to_add = int(g.num_edges(c_etype) * self.ratio)

--- a/tests/compute/test_transform.py
+++ b/tests/compute/test_transform.py
@@ -2381,11 +2381,18 @@ def test_module_gdc(idtype):
 
 @parametrize_idtype
 def test_module_node_shuffle(idtype):
+    import torch
+
+    dev = F.ctx()
     transform = dgl.NodeShuffle()
     g = dgl.heterograph({
         ('A', 'r', 'B'): ([0, 1], [1, 2]),
-    }, idtype=idtype, device=F.ctx())
+    }, idtype=idtype, device=dev)
+    g.nodes['A'].data['h'] = torch.randn(g.num_nodes('A'), 2).to(dev)
+    old_nfeat = g.nodes['A'].data['h']
     new_g = transform(g)
+    new_nfeat = g.nodes['A'].data['h']
+    assert torch.allclose(old_nfeat, new_nfeat)
 
 @unittest.skipIf(dgl.backend.backend_name != 'pytorch', reason='Only support PyTorch for now')
 @parametrize_idtype

--- a/tests/compute/test_transform.py
+++ b/tests/compute/test_transform.py
@@ -2394,11 +2394,15 @@ def test_module_drop_node(idtype):
     g = dgl.heterograph({
         ('A', 'r', 'B'): ([0, 1], [1, 2]),
     }, idtype=idtype, device=F.ctx())
+    num_nodes_old = g.num_nodes()
     new_g = transform(g)
     assert new_g.idtype == g.idtype
     assert new_g.device == g.device
     assert new_g.ntypes == g.ntypes
     assert new_g.canonical_etypes == g.canonical_etypes
+    num_nodes_new = g.num_nodes()
+    # Ensure that the original graph is not corrupted
+    assert num_nodes_old == num_nodes_new
 
 @unittest.skipIf(dgl.backend.backend_name != 'pytorch', reason='Only support PyTorch for now')
 @parametrize_idtype
@@ -2408,11 +2412,15 @@ def test_module_drop_edge(idtype):
         ('A', 'r1', 'B'): ([0, 1], [1, 2]),
         ('C', 'r2', 'C'): ([3, 4, 5], [6, 7, 8])
     }, idtype=idtype, device=F.ctx())
+    num_edges_old = g.num_edges()
     new_g = transform(g)
     assert new_g.idtype == g.idtype
     assert new_g.device == g.device
     assert new_g.ntypes == g.ntypes
     assert new_g.canonical_etypes == g.canonical_etypes
+    num_edges_new = g.num_edges()
+    # Ensure that the original graph is not corrupted
+    assert num_edges_old == num_edges_new
 
 @parametrize_idtype
 def test_module_add_edge(idtype):
@@ -2421,6 +2429,7 @@ def test_module_add_edge(idtype):
         ('A', 'r1', 'B'): ([0, 1, 2, 3, 4], [1, 2, 3, 4, 5]),
         ('C', 'r2', 'C'): ([0, 1, 2, 3, 4], [1, 2, 3, 4, 5])
     }, idtype=idtype, device=F.ctx())
+    num_edges_old = g.num_edges()
     new_g = transform(g)
     assert new_g.num_edges(('A', 'r1', 'B')) == 6
     assert new_g.num_edges(('C', 'r2', 'C')) == 6
@@ -2428,6 +2437,9 @@ def test_module_add_edge(idtype):
     assert new_g.device == g.device
     assert new_g.ntypes == g.ntypes
     assert new_g.canonical_etypes == g.canonical_etypes
+    num_edges_new = g.num_edges()
+    # Ensure that the original graph is not corrupted
+    assert num_edges_old == num_edges_new
 
 @parametrize_idtype
 def test_module_random_walk_pe(idtype):
@@ -2483,7 +2495,7 @@ def test_module_laplacian_pe(idtype):
 @pytest.mark.parametrize('g', get_cases(['has_scalar_e_feature']))
 def test_module_sign(g):
     import torch
-    
+
     atol = 1e-06
 
     ctx = F.ctx()


### PR DESCRIPTION
## Description
As pointed out in #4495 , a graph transform should not corrupt the original graph structure.

## Checklist
Please feel free to remove inapplicable items for your PR.
- [x] The PR title starts with [$CATEGORY] (such as [NN], [Model], [Doc], [Feature]])
- [ ] I've leverage the [tools](https://docs.google.com/document/d/1iHyj7zlmygKSk5gBPsqIqL5ASPzJSPREaNT_QdsiYA4/edit) to beautify the python and c++ code.
- [x] The PR is complete and small, read the [Google eng practice (CL equals to PR)](https://google.github.io/eng-practices/review/developer/small-cls.html) to understand more about small PR. In DGL, we consider PRs with less than 200 lines of core code change are small (example, test and documentation could be exempted).
- [x] All changes have test coverage
- [ ] Code is well-documented
- [x] To the best of my knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change
- [x] Related issue is referred in this PR
- [ ] If the PR is for a new model/paper, I've updated the example index [here](../examples/README.md).