### PR TITLE
[API Deprecation]Remove APIs in old dgl section in DGLGraph

### DIFF
--- a/examples/pytorch/ogb/deepwalk/reading_data.py
+++ b/examples/pytorch/ogb/deepwalk/reading_data.py
@@ -125,7 +125,6 @@ def net2graph(net_sm):
 
 
 def make_undirected(G):
-    # G.readonly(False)
     G.add_edges(G.edges()[1], G.edges()[0])
     return G
 

--- a/examples/pytorch/ogb/line/reading_data.py
+++ b/examples/pytorch/ogb/line/reading_data.py
@@ -124,7 +124,6 @@ def net2graph(net_sm):
 
 
 def make_undirected(G):
-    # G.readonly(False)
     G.add_edges(G.edges()[1], G.edges()[0])
     return G
 

--- a/python/dgl/heterograph.py
+++ b/python/dgl/heterograph.py
@@ -6066,29 +6066,6 @@ class DGLGraph(object):
     # DEPRECATED: from the old DGLGraph
     #################################################################
 
-    def from_networkx(self, nx_graph, node_attrs=None, edge_attrs=None):
-        """DEPRECATED: please use
-
-            ``dgl.from_networkx(nx_graph, node_attrs, edge_attrs)``
-
-        which will return a new graph created from the networkx graph.
-        """
-        raise DGLError('DGLGraph.from_networkx is deprecated. Please call the following\n\n'
-                       '\t dgl.from_networkx(nx_graph, node_attrs, edge_attrs)\n\n'
-                       ', which creates a new DGLGraph from the networkx graph.')
-
-    def from_scipy_sparse_matrix(self, spmat, multigraph=None):
-        """DEPRECATED: please use
-
-            ``dgl.from_scipy(spmat)``
-
-        which will return a new graph created from the scipy matrix.
-        """
-        raise DGLError('DGLGraph.from_scipy_sparse_matrix is deprecated. '
-                       'Please call the following\n\n'
-                       '\t dgl.from_scipy(spmat)\n\n'
-                       ', which creates a new DGLGraph from the scipy matrix.')
-
     def register_apply_node_func(self, func):
         """Deprecated: please directly call :func:`apply_nodes` with ``func``
         as argument.

--- a/python/dgl/heterograph.py
+++ b/python/dgl/heterograph.py
@@ -6062,36 +6062,6 @@ class DGLGraph(object):
         """
         return self.astype(F.int32)
 
-    #################################################################
-    # DEPRECATED: from the old DGLGraph
-    #################################################################
-
-    def send(self, edges, message_func, etype=None):
-        """Send messages along the given edges with the same edge type.
-
-        DEPRECATE: please use send_and_recv, update_all.
-        """
-        raise DGLError('DGLGraph.send is deprecated. As a replacement, use DGLGraph.apply_edges\n'
-                       ' API to compute messages as edge data. Then use DGLGraph.send_and_recv\n'
-                       ' and set the message function as dgl.function.copy_e to conduct message\n'
-                       ' aggregation.')
-
-    def recv(self, v, reduce_func, apply_node_func=None, etype=None, inplace=False):
-        r"""Receive and reduce incoming messages and update the features of node(s) :math:`v`.
-
-        DEPRECATE: please use send_and_recv, update_all.
-        """
-        raise DGLError('DGLGraph.recv is deprecated. As a replacement, use DGLGraph.apply_edges\n'
-                       ' API to compute messages as edge data. Then use DGLGraph.send_and_recv\n'
-                       ' and set the message function as dgl.function.copy_e to conduct message\n'
-                       ' aggregation.')
-
-    def readonly(self, readonly_state=True):
-        """Deprecated: DGLGraph will always be mutable."""
-        dgl_warning('DGLGraph.readonly is deprecated in v0.5.\n'
-                    'DGLGraph now always supports mutable operations like add_nodes'
-                    ' and add_edges.')
-
 ############################################################
 # Internal APIs
 ############################################################

--- a/python/dgl/heterograph.py
+++ b/python/dgl/heterograph.py
@@ -6066,38 +6066,6 @@ class DGLGraph(object):
     # DEPRECATED: from the old DGLGraph
     #################################################################
 
