### PR TITLE
[Fix] Fix `record_stream` for next PyTorch release

### DIFF
--- a/tensoradapter/pytorch/torch.cpp
+++ b/tensoradapter/pytorch/torch.cpp
@@ -41,7 +41,7 @@ TA_EXPORTS cudaStream_t CUDACurrentStream() {
 
 TA_EXPORTS void RecordStream(void* ptr, cudaStream_t stream, int device_id) {
   c10::DataPtr data_ptr{
-      ptr, ptr, &c10::cuda::CUDACachingAllocator::raw_delete,
+      ptr, ptr, c10::cuda::CUDACachingAllocator::get()->raw_deleter(),
       c10::Device(c10::DeviceType::CUDA, device_id)};
   c10::cuda::CUDACachingAllocator::recordStream(
       data_ptr,


### PR DESCRIPTION
## Description

Some recent changes to PyTorch's CUDA allocator will break `recordStream` in TensorAdaptor. This PR is to fix it while keeping backward compatibility.

## Checklist
Please feel free to remove inapplicable items for your PR.
- [x] The PR title starts with [$CATEGORY] (such as [NN], [Model], [Doc], [Feature]])
- [x] I've leverage the [tools](https://docs.google.com/document/d/1iHyj7zlmygKSk5gBPsqIqL5ASPzJSPREaNT_QdsiYA4/edit) to beautify the python and c++ code.
- [x] The PR is complete and small, read the [Google eng practice (CL equals to PR)](https://google.github.io/eng-practices/review/developer/small-cls.html) to understand more about small PR. In DGL, we consider PRs with less than 200 lines of core code change are small (example, test and documentation could be exempted).
- [x] All changes have test coverage
- [ ] Code is well-documented
- [x] To the best of my knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change
- [ ] Related issue is referred in this PR
- [ ] If the PR is for a new model/paper, I've updated the example index [here](../examples/README.md).

## Changes
<!-- You could use following template
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)
-->
