### PR TITLE
Add support for next cusparse release

### DIFF
--- a/src/array/cuda/csr_mm.cu
+++ b/src/array/cuda/csr_mm.cu
@@ -6,10 +6,11 @@
 #include <dgl/array.h>
 #include <dgl/runtime/device_api.h>
 
+#include <limits>
+
 #include "../../runtime/cuda/cuda_common.h"
 #include "./cusparse_dispatcher.cuh"
 #include "./functor.cuh"
-#include <limits>
 namespace dgl {
 
 using namespace dgl::runtime;
@@ -73,7 +74,7 @@ std::pair<CSRMatrix, NDArray> CusparseSpgemm(
   // below to estimate upperbound of num_prods to decide DEFAULT or ALG2
   int int_max = std::numeric_limits<int>::max();
   int64_t nnzAB_norm = (nnzA / A.num_rows) * (nnzB / B.num_rows);
-  int64_t dense_norm = B.num_cols;  //if denseMM, numprods = nrowA*ncolA*ncolB
+  int64_t dense_norm = B.num_cols;  // if denseMM, numprods=nrowA*ncolA*ncolB
   int64_t max_nprods = (nnzAB_norm > dense_norm) ? dense_norm : nnzAB_norm;
   max_nprods = max_nprods * A.num_rows * B.num_rows;
   cusparseSpGEMMAlg_t alg;
@@ -112,7 +113,7 @@ std::pair<CSRMatrix, NDArray> CusparseSpgemm(
     device->FreeWorkspace(ctx, workspace1);
     // rerun cusparseSpGEMM_workEstimation
     CUSPARSE_CALL(cusparseSpGEMM_workEstimation(thr_entry->cusparse_handle,
-                                                transA,transB, &alpha, matA,
+                                                transA, transB, &alpha, matA,
                                                 matB, &beta, matC, dtype, alg,
                                                 spgemmDesc, &workspace_size1,
                                                 NULL));
@@ -131,7 +132,7 @@ std::pair<CSRMatrix, NDArray> CusparseSpgemm(
     device->FreeWorkspace(ctx, workspace1);
     // rerun cusparseSpGEMM_workEstimation
     CUSPARSE_CALL(cusparseSpGEMM_workEstimation(thr_entry->cusparse_handle,
-                                                transA,transB, &alpha, matA,
+                                                transA, transB, &alpha, matA,
                                                 matB, &beta, matC, dtype, alg,
                                                 spgemmDesc, &workspace_size1,
                                                 NULL));

--- a/src/array/cuda/csr_mm.cu
+++ b/src/array/cuda/csr_mm.cu
@@ -9,7 +9,7 @@
 #include "../../runtime/cuda/cuda_common.h"
 #include "./cusparse_dispatcher.cuh"
 #include "./functor.cuh"
-
+#include <limits>
 namespace dgl {
 
 using namespace dgl::runtime;
@@ -51,8 +51,6 @@ std::pair<CSRMatrix, NDArray> CusparseSpgemm(
   IdType* dC_csrOffsets_data = dC_csrOffsets.Ptr<IdType>();
   constexpr auto idtype = cusparse_idtype<IdType>::value;
   constexpr auto dtype = cuda_dtype<DType>::value;
-  cusparseSpGEMMAlg_t alg = CUSPARSE_SPGEMM_ALG3;
-
   // Create sparse matrix A, B and C in CSR format
   CUSPARSE_CALL(cusparseCreateCsr(
       &matA, A.num_rows, A.num_cols, nnzA, A.indptr.Ptr<IdType>(),
@@ -71,6 +69,16 @@ std::pair<CSRMatrix, NDArray> CusparseSpgemm(
       idtype, CUSPARSE_INDEX_BASE_ZERO, dtype));
   // SpGEMM Computation
   cusparseSpGEMMDescr_t spgemmDesc;
+  // CUSPARSE_SPGEMM_DEFAULT not support getting num_prods > 2^31 -1
+  // below to estimate upperbound of num_prods to decide DEFAULT or ALG2
+  int int_max = std::numeric_limits<int>::max();
+  int64_t nnzAB_norm = (nnzA / A.num_rows) * (nnzB / B.num_rows);
+  int64_t dense_norm = B.num_cols;  //if denseMM, numprods = nrowA*ncolA*ncolB
+  int64_t max_nprods = (nnzAB_norm > dense_norm) ? dense_norm : nnzAB_norm;
+  max_nprods = max_nprods * A.num_rows * B.num_rows;
+  cusparseSpGEMMAlg_t alg;
+  alg = (max_nprods < int_max) ? CUSPARSE_SPGEMM_DEFAULT : CUSPARSE_SPGEMM_ALG2;
+
   CUSPARSE_CALL(cusparseSpGEMM_createDescr(&spgemmDesc));
   size_t workspace_size1 = 0, workspace_size2 = 0, workspace_size3 = 0;
   // ask bufferSize1 bytes for external memory
@@ -85,17 +93,81 @@ std::pair<CSRMatrix, NDArray> CusparseSpgemm(
       thr_entry->cusparse_handle, transA, transB, &alpha, matA, matB, &beta,
       matC, dtype, alg, spgemmDesc, &workspace_size1,
       workspace1));
-  // estimate memory for ALG2/ALG3; note chunk_fraction is only used by ALG3
-  CUSPARSE_CALL(cusparseSpGEMM_estimateMemory(
-      thr_entry->cusparse_handle, transA, transB, &alpha, matA, matB, &beta,
-      matC, dtype, alg, spgemmDesc, 0.01, /*chunk_fraction*/ &workspace_size3,
-      NULL, NULL));
-  void* workspace3 = (device->AllocWorkspace(ctx, workspace_size3));
+  int64_t num_prods;
+  CUSPARSE_CALL(cusparseSpGEMM_getNumProducts(spgemmDesc, &num_prods));
+  // printf("num_prods is: %ld\n", num_prods);
+  // user-defined medium problem size (below will use DEFAULT)
+  // assuming free GPU mem at least ~10G for alloc. workspace2
+  int64_t MEDIUM_NUM_PRODUCTS = 400*1000*1000;
+  // user-defined large problem size (above will use ALG3)
+  int64_t LARGE_NUM_PRODUCTS  = 1000*1000*1000;
 
-  CUSPARSE_CALL(cusparseSpGEMM_estimateMemory(
-      thr_entry->cusparse_handle, transA, transB, &alpha, matA, matB, &beta,
-      matC, dtype, alg, spgemmDesc, 0.01, /*chunk_fraction*/ &workspace_size3,
-      workspace3, &workspace_size2));
+  // switch to new SpGEMM algorithms for medium & large problem size
+  if (alg == CUSPARSE_SPGEMM_DEFAULT && num_prods > MEDIUM_NUM_PRODUCTS) {
+    // use ALG3 for very large problem
+    if (num_prods <= LARGE_NUM_PRODUCTS)
+      alg = CUSPARSE_SPGEMM_ALG2;
+    else
+      alg = CUSPARSE_SPGEMM_ALG3;
+    device->FreeWorkspace(ctx, workspace1);
+    // rerun cusparseSpGEMM_workEstimation
+    CUSPARSE_CALL(cusparseSpGEMM_workEstimation(thr_entry->cusparse_handle,
+                                                transA,transB, &alpha, matA,
+                                                matB, &beta, matC, dtype, alg,
+                                                spgemmDesc, &workspace_size1,
+                                                NULL));
+    void* workspace1 = (device->AllocWorkspace(ctx, workspace_size1));
+    CUSPARSE_CALL(cusparseSpGEMM_workEstimation(thr_entry->cusparse_handle,
+                                                transA, transB, &alpha, matA,
+                                                matB, &beta, matC, dtype, alg,
+                                                spgemmDesc, &workspace_size1,
+                                                workspace1));
+  } else if (alg == CUSPARSE_SPGEMM_ALG2 && num_prods > LARGE_NUM_PRODUCTS) {
+    // no need to rerun cusparseSpGEMM_workEstimation between ALG2 and ALG3
+    alg = CUSPARSE_SPGEMM_ALG3;
+  } else if (alg == CUSPARSE_SPGEMM_ALG2 && num_prods < MEDIUM_NUM_PRODUCTS) {
+    // use DEFAULT for small problems
+    alg = CUSPARSE_SPGEMM_DEFAULT;
+    device->FreeWorkspace(ctx, workspace1);
+    // rerun cusparseSpGEMM_workEstimation
+    CUSPARSE_CALL(cusparseSpGEMM_workEstimation(thr_entry->cusparse_handle,
+                                                transA,transB, &alpha, matA,
+                                                matB, &beta, matC, dtype, alg,
+                                                spgemmDesc, &workspace_size1,
+                                                NULL));
+    void* workspace1 = (device->AllocWorkspace(ctx, workspace_size1));
+    CUSPARSE_CALL(cusparseSpGEMM_workEstimation(thr_entry->cusparse_handle,
+                                                transA, transB, &alpha, matA,
+                                                matB, &beta, matC, dtype, alg,
+                                                spgemmDesc, &workspace_size1,
+                                                workspace1));
+  }
+
+  if (alg == CUSPARSE_SPGEMM_ALG2 || alg == CUSPARSE_SPGEMM_ALG3) {
+    // estimate memory for ALG2/ALG3; note chunk_fraction is only used by ALG3
+    // keep reducing chunk_fraction if num_prods is too large
+    float chunk_fraction = num_prods < 5 * LARGE_NUM_PRODUCTS ? 0.2 : 0.05;
+    CUSPARSE_CALL(cusparseSpGEMM_estimateMemory(thr_entry->cusparse_handle,
+                                                transA, transB, &alpha, matA,
+                                                matB, &beta, matC, dtype, alg,
+                                                spgemmDesc, chunk_fraction,
+                                                &workspace_size3,
+                                                NULL, NULL));
+    void* workspace3 = (device->AllocWorkspace(ctx, workspace_size3));
+    CUSPARSE_CALL(cusparseSpGEMM_estimateMemory(thr_entry->cusparse_handle,
+                                                transA, transB, &alpha, matA,
+                                                matB, &beta, matC, dtype, alg,
+                                                spgemmDesc, chunk_fraction,
+                                                &workspace_size3,
+                                                workspace3, &workspace_size2));
+    device->FreeWorkspace(ctx, workspace3);
+  } else {
+    CUSPARSE_CALL(cusparseSpGEMM_compute(thr_entry->cusparse_handle,
+                                         transA, transB, &alpha, matA,
+                                         matB, &beta, matC, dtype, alg,
+                                         spgemmDesc, &workspace_size2,
+                                         NULL));
+  }
   // ask bufferSize2 bytes for external memory
   void* workspace2 = device->AllocWorkspace(ctx, workspace_size2);
   // compute the intermediate product of A * B
@@ -122,7 +194,6 @@ std::pair<CSRMatrix, NDArray> CusparseSpgemm(
 
   device->FreeWorkspace(ctx, workspace1);
   device->FreeWorkspace(ctx, workspace2);
-  device->FreeWorkspace(ctx, workspace3);
   // destroy matrix/vector descriptors
   CUSPARSE_CALL(cusparseSpGEMM_destroyDescr(spgemmDesc));
   CUSPARSE_CALL(cusparseDestroySpMat(matA));

--- a/src/array/cuda/csr_mm.cu
+++ b/src/array/cuda/csr_mm.cu
@@ -51,7 +51,7 @@ std::pair<CSRMatrix, NDArray> CusparseSpgemm(
   IdType* dC_csrOffsets_data = dC_csrOffsets.Ptr<IdType>();
   constexpr auto idtype = cusparse_idtype<IdType>::value;
   constexpr auto dtype = cuda_dtype<DType>::value;
-  cusparseSpGEMMAlg_t alg = CUSPARSE_SPGEMM_ALG3;//CUSPARSE_SPGEMM_DEFAULT
+  cusparseSpGEMMAlg_t alg = CUSPARSE_SPGEMM_ALG3;
 
   // Create sparse matrix A, B and C in CSR format
   CUSPARSE_CALL(cusparseCreateCsr(
@@ -85,7 +85,7 @@ std::pair<CSRMatrix, NDArray> CusparseSpgemm(
       thr_entry->cusparse_handle, transA, transB, &alpha, matA, matB, &beta,
       matC, dtype, alg, spgemmDesc, &workspace_size1,
       workspace1));
-  // estimate memory if ALG2/ALG3 is enabled; note chunk_fraction is only used by ALG3
+  // estimate memory for ALG2/ALG3; note chunk_fraction is only used by ALG3
   CUSPARSE_CALL(cusparseSpGEMM_estimateMemory(
       thr_entry->cusparse_handle, transA, transB, &alpha, matA, matB, &beta,
       matC, dtype, alg, spgemmDesc, 0.01, /*chunk_fraction*/ &workspace_size3,

--- a/src/array/cuda/csr_mm.cu
+++ b/src/array/cuda/csr_mm.cu
@@ -114,9 +114,9 @@ std::pair<CSRMatrix, NDArray> CusparseSpgemm(
 
   // assume free GPU mem at least ~15G for below heuristics to work
   // user-defined medium problem size (below will use DEFAULT)
-  int64_t MEDIUM_NUM_PRODUCTS = 400*1000*1000;
+  int64_t MEDIUM_NUM_PRODUCTS = 400000000;  // 400*1000*1000;
   // user-defined large problem size (above will use ALG3)
-  int64_t LARGE_NUM_PRODUCTS  = 800*1000*1000;
+  int64_t LARGE_NUM_PRODUCTS  = 800000000;  // 800*1000*1000;
 
   // switch to ALG2/ALG3 for medium & large problem size
   if (alg == CUSPARSE_SPGEMM_DEFAULT && num_prods > MEDIUM_NUM_PRODUCTS) {

--- a/src/array/cuda/csr_mm.cu
+++ b/src/array/cuda/csr_mm.cu
@@ -112,7 +112,7 @@ std::pair<CSRMatrix, NDArray> CusparseSpgemm(
   int64_t num_prods;
   CUSPARSE_CALL(cusparseSpGEMM_getNumProducts(spgemmDesc, &num_prods));
 
-  // assume free GPU mem at least ~15G for below heuristics to work  
+  // assume free GPU mem at least ~15G for below heuristics to work
   // user-defined medium problem size (below will use DEFAULT)
   int64_t MEDIUM_NUM_PRODUCTS = 400*1000*1000;
   // user-defined large problem size (above will use ALG3)

--- a/src/array/cuda/csr_mm.cu
+++ b/src/array/cuda/csr_mm.cu
@@ -98,17 +98,18 @@ std::pair<CSRMatrix, NDArray> CusparseSpgemm(
                                                 matB, &beta, matC, dtype, alg,
                                                 spgemmDesc, &workspace_size1,
                                                 NULL));
-    void* workspace1 = (device->AllocWorkspace(ctx, workspace_size1));
+    workspace1 = (device->AllocWorkspace(ctx, workspace_size1));
     CUSPARSE_CALL(cusparseSpGEMM_workEstimation(thr_entry->cusparse_handle,
                                                 transA, transB, &alpha, matA,
                                                 matB, &beta, matC, dtype, alg,
                                                 spgemmDesc, &workspace_size1,
                                                 workspace1));
   } else {
-    CHECK(e == CUSPARSE_STATUS_SUCCESS) << "CUSPARSE ERROR: " << e;
+    CHECK(e == CUSPARSE_STATUS_SUCCESS) << "CUSPARSE ERROR in SpGEMM: " << e;
   }
 
-  // you can print num_prods, for better memory estimation
+  // get the number of intermediate products required for SpGEMM compute
+  // num_prods indicates device memory consumption for SpGEMM if using ALG2/3
   int64_t num_prods;
   CUSPARSE_CALL(cusparseSpGEMM_getNumProducts(spgemmDesc, &num_prods));
 
@@ -131,7 +132,7 @@ std::pair<CSRMatrix, NDArray> CusparseSpgemm(
                                                 matB, &beta, matC, dtype, alg,
                                                 spgemmDesc, &workspace_size1,
                                                 NULL));
-    void* workspace1 = (device->AllocWorkspace(ctx, workspace_size1));
+    workspace1 = (device->AllocWorkspace(ctx, workspace_size1));
     CUSPARSE_CALL(cusparseSpGEMM_workEstimation(thr_entry->cusparse_handle,
                                                 transA, transB, &alpha, matA,
                                                 matB, &beta, matC, dtype, alg,


### PR DESCRIPTION
## Description
Since next cuda release will deprecate `cusparse<t>csrgemm` functions, DGL build will fail by the time. I noticed that we choose to use old API instead of new `cusparseSpgemm` due to this failure https://github.com/dmlc/dgl/issues/3444. 

This PR re-enables  `cusparseSpgemm` API for `__CUDACC_VER_MAJOR__> 12 `, while ~~tentatively sticks to CUSPARSE_SPGEMM_ALG3~~ adaptively picks different algorithms  to alleviate memory pressure as well as avoid compromising speed a lot. As such, it can pass this case: https://github.com/dmlc/dgl/issues/3444

Note that the algorithm flags `CUSPARSE_SPGEMM_ALG3` and `CUSPARSE_SPGEMM_ALG2` will be introduced in the next release, because of lack of documentation at this moment, I can briefly describe perf. diff among cusparse spgemm algorithms (`default`, `alg2`, `alg3`):
- In terms of speed (time): `default` > `alg2` > `alg3`; here `>` means faster (better).
- In terms of mem. consumption:  `alg3` > `alg2` > `default`; here `>` means less mem. (better).

~~By using `CUSPARSE_SPGEMM_ALG3`, this PR is very conservative in terms of memory usage in trade-off of (speed)slowness.~~ 
Now, depending the number of products (returned by `cusparseSpGEMM_getNumProducts`), from small problems to large problems, `CUSPARSE_SPGEMM_DEFAULT`, `CUSPARSE_SPGEMM_ALG2` and `CUSPARSE_SPGEMM_ALG3` will be used in order. Also, to avoid algorithm switching overhead for small problems, it starts with `CUSPARSE_SPGEMM_DEFAULT` and falls back to ALG2/3 when necessary (large enough) as early as possible. As a result, for small problems, we observed very similar performance compared to the old API; however, for very large problems like https://github.com/dmlc/dgl/issues/3444, it could be 2-3X slower...

The heuristics of alg. switching are tuned based on a machine with at least 16G device memory, to ensure best dynamic range. We need to stay tuned on this spgemm use case as `cusparseSpgemm` can continuously improve over the time. 


## Checklist
Please feel free to remove inapplicable items for your PR.
- [x] The PR title starts with [$CATEGORY] (such as [NN], [Model], [Doc], [Feature]])
- [ ] I've leverage the [tools](https://docs.google.com/document/d/1iHyj7zlmygKSk5gBPsqIqL5ASPzJSPREaNT_QdsiYA4/edit) to beautify the python and c++ code.
- [x] The PR is complete and small, read the [Google eng practice (CL equals to PR)](https://google.github.io/eng-practices/review/developer/small-cls.html) to understand more about small PR. In DGL, we consider PRs with less than 200 lines of core code change are small (example, test and documentation could be exempted).
- [ ] All changes have test coverage
- [x] Code is well-documented
- [x] To the best of my knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change
- [ ] Related issue is referred in this PR
- [ ] If the PR is for a new model/paper, I've updated the example index [here](../examples/README.md).
