### PR TITLE
[Dist] alltoall gloo wrapper primitive returns None values in the output list of tensors which fails the torch.cat function 

### DIFF
--- a/tools/branch.info
+++ b/tools/branch.info
@@ -1,1 +1,0 @@
-flexpipeline

--- a/tools/branch.info
+++ b/tools/branch.info
@@ -1,0 +1,1 @@
+flexpipeline

--- a/tools/distpartitioning/gloo_wrapper.py
+++ b/tools/distpartitioning/gloo_wrapper.py
@@ -133,9 +133,7 @@ def alltoallv_cpu(rank, world_size, input_tensor_list):
     #extract un-padded message from the output_tensor_list and return it
     return_vals = []
     for s, t in zip(recv_counts, output_tensor_list):
-        if s[0] == 0:
-            return_vals.append(None)
-        else:
+        if s[0] != 0:
             return_vals.append(t[0:s[0]])
     return return_vals
 


### PR DESCRIPTION
## Description
<!-- Brief description. Refer to the related issues if existed.
It'll be great if relevant reviewers can be assigned as well.-->

In an all to all message, if the return value (tensor) from a node is empty tensor then None was returned to the function caller which is causing the torch.cat() to fail. Apparently torch concatenate function cannot handle None values in the input list of tensors. 

Now, with the fix, if the return'ed tensors are 0-sized tensors (please note that here we perform padding, so we need to remove padding and compare the sizes appropriately) then it instead of returning None, it does include None in the list of tensors to the invoking function.

## Checklist
Please feel free to remove inapplicable items for your PR.
- [X] The PR title starts with [$CATEGORY] (such as [NN], [Model], [Doc], [Feature]])
- [X] I've leverage the [tools](https://docs.google.com/document/d/1iHyj7zlmygKSk5gBPsqIqL5ASPzJSPREaNT_QdsiYA4/edit) to beautify the python and c++ code.
- [X] The PR is complete and small, read the [Google eng practice (CL equals to PR)](https://google.github.io/eng-practices/review/developer/small-cls.html) to understand more about small PR. In DGL, we consider PRs with less than 200 lines of core code change are small (example, test and documentation could be exempted).
- [X] All changes have test coverage
- [X] Code is well-documented
- [X] To the best of my knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change
- [ ] Related issue is referred in this PR
- [ ] If the PR is for a new model/paper, I've updated the example index [here](../examples/README.md).

## Changes
<!-- You could use following template
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)
-->
