### PR TITLE
[Bugfix] Fix that half-precision SpMM produce incorrect results

### DIFF
--- a/src/array/cuda/functor.cuh
+++ b/src/array/cuda/functor.cuh
@@ -180,7 +180,44 @@ struct Sum : _Sum<Idx, DType, atomic> {};
 template <typename Idx, bool atomic>
 struct Sum<Idx, half, atomic> : _Sum<Idx, half, atomic> {
   static constexpr __host__ __device__ __forceinline__ half zero() {
-    return __float2half_rn(0.);
+    return 0.0f;
+  }
+  static __device__ __forceinline__ void Call(
+    half *out_buf, Idx *arg_u_buf, Idx *arg_e_buf,
+    half val, Idx uid, Idx eid) {
+    if (!atomic) {
+      *out_buf += val;
+    } else {
+      cuda::AtomicAdd(out_buf, val);
+    }
+  }
+  static __device__ __forceinline__ void Call(
+      half *out_buf, Idx *arg_buf,
+      half val, Idx id) {
+    if (!atomic) {
+      *out_buf += val;
+    } else {
+      cuda::AtomicAdd(out_buf, val);
+    }
+  }
+  // float accumulator
+  static __device__ __forceinline__ void Call(
+    float *out_buf, Idx *arg_u_buf, Idx *arg_e_buf,
+    half val, Idx uid, Idx eid) {
+    if (!atomic) {
+      *out_buf += static_cast<float>(val);
+    } else {
+      cuda::AtomicAdd(out_buf, static_cast<float>(val));
+    }
+  }
+  static __device__ __forceinline__ void Call(
+      float *out_buf, Idx *arg_buf,
+      half val, Idx id) {
+    if (!atomic) {
+      *out_buf += static_cast<float>(val);
+    } else {
+      cuda::AtomicAdd(out_buf, static_cast<float>(val));
+    }
   }
 };
 
@@ -243,6 +280,57 @@ struct Max<Idx, half, atomic> : _Max<Idx, half, atomic> {
   static constexpr __host__ __device__ __forceinline__ half zero() {
     return __float2half_rn(-6.550400e+04f);
   }
+  static __device__ __forceinline__ void Call(
+    half *out_buf, Idx *arg_u_buf, Idx *arg_e_buf,
+    half val, Idx uid, Idx eid) {
+    if (!atomic) {
+      if (*out_buf < val) {
+        *out_buf = val;
+        *arg_u_buf = uid;
+        *arg_e_buf = eid;
+      }
+    } else {
+      cuda::AtomicMax(out_buf, val);
+    }
+  }
+  static __device__ __forceinline__ void Call(
+      half *out_buf, Idx *arg_buf,
+      half val, Idx id) {
+    if (!atomic) {
+      if (*out_buf < val) {
+        *out_buf = val;
+        *arg_buf = id;
+      }
+    } else {
+      cuda::AtomicMax(out_buf, val);
+    }
+  }
+  // float accumulator
+  static __device__ __forceinline__ void Call(
+    float *out_buf, Idx *arg_u_buf, Idx *arg_e_buf,
+    half val, Idx uid, Idx eid) {
+    if (!atomic) {
+      if (*out_buf < static_cast<float>(val)) {
+        *out_buf = static_cast<float>(val);
+        *arg_u_buf = uid;
+        *arg_e_buf = eid;
+      }
+    } else {
+      cuda::AtomicMax(out_buf, static_cast<float>(val));
+    }
+  }
+  static __device__ __forceinline__ void Call(
+      float *out_buf, Idx *arg_buf,
+      half val, Idx id) {
+    if (!atomic) {
+      if (*out_buf < static_cast<float>(val)) {
+        *out_buf = static_cast<float>(val);
+        *arg_buf = id;
+      }
+    } else {
+      cuda::AtomicMax(out_buf, static_cast<float>(val));
+    }
+  }
 };
 
 #if BF16_ENABLED
