### PR TITLE
[Dist] init node/edge data store for Node/EdgeDataView in appropriate place

### DIFF
--- a/python/dgl/distributed/dist_graph.py
+++ b/python/dgl/distributed/dist_graph.py
@@ -519,8 +519,7 @@ class DistGraph:
         self._client.map_shared_data(self._gpb)
 
     def _init_ndata_store(self):
-        '''Init node data store
-        '''
+        '''Initialize node data store.'''
         self._ndata_store = {}
         for ntype in self.ntypes:
             names = self._get_ndata_names(ntype)
@@ -541,8 +540,7 @@ class DistGraph:
                 self._ndata_store[ntype] = data
 
     def _init_edata_store(self):
-        '''Init edge data store
-        '''
+        '''Initialize edge data store.'''
         self._edata_store = {}
         for etype in self.canonical_etypes:
             names = self._get_edata_names(etype)

--- a/python/dgl/distributed/dist_graph.py
+++ b/python/dgl/distributed/dist_graph.py
@@ -522,8 +522,6 @@ class DistGraph:
 
         self._ndata_store = {}
         self._edata_store = {}
-        self._ndata = NodeDataView(self)
-        self._edata = EdgeDataView(self)
 
         self._num_nodes = 0
         self._num_edges = 0
@@ -554,8 +552,6 @@ class DistGraph:
 
         self._ndata_store = {}
         self._edata_store = {}
-        self._ndata = NodeDataView(self)
-        self._edata = EdgeDataView(self)
         self._num_nodes = 0
         self._num_edges = 0
         for part_md in self._gpb.metadata():
@@ -600,7 +596,7 @@ class DistGraph:
             The data view in the distributed graph storage.
         """
         assert len(self.ntypes) == 1, "ndata only works for a graph with one node type."
-        return self._ndata
+        return NodeDataView(self)
 
     @property
     def edata(self):
@@ -612,7 +608,7 @@ class DistGraph:
             The data view in the distributed graph storage.
         """
         assert len(self.etypes) == 1, "edata only works for a graph with one edge type."
-        return self._edata
+        return EdgeDataView(self)
 
     @property
     def idtype(self):

--- a/python/dgl/distributed/dist_graph.py
+++ b/python/dgl/distributed/dist_graph.py
@@ -13,7 +13,7 @@ from ..convert import graph as dgl_graph
 from ..transforms import compact_graphs
 from .. import heterograph_index
 from .. import backend as F
-from ..base import NID, EID, ETYPE, ALL, is_all
+from ..base import NID, EID, ETYPE, ALL, is_all, DGLError
 from .kvstore import KVServer, get_kvstore
 from .._ffi.ndarray import empty_shared_mem
 from ..ndarray import exist_shared_mem_array
@@ -176,24 +176,12 @@ class NodeDataView(MutableMapping):
 
     def __init__(self, g, ntype=None):
         self._graph = g
-        # When this is created, the server may already load node data. We need to
-        # initialize the node data in advance.
-        names = g._get_ndata_names(ntype)
         if ntype is None:
             self._data = g._ndata_store
         else:
-            if ntype in g._ndata_store:
-                self._data = g._ndata_store[ntype]
-            else:
-                self._data = {}
-                g._ndata_store[ntype] = self._data
-        for name in names:
-            assert name.is_node()
-            policy = PartitionPolicy(name.policy_str, g.get_partition_book())
-            dtype, shape, _ = g._client.get_data_meta(str(name))
-            # We create a wrapper on the existing tensor in the kvstore.
-            self._data[name.get_name()] = DistTensor(shape, dtype, name.get_name(),
-                                                     part_policy=policy, attach=False)
+            if ntype not in g.ntypes:
+                raise DGLError(f"Node type {ntype} does not exist.")
+            self._data = g._ndata_store[ntype]
 
     def _get_names(self):
         return list(self._data.keys())
@@ -230,24 +218,11 @@ class EdgeDataView(MutableMapping):
 
     def __init__(self, g, etype=None):
         self._graph = g
-        # When this is created, the server may already load edge data. We need to
-        # initialize the edge data in advance.
-        names = g._get_edata_names(etype)
         if etype is None:
             self._data = g._edata_store
         else:
