### PR TITLE
[API Deprecation]Remove 5 APIs in DGLGraph

### DIFF
--- a/examples/mxnet/monet/citation.py
+++ b/examples/mxnet/monet/citation.py
@@ -118,7 +118,7 @@ def main(args):
     pseudo = []
     for i in range(g.number_of_edges()):
         pseudo.append(
-            [1 / np.sqrt(g.in_degree(us[i])), 1 / np.sqrt(g.in_degree(vs[i]))]
+            [1 / np.sqrt(g.in_degrees(us[i])), 1 / np.sqrt(g.in_degrees(vs[i]))]
         )
     pseudo = nd.array(pseudo, ctx=ctx)
 

--- a/examples/pytorch/dgmg/model.py
+++ b/examples/pytorch/dgmg/model.py
@@ -204,7 +204,7 @@ class ChooseDestAndUpdate(nn.Module):
         if not self.training:
             dest = Categorical(dests_probs).sample().item()
 
-        if not g.has_edge_between(src, dest):
+        if not g.has_edges_between(src, dest):
             # For undirected graphs, we add edges for both directions
             # so that we can perform graph propagation.
             src_list = [src, dest]

--- a/examples/pytorch/ogb/cluster-sage/main.py
+++ b/examples/pytorch/ogb/cluster-sage/main.py
@@ -270,8 +270,8 @@ if __name__ == "__main__":
     mask[test_idx] = True
     graph.ndata["test_mask"] = mask
 
