### PR TITLE
Revert "[Performance] Make IdHashMap parallel"

### DIFF
--- a/src/array/cpu/array_utils.h
+++ b/src/array/cpu/array_utils.h
@@ -7,7 +7,6 @@
 #define DGL_ARRAY_CPU_ARRAY_UTILS_H_
 
 #include <dgl/aten/types.h>
-#include <dgl/runtime/parallel_for.h>
 #include <parallel_hashmap/phmap.h>
 
 #include <unordered_map>
@@ -82,13 +81,9 @@ class IdHashMap {
     const IdType* ids_data = static_cast<IdType*>(ids->data);
     const int64_t len = ids->shape[0];
     IdArray values = NewIdArray(len, ids->ctx, ids->dtype.bits);
-    IdType* values_data = values.Ptr<IdType>();
-    runtime::parallel_for(
-        0, len, 1000, [=] (size_t begin, size_t end) {
-          for (size_t i = begin; i < end; ++i) {
-            values_data[i] = Map(ids_data[i], default_val);
-          }
-        });
+    IdType* values_data = static_cast<IdType*>(values->data);
+    for (int64_t i = 0; i < len; ++i)
+      values_data[i] = Map(ids_data[i], default_val);
     return values;
   }
 


### PR DESCRIPTION
Reverts dmlc/dgl#4881 because they did not work as expected.