### PR TITLE
[API Deprecation]Remove adjacency_matrix_scipy and inplace args in candidates 

### DIFF
--- a/python/dgl/heterograph.py
+++ b/python/dgl/heterograph.py
@@ -4458,8 +4458,7 @@ class DGLGraph(object):
                       message_func,
                       reduce_func,
                       apply_node_func=None,
-                      etype=None,
-                      inplace=False):
+                      etype=None):
         """Send messages along the specified edges and reduce them on
         the destination nodes to update their features.
 
@@ -4494,9 +4493,6 @@ class DGLGraph(object):
               triplet format in the graph.
 
             Can be omitted if the graph has only one type of edges.
-
-        inplace: bool, optional
-            **DEPRECATED**.
 
         Notes
         -----
@@ -4570,8 +4566,6 @@ class DGLGraph(object):
 
         Note that the feature of node 0 remains the same as it has no incoming edges.
         """
-        if inplace:
-            raise DGLError('The `inplace` option is removed in v0.5.')
         # edge type
         etid = self.get_etype_id(etype)
         _, dtid = self._graph.metagraph.find_edge(etid)
@@ -4594,8 +4588,7 @@ class DGLGraph(object):
              message_func,
              reduce_func,
              apply_node_func=None,
-             etype=None,
-             inplace=False):
+             etype=None):
         """Pull messages from the specified node(s)' predecessors along the
         specified edge type, aggregate them to update the node features.
 
@@ -4626,9 +4619,6 @@ class DGLGraph(object):
               triplet format in the graph.
 
             Can be omitted if the graph has only one type of edges.
-
-        inplace: bool, optional
-            **DEPRECATED**.
 
         Notes
         -----
@@ -4676,8 +4666,6 @@ class DGLGraph(object):
                 [1.],
                 [1.]])
         """
-        if inplace:
-            raise DGLError('The `inplace` option is removed in v0.5.')
         v = utils.prepare_tensor(self, v, 'v')
         if len(v) == 0:
             # no computation
@@ -4698,8 +4686,7 @@ class DGLGraph(object):
              message_func,
              reduce_func,
              apply_node_func=None,
-             etype=None,
-             inplace=False):
+             etype=None):
         """Send message from the specified node(s) to their successors
         along the specified edge type and update their node features.
 
@@ -4730,9 +4717,6 @@ class DGLGraph(object):
               triplet format in the graph.
 
             Can be omitted if the graph has only one type of edges.
-
-        inplace: bool, optional
-            **DEPRECATED**.
 
         Notes
         -----
@@ -4773,8 +4757,6 @@ class DGLGraph(object):
                 [0.],
                 [0.]])
         """
-        if inplace:
-            raise DGLError('The `inplace` option is removed in v0.5.')
         edges = self.out_edges(u, form='eid', etype=etype)
         self.send_and_recv(edges, message_func, reduce_func, apply_node_func, etype=etype)
 

--- a/python/dgl/heterograph.py
+++ b/python/dgl/heterograph.py
@@ -4274,7 +4274,7 @@ class DGLGraph(object):
     # Message passing
     #################################################################
 
-    def apply_nodes(self, func, v=ALL, ntype=None, inplace=False):
+    def apply_nodes(self, func, v=ALL, ntype=None):
         """Update the features of the specified nodes by the provided function.
 
         Parameters
@@ -4294,8 +4294,6 @@ class DGLGraph(object):
         ntype : str, optional
             The node type name. Can be omitted if there is
             only one type of nodes in the graph.
-        inplace : bool, optional
-            **DEPRECATED**.
 
         Examples
         --------
@@ -4331,8 +4329,6 @@ class DGLGraph(object):
         --------
         apply_edges
         """
-        if inplace:
-            raise DGLError('The `inplace` option is removed in v0.5.')
         ntid = self.get_ntype_id(ntype)
         ntype = self.ntypes[ntid]
         if is_all(v):
@@ -4342,7 +4338,7 @@ class DGLGraph(object):
         ndata = core.invoke_node_udf(self, v_id, ntype, func, orig_nid=v_id)
         self._set_n_repr(ntid, v, ndata)
 
-    def apply_edges(self, func, edges=ALL, etype=None, inplace=False):
+    def apply_edges(self, func, edges=ALL, etype=None):
         """Update the features of the specified edges by the provided function.
 
         Parameters
@@ -4372,9 +4368,6 @@ class DGLGraph(object):
               triplet format in the graph.
 
             Can be omitted if the graph has only one type of edges.
-
-        inplace: bool, optional
-            **DEPRECATED**.
 
         Notes
         -----
@@ -4426,8 +4419,6 @@ class DGLGraph(object):
         --------
         apply_nodes
         """
-        if inplace:
-            raise DGLError('The `inplace` option is removed in v0.5.')
         # Graph with one relation type
         if self._graph.number_of_etypes() == 1 or etype is not None:
             etid = self.get_etype_id(etype)

--- a/python/dgl/heterograph.py
+++ b/python/dgl/heterograph.py
@@ -3713,15 +3713,6 @@ class DGLGraph(object):
         else:
             return self._graph.adjacency_matrix_tensors(etid, False, fmt)[2:]
 
-    def adjacency_matrix_scipy(self, transpose=False, fmt='csr', return_edge_ids=None):
-        """DEPRECATED: please use ``dgl.adjacency_matrix(transpose, scipy_fmt=fmt)``.
-        """
-        dgl_warning('DGLGraph.adjacency_matrix_scipy is deprecated. '
-                    'Please replace it with:\n\n\t'
-                    'DGLGraph.adjacency_matrix(transpose, scipy_fmt="{}").\n'.format(fmt))
-
-        return self.adjacency_matrix(transpose=transpose, scipy_fmt=fmt)
-
     def inc(self, typestr, ctx=F.cpu(), etype=None):
         """Return the incidence matrix representation of edges with the given
         edge type.


### PR DESCRIPTION
Remove ```function adjacency_matrix_scipy``` and ```in_place``` argument in ```push```,```pull```,```apply_edges```, ```apply_nodes``` and ```send_and_recv```

## Checklist
Please feel free to remove inapplicable items for your PR.
- [ ] The PR title starts with [$CATEGORY] (such as [NN], [Model], [Doc], [Feature]])
- [ ] I've leverage the [tools](https://docs.google.com/document/d/1iHyj7zlmygKSk5gBPsqIqL5ASPzJSPREaNT_QdsiYA4/edit) to beautify the python and c++ code.
- [ ] The PR is complete and small, read the [Google eng practice (CL equals to PR)](https://google.github.io/eng-practices/review/developer/small-cls.html) to understand more about small PR. In DGL, we consider PRs with less than 200 lines of core code change are small (example, test and documentation could be exempted).
- [ ] All changes have test coverage
- [ ] Code is well-documented
- [ ] To the best of my knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change
- [ ] Related issue is referred in this PR
- [ ] If the PR is for a new model/paper, I've updated the example index [here](../examples/README.md).

## Changes
<!-- You could use following template
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)
-->