-    graph.in_degree(0)
-    graph.out_degree(0)
+    graph.in_degrees(0)
+    graph.out_degrees(0)
     graph.find_edges(0)
 
     cluster_iter_data = ClusterIter(

--- a/python/dgl/heterograph.py
+++ b/python/dgl/heterograph.py
@@ -2624,20 +2624,6 @@ class DGLGraph(object):
         return len(self.ntypes) == 1 and len(self.etypes) == 1
 
     @property
-    def is_readonly(self):
-        """**DEPRECATED**: DGLGraph will always be mutable.
-
-        Returns
-        -------
-        bool
-            True if the graph is readonly, False otherwise.
-        """
-        dgl_warning('DGLGraph.is_readonly is deprecated in v0.5.\n'
-                    'DGLGraph now always supports mutable operations like add_nodes'
-                    ' and add_edges.')
-        return False
-
-    @property
     def idtype(self):
         """The data type for storing the structure-related graph information
         such as node and edge IDs.
@@ -2745,14 +2731,6 @@ class DGLGraph(object):
         else:
             return F.astype(ret, F.bool)
 
-    def has_node(self, vid, ntype=None):
-        """Whether the graph has a particular node of a given type.
-
-        **DEPRECATED**: see :func:`~DGLGraph.has_nodes`
-        """
-        dgl_warning("DGLGraph.has_node is deprecated. Please use DGLGraph.has_nodes")
-        return self.has_nodes(vid, ntype)
-
     def has_edges_between(self, u, v, etype=None):
         """Return whether the graph contains the given edges.
 
@@ -2842,15 +2820,6 @@ class DGLGraph(object):
             return bool(F.as_scalar(ret))
         else:
             return F.astype(ret, F.bool)
-
-    def has_edge_between(self, u, v, etype=None):
-        """Whether the graph has edges of type ``etype``.
-
-        **DEPRECATED**: please use :func:`~DGLGraph.has_edge_between`.
-        """
-        dgl_warning("DGLGraph.has_edge_between is deprecated. "
-                    "Please use DGLGraph.has_edges_between")
-        return self.has_edges_between(u, v, etype)
 
     def predecessors(self, v, etype=None):
         """Return the predecessor(s) of a particular node with the specified edge type.
@@ -3424,14 +3393,6 @@ class DGLGraph(object):
         else:
             raise DGLError('Invalid form: {}. Must be "all", "uv" or "eid".'.format(form))
 
-    def in_degree(self, v, etype=None):
-        """Return the in-degree of node ``v`` with edges of type ``etype``.
-
-        **DEPRECATED**: Please use in_degrees
-        """
-        dgl_warning("DGLGraph.in_degree is deprecated. Please use DGLGraph.in_degrees")
-        return self.in_degrees(v, etype)
-
     def in_degrees(self, v=ALL, etype=None):
         """Return the in-degree(s) of the given nodes.
 
@@ -3507,14 +3468,6 @@ class DGLGraph(object):
             return F.as_scalar(deg)
         else:
             return deg
-
-    def out_degree(self, u, etype=None):
-        """Return the out-degree of node `u` with edges of type ``etype``.
-
-        DEPRECATED: please use DGL.out_degrees
-        """
-        dgl_warning("DGLGraph.out_degree is deprecated. Please use DGLGraph.out_degrees")
-        return self.out_degrees(u, etype)
 
     def out_degrees(self, u=ALL, etype=None):
         """Return the out-degree(s) of the given nodes.

--- a/tests/compute/test_graph.py
+++ b/tests/compute/test_graph.py
@@ -61,16 +61,16 @@ def test_query():
         assert g.number_of_edges() == 20
 
         for i in range(10):
-            assert g.has_node(i)
+            assert g.has_nodes(i)
             assert i in g
-        assert not g.has_node(11)
+        assert not g.has_nodes(11)
         assert not 11 in g
         assert F.allclose(g.has_nodes([0,2,10,11]), F.tensor([1,1,0,0]))
 
         src, dst = edge_pair_input()
         for u, v in zip(src, dst):
-            assert g.has_edge_between(u, v)
-        assert not g.has_edge_between(0, 0)
+            assert g.has_edges_between(u, v)
+        assert not g.has_edges_between(0, 0)
         assert F.allclose(g.has_edges_between([0, 0, 3], [0, 9, 8]), F.tensor([0,1,1]))
         assert set(F.asnumpy(g.predecessors(9))) == set([0,5,7,4])
         assert set(F.asnumpy(g.successors(2))) == set([7,3])
@@ -110,11 +110,11 @@ def test_query():
         assert set(tup) == set(t_tup)
         assert list(F.asnumpy(src)) == sorted(list(F.asnumpy(src)))
 
-        assert g.in_degree(0) == 0
-        assert g.in_degree(9) == 4
+        assert g.in_degrees(0) == 0
+        assert g.in_degrees(9) == 4
         assert F.allclose(g.in_degrees([0, 9]), F.tensor([0, 4]))
-        assert g.out_degree(8) == 0
-        assert g.out_degree(9) == 1
+        assert g.out_degrees(8) == 0
+        assert g.out_degrees(9) == 1
         assert F.allclose(g.out_degrees([8, 9]), F.tensor([0, 1]))
 
         assert np.array_equal(
@@ -132,16 +132,16 @@ def test_query():
         assert g.number_of_edges() == 20
 
         for i in range(10):
-            assert g.has_node(i)
+            assert g.has_nodes(i)
             assert i in g
-        assert not g.has_node(11)
+        assert not g.has_nodes(11)
         assert not 11 in g
         assert F.allclose(g.has_nodes([0,2,10,11]), F.tensor([1,1,0,0]))
 
         src, dst = edge_pair_input(sort=True)
         for u, v in zip(src, dst):
-            assert g.has_edge_between(u, v)
-        assert not g.has_edge_between(0, 0)
+            assert g.has_edges_between(u, v)
+        assert not g.has_edges_between(0, 0)
         assert F.allclose(g.has_edges_between([0, 0, 3], [0, 9, 8]), F.tensor([0,1,1]))
         assert set(F.asnumpy(g.predecessors(9))) == set([0,5,7,4])
         assert set(F.asnumpy(g.successors(2))) == set([7,3])
@@ -184,11 +184,11 @@ def test_query():
         assert set(tup) == set(t_tup)
         assert list(F.asnumpy(src)) == sorted(list(F.asnumpy(src)))
 
-        assert g.in_degree(0) == 0
-        assert g.in_degree(9) == 4
+        assert g.in_degrees(0) == 0
+        assert g.in_degrees(9) == 4
         assert F.allclose(g.in_degrees([0, 9]), F.tensor([0, 4]))
-        assert g.out_degree(8) == 0
-        assert g.out_degree(9) == 1
+        assert g.out_degrees(8) == 0
+        assert g.out_degrees(9) == 1
         assert F.allclose(g.out_degrees([8, 9]), F.tensor([0, 1]))
 
         assert np.array_equal(
@@ -323,18 +323,18 @@ def test_hypersparse_query():
     g.add_nodes(1000001)
     g.add_edges([0], [1])
     for i in range(10):
-        assert g.has_node(i)
+        assert g.has_nodes(i)
         assert i in g
-    assert not g.has_node(1000002)
+    assert not g.has_nodes(1000002)
     assert g.edge_id(0, 1) == 0
     src, dst = g.find_edges([0])
     src, dst, eid = g.in_edges(1, form='all')
     src, dst, eid = g.out_edges(0, form='all')
     src, dst = g.edges()
-    assert g.in_degree(0) == 0
-    assert g.in_degree(1) == 1
-    assert g.out_degree(0) == 1
-    assert g.out_degree(1) == 0
+    assert g.in_degrees(0) == 0
+    assert g.in_degrees(1) == 1
+    assert g.out_degrees(0) == 1
+    assert g.out_degrees(1) == 0
 
 def test_empty_data_initialized():
     g = dgl.DGLGraph()

--- a/tests/compute/test_heterograph.py
+++ b/tests/compute/test_heterograph.py
@@ -269,12 +269,12 @@ def test_query(idtype):
         # number of edges
         assert [g.num_edges(etype) for etype in etypes] == [2, 4, 2, 2]
 
-        # has_node & has_nodes
+        # has_nodes
         for ntype in ntypes:
             n = g.number_of_nodes(ntype)
             for i in range(n):
-                assert g.has_node(i, ntype)
-            assert not g.has_node(n, ntype)
+                assert g.has_nodes(i, ntype)
+            assert not g.has_nodes(n, ntype)
             assert np.array_equal(
                 F.asnumpy(g.has_nodes([0, n], ntype)).astype('int32'), [1, 0])
 

--- a/tests/compute/test_pickle.py
+++ b/tests/compute/test_pickle.py
@@ -14,7 +14,6 @@ from test_utils import parametrize_idtype, get_cases
 from utils import assert_is_identical, assert_is_identical_hetero
 
 def _assert_is_identical_nodeflow(nf1, nf2):
-    assert nf1.is_readonly == nf2.is_readonly
     assert nf1.number_of_nodes() == nf2.number_of_nodes()
     src, dst = nf1.all_edges()
     src2, dst2 = nf2.all_edges()

--- a/tests/compute/test_sampling.py
+++ b/tests/compute/test_sampling.py
@@ -14,7 +14,7 @@ def check_random_walk(g, metapath, traces, ntypes, prob=None, trace_eids=None):
 
     for i in range(traces.shape[0]):
         for j in range(traces.shape[1] - 1):
-            assert g.has_edge_between(
+            assert g.has_edges_between(
                 traces[i, j], traces[i, j+1], etype=metapath[j])
             if prob is not None and prob in g.edges[metapath[j]].data:
                 p = F.asnumpy(g.edges[metapath[j]].data['p'])

--- a/tests/compute/test_shared_mem.py
+++ b/tests/compute/test_shared_mem.py
@@ -23,7 +23,6 @@ def create_test_graph(idtype):
     return g
 
 def _assert_is_identical_hetero(g, g2):
-    assert g.is_readonly == g2.is_readonly
     assert g.ntypes == g2.ntypes
     assert g.canonical_etypes == g2.canonical_etypes
 

--- a/tests/compute/test_transform.py
+++ b/tests/compute/test_transform.py
@@ -101,8 +101,8 @@ def test_no_backtracking():
     for i in range(1, N):
         e1 = G.edge_id(0, i)
         e2 = G.edge_id(i, 0)
-        assert not L.has_edge_between(e1, e2)
-        assert not L.has_edge_between(e2, e1)
+        assert not L.has_edges_between(e1, e2)
+        assert not L.has_edges_between(e2, e1)
 
 # reverse graph related
 @parametrize_idtype

--- a/tests/compute/utils.py
+++ b/tests/compute/utils.py
@@ -11,7 +11,6 @@ def check_fail(fn, *args, **kwargs):
         return True
 
 def assert_is_identical(g, g2):
-    assert g.is_readonly == g2.is_readonly
     assert g.number_of_nodes() == g2.number_of_nodes()
     src, dst = g.all_edges(order='eid')
     src2, dst2 = g2.all_edges(order='eid')
@@ -26,7 +25,6 @@ def assert_is_identical(g, g2):
         assert F.allclose(g.edata[k], g2.edata[k])
 
 def assert_is_identical_hetero(g, g2, ignore_internal_data=False):
-    assert g.is_readonly == g2.is_readonly
     assert g.ntypes == g2.ntypes
     assert g.canonical_etypes == g2.canonical_etypes
 

--- a/tutorials/models/3_generative_model/5_dgmg.py
+++ b/tutorials/models/3_generative_model/5_dgmg.py
@@ -625,7 +625,7 @@ class ChooseDestAndUpdate(nn.Module):
         if not self.training:
             dest = Categorical(dests_probs).sample().item()
 
-        if not g.has_edge_between(src, dest):
+        if not g.has_edges_between(src, dest):
             # For undirected graphs, add edges for both directions
             # so that you can perform graph propagation.
             src_list = [src, dest]


### PR DESCRIPTION
Remove ```has_edge_between```  ```has_node``` ```in_degree``` ```is_readonly```  ```out_degree``` in ```DGLGraph```.

## Checklist
Please feel free to remove inapplicable items for your PR.
- [ ] The PR title starts with [$CATEGORY] (such as [NN], [Model], [Doc], [Feature]])
- [ ] I've leverage the [tools](https://docs.google.com/document/d/1iHyj7zlmygKSk5gBPsqIqL5ASPzJSPREaNT_QdsiYA4/edit) to beautify the python and c++ code.
- [ ] The PR is complete and small, read the [Google eng practice (CL equals to PR)](https://google.github.io/eng-practices/review/developer/small-cls.html) to understand more about small PR. In DGL, we consider PRs with less than 200 lines of core code change are small (example, test and documentation could be exempted).
- [ ] All changes have test coverage
- [ ] Code is well-documented
- [ ] To the best of my knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change
- [ ] Related issue is referred in this PR
- [ ] If the PR is for a new model/paper, I've updated the example index [here](../examples/README.md).

## Changes
<!-- You could use following template
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)
-->
