### PR TITLE
[Quality of life] Fix warnings raised by the core library

### DIFF
--- a/apps/kg/train_pytorch.py
+++ b/apps/kg/train_pytorch.py
@@ -24,10 +24,9 @@ from torch.utils.data import DataLoader
 import torch.optim as optim
 import torch as th
 
-from distutils.version import LooseVersion
-TH_VERSION = LooseVersion(th.__version__)
-if TH_VERSION.version[0] == 1 and TH_VERSION.version[1] < 2:
-    raise Exception("DGL-ke has to work with Pytorch version >= 1.2")
+from packaging import version
+if version.parse(th.__version__) < version.parse("1.2"):
+    raise RuntimeError("DGL-ke has to work with Pytorch version >= 1.2")
 from models.pytorch.tensor_models import thread_wrapped_func
 
 import os

--- a/apps/kg/train_pytorch.py
+++ b/apps/kg/train_pytorch.py
@@ -24,7 +24,7 @@ from torch.utils.data import DataLoader
 import torch.optim as optim
 import torch as th
 
-from packaging import version
+from setuptools.extern.packaging import version
 if version.parse(th.__version__) < version.parse("1.2"):
     raise RuntimeError("DGL-ke has to work with Pytorch version >= 1.2")
 from models.pytorch.tensor_models import thread_wrapped_func

--- a/python/dgl/_dataloading/pytorch/dataloader.py
+++ b/python/dgl/_dataloading/pytorch/dataloader.py
@@ -3,7 +3,7 @@ import inspect
 import math
 import threading
 import queue
-from distutils.version import LooseVersion
+from packaging import version
 import torch as th
 from torch.utils.data import DataLoader, IterableDataset
 from torch.utils.data.distributed import DistributedSampler
@@ -20,9 +20,9 @@ __all__ = ['NodeDataLoader', 'EdgeDataLoader', 'GraphDataLoader',
            '_pop_subgraph_storage', '_pop_storages',
            '_restore_subgraph_storage', '_restore_storages']
 
-PYTORCH_VER = LooseVersion(th.__version__)
-PYTORCH_16 = PYTORCH_VER >= LooseVersion("1.6.0")
-PYTORCH_17 = PYTORCH_VER >= LooseVersion("1.7.0")
+PYTORCH_VER = version.parse(th.__version__)
+PYTORCH_16 = PYTORCH_VER >= version.parse("1.6.0")
+PYTORCH_17 = PYTORCH_VER >= version.parse("1.7.0")
 
 def _check_graph_type(g):
     if isinstance(g, DistGraph):

--- a/python/dgl/_dataloading/pytorch/dataloader.py
+++ b/python/dgl/_dataloading/pytorch/dataloader.py
@@ -3,7 +3,7 @@ import inspect
 import math
 import threading
 import queue
-from packaging import version
+from setuptools.extern.packaging import version
 import torch as th
 from torch.utils.data import DataLoader, IterableDataset
 from torch.utils.data.distributed import DistributedSampler

--- a/python/dgl/backend/mxnet/tensor.py
+++ b/python/dgl/backend/mxnet/tensor.py
@@ -3,7 +3,7 @@ from __future__ import absolute_import
 import builtins
 import numbers
 import os
-from distutils.version import LooseVersion
+from packaging import version
 
 import mxnet as mx
 import mxnet.ndarray as nd
@@ -13,7 +13,7 @@ from ... import ndarray as dglnd
 from ..._deprecate import kernel as K
 from ...function.base import TargetCode
 
-if LooseVersion(mx.__version__) < LooseVersion("1.6.0"):
+if version.parse(mx.__version__) < version.parse("1.6.0"):
     raise RuntimeError("DGL requires MXNet >= 1.6")
 
 # After MXNet 1.5, empty tensors aren't supprted by default.

--- a/python/dgl/backend/mxnet/tensor.py
+++ b/python/dgl/backend/mxnet/tensor.py
@@ -31,7 +31,7 @@ def data_type_dict():
         "int16": np.int16,
         "int32": np.int32,
         "int64": np.int64,
-        "bool": np.bool,
+        "bool": np.bool_,
     }  # mxnet does not support bool
 
 
@@ -40,7 +40,7 @@ def cpu():
 
 
 def tensor(data, dtype=None):
-    if dtype == np.bool:
+    if dtype == np.bool_:
         # mxnet doesn't support bool
         dtype = np.int32
     if isinstance(data, nd.NDArray):
@@ -53,7 +53,7 @@ def tensor(data, dtype=None):
             data = [data]
         if dtype is None:
             if isinstance(data, np.ndarray):
-                dtype = np.int32 if data.dtype == np.bool else data.dtype
+                dtype = np.int32 if data.dtype == np.bool_ else data.dtype
             elif len(data) == 0:
                 dtype = np.int64
             else:
