### PR TITLE
[Misc] Fix the lint error by marking constructor explicit

### DIFF
--- a/src/graph/transform/cuda/cuda_to_block.cu
+++ b/src/graph/transform/cuda/cuda_to_block.cu
@@ -43,7 +43,7 @@ namespace {
 template<typename IdType>
 class DeviceNodeMapMaker {
  public:
-  DeviceNodeMapMaker(
+  explicit DeviceNodeMapMaker(
       const std::vector<int64_t>& maxNodesPerType) :
       max_num_nodes_(0) {
     max_num_nodes_ = *std::max_element(maxNodesPerType.begin(),

--- a/src/rpc/network/msg_queue.h
+++ b/src/rpc/network/msg_queue.h
@@ -93,7 +93,7 @@ class MessageQueue {
    * \param queue_size size (bytes) of message queue
    * \param num_producers number of producers, use 1 by default
    */
-  MessageQueue(int64_t queue_size /* in bytes */,
+  explicit MessageQueue(int64_t queue_size /* in bytes */,
                int num_producers = 1);
 
   /*!


### PR DESCRIPTION
## Description
<!-- Brief description. Refer to the related issues if existed.
It'll be great if relevant reviewers can be assigned as well.-->
Fix the follow lint error.

Checking code style of C++ codes...
src/graph/transform/cuda/cuda_to_block.cu:46:  Single-parameter constructors should be marked explicit.  [runtime/explicit] [5]
src/rpc/network/msg_queue.h:97:  Constructors callable with one argument should be marked explicit.  [runtime/explicit] [5]

Issue identified when running CI in https://github.com/dmlc/dgl/pull/4810.

## Checklist
Please feel free to remove inapplicable items for your PR.
- [ ] The PR title starts with [$CATEGORY] (such as [NN], [Model], [Doc], [Feature]])
- [ ] I've leverage the [tools](https://docs.google.com/document/d/1iHyj7zlmygKSk5gBPsqIqL5ASPzJSPREaNT_QdsiYA4/edit) to beautify the python and c++ code.
- [ ] The PR is complete and small, read the [Google eng practice (CL equals to PR)](https://google.github.io/eng-practices/review/developer/small-cls.html) to understand more about small PR. In DGL, we consider PRs with less than 200 lines of core code change are small (example, test and documentation could be exempted).
- [ ] All changes have test coverage
- [ ] Code is well-documented
- [ ] To the best of my knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change
- [ ] Related issue is referred in this PR
- [ ] If the PR is for a new model/paper, I've updated the example index [here](../examples/README.md).

## Changes
<!-- You could use following template
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)
-->
