### PR TITLE
[Dist] Pyarrow reading large csv files memory optimization

### DIFF
--- a/tools/distpartitioning/dataset_utils.py
+++ b/tools/distpartitioning/dataset_utils.py
@@ -337,11 +337,18 @@ def get_dataset(input_dir, graph_name, rank, world_size, schema_map):
             if not os.path.isabs(edge_file):
                 edge_file = os.path.join(input_dir, edge_file)
             logging.info(f'Loading edges of etype[{etype_name}] from {edge_file}')
-            data_df = csv.read_csv(edge_file,
-                        read_options=pyarrow.csv.ReadOptions(autogenerate_column_names=True), 
-                        parse_options=pyarrow.csv.ParseOptions(delimiter=' '))
-            src_ids.append(data_df['f0'].to_numpy())
-            dst_ids.append(data_df['f1'].to_numpy())
+
+            read_options=pyarrow.csv.ReadOptions(use_threads=True, block_size=4096, autogenerate_column_names=True)
+            parse_options=pyarrow.csv.ParseOptions(delimiter=' ')
+            with pyarrow.csv.open_csv(edge_file, read_options=read_options, parse_options=parse_options) as reader:
+                for next_chunk in reader:
+                    if next_chunk is None:
+                        break
+
+                    next_table = pyarrow.Table.from_batches([next_chunk])
+                    src_ids.append(next_table['f0'].to_numpy())
+                    dst_ids.append(next_table['f1'].to_numpy())
+
         src_ids = np.concatenate(src_ids)
         dst_ids = np.concatenate(dst_ids)
 

--- a/tools/distpartitioning/dist_lookup.py
+++ b/tools/distpartitioning/dist_lookup.py
@@ -3,6 +3,7 @@ import os
 import numpy as np
 import pyarrow
 import torch
+import copy
 
 from pyarrow import csv
 from gloo_wrapper import alltoallv_cpu
@@ -60,10 +61,19 @@ class DistLookupService:
 
             filename = f'{ntype}.txt'
             logging.info(f'[Rank: {rank}] Reading file: {os.path.join(input_dir, filename)}')
-            df = csv.read_csv(os.path.join(input_dir, '{}.txt'.format(ntype)), \
-                read_options=pyarrow.csv.ReadOptions(autogenerate_column_names=True), \
-                parse_options=pyarrow.csv.ParseOptions(delimiter=' '))
-            ntype_partids = df['f0'].to_numpy()
+
+            read_options=pyarrow.csv.ReadOptions(use_threads=True, block_size=4096, autogenerate_column_names=True)
+            parse_options=pyarrow.csv.ParseOptions(delimiter=' ')
+            ntype_partids = []
+            with pyarrow.csv.open_csv(os.path.join(input_dir, '{}.txt'.format(ntype)),
+                    read_options=read_options, parse_options=parse_options) as reader:
+                for next_chunk in reader:
+                    if next_chunk is None:
+                        break
+                    next_table = pyarrow.Table.from_batches([next_chunk])
+                    ntype_partids.append(next_table['f0'].to_numpy())
+
+            ntype_partids = np.concatenate(ntype_partids)
             count = len(ntype_partids)
             ntype_count.append(count)
 
@@ -75,8 +85,12 @@ class DistLookupService:
                 end = count
             type_nid_begin.append(start)
             type_nid_end.append(end)
+
             # Slice the partition-ids which belong to the current instance.
-            partid_list.append(ntype_partids[start:end])
+            partid_list.append(copy.deepcopy(ntype_partids[start:end]))
+
+            # Explicitly release the array read from the file.
+            del ntype_partids
 
         # Store all the information in the object instance variable.
         self.id_map = id_map


### PR DESCRIPTION
## Description
<!-- Brief description. Refer to the related issues if existed.
It'll be great if relevant reviewers can be assigned as well.-->
Default reading of large files using pyarrow, treating it as a single chunk takes very large amounts of memory footprints. In addition, this memory lingers in the VmData space and does not return to the system memory. 

To avoid this situation and to reduce the memory footprint of pyarrow reading csv files we now use Chunked reading of csv files  using pyarrow and allowing it to read one chunk at a time. 

In addition, if storing a slice of the numpy array read from a large file is resulting in original numpy array not getting released back to the system and stays throught out the execution in the VmData space. We now do a copy.deepcopy() of the slice which will create a separate memory block and when the original numpy array gets out-of-scope it gets released to the system. 

## Checklist
Please feel free to remove inapplicable items for your PR.
- [X] The PR title starts with [$CATEGORY] (such as [NN], [Model], [Doc], [Feature]])
- [X] I've leverage the [tools](https://docs.google.com/document/d/1iHyj7zlmygKSk5gBPsqIqL5ASPzJSPREaNT_QdsiYA4/edit) to beautify the python and c++ code.
- [X] The PR is complete and small, read the [Google eng practice (CL equals to PR)](https://google.github.io/eng-practices/review/developer/small-cls.html) to understand more about small PR. In DGL, we consider PRs with less than 200 lines of core code change are small (example, test and documentation could be exempted).
- [X] All changes have test coverage
- [X] Code is well-documented
- [X] To the best of my knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change
- [ ] Related issue is referred in this PR
- [ ] If the PR is for a new model/paper, I've updated the example index [here](../examples/README.md).

## Changes
<!-- You could use following template
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)
-->
