### PR TITLE
[Dist] alltoall gloo wrapper primitive returns None values in the output list of tensors which fails the torch.cat function

### DIFF
--- a/tools/distpartitioning/dist_lookup.py
+++ b/tools/distpartitioning/dist_lookup.py
@@ -296,6 +296,9 @@ class DistLookupService:
 
         # Send the shuffle-global-nids to their respective ranks.
         mapped_global_nids = alltoallv_cpu(self.rank, self.world_size, shuffle_nids_list)
+        for idx in range(len(mapped_global_nids)):
+            if mapped_global_nids[idx] == None:
+                mapped_global_nids[idx] = torch.empty((0,), dtype=torch.int64)
 
         # Reorder to match global_nids (function parameter).
         global_nids_order = np.concatenate(id_list)


### PR DESCRIPTION

## Description
<!-- Brief description. Refer to the related issues if existed.
It'll be great if relevant reviewers can be assigned as well.-->

In an all to all message, if the return value (tensor) from a node is empty tensor then None was returned to the function caller which is causing the torch.cat() to fail. Apparently torch concatenate function cannot handle None values in the input list of tensors.

Now, with the fix, if the return'ed tensors are 0-sized tensors (please note that here we perform padding, so we need to remove padding and compare the sizes appropriately) then it instead of returning None, it does include None in the list of tensors to the invoking function.

## Checklist
Please feel free to remove inapplicable items for your PR.
- [X] The PR title starts with [$CATEGORY] (such as [NN], [Model], [Doc], [Feature]])
- [X] I've leverage the [tools](https://docs.google.com/document/d/1iHyj7zlmygKSk5gBPsqIqL5ASPzJSPREaNT_QdsiYA4/edit) to beautify the python and c++ code.
- [X] The PR is complete and small, read the [Google eng practice (CL equals to PR)](https://google.github.io/eng-practices/review/developer/small-cls.html) to understand more about small PR. In DGL, we consider PRs with less than 200 lines of core code change are small (example, test and documentation could be exempted).
- [X] All changes have test coverage
- [X] Code is well-documented
- [X] To the best of my knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change
- [ ] Related issue is referred in this PR
- [ ] If the PR is for a new model/paper, I've updated the example index [here](../examples/README.md).

## Changes
<!-- You could use following template
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)
-->
