### PR TITLE
[Sparse] Add HGNN example

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -247,6 +247,10 @@ To quickly locate the examples of your interest, search for the tagged keywords 
     - Example code: [pytorch](../examples/pytorch/dtgrnn)
     - Tags: Static discrete temporal graph, traffic forecasting
 
+- <a name="hgnn"></a> Feng et al. Hypergraph Neural Networks. [Paper link](https://arxiv.org/abs/1809.09401).
+    - Example code: [pytorch](../examples/sparse/hgnn)
+    - Tags: hypergraph
+
 ## 2017
 
 - <a name="gcn"></a> Kipf and Welling. Semi-Supervised Classification with Graph Convolutional Networks. [Paper link](https://arxiv.org/abs/1609.02907). 

--- a/examples/sparse/hgnn.py
+++ b/examples/sparse/hgnn.py
@@ -1,3 +1,6 @@
+"""
+Hypergraph Neural Networks (https://arxiv.org/pdf/1809.09401.pdf)
+"""
 import dgl
 import dgl.data
 import dgl.mock_sparse

--- a/examples/sparse/hgnn.py
+++ b/examples/sparse/hgnn.py
@@ -1,0 +1,92 @@
+import dgl
+import dgl.data
+import dgl.mock_sparse
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+from torchmetrics.functional import accuracy
+import tqdm
+
+dataset = dgl.data.CoraGraphDataset()
+
+graph = dataset[0]
+# The paper created the hypergraph by "each time one vertex in the
+# graph is selected as the centroid and its connected vertices
+# are used to generate one hyperedge including the centroid
+# itself".  In this case, the incidence matrix of the hypergraph
+# is the same as the adjacency matrix of the original graph (with
+# self-loops).
+# We follow the paper assuming that the rows of the incidence matrix
+# are nodes and the columns are edges.
+
+# QUESTION: can we either (1) easily convert a PyTorch sparse matrix
+# to a DGL sparse matrix, or (2) make g.adj() a DGL sparse matrix
+# in the future?
+adj = dgl.add_self_loop(graph).adj().coalesce()
+row, col = adj.indices()
+values = adj.values()
+H = dgl.mock_sparse.create_from_coo(row, col, values)
+
+X = graph.ndata["feat"]
+Y = graph.ndata["label"]
+train_mask = graph.ndata["train_mask"]
+val_mask = graph.ndata["val_mask"]
+test_mask = graph.ndata["test_mask"]
+
+
+class HGNN(nn.Module):
+    def __init__(self, in_size, out_size, hidden_dims=16):
+        super().__init__()
+
+        self.Theta1 = nn.Linear(in_size, hidden_dims)
+        self.Theta2 = nn.Linear(hidden_dims, out_size)
+        self.dropout = nn.Dropout(0.5)
+
+    def forward(self, H, X):
+        d_V = H.sum(1)  # node degree
+        d_E = H.sum(0)  # edge degree
+        D_V_invsqrt = dgl.mock_sparse.diag(d_V ** -0.5)  # D_V ** (-1/2)
+        D_E_inv = dgl.mock_sparse.diag(d_E ** -1)  # D_E ** (-1)
+        # Minor suggestion: could we have dgl.mock_sparse.eye(N)?
+        W = dgl.mock_sparse.diag(torch.ones(d_E.shape[0]))
+
+        conv = D_V_invsqrt @ H @ W @ D_E_inv @ H.T @ D_V_invsqrt
+
+        X = conv @ self.Theta1(self.dropout(X))
+        X = F.relu(X)
+        X = conv @ self.Theta2(self.dropout(X))
+        return X
+
+
+model = HGNN(X.shape[1], dataset.num_classes)
+opt = torch.optim.Adam(model.parameters(), lr=0.001)
+best_val_acc, best_test_acc = 0, 0
+
+with tqdm.trange(500) as tq:
+    for epoch in tq:
+        # Train
+        model.train()
+        Y_hat = model(H, X)
+        loss = F.cross_entropy(Y_hat[train_mask], Y[train_mask])
+        opt.zero_grad()
+        loss.backward()
+        opt.step()
+
+        # Evaluate
+        model.eval()
+        Y_hat = model(H, X)
+        val_acc = accuracy(Y_hat[val_mask], Y[val_mask])
+        test_acc = accuracy(Y_hat[test_mask], Y[test_mask])
+        if val_acc > best_val_acc:
+            best_val_acc = val_acc
+            best_test_acc = test_acc
+
+        tq.set_postfix(
+            {
+                "Loss": f"{loss.item():.5f}",
+                "Val acc": f"{val_acc:.5f}",
+                "Test acc": f"{test_acc:.5f}",
+            },
+            refresh=False,
+        )
+print(f"Best val acc: {best_val_acc} Best test acc: {best_test_acc}")

--- a/examples/sparse/hgnn.py
+++ b/examples/sparse/hgnn.py
@@ -3,7 +3,7 @@ Hypergraph Neural Networks (https://arxiv.org/pdf/1809.09401.pdf)
 """
 import dgl
 import dgl.data
-import dgl.mock_sparse
+import dgl.mock_sparse as dglsp
 import torch
 import torch.nn as nn
 import torch.nn.functional as F
@@ -22,9 +22,9 @@ class HGNN(nn.Module):
         d_V = H.sum(1)  # node degree
         d_E = H.sum(0)  # edge degree
         n_edges = d_E.shape[0]
-        D_V_invsqrt = dgl.mock_sparse.diag(d_V ** -0.5)  # D_V ** (-1/2)
-        D_E_inv = dgl.mock_sparse.diag(d_E ** -1)  # D_E ** (-1)
-        W = dgl.mock_sparse.identity((n_edges, n_edges))
+        D_V_invsqrt = dglsp.diag(d_V ** -0.5)  # D_V ** (-1/2)
+        D_E_inv = dglsp.diag(d_E ** -1)  # D_E ** (-1)
+        W = dglsp.identity((n_edges, n_edges))
         self.laplacian = D_V_invsqrt @ H @ W @ D_E_inv @ H.T @ D_V_invsqrt
 
     def forward(self, X):
@@ -60,8 +60,8 @@ def load_data():
     # We follow the paper and assume that the rows of the incidence matrix
     # are for nodes and the columns are for edges.
     src, dst = graph.edges()
-    H = dgl.mock_sparse.create_from_coo(dst, src)
-    H = H + dgl.mock_sparse.identity(H.shape)
+    H = dglsp.create_from_coo(dst, src)
+    H = H + dglsp.identity(H.shape)
 
     X = graph.ndata["feat"]
     Y = graph.ndata["label"]

--- a/examples/sparse/hgnn.py
+++ b/examples/sparse/hgnn.py
@@ -18,7 +18,9 @@ class HGNN(nn.Module):
         self.Theta2 = nn.Linear(hidden_dims, out_size)
         self.dropout = nn.Dropout(0.5)
 
-        # Compute the Laplacian with Sparse Matrix API
+        ###########################################################
+        # (HIGHLIGHT) Compute the Laplacian with Sparse Matrix API
+        ###########################################################
         d_V = H.sum(1)  # node degree
         d_E = H.sum(0)  # edge degree
         n_edges = d_E.shape[0]
@@ -33,13 +35,13 @@ class HGNN(nn.Module):
         X = self.laplacian @ self.Theta2(self.dropout(X))
         return X
 
-def train(model, opt, X, Y, train_mask):
+def train(model, optimizer, X, Y, train_mask):
     model.train()
     Y_hat = model(X)
     loss = F.cross_entropy(Y_hat[train_mask], Y[train_mask])
-    opt.zero_grad()
+    optimizer.zero_grad()
     loss.backward()
-    opt.step()
+    optimizer.step()
 
 def evaluate(model, X, Y, val_mask, test_mask):
     model.eval()
@@ -73,11 +75,11 @@ def load_data():
 def main():
     H, X, Y, num_classes, train_mask, val_mask, test_mask = load_data()
     model = HGNN(H, X.shape[1], num_classes)
-    opt = torch.optim.Adam(model.parameters(), lr=0.001)
+    optimizer = torch.optim.Adam(model.parameters(), lr=0.001)
 
     with tqdm.trange(500) as tq:
         for epoch in tq:
-            train(model, opt, X, Y, train_mask)
+            train(model, optimizer, X, Y, train_mask)
             val_acc, test_acc = evaluate(model, X, Y, val_mask, test_mask)
             tq.set_postfix(
                 {

--- a/examples/sparse/hgnn.py
+++ b/examples/sparse/hgnn.py
@@ -10,86 +10,82 @@ import torch.nn.functional as F
 from torchmetrics.functional import accuracy
 import tqdm
 
-dataset = dgl.data.CoraGraphDataset()
-
-graph = dataset[0]
-# The paper created the hypergraph by "each time one vertex in the
-# graph is selected as the centroid and its connected vertices
-# are used to generate one hyperedge including the centroid
-# itself".  In this case, the incidence matrix of the hypergraph
-# is the same as the adjacency matrix of the original graph (with
-# self-loops).
-# We follow the paper assuming that the rows of the incidence matrix
-# are nodes and the columns are edges.
-
-# QUESTION: can we either (1) easily convert a PyTorch sparse matrix
-# to a DGL sparse matrix, or (2) make g.adj() a DGL sparse matrix
-# in the future?
-adj = dgl.add_self_loop(graph).adj().coalesce()
-row, col = adj.indices()
-values = adj.values()
-H = dgl.mock_sparse.create_from_coo(row, col, values)
-
-X = graph.ndata["feat"]
-Y = graph.ndata["label"]
-train_mask = graph.ndata["train_mask"]
-val_mask = graph.ndata["val_mask"]
-test_mask = graph.ndata["test_mask"]
-
-
 class HGNN(nn.Module):
-    def __init__(self, in_size, out_size, hidden_dims=16):
+    def __init__(self, H, in_size, out_size, hidden_dims=16):
         super().__init__()
 
         self.Theta1 = nn.Linear(in_size, hidden_dims)
         self.Theta2 = nn.Linear(hidden_dims, out_size)
         self.dropout = nn.Dropout(0.5)
 
-    def forward(self, H, X):
+        # Compute the Laplacian with Sparse Matrix API
         d_V = H.sum(1)  # node degree
         d_E = H.sum(0)  # edge degree
+        n_edges = d_E.shape[0]
         D_V_invsqrt = dgl.mock_sparse.diag(d_V ** -0.5)  # D_V ** (-1/2)
         D_E_inv = dgl.mock_sparse.diag(d_E ** -1)  # D_E ** (-1)
-        # Minor suggestion: could we have dgl.mock_sparse.eye(N)?
-        W = dgl.mock_sparse.diag(torch.ones(d_E.shape[0]))
+        W = dgl.mock_sparse.identity((n_edges, n_edges))
+        self.laplacian = D_V_invsqrt @ H @ W @ D_E_inv @ H.T @ D_V_invsqrt
 
-        conv = D_V_invsqrt @ H @ W @ D_E_inv @ H.T @ D_V_invsqrt
-
-        X = conv @ self.Theta1(self.dropout(X))
+    def forward(self, X):
+        X = self.laplacian @ self.Theta1(self.dropout(X))
         X = F.relu(X)
-        X = conv @ self.Theta2(self.dropout(X))
+        X = self.laplacian @ self.Theta2(self.dropout(X))
         return X
 
+def train(model, opt, X, Y, train_mask):
+    model.train()
+    Y_hat = model(X)
+    loss = F.cross_entropy(Y_hat[train_mask], Y[train_mask])
+    opt.zero_grad()
+    loss.backward()
+    opt.step()
 
-model = HGNN(X.shape[1], dataset.num_classes)
-opt = torch.optim.Adam(model.parameters(), lr=0.001)
-best_val_acc, best_test_acc = 0, 0
+def evaluate(model, X, Y, val_mask, test_mask):
+    model.eval()
+    Y_hat = model(X)
+    val_acc = accuracy(Y_hat[val_mask], Y[val_mask])
+    test_acc = accuracy(Y_hat[test_mask], Y[test_mask])
+    return val_acc, test_acc
 
-with tqdm.trange(500) as tq:
-    for epoch in tq:
-        # Train
-        model.train()
-        Y_hat = model(H, X)
-        loss = F.cross_entropy(Y_hat[train_mask], Y[train_mask])
-        opt.zero_grad()
-        loss.backward()
-        opt.step()
+def load_data():
+    dataset = dgl.data.CoraGraphDataset()
 
-        # Evaluate
-        model.eval()
-        Y_hat = model(H, X)
-        val_acc = accuracy(Y_hat[val_mask], Y[val_mask])
-        test_acc = accuracy(Y_hat[test_mask], Y[test_mask])
-        if val_acc > best_val_acc:
-            best_val_acc = val_acc
-            best_test_acc = test_acc
+    graph = dataset[0]
+    # The paper created a hypergraph from the original graph. For each node in
+    # the original graph, a hyperedge in the hypergraph is created to connect
+    # its neighbors and itself. In this case, the incidence matrix of the
+    # hypergraph is the same as the adjacency matrix of the original graph (with
+    # self-loops).
+    # We follow the paper and assume that the rows of the incidence matrix
+    # are for nodes and the columns are for edges.
+    src, dst = graph.edges()
+    H = dgl.mock_sparse.create_from_coo(dst, src)
+    H = H + dgl.mock_sparse.identity(H.shape)
 
-        tq.set_postfix(
-            {
-                "Loss": f"{loss.item():.5f}",
-                "Val acc": f"{val_acc:.5f}",
-                "Test acc": f"{test_acc:.5f}",
-            },
-            refresh=False,
-        )
-print(f"Best val acc: {best_val_acc} Best test acc: {best_test_acc}")
+    X = graph.ndata["feat"]
+    Y = graph.ndata["label"]
+    train_mask = graph.ndata["train_mask"]
+    val_mask = graph.ndata["val_mask"]
+    test_mask = graph.ndata["test_mask"]
+    return H, X, Y, dataset.num_classes, train_mask, val_mask, test_mask
+
+def main():
+    H, X, Y, num_classes, train_mask, val_mask, test_mask = load_data()
+    model = HGNN(H, X.shape[1], num_classes)
+    opt = torch.optim.Adam(model.parameters(), lr=0.001)
+
+    with tqdm.trange(500) as tq:
+        for epoch in tq:
+            train(model, opt, X, Y, train_mask)
+            val_acc, test_acc = evaluate(model, X, Y, val_mask, test_mask)
+            tq.set_postfix(
+                {
+                    "Val acc": f"{val_acc:.5f}",
+                    "Test acc": f"{test_acc:.5f}",
+                },
+                refresh=False,
+            )
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
## Description
Add HGNN example (https://arxiv.org/pdf/1809.09401.pdf).
Closes #4870.

I listed a question and a small suggestion in the code and I'll list here as well:
* Make `DGLGraph.adj()` return a DGL sparse matrix instead of PyTorch sparse matrix, or do we have a convenient conversion function?
* Have an `eye()` function to construct identity sparse matrix.

## Checklist
Please feel free to remove inapplicable items for your PR.
- [x] The PR title starts with [$CATEGORY] (such as [NN], [Model], [Doc], [Feature]])
- [x] I've leverage the [tools](https://docs.google.com/document/d/1iHyj7zlmygKSk5gBPsqIqL5ASPzJSPREaNT_QdsiYA4/edit) to beautify the python and c++ code.
- [x] The PR is complete and small, read the [Google eng practice (CL equals to PR)](https://google.github.io/eng-practices/review/developer/small-cls.html) to understand more about small PR. In DGL, we consider PRs with less than 200 lines of core code change are small (example, test and documentation could be exempted).
- [x] All changes have test coverage
- [x] Code is well-documented
- [x] To the best of my knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change
- [x] Related issue is referred in this PR
- [x] If the PR is for a new model/paper, I've updated the example index [here](../examples/README.md).

## Changes
<!-- You could use following template
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)
-->
