### PR TITLE
[Bugfix] Turn off `use_alternate_stream` when TensorAdaptor is not enabled

### DIFF
--- a/python/dgl/_ffi/base.py
+++ b/python/dgl/_ffi/base.py
@@ -148,3 +148,7 @@ def load_tensor_adapter(backend, version):
     if not tensor_adapter_loaded:
         logger = logging.getLogger("dgl-core")
         logger.debug("Memory optimization with PyTorch is not enabled.")
+
+
+def is_tensor_adaptor_enabled() -> bool:
+    return tensor_adapter_loaded

--- a/python/dgl/_ffi/base.py
+++ b/python/dgl/_ffi/base.py
@@ -151,4 +151,5 @@ def load_tensor_adapter(backend, version):
 
 
 def is_tensor_adaptor_enabled() -> bool:
+    """Check whether TensorAdaptor is enabled."""
     return tensor_adapter_loaded


### PR DESCRIPTION
## Description

Try to fix https://github.com/dmlc/dgl/issues/4982.

`use_alternate_streams` requires `record_stream` to be stream-safe, which is only available when TensorAdaptor is enabled.

## Checklist
Please feel free to remove inapplicable items for your PR.
- [ ] The PR title starts with [$CATEGORY] (such as [NN], [Model], [Doc], [Feature]])
- [ ] I've leverage the [tools](https://docs.google.com/document/d/1iHyj7zlmygKSk5gBPsqIqL5ASPzJSPREaNT_QdsiYA4/edit) to beautify the python and c++ code.
- [ ] The PR is complete and small, read the [Google eng practice (CL equals to PR)](https://google.github.io/eng-practices/review/developer/small-cls.html) to understand more about small PR. In DGL, we consider PRs with less than 200 lines of core code change are small (example, test and documentation could be exempted).
- [ ] All changes have test coverage
- [ ] Code is well-documented
- [ ] To the best of my knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change
- [ ] Related issue is referred in this PR
- [ ] If the PR is for a new model/paper, I've updated the example index [here](../examples/README.md).

## Changes
<!-- You could use following template
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)
-->