-    def register_apply_node_func(self, func):
-        """Deprecated: please directly call :func:`apply_nodes` with ``func``
-        as argument.
-        """
-        raise DGLError('DGLGraph.register_apply_node_func is deprecated.'
-                       ' Please directly call apply_nodes with func as the argument.')
-
-    def register_apply_edge_func(self, func):
-        """Deprecated: please directly call :func:`apply_edges` with ``func``
-        as argument.
-        """
-        raise DGLError('DGLGraph.register_apply_edge_func is deprecated.'
-                       ' Please directly call apply_edges with func as the argument.')
-
-    def register_message_func(self, func):
-        """Deprecated: please directly call :func:`update_all` with ``func``
-        as argument.
-        """
-        raise DGLError('DGLGraph.register_message_func is deprecated.'
-                       ' Please directly call update_all with func as the argument.')
-
-    def register_reduce_func(self, func):
-        """Deprecated: please directly call :func:`update_all` with ``func``
-        as argument.
-        """
-        raise DGLError('DGLGraph.register_reduce_func is deprecated.'
-                       ' Please directly call update_all with func as the argument.')
-
-    def group_apply_edges(self, group_by, func, edges=ALL, etype=None, inplace=False):
-        """**DEPRECATED**: The API is removed in 0.5."""
-        raise DGLError('DGLGraph.group_apply_edges is removed in 0.5.')
-
     def send(self, edges, message_func, etype=None):
         """Send messages along the given edges with the same edge type.
 
@@ -6117,28 +6085,6 @@ class DGLGraph(object):
                        ' API to compute messages as edge data. Then use DGLGraph.send_and_recv\n'
                        ' and set the message function as dgl.function.copy_e to conduct message\n'
                        ' aggregation.')
-
-    def multi_recv(self, v, reducer_dict, cross_reducer, apply_node_func=None, inplace=False):
-        r"""Receive messages from multiple edge types and perform aggregation.
-
-        DEPRECATE: please use multi_send_and_recv, multi_update_all.
-        """
-        raise DGLError('DGLGraph.multi_recv is deprecated. As a replacement,\n'
-                       ' use DGLGraph.apply_edges API to compute messages as edge data.\n'
-                       ' Then use DGLGraph.multi_send_and_recv and set the message function\n'
-                       ' as dgl.function.copy_e to conduct message aggregation.')
-
-    def multi_send_and_recv(self, etype_dict, cross_reducer, apply_node_func=None, inplace=False):
-        r"""**DEPRECATED**: The API is removed in v0.5."""
-        raise DGLError('DGLGraph.multi_pull is removed in v0.5. As a replacement,\n'
-                       ' use DGLGraph.edge_subgraph to extract the subgraph first \n'
-                       ' and then call DGLGraph.multi_update_all.')
-
-    def multi_pull(self, v, etype_dict, cross_reducer, apply_node_func=None, inplace=False):
-        r"""**DEPRECATED**: The API is removed in v0.5."""
-        raise DGLError('DGLGraph.multi_pull is removed in v0.5. As a replacement,\n'
-                       ' use DGLGraph.edge_subgraph to extract the subgraph first \n'
-                       ' and then call DGLGraph.multi_update_all.')
 
     def readonly(self, readonly_state=True):
         """Deprecated: DGLGraph will always be mutable."""

--- a/tests/distributed/test_distributed_sampling.py
+++ b/tests/distributed/test_distributed_sampling.py
@@ -96,7 +96,6 @@ def check_rpc_sampling(tmpdir, num_server):
     generate_ip_config("rpc_ip_config.txt", num_server, num_server)
 
     g = CitationGraphDataset("cora")[0]
-    g.readonly()
     print(g.idtype)
     num_parts = num_server
     num_hops = 1
@@ -128,7 +127,6 @@ def check_rpc_find_edges_shuffle(tmpdir, num_server):
     generate_ip_config("rpc_ip_config.txt", num_server, num_server)
 
     g = CitationGraphDataset("cora")[0]
-    g.readonly()
     num_parts = num_server
 
     orig_nid, orig_eid = partition_graph(g, 'test_find_edges', num_parts, tmpdir,
@@ -225,7 +223,6 @@ def check_rpc_get_degree_shuffle(tmpdir, num_server):
     generate_ip_config("rpc_ip_config.txt", num_server, num_server)
 
     g = CitationGraphDataset("cora")[0]
-    g.readonly()
     num_parts = num_server
 
     orig_nid, _ = partition_graph(g, 'test_get_degrees', num_parts, tmpdir,
@@ -278,7 +275,6 @@ def check_rpc_sampling_shuffle(tmpdir, num_server, num_groups=1):
     generate_ip_config("rpc_ip_config.txt", num_server, num_server)
 
     g = CitationGraphDataset("cora")[0]
-    g.readonly()
     num_parts = num_server
     num_hops = 1
 
@@ -906,7 +902,6 @@ def check_rpc_in_subgraph_shuffle(tmpdir, num_server):
     generate_ip_config("rpc_ip_config.txt", num_server, num_server)
 
     g = CitationGraphDataset("cora")[0]
-    g.readonly()
     num_parts = num_server
 
     orig_nid, orig_eid = partition_graph(g, 'test_in_subgraph', num_parts, tmpdir,


### PR DESCRIPTION
Remove formxxx, multixxx, readonly, registerxxx, send, recv, group_apply_edges

## Checklist
Please feel free to remove inapplicable items for your PR.
- [ ] The PR title starts with [$CATEGORY] (such as [NN], [Model], [Doc], [Feature]])
- [ ] I've leverage the [tools](https://docs.google.com/document/d/1iHyj7zlmygKSk5gBPsqIqL5ASPzJSPREaNT_QdsiYA4/edit) to beautify the python and c++ code.
- [ ] The PR is complete and small, read the [Google eng practice (CL equals to PR)](https://google.github.io/eng-practices/review/developer/small-cls.html) to understand more about small PR. In DGL, we consider PRs with less than 200 lines of core code change are small (example, test and documentation could be exempted).
- [ ] All changes have test coverage
- [ ] Code is well-documented
- [ ] To the best of my knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change
- [ ] Related issue is referred in this PR
- [ ] If the PR is for a new model/paper, I've updated the example index [here](../examples/README.md).

## Changes
<!-- You could use following template
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)
-->
