### PR TITLE
[Examples] GCN example correction (#4969)

### DIFF
--- a/examples/pytorch/gcn/train.py
+++ b/examples/pytorch/gcn/train.py
@@ -94,12 +94,6 @@ if __name__ == "__main__":
     labels = g.ndata["label"]
     masks = g.ndata["train_mask"], g.ndata["val_mask"], g.ndata["test_mask"]
 
-    # normalization
-    degs = g.in_degrees().float()
-    norm = torch.pow(degs, -0.5).to(device)
-    norm[torch.isinf(norm)] = 0
-    g.ndata["norm"] = norm.unsqueeze(1)
-
     # create GCN model
     in_size = features.shape[1]
     out_size = data.num_classes


### PR DESCRIPTION
Correction as mentioned in #4969 

I noticed that there is a normalisation step on line 97 while the normalised values are not used downstream. Even if this was meant to show the normalisation step, it would not be calculating the normalisation step described in the CGN paper. The paper considers both in and out degrees while the normalisation in the code only describes normalisation using the in degrees. In the end, the normalised values are assigned to g.ndata["norm"] but these values are not used afterwards.

Having a normalisation step here is also unnecessary since the GraphConv layer that is used already takes care of the normalisation. https://docs.dgl.ai/en/0.9.x/_modules/dgl/nn/pytorch/conv/graphconv.html#GraphConv

It confused me for a second thinking that I had to do the normalisation myself but this is already handled by the GraphConf.


