### PR TITLE
[Doc] Add Labor Sampler documentation

### DIFF
--- a/docs/source/api/python/dgl.dataloading.rst
+++ b/docs/source/api/python/dgl.dataloading.rst
@@ -43,6 +43,7 @@ Samplers
 
     Sampler
     NeighborSampler
+    LaborSampler
     MultiLayerFullNeighborSampler
     ClusterGCNSampler
     ShaDowKHopSampler

--- a/docs/source/api/python/dgl.sampling.rst
+++ b/docs/source/api/python/dgl.sampling.rst
@@ -22,6 +22,7 @@ Neighbor sampling
     :toctree: ../../generated/
 
     sample_neighbors
+    sample_labors
     sample_neighbors_biased
     select_topk
     PinSAGESampler


### PR DESCRIPTION
Fixes #4967 by adding LaborSampler to dgl.dataloading doc index and sample_labors to dgl.sampling doc index.