### PR TITLE
[Test] Fix duplicate seed generation in unit test

### DIFF
--- a/tests/pytorch/test_nn.py
+++ b/tests/pytorch/test_nn.py
@@ -1517,7 +1517,6 @@ def test_hgt(idtype, in_size, num_heads):
     assert sorted_y.shape == (g.num_nodes(), head_size * num_heads)
     # mini-batch
     train_idx = th.randperm(100, dtype=idtype)[:10]
-    #train_idx = th.randint(0, 100, (10, ), dtype = idtype)
     sampler = dgl.dataloading.NeighborSampler([-1])
     train_loader = dgl.dataloading.DataLoader(g, train_idx.to(dev), sampler,
                                             batch_size=8, device=dev,

--- a/tests/pytorch/test_nn.py
+++ b/tests/pytorch/test_nn.py
@@ -1516,7 +1516,8 @@ def test_hgt(idtype, in_size, num_heads):
     sorted_y = m(sorted_g, sorted_x, sorted_ntype, sorted_etype, presorted=False)
     assert sorted_y.shape == (g.num_nodes(), head_size * num_heads)
     # mini-batch
-    train_idx = th.randint(0, 100, (10, ), dtype = idtype)
+    train_idx = th.randperm(100, dtype=idtype)[:10]
+    #train_idx = th.randint(0, 100, (10, ), dtype = idtype)
     sampler = dgl.dataloading.NeighborSampler([-1])
     train_loader = dgl.dataloading.DataLoader(g, train_idx.to(dev), sampler,
                                             batch_size=8, device=dev,


### PR DESCRIPTION
## Description
Fixes #4947.  Until we handle #3431, the workaround is to ensure that the seed nodes generated do not have duplicates.