### PR TITLE
[API Deprecation]Remove node_attrs and edge_attrs in batch.py

### DIFF
--- a/python/dgl/batch.py
+++ b/python/dgl/batch.py
@@ -2,7 +2,7 @@
 from collections.abc import Mapping
 
 from . import backend as F
-from .base import ALL, is_all, DGLError, dgl_warning, NID, EID
+from .base import ALL, is_all, DGLError, NID, EID
 from .heterograph_index import disjoint_union, slice_gidx
 from .heterograph import DGLGraph
 from . import convert
@@ -11,8 +11,7 @@ from . import utils
 
 __all__ = ['batch', 'unbatch', 'slice_batch']
 
-def batch(graphs, ndata=ALL, edata=ALL, *,
-          node_attrs=None, edge_attrs=None):
+def batch(graphs, ndata=ALL, edata=ALL):
     r"""Batch a collection of :class:`DGLGraph` s into one graph for more efficient
     graph computation.
 
@@ -151,14 +150,6 @@ def batch(graphs, ndata=ALL, edata=ALL, *,
     """
     if len(graphs) == 0:
         raise DGLError('The input list of graphs cannot be empty.')
-    if node_attrs is not None:
-        dgl_warning('Arguments node_attrs has been deprecated. Please use'
-                    ' ndata instead.')
-        ndata = node_attrs
-    if edge_attrs is not None:
-        dgl_warning('Arguments edge_attrs has been deprecated. Please use'
-                    ' edata instead.')
-        edata = edge_attrs
     if not (is_all(ndata) or isinstance(ndata, list) or ndata is None):
         raise DGLError('Invalid argument ndata: must be a string list but got {}.'.format(
             type(ndata)))

--- a/tests/compute/test_batched_heterograph.py
+++ b/tests/compute/test_batched_heterograph.py
@@ -237,10 +237,6 @@ def test_features(idtype):
         node_attrs={'user': ['h2'], 'game': ['h2']},
         edge_attrs={('user', 'follows', 'user'): ['h1']})
 
-    # test legacy
-    bg = dgl.batch([g1, g2], edge_attrs=['h1'])
-    assert 'h2' not in bg.edges['follows'].data.keys()
-
 
 @unittest.skipIf(F.backend_name == 'mxnet', reason="MXNet does not support split array with zero-length segment.")
 @parametrize_idtype


### PR DESCRIPTION
## Description
Remove ```node_attrs``` and ```edge_attrs``` from dgl.batch API argument list.

## Checklist
Please feel free to remove inapplicable items for your PR.
- [ ] The PR title starts with [$CATEGORY] (such as [NN], [Model], [Doc], [Feature]])
- [ ] I've leverage the [tools](https://docs.google.com/document/d/1iHyj7zlmygKSk5gBPsqIqL5ASPzJSPREaNT_QdsiYA4/edit) to beautify the python and c++ code.
- [ ] The PR is complete and small, read the [Google eng practice (CL equals to PR)](https://google.github.io/eng-practices/review/developer/small-cls.html) to understand more about small PR. In DGL, we consider PRs with less than 200 lines of core code change are small (example, test and documentation could be exempted).
- [ ] All changes have test coverage
- [ ] Code is well-documented
- [ ] To the best of my knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change
- [ ] Related issue is referred in this PR
- [ ] If the PR is for a new model/paper, I've updated the example index [here](../examples/README.md).

## Changes
<!-- You could use following template
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)
-->