@@ -165,7 +165,7 @@ def to_backend_ctx(dglctx):
 
 
 def astype(input, ty):
-    if ty == np.bool:
+    if ty == np.bool_:
         ty = np.int32
     return input.astype(ty)
 

--- a/python/dgl/backend/mxnet/tensor.py
+++ b/python/dgl/backend/mxnet/tensor.py
@@ -3,7 +3,7 @@ from __future__ import absolute_import
 import builtins
 import numbers
 import os
-from packaging import version
+from setuptools.extern.packaging import version
 
 import mxnet as mx
 import mxnet.ndarray as nd

--- a/python/dgl/backend/pytorch/tensor.py
+++ b/python/dgl/backend/pytorch/tensor.py
@@ -2,7 +2,7 @@ from __future__ import absolute_import
 
 import builtins
 import numbers
-from distutils.version import LooseVersion
+from packaging import version
 
 import numpy as np
 import scipy  # Weird bug in new pytorch when import scipy after import torch
@@ -13,7 +13,7 @@ from ... import ndarray as nd
 from ..._deprecate import kernel as K
 from ...function.base import TargetCode
 
-if LooseVersion(th.__version__) < LooseVersion("1.9.0"):
+if version.parse(th.__version__) < version.parse("1.9.0"):
     raise RuntimeError("DGL requires PyTorch >= 1.9.0")
 
 
@@ -425,7 +425,7 @@ def zerocopy_from_numpy(np_array):
     return th.as_tensor(np_array)
 
 
-if LooseVersion(th.__version__) >= LooseVersion("1.10.0"):
+if version.parse(th.__version__) >= version.parse("1.10.0"):
 
     def zerocopy_to_dgl_ndarray(data):
         if data.dtype == th.bool:

--- a/python/dgl/backend/pytorch/tensor.py
+++ b/python/dgl/backend/pytorch/tensor.py
@@ -2,11 +2,11 @@ from __future__ import absolute_import
 
 import builtins
 import numbers
-from packaging import version
 
 import numpy as np
 import scipy  # Weird bug in new pytorch when import scipy after import torch
 import torch as th
+from setuptools.extern.packaging import version
 from torch.utils import dlpack
 
 from ... import ndarray as nd

--- a/python/dgl/backend/pytorch/tensor.py
+++ b/python/dgl/backend/pytorch/tensor.py
@@ -341,7 +341,7 @@ def pack_padded_tensor(input, lengths):
 
 def boolean_mask(input, mask):
     if "bool" not in str(mask.dtype):
-        mask = th.tensor(mask, dtype=th.bool)
+        mask = th.as_tensor(mask, dtype=th.bool)
     return input[mask]
 
 

--- a/python/dgl/backend/tensorflow/tensor.py
+++ b/python/dgl/backend/tensorflow/tensor.py
@@ -3,7 +3,7 @@ from __future__ import absolute_import
 
 import builtins
 import numbers
-from packaging import version
+from setuptools.extern.packaging import version
 
 import numpy as np
 import tensorflow as tf

--- a/python/dgl/backend/tensorflow/tensor.py
+++ b/python/dgl/backend/tensorflow/tensor.py
@@ -3,7 +3,7 @@ from __future__ import absolute_import
 
 import builtins
 import numbers
-from distutils.version import LooseVersion
+from packaging import version
 
 import numpy as np
 import tensorflow as tf
@@ -12,7 +12,7 @@ from ... import ndarray as nd
 from ..._deprecate import kernel as K
 from ...function.base import TargetCode
 
-if LooseVersion(tf.__version__) < LooseVersion("2.3.0"):
+if version.parse(tf.__version__) < version.parse("2.3.0"):
     raise RuntimeError(
         "DGL requires TensorFlow>=2.3.0 for the official DLPack support."
     )

--- a/python/dgl/data/fakenews.py
+++ b/python/dgl/data/fakenews.py
@@ -162,9 +162,9 @@ class FakeNewsDataset(DGLBuiltinDataset):
         train_idx = np.load(os.path.join(self.raw_path, "train_idx.npy"))
         val_idx = np.load(os.path.join(self.raw_path, "val_idx.npy"))
         test_idx = np.load(os.path.join(self.raw_path, "test_idx.npy"))
-        train_mask = np.zeros(num_graphs, dtype=np.bool)
-        val_mask = np.zeros(num_graphs, dtype=np.bool)
-        test_mask = np.zeros(num_graphs, dtype=np.bool)
+        train_mask = np.zeros(num_graphs, dtype=np.bool_)
+        val_mask = np.zeros(num_graphs, dtype=np.bool_)
+        test_mask = np.zeros(num_graphs, dtype=np.bool_)
         train_mask[train_idx] = True
         val_mask[val_idx] = True
         test_mask[test_idx] = True