-            if etype in g._edata_store:
-                self._data = g._edata_store[etype]
-            else:
-                self._data = {}
-                g._edata_store[etype] = self._data
-        for name in names:
-            assert name.is_edge()
-            policy = PartitionPolicy(name.policy_str, g.get_partition_book())
-            dtype, shape, _ = g._client.get_data_meta(str(name))
-            # We create a wrapper on the existing tensor in the kvstore.
-            self._data[name.get_name()] = DistTensor(shape, dtype, name.get_name(),
-                                                     part_policy=policy, attach=False)
+            c_etype = g.to_canonical_etype(etype)
+            self._data = g._edata_store[c_etype]
 
     def _get_names(self):
         return list(self._data.keys())
@@ -520,8 +495,8 @@ class DistGraph:
                 rpc.recv_response()
             self._client.barrier()
 
-        self._ndata_store = {}
-        self._edata_store = {}
+        self._init_ndata_store()
+        self._init_edata_store()
 
         self._num_nodes = 0
         self._num_edges = 0
@@ -543,6 +518,50 @@ class DistGraph:
             self._gpb = gpb
         self._client.map_shared_data(self._gpb)
 
+    def _init_ndata_store(self):
+        '''Init node data store
+        '''
+        self._ndata_store = {}
+        for ntype in self.ntypes:
+            names = self._get_ndata_names(ntype)
+            data = {}
+            for name in names:
+                assert name.is_node()
+                policy = PartitionPolicy(name.policy_str,
+                    self.get_partition_book()
+                )
+                dtype, shape, _ = self._client.get_data_meta(str(name))
+                # We create a wrapper on the existing tensor in the kvstore.
+                data[name.get_name()] = DistTensor(shape, dtype,
+                    name.get_name(), part_policy=policy, attach=False
+                )
+            if len(self.ntypes) == 1:
+                self._ndata_store = data
+            else:
+                self._ndata_store[ntype] = data
+
+    def _init_edata_store(self):
+        '''Init edge data store
+        '''
+        self._edata_store = {}
+        for etype in self.canonical_etypes:
+            names = self._get_edata_names(etype)
+            data = {}
+            for name in names:
+                assert name.is_edge()
+                policy = PartitionPolicy(name.policy_str,
+                    self.get_partition_book()
+                )
+                dtype, shape, _ = self._client.get_data_meta(str(name))
+                # We create a wrapper on the existing tensor in the kvstore.
+                data[name.get_name()] = DistTensor(shape, dtype,
+                    name.get_name(), part_policy=policy, attach=False
+                )
+            if len(self.canonical_etypes) == 1:
+                self._edata_store = data
+            else:
+                self._edata_store[etype] = data
+
     def __getstate__(self):
         return self.graph_name, self._gpb
 
@@ -550,8 +569,8 @@ class DistGraph:
         self.graph_name, gpb = state
         self._init(gpb)
 
-        self._ndata_store = {}
-        self._edata_store = {}
+        self._init_ndata_store()
+        self._init_edata_store()
         self._num_nodes = 0
         self._num_edges = 0
         for part_md in self._gpb.metadata():

--- a/python/dgl/distributed/dist_graph.py
+++ b/python/dgl/distributed/dist_graph.py
@@ -176,7 +176,7 @@ class NodeDataView(MutableMapping):
 
     def __init__(self, g, ntype=None):
         self._graph = g
-        if ntype is None:
+        if ntype is None or len(g.ntypes) == 1:
             self._data = g._ndata_store
         else:
             if ntype not in g.ntypes:
@@ -218,7 +218,7 @@ class EdgeDataView(MutableMapping):
 
     def __init__(self, g, etype=None):
         self._graph = g
-        if etype is None:
+        if etype is None or len(g.canonical_etypes) == 1:
             self._data = g._edata_store
         else:
             c_etype = g.to_canonical_etype(etype)

--- a/python/dgl/distributed/graph_partition_book.py
+++ b/python/dgl/distributed/graph_partition_book.py
@@ -794,7 +794,7 @@ class BasicPartitionBook(GraphPartitionBook):
             DEFAULT_ETYPE,
             DEFAULT_ETYPE[1],
         ), "Base partition book only supports homogeneous graph."
