### PR TITLE
[Model] Fix bug of gatv2 when input is block

### DIFF
--- a/python/dgl/nn/pytorch/conv/gatv2conv.py
+++ b/python/dgl/nn/pytorch/conv/gatv2conv.py
@@ -294,11 +294,11 @@ class GATv2Conv(nn.Module):
                 if self.share_weights:
                     feat_dst = feat_src
                 else:
-                    feat_dst = self.fc_dst(h_src).view(
+                    feat_dst = self.fc_dst(h_dst).view(
                         -1, self._num_heads, self._out_feats
                     )
                 if graph.is_block:
-                    feat_dst = feat_src[: graph.number_of_dst_nodes()]
+                    feat_dst = feat_dst[: graph.number_of_dst_nodes()]
                     h_dst = h_dst[: graph.number_of_dst_nodes()]
             graph.srcdata.update(
                 {"el": feat_src}


### PR DESCRIPTION
## Description
Gatv2 has different weight in src and dst, the code using same one when graph is block. 

## Checklist
Please feel free to remove inapplicable items for your PR.
- [x] The PR title starts with [$CATEGORY] (such as [NN], [Model], [Doc], [Feature]])
- [ ] I've leverage the [tools](https://docs.google.com/document/d/1iHyj7zlmygKSk5gBPsqIqL5ASPzJSPREaNT_QdsiYA4/edit) to beautify the python and c++ code.
- [x] The PR is complete and small, read the [Google eng practice (CL equals to PR)](https://google.github.io/eng-practices/review/developer/small-cls.html) to understand more about small PR. In DGL, we consider PRs with less than 200 lines of core code change are small (example, test and documentation could be exempted).
- [ ] All changes have test coverage
- [ ] Code is well-documented
- [ ] To the best of my knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change
- [x] Related issue is referred in this PR
- [ ] If the PR is for a new model/paper, I've updated the example index [here](../examples/README.md).

## Changes
<!-- You could use following template
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)
-->