@@ -303,6 +391,57 @@ template <typename Idx, bool atomic>
 struct Min<Idx, half, atomic> : _Min<Idx, half, atomic> {
   static constexpr __host__ __device__ __forceinline__ half zero() {
     return __float2half_rn(6.550400e+04f);
+  }
+  static __device__ __forceinline__ void Call(
+    half *out_buf, Idx *arg_u_buf, Idx *arg_e_buf,
+    half val, Idx uid, Idx eid) {
+    if (!atomic) {
+      if (*out_buf > val) {
+        *out_buf = val;
+        *arg_u_buf = uid;
+        *arg_e_buf = eid;
+      }
+    } else {
+      cuda::AtomicMin(out_buf, val);
+    }
+  }
+  static __device__ __forceinline__ void Call(
+      half *out_buf, Idx *arg_buf,
+      half val, Idx id) {
+    if (!atomic) {
+      if (*out_buf > val) {
+        *out_buf = val;
+        *arg_buf = id;
+      }
+    } else {
+      cuda::AtomicMin(out_buf, val);
+    }
+  }
+  // float accumulator
+  static __device__ __forceinline__ void Call(
+    float *out_buf, Idx *arg_u_buf, Idx *arg_e_buf,
+    half val, Idx uid, Idx eid) {
+    if (!atomic) {
+      if (*out_buf > static_cast<float>(val)) {
+        *out_buf = static_cast<float>(val);
+        *arg_u_buf = uid;
+        *arg_e_buf = eid;
+      }
+    } else {
+      cuda::AtomicMin(out_buf, static_cast<float>(val));
+    }
+  }
+  static __device__ __forceinline__ void Call(
+      float *out_buf, Idx *arg_buf,
+      half val, Idx id) {
+    if (!atomic) {
+      if (*out_buf > static_cast<float>(val)) {
+        *out_buf = static_cast<float>(val);
+        *arg_buf = id;
+      }
+    } else {
+      cuda::AtomicMin(out_buf, static_cast<float>(val));
+    }
   }
 };
 

--- a/src/array/cuda/functor.cuh
+++ b/src/array/cuda/functor.cuh
@@ -178,13 +178,13 @@ template <typename Idx, typename DType, bool atomic = false>
 struct Sum : _Sum<Idx, DType, atomic> {};
 
 template <typename Idx, bool atomic>