--- a/python/dgl/data/fraud.py
+++ b/python/dgl/data/fraud.py
@@ -227,9 +227,9 @@ class FraudDataset(DGLBuiltinDataset):
             int(train_size * len(index)) : len(index)
             - int(val_size * len(index))
         ]
-        train_mask = np.zeros(N, dtype=np.bool)
-        val_mask = np.zeros(N, dtype=np.bool)
-        test_mask = np.zeros(N, dtype=np.bool)
+        train_mask = np.zeros(N, dtype=np.bool_)
+        val_mask = np.zeros(N, dtype=np.bool_)
+        test_mask = np.zeros(N, dtype=np.bool_)
         train_mask[train_idx] = True
         val_mask[val_idx] = True
         test_mask[test_idx] = True

--- a/python/dgl/data/minigc.py
+++ b/python/dgl/data/minigc.py
@@ -178,7 +178,7 @@ class MiniGCDataset(DGLDataset):
         for i in range(self.num_graphs):
             # convert to DGLGraph, and add self loops
             self.graphs[i] = add_self_loop(from_networkx(self.graphs[i]))
-        self.labels = F.tensor(np.array(self.labels).astype(np.int))
+        self.labels = F.tensor(np.array(self.labels).astype(np.int64))
 
     def _gen_cycle(self, n):
         for _ in range(n):

--- a/python/dgl/data/qm9.py
+++ b/python/dgl/data/qm9.py
@@ -182,7 +182,7 @@ class QM9Dataset(DGLDataset):
         n_atoms = self.N[idx]
         R = self.R[self.N_cumsum[idx]:self.N_cumsum[idx + 1]]
         dist = np.linalg.norm(R[:, None, :] - R[None, :, :], axis=-1)
-        adj = sp.csr_matrix(dist <= self.cutoff) - sp.eye(n_atoms, dtype=np.bool)
+        adj = sp.csr_matrix(dist <= self.cutoff) - sp.eye(n_atoms, dtype=np.bool_)
         adj = adj.tocoo()
         u, v = F.tensor(adj.row), F.tensor(adj.col)
         g = dgl_graph((u, v))

--- a/python/dgl/dataloading/dataloader.py
+++ b/python/dgl/dataloading/dataloader.py
@@ -3,7 +3,7 @@ from collections.abc import Mapping, Sequence
 from queue import Queue, Empty, Full
 import itertools
 import threading
-from packaging import version
+from setuptools.extern.packaging import version
 import math
 import inspect
 import re

--- a/python/dgl/dataloading/dataloader.py
+++ b/python/dgl/dataloading/dataloader.py
@@ -3,7 +3,7 @@ from collections.abc import Mapping, Sequence
 from queue import Queue, Empty, Full
 import itertools
 import threading
-from distutils.version import LooseVersion
+from packaging import version
 import math
 import inspect
 import re
@@ -31,7 +31,7 @@ from .. import backend as F
 from ..distributed import DistGraph
 from ..multiprocessing import call_once_and_share
 
-PYTORCH_VER = LooseVersion(torch.__version__)
+PYTORCH_VER = version.parse(torch.__version__)
 PYTHON_EXIT_STATUS = False
 def _set_python_exit_flag():
     global PYTHON_EXIT_STATUS
@@ -76,7 +76,7 @@ class _TensorizedDatasetIter(object):
         # convert the type-ID pairs to dictionary
         type_ids = batch[:, 0]
         indices = batch[:, 1]
-        if PYTORCH_VER >= LooseVersion("1.10.0"):
+        if PYTORCH_VER >= version.parse("1.10.0"):
             _, type_ids_sortidx = torch.sort(type_ids, stable=True)
         else:
             if not self.shuffle:

--- a/python/dgl/nn/pytorch/glob.py
+++ b/python/dgl/nn/pytorch/glob.py
@@ -729,8 +729,8 @@ class MultiHeadAttention(nn.Module):
         max_len_x = max(lengths_x)
         max_len_mem = max(lengths_mem)
         device = x.device
-        lengths_x = th.tensor(lengths_x, dtype=th.int64, device=device)
-        lengths_mem = th.tensor(lengths_mem, dtype=th.int64, device=device)
+        lengths_x = th.as_tensor(lengths_x, dtype=th.int64, device=device)
+        lengths_mem = th.as_tensor(lengths_mem, dtype=th.int64, device=device)
 
         queries = self.proj_q(x).view(-1, self.num_heads, self.d_head)
         keys = self.proj_k(mem).view(-1, self.num_heads, self.d_head)

