### PR TITLE
[Performance] Make IdHashMap parallel

### DIFF
--- a/src/array/cpu/array_utils.h
+++ b/src/array/cpu/array_utils.h
@@ -84,8 +84,8 @@ class IdHashMap {
     IdArray values = NewIdArray(len, ids->ctx, ids->dtype.bits);
     IdType* values_data = values.Ptr<IdType>();
     runtime::parallel_for(
-        0, len, 1000, [=] (size_t b, size_t e) {
-          for (size_t i = b; i < e; ++i) {
+        0, len, 1000, [=] (size_t begin, size_t end) {
+          for (size_t i = begin; i < end; ++i) {
             values_data[i] = Map(ids_data[i], default_val);
           }
         });

--- a/src/array/cpu/array_utils.h
+++ b/src/array/cpu/array_utils.h
@@ -81,9 +81,13 @@ class IdHashMap {
     const IdType* ids_data = static_cast<IdType*>(ids->data);
     const int64_t len = ids->shape[0];
     IdArray values = NewIdArray(len, ids->ctx, ids->dtype.bits);
-    IdType* values_data = static_cast<IdType*>(values->data);
-    for (int64_t i = 0; i < len; ++i)
-      values_data[i] = Map(ids_data[i], default_val);
+    IdType* values_data = values.Ptr<IdType>();
+    runtime::parallel_for(
+        0, len, 1000, [=] (size_t b, size_t e) {
+          for (size_t i = b; i < e; ++i) {
+            values_data[i] = Map(ids_data[i], default_val);
+          }
+        });
     return values;
   }
 

--- a/src/array/cpu/array_utils.h
+++ b/src/array/cpu/array_utils.h
@@ -7,6 +7,7 @@
 #define DGL_ARRAY_CPU_ARRAY_UTILS_H_
 
 #include <dgl/aten/types.h>
+#include <dgl/runtime/parallel_for.h>
 #include <parallel_hashmap/phmap.h>
 
 #include <unordered_map>


### PR DESCRIPTION
## Description
`IdHashMap::Map` is executed sequentially.  So I make it parallelizable.  This should mitigate the low CPU utilization in distributed training (#4357 ) to some extent.
