### PR TITLE
ParMETIS preprocessing is failing in a multi-node cluster because of the incorrect rank of the process

### DIFF
--- a/tools/distpartitioning/parmetis_preprocess.py
+++ b/tools/distpartitioning/parmetis_preprocess.py
@@ -26,17 +26,18 @@ def get_proc_info():
     MPI_WORLDSIZE appropriately as described above to retrieve total no. of
     processes, when needed.
 
+    MPI_LOCALRANKID is only valid on a single-node cluster. In a multi-node cluster
+    the correct key to use is PMI_RANK. In a multi-node cluster, MPI_LOCALRANKID
+    returns local rank of the process in the context of a particular node in which
+    it is unique.
+
     Returns:
     --------
     integer :
         Rank of the current process.
     """
     env_variables = dict(os.environ)
-    if "OMPI_COMM_WORLD_RANK" in env_variables:
-        local_rank = int(os.environ.get("OMPI_COMM_WORLD_RANK") or 0)
-    elif "MPI_LOCALRANKID" in env_variables:
-        local_rank = int(os.environ.get("MPI_LOCALRANKID") or 0)
-    return local_rank
+    return int(os.environ.get("PMI_RANK") or 0)
 
 
 def gen_edge_files(schema_map, output):


### PR DESCRIPTION
## Description
<!-- Brief description. Refer to the related issues if existed.
It'll be great if relevant reviewers can be assigned as well.-->

The rank of the process was incorrect in a multi-node setting. Now updated the key to use from the environment
dictionary to retrieve the rank of the process correctly.

## Checklist
Please feel free to remove inapplicable items for your PR.
- [X] The PR title starts with [$CATEGORY] (such as [NN], [Model], [Doc], [Feature]])
- [X] I've leverage the [tools](https://docs.google.com/document/d/1iHyj7zlmygKSk5gBPsqIqL5ASPzJSPREaNT_QdsiYA4/edit) to beautify the python and c++ code.
- [X] The PR is complete and small, read the [Google eng practice (CL equals to PR)](https://google.github.io/eng-practices/review/developer/small-cls.html) to understand more about small PR. In DGL, we consider PRs with less than 200 lines of core code change are small (example, test and documentation could be exempted).
- [X] All changes have test coverage
- [X] Code is well-documented
- [X] To the best of my knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change
- [ ] Related issue is referred in this PR
- [ ] If the PR is for a new model/paper, I've updated the example index [here](../examples/README.md).

## Changes
<!-- You could use following template
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)
-->