--- a/src/array/cuda/gather_mm.cu
+++ b/src/array/cuda/gather_mm.cu
@@ -168,7 +168,6 @@ __global__ void GatherMMScatterKernel2(
       __syncwarp();
 
       for (unsigned int outloop = 0; outloop < out_len; outloop += 32) {
-        DType out_reg = static_cast<DType>(0.0f);  // thread private
         const unsigned int l = laneId;
         if (l < out_len) {
           const DType b_val = B[row_b * out_len + (outloop + l)];

--- a/tests/compute/test_sparse.py
+++ b/tests/compute/test_sparse.py
@@ -1,4 +1,4 @@
-from packaging import version
+from setuptools.extern.packaging import version
 import random
 import unittest
 

--- a/tests/compute/test_sparse.py
+++ b/tests/compute/test_sparse.py
@@ -373,7 +373,7 @@ def test_segment_mm(idtype, feat_size, dtype, tol):
             "Only support float32 and float64 on CPU."
         )
     if F._default_context_str == "gpu" \
-        and version.parsee(torch.version.cuda) < version.parse("11.0") \
+        and version.parse(torch.version.cuda) < version.parse("11.0") \
         and dtype == torch.bfloat16:
         pytest.skip(
             "BF16 requires CUDA >= 11.0."

--- a/tests/compute/test_sparse.py
+++ b/tests/compute/test_sparse.py
@@ -1,4 +1,4 @@
-from distutils.version import LooseVersion
+from packaging import version
 import random
 import unittest
 
@@ -189,7 +189,7 @@ def test_spmm(idtype, g, shp, msg, reducer):
     [(torch.float16, 1e-3, 0.5), (torch.bfloat16, 4e-3, 2.)]
 )
 def test_half_spmm(idtype, dtype, rtol, atol):
-    if LooseVersion(torch.version.cuda) < LooseVersion("11.0") \
+    if version.parse(torch.version.cuda) < version.parse("11.0") \
         and dtype == torch.bfloat16:
         pytest.skip("BF16 requires CUDA >= 11.0.")
 
@@ -373,7 +373,7 @@ def test_segment_mm(idtype, feat_size, dtype, tol):
             "Only support float32 and float64 on CPU."
         )
     if F._default_context_str == "gpu" \
-        and LooseVersion(torch.version.cuda) < LooseVersion("11.0") \
+        and version.parsee(torch.version.cuda) < version.parse("11.0") \
         and dtype == torch.bfloat16:
         pytest.skip(
             "BF16 requires CUDA >= 11.0."
@@ -426,7 +426,7 @@ def test_gather_mm_idx_b(feat_size, dtype, tol):
     if F._default_context_str == "cpu" and dtype in (torch.float16, torch.bfloat16):
         pytest.skip("Only support float32 and float64 on CPU.")
     if F._default_context_str == "gpu" \
-        and LooseVersion(torch.version.cuda) < LooseVersion("11.0") \
+        and version.parse(torch.version.cuda) < version.parse("11.0") \
         and dtype == torch.bfloat16:
         pytest.skip("BF16 requires CUDA >= 11.0.")
 


### PR DESCRIPTION
## Description

Try to fix warnings raised by the core library. For warnings root caused by deprecated usages in unit tests, I just leave them there.

Main changes are:
1. `distutils.version.LooseVersion` -> `setuptools.extern.packaging.version.parse` because the former one is deprecated. We use the `packaging` vendored in `setuptools` in case users haven't installed it.
2. `np.bool/int` -> `np.bool_/int64`. Besides, there're many warnings on the use of `np.float` (should be either `np.float32` or `np.float64`) in unit tests, but they are not raised in the core lib so I don't fix them.
3. Some `torch.tensor` -> `torch.as_tensor` to convert tensors with different `dtype` and `device`. 

Note: I will format the changed files after this PR is approved. Otherwise, there will be too many irrelevant changes.

## Checklist
Please feel free to remove inapplicable items for your PR.
- [ ] The PR title starts with [$CATEGORY] (such as [NN], [Model], [Doc], [Feature]])
- [ ] I've leverage the [tools](https://docs.google.com/document/d/1iHyj7zlmygKSk5gBPsqIqL5ASPzJSPREaNT_QdsiYA4/edit) to beautify the python and c++ code.
- [ ] The PR is complete and small, read the [Google eng practice (CL equals to PR)](https://google.github.io/eng-practices/review/developer/small-cls.html) to understand more about small PR. In DGL, we consider PRs with less than 200 lines of core code change are small (example, test and documentation could be exempted).
- [ ] All changes have test coverage
- [ ] Code is well-documented
- [ ] To the best of my knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change
- [ ] Related issue is referred in this PR
- [ ] If the PR is for a new model/paper, I've updated the example index [here](../examples/README.md).