### PR TITLE
[Cleanup] Remove duplicated _IndexSelect

### DIFF
--- a/src/array/cuda/spmm.cu
+++ b/src/array/cuda/spmm.cu
@@ -45,7 +45,7 @@ void SpMMCsr(
       int64_t x_length = 1;
       for (int i = 1; i < ufeat->ndim; ++i) x_length *= ufeat->shape[i];
       if (!IsNullArray(csr.data)) {
-        efeat = _IndexSelect<DType, IdType>(efeat, csr.data);
+        efeat = IndexSelect(efeat, csr.data);
       }
       CusparseCsrmm2<DType, IdType>(
           ufeat->ctx, csr, static_cast<DType*>(ufeat->data),

--- a/src/array/cuda/spmm_hetero.cu
+++ b/src/array/cuda/spmm_hetero.cu
@@ -134,7 +134,7 @@ void SpMMCsrHetero(
           cusparse_available<DType, IdType>(more_nnz)) {  // cusparse
         NDArray efeat = vec_efeat[etype];
         if (!IsNullArray(csr.data))
-          efeat = _IndexSelect<DType, IdType>(efeat, csr.data);
+          efeat = IndexSelect(efeat, csr.data);
         CusparseCsrmm2Hetero<DType, IdType>(
             csr.indptr->ctx, csr, static_cast<DType*>(vec_ufeat[src_id]->data),
             static_cast<DType*>(efeat->data),


### PR DESCRIPTION
## Description

Since the `IndexSelect` in `array_op.h` has support fp16, remove the duplicated `_IndexSelect` function and corresponding kernels in `spmm.cuh`.

## Checklist
Please feel free to remove inapplicable items for your PR.
- [x] The PR title starts with [$CATEGORY] (such as [NN], [Model], [Doc], [Feature]])
- [x] I've leverage the [tools](https://docs.google.com/document/d/1iHyj7zlmygKSk5gBPsqIqL5ASPzJSPREaNT_QdsiYA4/edit) to beautify the python and c++ code.
- [x] The PR is complete and small, read the [Google eng practice (CL equals to PR)](https://google.github.io/eng-practices/review/developer/small-cls.html) to understand more about small PR. In DGL, we consider PRs with less than 200 lines of core code change are small (example, test and documentation could be exempted).
- [ ] All changes have test coverage
- [ ] Code is well-documented
- [x] To the best of my knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change
- [ ] Related issue is referred in this PR
- [ ] If the PR is for a new model/paper, I've updated the example index [here](../examples/README.md).