### PR TITLE
Update to cugraph 22.12 nightly image

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -298,7 +298,7 @@ pipeline {
               agent {
                 docker {
                   label "linux-cpu-node"
-                  image "rapidsai/cugraph_nightly_torch-cuda:11.5-base-ubuntu18.04-py3.9-pytorch1.12.0-rapids22.10"
+                  image "rapidsai/cugraph_nightly_torch-cuda:11.5-base-ubuntu18.04-py3.9-pytorch1.12.0-rapids22.12"
                   args "-u root"
                   alwaysPull true
                 }
@@ -525,7 +525,7 @@ pipeline {
               agent {
                 docker {
                   label "linux-gpu-node"
-                  image "rapidsai/cugraph_nightly_torch-cuda:11.5-base-ubuntu18.04-py3.9-pytorch1.12.0-rapids22.10"
+                  image "rapidsai/cugraph_nightly_torch-cuda:11.5-base-ubuntu18.04-py3.9-pytorch1.12.0-rapids22.12"
                   args "--runtime nvidia --shm-size=8gb"
                   alwaysPull true
                 }


### PR DESCRIPTION
## Description

Updating to cugraph 22.12 nightly image to allow us to unlock  https://github.com/dmlc/dgl/pull/4743 and https://github.com/dmlc/dgl/pull/4701 . 

@tingyu66  and I have tested that it passes cugraph tests locally by following :

#### DockerFile to build
```DockerFile
FROM rapidsai/cugraph_nightly_torch-cuda:11.5-base-ubuntu18.04-py3.9-pytorch1.12.0-rapids22.12
RUN cd / && git clone https://github.com/dmlc/dgl.git 
RUN cd / && cd dgl && git submodule update --init --recursive 
RUN cd /dgl && git fetch origin pull/4743/head:b_4737 && git checkout b_4737
RUN cd /dgl && bash tests/scripts/build_dgl.sh cugraph
```

#### Command used to test:
```python3
cd /dgl && bash tests/scripts/cugraph_unit_test.sh cugraph
```