-        return self.canonical_etypes
+        return self.canonical_etypes[0]
 
 
 class RangePartitionBook(GraphPartitionBook):

--- a/python/dgl/distributed/standalone_kvstore.py
+++ b/python/dgl/distributed/standalone_kvstore.py
@@ -58,6 +58,7 @@ class KVClient(object):
     def delete_data(self, name):
         '''delete the data'''
         del self._data[name]
+        self._gdata_name_list.remove(name)
 
     def data_name_list(self):
         '''get the names of all data'''

--- a/tests/distributed/test_dist_graph_store.py
+++ b/tests/distributed/test_dist_graph_store.py
@@ -736,6 +736,12 @@ def check_dist_graph_hetero(g, num_clients, num_nodes, num_edges):
         data = g.nodes[ntype].data[name][nids]
         data = F.squeeze(data, 1)
         assert np.all(F.asnumpy(data == nids))
+    expect_except = False
+    try:
+        g.nodes['xxx'].data['x']
+    except dgl.DGLError:
+        expect_except = True
+    assert expect_except
 
     # Test reading edge data
     etype = 'r1'
@@ -750,6 +756,12 @@ def check_dist_graph_hetero(g, num_clients, num_nodes, num_edges):
         data = g.edges[c_etype].data[name][eids]
         data = F.squeeze(data, 1)
         assert np.all(F.asnumpy(data == eids))
+    expect_except = False
+    try:
+        g.edges['xxx'].data['x']
+    except dgl.DGLError:
+        expect_except = True
+    assert expect_except
 
     # Test edge_subgraph
     sg = g.edge_subgraph({"r1": eids})

--- a/tests/distributed/test_dist_graph_store.py
+++ b/tests/distributed/test_dist_graph_store.py
@@ -398,7 +398,12 @@ def check_dist_graph(g, num_clients, num_nodes, num_edges):
     test3 = dgl.distributed.DistTensor(
         new_shape, F.float32, "test3", init_func=rand_init
     )
+    test3_name = test3.kvstore_key
+    assert test3_name in g._client.data_name_list()
+    assert test3_name in g._client.gdata_name_list()
     del test3
+    assert test3_name not in g._client.data_name_list()
+    assert test3_name not in g._client.gdata_name_list()
     test3 = dgl.distributed.DistTensor(
         (g.number_of_nodes(), 3), F.float32, "test3"
     )
@@ -737,6 +742,7 @@ def check_dist_graph_hetero(g, num_clients, num_nodes, num_edges):
         data = g.nodes[ntype].data[name][nids]
         data = F.squeeze(data, 1)
         assert np.all(F.asnumpy(data == nids))
+    assert len(g.nodes['n2'].data) == 0
     expect_except = False
     try:
         g.nodes['xxx'].data['x']
@@ -757,6 +763,7 @@ def check_dist_graph_hetero(g, num_clients, num_nodes, num_edges):
         data = g.edges[c_etype].data[name][eids]
         data = F.squeeze(data, 1)
         assert np.all(F.asnumpy(data == eids))
+    assert len(g.edges['r2'].data) == 0
     expect_except = False
     try:
         g.edges['xxx'].data['x']

--- a/tests/distributed/test_dist_graph_store.py
+++ b/tests/distributed/test_dist_graph_store.py
@@ -697,12 +697,19 @@ def create_random_hetero():
         )
         edges[etype] = (arr.row, arr.col)
     g = dgl.heterograph(edges, num_nodes)
-    g.nodes["n1"].data["feat"] = F.unsqueeze(
-        F.arange(0, g.number_of_nodes("n1")), 1
-    )
-    g.edges["r1"].data["feat"] = F.unsqueeze(
-        F.arange(0, g.number_of_edges("r1")), 1
-    )
+    # assign ndata & edata.
+    # data with same name as ntype/etype is assigned on purpose to verify
+    # such same names can be correctly handled in DistGraph.
+    ntype = 'n1'
+    for name in ['feat', ntype]:
+        g.nodes[ntype].data[name] = F.unsqueeze(
+            F.arange(0, g.num_nodes(ntype)), 1
+        )
+    etype = 'r1'
+    for name in ['feat', etype]:
+        g.edges[etype].data[name] = F.unsqueeze(
+            F.arange(0, g.num_edges(etype)), 1
+        )
     return g
 
 
