### PR TITLE
[Sparse] Misc Fix for GPU

### DIFF
--- a/python/dgl/mock_sparse/elementwise_op_sp.py
+++ b/python/dgl/mock_sparse/elementwise_op_sp.py
@@ -73,7 +73,7 @@ def sp_add(
             "The shape of sparse matrix A {} and"
             " B {} are expected to match".format(A.shape, B.shape)
         )
-        C = A.adj + B.adj
+        C = (A.adj + B.adj).coalesce()
         return SparseMatrix(C.indices()[0], C.indices()[1], C.values(), C.shape)
     raise RuntimeError(
         "Elementwise addition between {} and {} is not "

--- a/python/dgl/mock_sparse/sp_matrix.py
+++ b/python/dgl/mock_sparse/sp_matrix.py
@@ -62,7 +62,7 @@ class SparseMatrix:
         shape: Optional[Tuple[int, int]] = None,
     ):
         if val is None:
-            val = torch.ones(row.shape[0])
+            val = torch.ones(row.shape[0]).to(row.device)
         i = torch.cat((row.unsqueeze(0), col.unsqueeze(0)), 0)
         if shape is None:
             self.adj = torch.sparse_coo_tensor(i, val).coalesce()


### PR DESCRIPTION
## Description
Otherwise the example SIGN `examples/sparse/sign.py` will fail with GPU.

## Checklist
Please feel free to remove inapplicable items for your PR.
- [x] The PR title starts with [$CATEGORY] (such as [NN], [Model], [Doc], [Feature]])
- [ ] I've leverage the [tools](https://docs.google.com/document/d/1iHyj7zlmygKSk5gBPsqIqL5ASPzJSPREaNT_QdsiYA4/edit) to beautify the python and c++ code.
- [x] The PR is complete and small, read the [Google eng practice (CL equals to PR)](https://google.github.io/eng-practices/review/developer/small-cls.html) to understand more about small PR. In DGL, we consider PRs with less than 200 lines of core code change are small (example, test and documentation could be exempted).
- [ ] All changes have test coverage
- [ ] Code is well-documented
- [x] To the best of my knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change
- [ ] Related issue is referred in this PR
- [ ] If the PR is for a new model/paper, I've updated the example index [here](../examples/README.md).