### PR TITLE
[API Deprecation] Remove emb_tensor in dgl.nn

### DIFF
--- a/python/dgl/nn/pytorch/sparse_emb.py
+++ b/python/dgl/nn/pytorch/sparse_emb.py
@@ -335,19 +335,6 @@ class NodeEmbedding:  # NodeEmbedding
         self._trace = []
 
     @property
-    def emb_tensor(self):
-        """Return the tensor storing the node embeddings
-
-        DEPRECATED: renamed weight
-
-        Returns
-        -------
-        torch.Tensor
-            The tensor storing the node embeddings
-        """
-        return self._tensor
-
-    @property
     def weight(self):
         """Return the tensor storing the node embeddings
 

--- a/python/dgl/optim/pytorch/sparse_optim.py
+++ b/python/dgl/optim/pytorch/sparse_optim.py
@@ -526,7 +526,7 @@ class SparseAdagrad(SparseGradOptimizer):
             ), "SparseAdagrad only supports dgl.nn.NodeEmbedding"
 
             emb_name = emb.name
-            if th.device(emb.emb_tensor.device) == th.device("cpu"):
+            if th.device(emb.weight.device) == th.device("cpu"):
                 # if our embedding is on the CPU, our state also has to be
                 if self._rank < 0:
                     state = th.empty(
@@ -550,9 +550,9 @@ class SparseAdagrad(SparseGradOptimizer):
             else:
                 # distributed state on on gpu
                 state = th.empty(
-                    emb.emb_tensor.shape,
+                    emb.weight.shape,
                     dtype=th.float32,
-                    device=emb.emb_tensor.device,
+                    device=emb.weight.device,
                 ).zero_()
             emb.set_optm_state(state)
 
@@ -689,7 +689,7 @@ class SparseAdam(SparseGradOptimizer):
             ), "SparseAdam only supports dgl.nn.NodeEmbedding"
             emb_name = emb.name
             self._is_using_uva[emb_name] = self._use_uva
-            if th.device(emb.emb_tensor.device) == th.device("cpu"):
+            if th.device(emb.weight.device) == th.device("cpu"):
                 # if our embedding is on the CPU, our state also has to be
                 if self._rank < 0:
                     state_step = th.empty(
@@ -743,19 +743,19 @@ class SparseAdam(SparseGradOptimizer):
 
                 # distributed state on on gpu
                 state_step = th.empty(
-                    [emb.emb_tensor.shape[0]],
+                    [emb.weight.shape[0]],
                     dtype=th.int32,
-                    device=emb.emb_tensor.device,
+                    device=emb.weight.device,
                 ).zero_()
                 state_mem = th.empty(
-                    emb.emb_tensor.shape,
+                    emb.weight.shape,
                     dtype=self._dtype,
-                    device=emb.emb_tensor.device,
+                    device=emb.weight.device,
                 ).zero_()
                 state_power = th.empty(
-                    emb.emb_tensor.shape,
+                    emb.weight.shape,
                     dtype=self._dtype,
-                    device=emb.emb_tensor.device,
+                    device=emb.weight.device,
                 ).zero_()
             state = (state_step, state_mem, state_power)
             emb.set_optm_state(state)


### PR DESCRIPTION
Remove ```emb_tensor``` in dgl.nn,  function definition is in sparse_emb.py.

## Checklist
Please feel free to remove inapplicable items for your PR.
- [ ] The PR title starts with [$CATEGORY] (such as [NN], [Model], [Doc], [Feature]])
- [ ] I've leverage the [tools](https://docs.google.com/document/d/1iHyj7zlmygKSk5gBPsqIqL5ASPzJSPREaNT_QdsiYA4/edit) to beautify the python and c++ code.
- [ ] The PR is complete and small, read the [Google eng practice (CL equals to PR)](https://google.github.io/eng-practices/review/developer/small-cls.html) to understand more about small PR. In DGL, we consider PRs with less than 200 lines of core code change are small (example, test and documentation could be exempted).
- [ ] All changes have test coverage
- [ ] Code is well-documented
- [ ] To the best of my knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change
- [ ] Related issue is referred in this PR
- [ ] If the PR is for a new model/paper, I've updated the example index [here](../examples/README.md).

## Changes
<!-- You could use following template
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)
-->