@@ -723,22 +730,26 @@ def check_dist_graph_hetero(g, num_clients, num_nodes, num_edges):
     assert g.number_of_edges() == sum([num_edges[etype] for etype in num_edges])
 
     # Test reading node data
-    nids = F.arange(0, int(g.number_of_nodes("n1") / 2))
-    feats1 = g.nodes["n1"].data["feat"][nids]
-    feats = F.squeeze(feats1, 1)
-    assert np.all(F.asnumpy(feats == nids))
+    ntype = 'n1'
+    nids = F.arange(0, g.num_nodes(ntype) // 2)
+    for name in ['feat', ntype]:
+        data = g.nodes[ntype].data[name][nids]
+        data = F.squeeze(data, 1)
+        assert np.all(F.asnumpy(data == nids))
 
     # Test reading edge data
-    eids = F.arange(0, int(g.number_of_edges("r1") / 2))
-    # access via etype
-    feats = g.edges["r1"].data["feat"][eids]
-    feats = F.squeeze(feats, 1)
-    assert np.all(F.asnumpy(feats == eids))
-    # access via canonical etype
-    c_etype = g.to_canonical_etype("r1")
-    feats = g.edges[c_etype].data["feat"][eids]
-    feats = F.squeeze(feats, 1)
-    assert np.all(F.asnumpy(feats == eids))
+    etype = 'r1'
+    eids = F.arange(0, g.num_edges(etype) // 2)
+    for name in ['feat', etype]:
+        # access via etype
+        data = g.edges[etype].data[name][eids]
+        data = F.squeeze(data, 1)
+        assert np.all(F.asnumpy(data == eids))
+        # access via canonical etype
+        c_etype = g.to_canonical_etype(etype)
+        data = g.edges[c_etype].data[name][eids]
+        data = F.squeeze(data, 1)
+        assert np.all(F.asnumpy(data == eids))
 
     # Test edge_subgraph
     sg = g.edge_subgraph({"r1": eids})

--- a/tests/distributed/test_dist_graph_store.py
+++ b/tests/distributed/test_dist_graph_store.py
@@ -699,7 +699,8 @@ def create_random_hetero():
     g = dgl.heterograph(edges, num_nodes)
     # assign ndata & edata.
     # data with same name as ntype/etype is assigned on purpose to verify
-    # such same names can be correctly handled in DistGraph.
+    # such same names can be correctly handled in DistGraph. See more details
+    # in issue #4887 and #4463 on github.
     ntype = 'n1'
     for name in ['feat', ntype]:
         g.nodes[ntype].data[name] = F.unsqueeze(


### PR DESCRIPTION
## Description
<!-- Brief description. Refer to the related issues if existed.
It'll be great if relevant reviewers can be assigned as well.-->
fix for #4887 && #4463

The direct cause of the crash is `NodeDataView` with `ntype=None` is always instantiated in `DistGraph.__init__()` and assigned to `g._ndata`. For a heterogeneous graph, instantiating with `ntype=None` will merge all data for all ntypes into single dict instead of `a dict of dict`. This is what we expect for heterogeneous graph.

as for this fix, I think we don't need to always instantiate and assign `g._ndata` in `__init__()`. It's ok to delay it.
## Checklist
Please feel free to remove inapplicable items for your PR.
- [ ] The PR title starts with [$CATEGORY] (such as [NN], [Model], [Doc], [Feature]])
- [ ] I've leverage the [tools](https://docs.google.com/document/d/1iHyj7zlmygKSk5gBPsqIqL5ASPzJSPREaNT_QdsiYA4/edit) to beautify the python and c++ code.
- [ ] The PR is complete and small, read the [Google eng practice (CL equals to PR)](https://google.github.io/eng-practices/review/developer/small-cls.html) to understand more about small PR. In DGL, we consider PRs with less than 200 lines of core code change are small (example, test and documentation could be exempted).
- [ ] All changes have test coverage
- [ ] Code is well-documented
- [ ] To the best of my knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change
- [ ] Related issue is referred in this PR
- [ ] If the PR is for a new model/paper, I've updated the example index [here](../examples/README.md).

## Changes
<!-- You could use following template
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)
-->