-struct Sum<Idx, half, atomic> : _Sum<Idx, half, atomic> {
-  static constexpr __host__ __device__ __forceinline__ half zero() {
+struct Sum<Idx, __half, atomic> : _Sum<Idx, __half, atomic> {
+  static constexpr __host__ __device__ __forceinline__ __half zero() {
     return 0.0f;
   }
   static __device__ __forceinline__ void Call(
-    half *out_buf, Idx *arg_u_buf, Idx *arg_e_buf,
-    half val, Idx uid, Idx eid) {
+    __half *out_buf, Idx *arg_u_buf, Idx *arg_e_buf,
+    __half val, Idx uid, Idx eid) {
     if (!atomic) {
       *out_buf += val;
     } else {
@@ -192,8 +192,8 @@ struct Sum<Idx, half, atomic> : _Sum<Idx, half, atomic> {
     }
   }
   static __device__ __forceinline__ void Call(
-      half *out_buf, Idx *arg_buf,
-      half val, Idx id) {
+      __half *out_buf, Idx *arg_buf,
+      __half val, Idx id) {
     if (!atomic) {
       *out_buf += val;
     } else {
@@ -203,7 +203,7 @@ struct Sum<Idx, half, atomic> : _Sum<Idx, half, atomic> {
   // float accumulator
   static __device__ __forceinline__ void Call(
     float *out_buf, Idx *arg_u_buf, Idx *arg_e_buf,
-    half val, Idx uid, Idx eid) {
+    __half val, Idx uid, Idx eid) {
     if (!atomic) {
       *out_buf += static_cast<float>(val);
     } else {
@@ -212,7 +212,7 @@ struct Sum<Idx, half, atomic> : _Sum<Idx, half, atomic> {
   }
   static __device__ __forceinline__ void Call(
       float *out_buf, Idx *arg_buf,
-      half val, Idx id) {
+      __half val, Idx id) {
     if (!atomic) {
       *out_buf += static_cast<float>(val);
     } else {
@@ -276,13 +276,13 @@ template <typename Idx, typename DType, bool atomic = false>
 struct Max : _Max<Idx, DType, atomic> {};
 
 template <typename Idx, bool atomic>
-struct Max<Idx, half, atomic> : _Max<Idx, half, atomic> {
-  static constexpr __host__ __device__ __forceinline__ half zero() {
+struct Max<Idx, __half, atomic> : _Max<Idx, __half, atomic> {
+  static constexpr __host__ __device__ __forceinline__ __half zero() {
     return __float2half_rn(-6.550400e+04f);
   }
   static __device__ __forceinline__ void Call(
-    half *out_buf, Idx *arg_u_buf, Idx *arg_e_buf,
-    half val, Idx uid, Idx eid) {
+    __half *out_buf, Idx *arg_u_buf, Idx *arg_e_buf,
+    __half val, Idx uid, Idx eid) {
     if (!atomic) {
       if (*out_buf < val) {
         *out_buf = val;
@@ -294,8 +294,8 @@ struct Max<Idx, half, atomic> : _Max<Idx, half, atomic> {
     }
   }
   static __device__ __forceinline__ void Call(
-      half *out_buf, Idx *arg_buf,
-      half val, Idx id) {
+      __half *out_buf, Idx *arg_buf,
+      __half val, Idx id) {
     if (!atomic) {
       if (*out_buf < val) {
         *out_buf = val;
@@ -308,7 +308,7 @@ struct Max<Idx, half, atomic> : _Max<Idx, half, atomic> {
   // float accumulator
   static __device__ __forceinline__ void Call(
     float *out_buf, Idx *arg_u_buf, Idx *arg_e_buf,
-    half val, Idx uid, Idx eid) {
+    __half val, Idx uid, Idx eid) {
     if (!atomic) {
       if (*out_buf < static_cast<float>(val)) {
         *out_buf = static_cast<float>(val);
@@ -321,7 +321,7 @@ struct Max<Idx, half, atomic> : _Max<Idx, half, atomic> {
   }
   static __device__ __forceinline__ void Call(
       float *out_buf, Idx *arg_buf,
-      half val, Idx id) {
+      __halflf val, Idx id) {
     if (!atomic) {
       if (*out_buf < static_cast<float>(val)) {
         *out_buf = static_cast<float>(val);
@@ -388,13 +388,13 @@ template <typename Idx, typename DType, bool atomic = false>
 struct Min : _Min<Idx, DType, atomic> {};
 
 template <typename Idx, bool atomic>
-struct Min<Idx, half, atomic> : _Min<Idx, half, atomic> {
-  static constexpr __host__ __device__ __forceinline__ half zero() {
+struct Min<Idx, __half, atomic> : _Min<Idx, __half, atomic> {
+  static constexpr __host__ __device__ __forceinline__ __half zero() {
     return __float2half_rn(6.550400e+04f);
   }
   static __device__ __forceinline__ void Call(
-    half *out_buf, Idx *arg_u_buf, Idx *arg_e_buf,
-    half val, Idx uid, Idx eid) {
+    __half *out_buf, Idx *arg_u_buf, Idx *arg_e_buf,
+    __half val, Idx uid, Idx eid) {
     if (!atomic) {
       if (*out_buf > val) {
         *out_buf = val;
@@ -406,8 +406,8 @@ struct Min<Idx, half, atomic> : _Min<Idx, half, atomic> {
     }
   }
   static __device__ __forceinline__ void Call(
-      half *out_buf, Idx *arg_buf,
-      half val, Idx id) {
+      __half *out_buf, Idx *arg_buf,
+      __half val, Idx id) {
     if (!atomic) {
       if (*out_buf > val) {
         *out_buf = val;
@@ -420,7 +420,7 @@ struct Min<Idx, half, atomic> : _Min<Idx, half, atomic> {
   // float accumulator
   static __device__ __forceinline__ void Call(
     float *out_buf, Idx *arg_u_buf, Idx *arg_e_buf,
-    half val, Idx uid, Idx eid) {
+    __half val, Idx uid, Idx eid) {
     if (!atomic) {
       if (*out_buf > static_cast<float>(val)) {
         *out_buf = static_cast<float>(val);
@@ -433,7 +433,7 @@ struct Min<Idx, half, atomic> : _Min<Idx, half, atomic> {
   }
   static __device__ __forceinline__ void Call(
       float *out_buf, Idx *arg_buf,
-      half val, Idx id) {
+      __half val, Idx id) {
     if (!atomic) {
       if (*out_buf > static_cast<float>(val)) {
         *out_buf = static_cast<float>(val);

--- a/src/array/cuda/functor.cuh
+++ b/src/array/cuda/functor.cuh
@@ -196,19 +196,13 @@ struct Sum<Idx, __half, atomic> : _Sum<Idx, __half, atomic> {
   static __device__ __forceinline__ void Call(
       float *out_buf, Idx *arg_u_buf, Idx *arg_e_buf,
       __half val, Idx uid, Idx eid) {
-    if (!atomic) {
-      *out_buf += static_cast<float>(val);
-    } else {
-      cuda::AtomicAdd(out_buf, static_cast<float>(val));
-    }
+    _Sum<Idx, float, atomic>::Call(out_buf, arg_u_buf, arg_e_buf,
+        static_cast<float>(val), uid, eid);
   }
   static __device__ __forceinline__ void Call(
       float *out_buf, Idx *arg_buf, __half val, Idx id) {
-    if (!atomic) {
-      *out_buf += static_cast<float>(val);
-    } else {
-      cuda::AtomicAdd(out_buf, static_cast<float>(val));
-    }
+    _Sum<Idx, float, atomic>::Call(out_buf, arg_buf,
+        static_cast<float>(val), id);
   }
 };
 
@@ -232,19 +226,13 @@ struct Sum<Idx, __nv_bfloat16, atomic> : _Sum<Idx, __nv_bfloat16, atomic> {
   static __device__ __forceinline__ void Call(
       float *out_buf, Idx *arg_u_buf, Idx *arg_e_buf,
       __nv_bfloat16 val, Idx uid, Idx eid) {
-    if (!atomic) {
-      *out_buf += static_cast<float>(val);
-    } else {
-      cuda::AtomicAdd(out_buf, static_cast<float>(val));
-    }
+    _Sum<Idx, float, atomic>::Call(out_buf, arg_u_buf, arg_e_buf,
+        static_cast<float>(val), uid, eid);
   }
   static __device__ __forceinline__ void Call(
       float *out_buf, Idx *arg_buf, __nv_bfloat16 val, Idx id) {
-    if (!atomic) {
-      *out_buf += static_cast<float>(val);
-    } else {
-      cuda::AtomicAdd(out_buf, static_cast<float>(val));
-    }
+    _Sum<Idx, float, atomic>::Call(out_buf, arg_buf,
+        static_cast<float>(val), id);
   }
 };
 #endif  // BF16_ENABLED
@@ -313,26 +301,13 @@ struct Max<Idx, __half, atomic> : _Max<Idx, __half, atomic> {
   static __device__ __forceinline__ void Call(
       float *out_buf, Idx *arg_u_buf, Idx *arg_e_buf,
       __half val, Idx uid, Idx eid) {
-    if (!atomic) {
-      if (*out_buf < static_cast<float>(val)) {
-        *out_buf = static_cast<float>(val);
-        *arg_u_buf = uid;
-        *arg_e_buf = eid;
-      }
-    } else {
-      cuda::AtomicMax(out_buf, static_cast<float>(val));
-    }
+    _Max<Idx, float, atomic>::Call(out_buf, arg_u_buf, arg_e_buf,
+        static_cast<float>(val), uid, eid);
   }
   static __device__ __forceinline__ void Call(
       float *out_buf, Idx *arg_buf, __half val, Idx id) {
-    if (!atomic) {
-      if (*out_buf < static_cast<float>(val)) {
-        *out_buf = static_cast<float>(val);
-        *arg_buf = id;
-      }
-    } else {
-      cuda::AtomicMax(out_buf, static_cast<float>(val));
-    }
+    _Max<Idx, float, atomic>::Call(out_buf, arg_buf,
+        static_cast<float>(val), id);
   }
 };
 
@@ -356,26 +331,13 @@ struct Max<Idx, __nv_bfloat16, atomic> : _Max<Idx, __nv_bfloat16, atomic> {
   static __device__ __forceinline__ void Call(
       float *out_buf, Idx *arg_u_buf, Idx *arg_e_buf,
       __nv_bfloat16 val, Idx uid, Idx eid) {
-    if (!atomic) {
-      if (*out_buf < static_cast<float>(val)) {
-        *out_buf = static_cast<float>(val);
-        *arg_u_buf = uid;
-        *arg_e_buf = eid;
-      }
-    } else {
-      cuda::AtomicMax(out_buf, static_cast<float>(val));
-    }
+    _Max<Idx, float, atomic>::Call(out_buf, arg_u_buf, arg_e_buf,
+        static_cast<float>(val), uid, eid);
   }
   static __device__ __forceinline__ void Call(
       float *out_buf, Idx *arg_buf, __nv_bfloat16 val, Idx id) {
-    if (!atomic) {
-      if (*out_buf < static_cast<float>(val)) {
-        *out_buf = static_cast<float>(val);
-        *arg_buf = id;
-      }
-    } else {
-      cuda::AtomicMax(out_buf, static_cast<float>(val));
-    }
+    _Max<Idx, float, atomic>::Call(out_buf, arg_buf,
+        static_cast<float>(val), id);
   }
 };
 #endif  // BF16_ENABLED
@@ -444,26 +406,13 @@ struct Min<Idx, __half, atomic> : _Min<Idx, __half, atomic> {
   static __device__ __forceinline__ void Call(
       float *out_buf, Idx *arg_u_buf, Idx *arg_e_buf,
       __half val, Idx uid, Idx eid) {
-    if (!atomic) {
-      if (*out_buf > static_cast<float>(val)) {
-        *out_buf = static_cast<float>(val);
-        *arg_u_buf = uid;
-        *arg_e_buf = eid;
-      }
-    } else {
-      cuda::AtomicMin(out_buf, static_cast<float>(val));
-    }
+    _Min<Idx, float, atomic>::Call(out_buf, arg_u_buf, arg_e_buf,
+        static_cast<float>(val), uid, eid);
   }
   static __device__ __forceinline__ void Call(
       float *out_buf, Idx *arg_buf, __half val, Idx id) {
-    if (!atomic) {
-      if (*out_buf > static_cast<float>(val)) {
-        *out_buf = static_cast<float>(val);
-        *arg_buf = id;
-      }
-    } else {
-      cuda::AtomicMin(out_buf, static_cast<float>(val));
-    }
+    _Min<Idx, float, atomic>::Call(out_buf, arg_buf,
+        static_cast<float>(val), id);
   }
 };
 
@@ -487,26 +436,13 @@ struct Min<Idx, __nv_bfloat16, atomic> : _Min<Idx, __nv_bfloat16, atomic> {
   static __device__ __forceinline__ void Call(
       float *out_buf, Idx *arg_u_buf, Idx *arg_e_buf,
       __nv_bfloat16 val, Idx uid, Idx eid) {
-    if (!atomic) {
-      if (*out_buf > static_cast<float>(val)) {
-        *out_buf = static_cast<float>(val);
-        *arg_u_buf = uid;
-        *arg_e_buf = eid;
-      }
-    } else {
-      cuda::AtomicMin(out_buf, static_cast<float>(val));
-    }
+    _Min<Idx, float, atomic>::Call(out_buf, arg_u_buf, arg_e_buf,
+        static_cast<float>(val), uid, eid);
   }
   static __device__ __forceinline__ void Call(
       float *out_buf, Idx *arg_buf, __nv_bfloat16 val, Idx id) {
-    if (!atomic) {
-      if (*out_buf > static_cast<float>(val)) {
-        *out_buf = static_cast<float>(val);
-        *arg_buf = id;
-      }
-    } else {
-      cuda::AtomicMin(out_buf, static_cast<float>(val));
-    }
+    _Min<Idx, float, atomic>::Call(out_buf, arg_buf,
+        static_cast<float>(val), id);
   }
 };
 #endif  // BF16_ENABLED

--- a/src/array/cuda/segment_reduce.cuh
+++ b/src/array/cuda/segment_reduce.cuh
@@ -16,6 +16,7 @@
 namespace dgl {
 
 using namespace cuda;
+using namespace runtime;
 
 namespace aten {
 namespace cuda {
@@ -32,7 +33,7 @@ __global__ void SegmentReduceKernel(
   for (int row = blockIdx.x; row < n; row += gridDim.x) {
     int col = blockIdx.y * blockDim.x + threadIdx.x;
     while (col < dim) {
-      typename runtime::accum_dtype<DType>::type local_accum = ReduceOp::zero();
+      typename accum_dtype<DType>::type local_accum = ReduceOp::zero();
       IdType local_arg = -1;
       for (IdType i = offsets[row]; i < offsets[row + 1]; ++i) {
         ReduceOp::Call(&local_accum, &local_arg, feat[i * dim + col], i);

--- a/src/array/cuda/segment_reduce.cuh
+++ b/src/array/cuda/segment_reduce.cuh
@@ -32,12 +32,12 @@ __global__ void SegmentReduceKernel(
   for (int row = blockIdx.x; row < n; row += gridDim.x) {
     int col = blockIdx.y * blockDim.x + threadIdx.x;
     while (col < dim) {
-      DType local_accum = ReduceOp::zero();
+      typename runtime::accum_dtype<DType>::type local_accum = ReduceOp::zero();
       IdType local_arg = -1;
       for (IdType i = offsets[row]; i < offsets[row + 1]; ++i) {
         ReduceOp::Call(&local_accum, &local_arg, feat[i * dim + col], i);
       }
-      out[row * dim + col] = local_accum;
+      out[row * dim + col] = static_cast<DType>(local_accum);
       if (ReduceOp::require_arg) arg[row * dim + col] = local_arg;
       col += gridDim.y * blockDim.x;
     }

--- a/src/array/cuda/spmm.cuh
+++ b/src/array/cuda/spmm.cuh
@@ -146,7 +146,7 @@ void _Transpose(const DType* in, DType* out, int row, int col) {
  * @note cuBLAS has no geam API for half data type, fallback to our kernel.
  */
 template <>
-void _Transpose<half>(const half* in, half* out, int row, int col) {
+void _Transpose<__half>(const __half* in, __half* out, int row, int col) {
   cudaStream_t stream = runtime::getCurrentCUDAStream();
   int nt = FindNumThreads(row);
   int nb = col;
@@ -664,7 +664,7 @@ void SpMMCoo(
     const BcastOff& bcast, const COOMatrix& coo, NDArray ufeat, NDArray efeat,
     NDArray out, NDArray argu, NDArray arge) {
 #if defined(CUDART_VERSION) && CUDART_VERSION <= 10000
-  if (std::is_same<DType, half>::value)
+  if (std::is_same<DType, __half>::value)
     LOG(FATAL) << "SpMMCoo requires atomicCAS, which is not supported "
                << "for float16 in CUDA 10.0. Please upgrade your CUDA "
                << "to later versions.";

--- a/src/array/cuda/spmm.cuh
+++ b/src/array/cuda/spmm.cuh
@@ -624,7 +624,8 @@ __global__ void SpMMCmpCsrHeteroKernel(
         const DType* eoff =
             BinaryOp::use_rhs ? (efeat + eid * efeat_len) : nullptr;
         DType tmp_out = BinaryOp::Call(uoff + lhs_add, eoff + rhs_add);
-        ReduceOp::Call(&local_accum, &local_argu, &local_arge, tmp_out, cid, eid);
+        ReduceOp::Call(
+            &local_accum, &local_argu, &local_arge,tmp_out, cid, eid);
       }
       // Update output only when max/min values are different that original
       // output
@@ -672,7 +673,7 @@ void SpMMCoo(
    * current implementation.
    */
 #if BF16_ENABLED
-  if (std::is_same<DType, __half>::value || 
+  if (std::is_same<DType, __half>::value ||
       std::is_same<DType, __nv_bfloat16>::value)
 #else
   if (std::is_same<DType, __half>::value)

--- a/src/array/cuda/spmm.cuh
+++ b/src/array/cuda/spmm.cuh
@@ -553,7 +553,7 @@ __global__ void SpMMCsrKernel(
   while (ty < num_rows) {
     int tx = blockIdx.y * blockDim.x + threadIdx.x;
     while (tx < out_len) {
-      DType local_accum = ReduceOp::zero();
+      typename accum_dtype<DType>::type local_accum = ReduceOp::zero();
       Idx local_argu = 0, local_arge = 0;
       const int lhs_add = UseBcast ? ubcast_off[tx] : tx;
       const int rhs_add = UseBcast ? ebcast_off[tx] : tx;
@@ -573,7 +573,7 @@ __global__ void SpMMCsrKernel(
       // Separate kernel `SpMMCmpCsrHeteroKernel` is used for max- and
       // min-reducer. It does not affect the output on homogeneous graph as
       // `out` is initialized to zero.
-      out[ty * out_len + tx] += local_accum;
+      out[ty * out_len + tx] += static_cast<DType>(local_accum);
       if (ReduceOp::require_arg && BinaryOp::use_lhs)
         arg_u[ty * out_len + tx] = local_argu;
       if (ReduceOp::require_arg && BinaryOp::use_rhs)

--- a/src/array/cuda/spmm.cuh
+++ b/src/array/cuda/spmm.cuh
@@ -625,7 +625,7 @@ __global__ void SpMMCmpCsrHeteroKernel(
             BinaryOp::use_rhs ? (efeat + eid * efeat_len) : nullptr;
         DType tmp_out = BinaryOp::Call(uoff + lhs_add, eoff + rhs_add);
         ReduceOp::Call(
-            &local_accum, &local_argu, &local_arge,tmp_out, cid, eid);
+            &local_accum, &local_argu, &local_arge, tmp_out, cid, eid);
       }
       // Update output only when max/min values are different that original
       // output

--- a/src/runtime/cuda/cuda_common.h
+++ b/src/runtime/cuda/cuda_common.h
@@ -132,6 +132,29 @@ struct cuda_dtype<double> {
   static constexpr cudaDataType_t value = CUDA_R_64F;
 };
 
+/*
+ * \brief Accumulator type for SpMM.
+ */
+template <typename T>
+struct accum_dtype {
+  typedef float type;
+};
+
+template <>
+struct accum_dtype<half> {
+  typedef float type;
+};
+
+template <>
+struct accum_dtype<float> {
+  typedef float type;
+};
+
+template <>
+struct accum_dtype<double> {
+  typedef double type;
+};
+
 #if CUDART_VERSION >= 11000
 /**
  * @brief Cast index data type to cusparseIndexType_t.

--- a/src/runtime/cuda/cuda_common.h
+++ b/src/runtime/cuda/cuda_common.h
@@ -154,7 +154,7 @@ struct accum_dtype<__half> {
 
 #if BF16_ENABLED
 template <>
-struct accum_dtype<__nvbfloat16> {
+struct accum_dtype<__nv_bfloat16> {
   typedef float type;
 };
 #endif  // BF16_ENABLED

--- a/src/runtime/cuda/cuda_common.h
+++ b/src/runtime/cuda/cuda_common.h
@@ -118,9 +118,16 @@ struct cuda_dtype {
 };
 
 template <>
-struct cuda_dtype<half> {
+struct cuda_dtype<__half> {
   static constexpr cudaDataType_t value = CUDA_R_16F;
 };
+
+#if BF16_ENABLED
+template <>
+struct cuda_dtype<__nv_bfloat16> {
+  static constexpr cudaDataType_t value = CUDA_R_16BF;
+};
+#endif  // BF16_ENABLED
 
 template <>
 struct cuda_dtype<float> {
@@ -141,9 +148,16 @@ struct accum_dtype {
 };
 
 template <>
-struct accum_dtype<half> {
+struct accum_dtype<__half> {
   typedef float type;
 };
+
+#if BF16_ENABLED
+template <>
+struct accum_dtype<__nvbfloat16> {
+  typedef float type;
+};
+#endif  // BF16_ENABLED
 
 template <>
 struct accum_dtype<float> {

--- a/tests/compute/test_sparse.py
+++ b/tests/compute/test_sparse.py
@@ -174,6 +174,7 @@ def test_spmm(idtype, g, shp, msg, reducer):
     if "v" in g.dstdata:
         g.dstdata.pop("v")
 
+
 @unittest.skipIf(
     dgl.backend.backend_name != "pytorch",
     reason="Only support PyTorch for now."
@@ -205,7 +206,7 @@ def test_half_spmm(idtype, dtype, rtol, atol):
     assert torch.allclose(res_fp32, res_half, rtol=rtol, atol=atol)
 
     # test SpMMCOO
-    # TODO(Xin): temporally disabled because SpMMCOO has not been fixed.
+    # TODO(Xin): half-precision SpMMCoo is temporally disabled.
     # g = g.formats(['coo'])
     # res_fp32 = dgl.ops.copy_u_sum(g, feat_fp32)[0]
     # res_half = dgl.ops.copy_u_sum(g, feat_half)[0].float()

--- a/tests/compute/test_sparse.py
+++ b/tests/compute/test_sparse.py
@@ -174,6 +174,43 @@ def test_spmm(idtype, g, shp, msg, reducer):
     if "v" in g.dstdata:
         g.dstdata.pop("v")
 
+@unittest.skipIf(
+    dgl.backend.backend_name != "pytorch",
+    reason="Only support PyTorch for now."
+)
+@unittest.skipIf(
+    F._default_context_str == "cpu",
+    reason="Don't support half precision on CPU."
+)
+@parametrize_idtype
+@pytest.mark.parametrize(
+    "dtype, rtol, atol",
+    [(torch.float16, 1e-3, 0.5), (torch.bfloat16, 4e-3, 2.)]
+)
+def test_half_spmm(idtype, dtype, rtol, atol):
+    if LooseVersion(torch.version.cuda) < LooseVersion("11.0") \
+        and dtype == torch.bfloat16:
+        pytest.skip("BF16 requires CUDA >= 11.0.")
+
+    # make sure the spmm result is < 512 to match the rtol/atol we set.
+    g = dgl.graph((torch.arange(900), torch.tensor([0] * 900)),
+                  idtype=idtype, device=F.ctx())
+    feat_fp32 = torch.rand((g.num_src_nodes(), 32)).to(0)
+    feat_half = feat_fp32.to(dtype)
+
+    # test SpMMCSR
+    g = g.formats(['csc'])
+    res_fp32 = dgl.ops.copy_u_sum(g, feat_fp32)[0]
+    res_half = dgl.ops.copy_u_sum(g, feat_half)[0].float()
+    assert torch.allclose(res_fp32, res_half, rtol=rtol, atol=atol)
+
+    # test SpMMCOO
+    # TODO(Xin): temporally disabled because SpMMCOO has not been fixed.
+    # g = g.formats(['coo'])
+    # res_fp32 = dgl.ops.copy_u_sum(g, feat_fp32)[0]
+    # res_half = dgl.ops.copy_u_sum(g, feat_half)[0].float()
+    # assert torch.allclose(res_fp32, res_half, rtol=rtol, atol=atol)
+
 
 @pytest.mark.parametrize("g", graphs)
 @pytest.mark.parametrize("shp", sddmm_shapes)


### PR DESCRIPTION
## Description

Resolve https://github.com/dmlc/dgl/issues/4674 by using float32 accumulators for half-precision SpMM.

## Checklist
Please feel free to remove inapplicable items for your PR.
- [x] The PR title starts with [$CATEGORY] (such as [NN], [Model], [Doc], [Feature]])
- [x] I've leverage the [tools](https://docs.google.com/document/d/1iHyj7zlmygKSk5gBPsqIqL5ASPzJSPREaNT_QdsiYA4/edit) to beautify the python and c++ code.
- [x] The PR is complete and small, read the [Google eng practice (CL equals to PR)](https://google.github.io/eng-practices/review/developer/small-cls.html) to understand more about small PR. In DGL, we consider PRs with less than 200 lines of core code change are small (example, test and documentation could be exempted).
- [x] All changes have test coverage
- [x] Code is well-documented
- [x] To the best of my knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change
- [x] Related issue is referred in this PR

## Changes
- Add float32 accumulators for half-precision SpMM.
- Update SpMM kernels.

Run the example in #4674, now the result is
```bash
tensor([6617.6919, 6586.2812, 6619.5034, 6558.4487, 6553.0786, 6624.6333,
        6560.0791, 6557.0645, 6509.3472, 6568.6904, 6587.9985, 6597.6553,
        6595.7559, 6583.3838, 6578.9878, 6595.5063, 6539.8848, 6558.6309,
        6590.0713, 6601.4785, 6588.4810, 6520.0093, 6593.1357, 6583.6230,
        6572.8008, 6606.7241, 6598.8960, 6533.9819, 6569.7227, 6629.5200,
        6628.0483, 6561.9619], device='cuda:0')
tensor([6616., 6588., 6620., 6560., 6552., 6624., 6560., 6556., 6508., 6568.,
        6588., 6596., 6596., 6584., 6580., 6596., 6540., 6560., 6592., 6600.,
        6588., 6520., 6592., 6584., 6572., 6608., 6600., 6532., 6568., 6628.,
        6628., 6560.], device='cuda:0', dtype=torch.float16)
```