### PR TITLE
[Doc] Fix typo distributed-preprocessing.rst

### DIFF
--- a/docs/source/guide/distributed-preprocessing.rst
+++ b/docs/source/guide/distributed-preprocessing.rst
@@ -183,7 +183,7 @@ and chunk sizes (e.g., number of nodes, number of edges).
                  "format" : {"name": "csv", "delimiter": " "},
                  "data" : ["edges/affiliated_with-part1.csv", "edges/affiliated_with-part2.csv"]
             },
-            "author:affiliated_with:institution" : {
+            "paper:cites:paper" : {
                  "format" : {"name": "csv", "delimiter": " "},
                  "data" : ["edges/cites-part1.csv", "edges/cites-part2.csv"]
             }

--- a/docs/source/guide/distributed-preprocessing.rst
+++ b/docs/source/guide/distributed-preprocessing.rst
@@ -174,7 +174,7 @@ and chunk sizes (e.g., number of nodes, number of edges).
            [648874463, 648874463]     # number of paper:cites:paper edges per chunk
        ],
        "edges" : {
-            "author:write:paper" : {  # edge type
+            "author:writes:paper" : {  # edge type
                  "format" : {"name": "csv", "delimiter": " "},
                  # The list of paths. Can be relative or absolute.
                  "data" : ["edges/writes-part1.csv", "edges/writes-part2.csv"]


### PR DESCRIPTION
This seems a copy paste type for the paper:cites:paper edge type.
