### PR TITLE
[Performance] Fix for number of threads in COOToCSR

### DIFF
--- a/src/array/cpu/spmat_op_impl_coo.cc
+++ b/src/array/cpu/spmat_op_impl_coo.cc
@@ -639,7 +639,7 @@ N*P).
 template <DGLDeviceType XPU, typename IdType>
 CSRMatrix COOToCSR(COOMatrix coo) {
   if (!coo.row_sorted) {
-    const int64_t num_threads = omp_get_num_threads();
+    const int64_t num_threads = omp_get_max_threads();
     const int64_t num_nodes = coo.num_rows;
     const int64_t num_edges = coo.row->shape[0];
     // Besides graph density, num_threads is also taken into account. Below


### PR DESCRIPTION
## Description
The wrong number of threads (always 1) was taken into account when selecting the COOdoCSR algorithm.
After the change, there is a significant performance improvement.
Microbenchmark (created as modification of [tests/cpp/test_spmat_coo.cc](https://gist.github.com/anko-intel/7e86c74342e3d45233c4cb849ace76eb)) gives following results on r6i.16xlarge (Intel(R) Xeon(R) Platinum 8375C) run with:
`numactl --physcpubind=0-31 ./build/runUnitTests --gtest_filter=*Big*`




index type | N | NNZ | 100%-sparsity | before [us] | after[us] | before/after
-- | -- | -- | -- | -- | -- | --
int32 | 5 111 000 | 2 612 233 | 0.00001% | 38 654 | 3 436 | 11.2
int64 | 5 111 000 | 2 612 233 | 0.00001% | 133 154 | 9 529 | 14.0
int32 | 12 000 333 | 14 400 800 | 0.00001% | 204 931 | 49 575 | 4.1
int64 | 12 000 333 | 14 400 800 | 0.00001% | 321 307 | 80 980 | 4.0
int32 | 32 768 | 9 664 | 0.0009% | 254 | 44 | 5.8
int64 | 32 768 | 9 664 | 0.0009% | 248 | 32 | 7.8
int32 | 128 603 | 148 849 | 0.0009% | 875 | 126 | 6.9
int64 | 128 603 | 148 849 | 0.0009% | 915 | 142 | 6.4
int32 | 1 024 | 630 | 0.06% | 31 | 28 | 1.1
int64 | 1 024 | 630 | 0.06% | 28 | 26 | 1.1
int32 | 1 024 | 5 243 | 0.5% | 42 | 39 | 1.1
int64 | 1 024 | 5 243 | 0.5% | 38 | 34 | 1.1

## Checklist
Please feel free to remove inapplicable items for your PR.
- [x] The PR title starts with [$CATEGORY] (such as [NN], [Model], [Doc], [Feature]])
- [x] I've leverage the [tools](https://docs.google.com/document/d/1iHyj7zlmygKSk5gBPsqIqL5ASPzJSPREaNT_QdsiYA4/edit) to beautify the python and c++ code.
- [x] The PR is complete and small, read the [Google eng practice (CL equals to PR)](https://google.github.io/eng-practices/review/developer/small-cls.html) to understand more about small PR. In DGL, we consider PRs with less than 200 lines of core code change are small (example, test and documentation could be exempted).




