### PR TITLE
[CI] deprecate CI tests for MXNet

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -544,50 +544,6 @@ pipeline {
                 }
               }
             }
-            stage('MXNet CPU') {
-              agent {
-                docker {
-                  label "linux-cpu-node"
-                  image "dgllib/dgl-ci-cpu:cu101_v220629"
-                  alwaysPull true
-                }
-              }
-              stages {
-                stage('MXNet CPU Unit test') {
-                  steps {
-                    unit_test_linux('mxnet', 'cpu')
-                  }
-                }
-              }
-              post {
-                always {
-                  cleanWs disableDeferredWipeout: true, deleteDirs: true
-                }
-              }
-            }
-            stage('MXNet GPU') {
-              agent {
-                docker {
-                  label "linux-gpu-node"
-                  image "dgllib/dgl-ci-gpu:cu101_v220816"
-                  args "--runtime nvidia"
-                  alwaysPull true
-                }
-              }
-              stages {
-                stage('MXNet GPU Unit test') {
-                  steps {
-                    sh 'nvidia-smi'
-                    unit_test_linux('mxnet', 'gpu')
-                  }
-                }
-              }
-              post {
-                always {
-                  cleanWs disableDeferredWipeout: true, deleteDirs: true
-                }
-              }
-            }
             stage('DGL-Go') {
               agent {
                 docker {


### PR DESCRIPTION
## Description
<!-- Brief description. Refer to the related issues if existed.
It'll be great if relevant reviewers can be assigned as well.-->
For now, only the CI tests are disabled.

How about deprecating all code/script that are for MXNet?
## Checklist
Please feel free to remove inapplicable items for your PR.
- [ ] The PR title starts with [$CATEGORY] (such as [NN], [Model], [Doc], [Feature]])
- [ ] I've leverage the [tools](https://docs.google.com/document/d/1iHyj7zlmygKSk5gBPsqIqL5ASPzJSPREaNT_QdsiYA4/edit) to beautify the python and c++ code.
- [ ] The PR is complete and small, read the [Google eng practice (CL equals to PR)](https://google.github.io/eng-practices/review/developer/small-cls.html) to understand more about small PR. In DGL, we consider PRs with less than 200 lines of core code change are small (example, test and documentation could be exempted).
- [ ] All changes have test coverage
- [ ] Code is well-documented
- [ ] To the best of my knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change
- [ ] Related issue is referred in this PR
- [ ] If the PR is for a new model/paper, I've updated the example index [here](../examples/README.md).

## Changes
<!-- You could use following template
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)
-->
