### PR TITLE
[Bug fix] Fix bug when feature_tid is empty

### DIFF
--- a/tools/distpartitioning/data_shuffle.py
+++ b/tools/distpartitioning/data_shuffle.py
@@ -431,7 +431,7 @@ def exchange_features(rank, world_size, num_parts, feature_tids, type_id_map, id
                         own_global_ids)
 
     end = timer()
-    logging.info(f'[Rank: {rank}] Total time for feature exchange {feat_key}: {timedelta(seconds = end - start)}')
+    logging.info(f'[Rank: {rank}] Total time for feature exchange: {timedelta(seconds = end - start)}')
     return own_features, own_global_ids
 
 def exchange_graph_data(rank, world_size, num_parts, node_features, edge_features, 


### PR DESCRIPTION
## Description
Fix a printing bug in [data_shuffle.py](https://github.com/dmlc/dgl/compare/master...classicsong:dgl:fix-data-shuffle?expand=1#diff-22f392bed959e7c4b021499e57b49c4c6ad40eaa552154ffcb61debb4d6271f0)

## Checklist
Please feel free to remove inapplicable items for your PR.
- [x] The PR title starts with [$CATEGORY] (such as [NN], [Model], [Doc], [Feature]])
- [ ] I've leverage the [tools](https://docs.google.com/document/d/1iHyj7zlmygKSk5gBPsqIqL5ASPzJSPREaNT_QdsiYA4/edit) to beautify the python and c++ code.
- [ ] The PR is complete and small, read the [Google eng practice (CL equals to PR)](https://google.github.io/eng-practices/review/developer/small-cls.html) to understand more about small PR. In DGL, we consider PRs with less than 200 lines of core code change are small (example, test and documentation could be exempted).
- [ ] All changes have test coverage
- [x] Code is well-documented
- [x] To the best of my knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change
- [ ] Related issue is referred in this PR
- [ ] If the PR is for a new model/paper, I've updated the example index [here](../examples/README.md).

## Changes
<!-- You could use following template
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)
-->
