### PR TITLE
[Bugfix] Fix that UVA cannot work on old GPUs

### DIFF
--- a/src/array/cuda/array_index_select.cu
+++ b/src/array/cuda/array_index_select.cu
@@ -18,7 +18,7 @@ template <DGLDeviceType XPU, typename DType, typename IdType>
 NDArray IndexSelect(NDArray array, IdArray index) {
   cudaStream_t stream = runtime::getCurrentCUDAStream();
   const DType* array_data = array.Ptr<DType>();
-  if (array->ctx.device_type == kDGLCPU) {
+  if (array.IsPinned()) {
     CUDA_CALL(cudaHostGetDevicePointer(&array_data, array.Ptr<DType>(), 0));
   }
   const IdType* idx_data = static_cast<IdType*>(index->data);

--- a/src/array/cuda/array_index_select.cu
+++ b/src/array/cuda/array_index_select.cu
@@ -17,7 +17,10 @@ namespace impl {
 template <DGLDeviceType XPU, typename DType, typename IdType>
 NDArray IndexSelect(NDArray array, IdArray index) {
   cudaStream_t stream = runtime::getCurrentCUDAStream();
-  const DType* array_data = static_cast<DType*>(array->data);
+  const DType* array_data = array.Ptr<DType>();
+  if (array->ctx.device_type == kDGLCPU) {
+    CUDA_CALL(cudaHostGetDevicePointer(&array_data, array.Ptr<DType>(), 0));
+  }
   const IdType* idx_data = static_cast<IdType*>(index->data);
   const int64_t arr_len = array->shape[0];
   const int64_t len = index->shape[0];

--- a/src/array/cuda/rowwise_sampling.cu
+++ b/src/array/cuda/rowwise_sampling.cu
@@ -253,14 +253,23 @@ COOMatrix _CSRRowWiseSamplingUniform(
   IdArray picked_row = NewIdArray(num_rows * num_picks, ctx, sizeof(IdType) * 8);
   IdArray picked_col = NewIdArray(num_rows * num_picks, ctx, sizeof(IdType) * 8);
   IdArray picked_idx = NewIdArray(num_rows * num_picks, ctx, sizeof(IdType) * 8);
-  const IdType * const in_ptr = static_cast<const IdType*>(mat.indptr->data);
-  const IdType * const in_cols = static_cast<const IdType*>(mat.indices->data);
   IdType* const out_rows = static_cast<IdType*>(picked_row->data);
   IdType* const out_cols = static_cast<IdType*>(picked_col->data);
   IdType* const out_idxs = static_cast<IdType*>(picked_idx->data);
 
-  const IdType* const data = CSRHasData(mat) ?
-      static_cast<IdType*>(mat.data->data) : nullptr;
+  const IdType* in_ptr = mat.indptr.Ptr<IdType>();
+  const IdType* in_cols = mat.indices.Ptr<IdType>();
+  const IdType* data = CSRHasData(mat) ? mat.data.Ptr<IdType>() : nullptr;
+  if (mat.is_pinned) {
+    CUDA_CALL(cudaHostGetDevicePointer(
+        &in_ptr, mat.indptr.Ptr<IdType>(), 0));
+    CUDA_CALL(cudaHostGetDevicePointer(
+        &in_cols, mat.indices.Ptr<IdType>(), 0));
+    if (CSRHasData(mat)) {
+      CUDA_CALL(cudaHostGetDevicePointer(
+          &data, mat.data.Ptr<IdType>(), 0));
+    }
+  }
 
   // compute degree
   IdType * out_deg = static_cast<IdType*>(

--- a/src/array/cuda/uvm/array_index_select_uvm.cu
+++ b/src/array/cuda/uvm/array_index_select_uvm.cu
@@ -17,7 +17,6 @@ namespace impl {
 template<typename DType, typename IdType>
 NDArray IndexSelectCPUFromGPU(NDArray array, IdArray index) {
   cudaStream_t stream = runtime::getCurrentCUDAStream();
-  const DType* array_data = static_cast<DType*>(array->data);
   const IdType* idx_data = static_cast<IdType*>(index->data);
   const int64_t arr_len = array->shape[0];
   const int64_t len = index->shape[0];
@@ -25,6 +24,8 @@ NDArray IndexSelectCPUFromGPU(NDArray array, IdArray index) {
   std::vector<int64_t> shape{len};
 
   CHECK(array.IsPinned());
+  const DType* array_data = nullptr;
+  CUDA_CALL(cudaHostGetDevicePointer(&array_data, array.Ptr<DType>(), 0));
   CHECK_EQ(index->ctx.device_type, kDGLCUDA);
 
   for (int d = 1; d < array->ndim; ++d) {
@@ -76,7 +77,6 @@ template NDArray IndexSelectCPUFromGPU<int64_t, int64_t>(NDArray, IdArray);
 template<typename DType, typename IdType>
 void IndexScatterGPUToCPU(NDArray dest, IdArray index, NDArray source) {
   cudaStream_t stream = runtime::getCurrentCUDAStream();
-  DType* dest_data = static_cast<DType*>(dest->data);
   const DType* source_data = static_cast<DType*>(source->data);
   const IdType* idx_data = static_cast<IdType*>(index->data);
   const int64_t arr_len = dest->shape[0];
@@ -85,6 +85,8 @@ void IndexScatterGPUToCPU(NDArray dest, IdArray index, NDArray source) {
   std::vector<int64_t> shape{len};
 
   CHECK(dest.IsPinned());
+  DType* dest_data = nullptr;
+  CUDA_CALL(cudaHostGetDevicePointer(&dest_data, dest.Ptr<DType>(), 0));
   CHECK_EQ(index->ctx.device_type, kDGLCUDA);
   CHECK_EQ(source->ctx.device_type, kDGLCUDA);
 


### PR DESCRIPTION
## Description

Resolves #4726.

The device attribute `cudaDevAttrCanUseHostPointerForRegisteredMem` of K80 is 0, so we cannot access the host pointer directly from the device even with UVA. We should get the corresponding device pointer via `cudaHostGetDevicePointer`.

For devices whose `cudaDevAttrCanUseHostPointerForRegisteredMem` is 1, the device pointer returned by `cudaHostGetDevicePointer` will match the original host pointer.

## Checklist
Please feel free to remove inapplicable items for your PR.
- [x] The PR title starts with [$CATEGORY] (such as [NN], [Model], [Doc], [Feature]])
- [x] I've leverage the [tools](https://docs.google.com/document/d/1iHyj7zlmygKSk5gBPsqIqL5ASPzJSPREaNT_QdsiYA4/edit) to beautify the python and c++ code.
- [x] The PR is complete and small, read the [Google eng practice (CL equals to PR)](https://google.github.io/eng-practices/review/developer/small-cls.html) to understand more about small PR. In DGL, we consider PRs with less than 200 lines of core code change are small (example, test and documentation could be exempted).
- [x] All changes have test coverage
- [x] Code is well-documented
- [x] To the best of my knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change
- [x] Related issue is referred in this PR

## Changes
1. All functions with the `ATEN_CSR_SWITCH_CUDA_UVA` dispatcher
2. `IndexSelect()`
3. `IndexSelectCPUFromGPU()` and `IndexScatterGPUToCPU()`