### PR TITLE
[DIST] Message size to retrieve SHUFFLE_GLOBAL_NIDs is resulting in very large messages and resulting in killed process

### DIFF
--- a/tools/distpartitioning/globalids.py
+++ b/tools/distpartitioning/globalids.py
@@ -98,10 +98,7 @@ def lookup_shuffle_global_nids_edges(rank, world_size, edge_data, id_lookup, nod
     # Determine the no. of times each process has to send alltoall messages.
     all_sizes = allgather_sizes([node_list.shape[0]], world_size, return_sizes=True)
     max_count = np.amax(all_sizes)
-    if max_count >= BATCH_SIZE:
-        num_splits = max_count // BATCH_SIZE + 1
-    else:
-        num_splits = 1
+    num_splits = max_count // BATCH_SIZE + 1
 
     # Split the message into batches and send.
     splits = np.array_split(node_list, num_splits)

--- a/tools/distpartitioning/globalids.py
+++ b/tools/distpartitioning/globalids.py
@@ -104,7 +104,6 @@ def lookup_shuffle_global_nids_edges(rank, world_size, edge_data, id_lookup, nod
     splits = np.array_split(node_list, num_splits)
     shuffle_mappings = []
     for item in splits:
-        logging.info(f'[Rank: {rank} SENDING : {item.shape}')
         shuffle_ids = id_lookup.get_shuffle_nids(item,
                                             node_data[constants.GLOBAL_NID],
                                             node_data[constants.SHUFFLE_GLOBAL_NID])

--- a/tools/distpartitioning/gloo_wrapper.py
+++ b/tools/distpartitioning/gloo_wrapper.py
@@ -2,7 +2,7 @@ import numpy as np
 import torch
 import torch.distributed as dist
 
-def allgather_sizes(send_data, world_size):
+def allgather_sizes(send_data, world_size, return_sizes=False):
     """ 
     Perform all gather on list lengths, used to compute prefix sums
     to determine the offsets on each ranks. This is used to allocate
@@ -14,6 +14,9 @@ def allgather_sizes(send_data, world_size):
         Data on which allgather is performed.
     world_size : integer
         No. of processes configured for execution
+    return_sizes : bool
+        Boolean flag to indicate whether to return raw sizes from each process
+        or perform prefix sum on the raw sizes.
 
     Returns : 
     ---------
@@ -29,6 +32,10 @@ def allgather_sizes(send_data, world_size):
 
     #all_gather message
     dist.all_gather(in_tensor, out_tensor)
+
+    # Return on the raw sizes from each process
+    if return_sizes:
+        return torch.cat(in_tensor).numpy()
 
     #gather sizes in on array to return to the invoking function
     rank_sizes = np.zeros(world_size + 1, dtype=np.int64)


### PR DESCRIPTION
## Description
<!-- Brief description. Refer to the related issues if existed.
It'll be great if relevant reviewers can be assigned as well.-->
When retrieving SHUFFLE_GLOBAL_NID's for src and dst end points of the local edges in the current graph partition we used to send both the source and destination end points as a single list to the distributed lookup service. For Fe_large graph this message size is becoming about 50GB+ (3.2 billion edges). This increases the pressure on the memory used to send/receive such a large message and in the case of fe_large graph the process is getting killed. 

Now, we batch the outgoing message to distributed lookup service and ensure that the in each iteration we only send a message of maximum size of 250 MILLION entries (which is about 2 GB). This will reduce the memory need to support this operation and with this change fe_large graph is able to run correctly. 

Also another optimization is to NOT send destination end points to the distributed lookup service, since current process will have associated SHUFFLE_GLOBAL_NID's. We use current process local information to retrieve these IDs. 

## Checklist
Please feel free to remove inapplicable items for your PR.
- [X] The PR title starts with [$CATEGORY] (such as [NN], [Model], [Doc], [Feature]])
- [X] I've leverage the [tools](https://docs.google.com/document/d/1iHyj7zlmygKSk5gBPsqIqL5ASPzJSPREaNT_QdsiYA4/edit) to beautify the python and c++ code.
- [X] The PR is complete and small, read the [Google eng practice (CL equals to PR)](https://google.github.io/eng-practices/review/developer/small-cls.html) to understand more about small PR. In DGL, we consider PRs with less than 200 lines of core code change are small (example, test and documentation could be exempted).
- [X] All changes have test coverage
- [X] Code is well-documented
- [X] To the best of my knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change
- [ ] Related issue is referred in this PR
- [ ] If the PR is for a new model/paper, I've updated the example index [here](../examples/README.md).

## Changes
<!-- You could use following template
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)
-->
