### PR TITLE
[Fix core lib warning] Fix numpy dtype

### DIFF
--- a/python/dgl/backend/mxnet/tensor.py
+++ b/python/dgl/backend/mxnet/tensor.py
@@ -31,7 +31,7 @@ def data_type_dict():
         "int16": np.int16,
         "int32": np.int32,
         "int64": np.int64,
-        "bool": np.bool,
+        "bool": np.bool_,
     }  # mxnet does not support bool
 
 
@@ -40,7 +40,7 @@ def cpu():
 
 
 def tensor(data, dtype=None):
-    if dtype == np.bool:
+    if dtype == np.bool_:
         # mxnet doesn't support bool
         dtype = np.int32
     if isinstance(data, nd.NDArray):
@@ -53,7 +53,7 @@ def tensor(data, dtype=None):
             data = [data]
         if dtype is None:
             if isinstance(data, np.ndarray):
-                dtype = np.int32 if data.dtype == np.bool else data.dtype
+                dtype = np.int32 if data.dtype == np.bool_ else data.dtype
             elif len(data) == 0:
                 dtype = np.int64
             else:
@@ -165,7 +165,7 @@ def to_backend_ctx(dglctx):
 
 
 def astype(input, ty):
-    if ty == np.bool:
+    if ty == np.bool_:
         ty = np.int32
     return input.astype(ty)
 

--- a/python/dgl/data/fakenews.py
+++ b/python/dgl/data/fakenews.py
@@ -162,9 +162,9 @@ class FakeNewsDataset(DGLBuiltinDataset):
         train_idx = np.load(os.path.join(self.raw_path, "train_idx.npy"))
         val_idx = np.load(os.path.join(self.raw_path, "val_idx.npy"))
         test_idx = np.load(os.path.join(self.raw_path, "test_idx.npy"))
-        train_mask = np.zeros(num_graphs, dtype=np.bool)
-        val_mask = np.zeros(num_graphs, dtype=np.bool)
-        test_mask = np.zeros(num_graphs, dtype=np.bool)
+        train_mask = np.zeros(num_graphs, dtype=np.bool_)
+        val_mask = np.zeros(num_graphs, dtype=np.bool_)
+        test_mask = np.zeros(num_graphs, dtype=np.bool_)
         train_mask[train_idx] = True
         val_mask[val_idx] = True
         test_mask[test_idx] = True

--- a/python/dgl/data/fraud.py
+++ b/python/dgl/data/fraud.py
@@ -227,9 +227,9 @@ class FraudDataset(DGLBuiltinDataset):
             int(train_size * len(index)) : len(index)
             - int(val_size * len(index))
         ]
-        train_mask = np.zeros(N, dtype=np.bool)
-        val_mask = np.zeros(N, dtype=np.bool)
-        test_mask = np.zeros(N, dtype=np.bool)
+        train_mask = np.zeros(N, dtype=np.bool_)
+        val_mask = np.zeros(N, dtype=np.bool_)
+        test_mask = np.zeros(N, dtype=np.bool_)
         train_mask[train_idx] = True
         val_mask[val_idx] = True
         test_mask[test_idx] = True

--- a/python/dgl/data/minigc.py
+++ b/python/dgl/data/minigc.py
@@ -178,7 +178,7 @@ class MiniGCDataset(DGLDataset):
         for i in range(self.num_graphs):
             # convert to DGLGraph, and add self loops
             self.graphs[i] = add_self_loop(from_networkx(self.graphs[i]))
-        self.labels = F.tensor(np.array(self.labels).astype(np.int))
+        self.labels = F.tensor(np.array(self.labels).astype(np.int64))
 
     def _gen_cycle(self, n):
         for _ in range(n):

--- a/python/dgl/data/qm9.py
+++ b/python/dgl/data/qm9.py
@@ -182,7 +182,7 @@ class QM9Dataset(DGLDataset):
         n_atoms = self.N[idx]
         R = self.R[self.N_cumsum[idx]:self.N_cumsum[idx + 1]]
         dist = np.linalg.norm(R[:, None, :] - R[None, :, :], axis=-1)
-        adj = sp.csr_matrix(dist <= self.cutoff) - sp.eye(n_atoms, dtype=np.bool)
+        adj = sp.csr_matrix(dist <= self.cutoff) - sp.eye(n_atoms, dtype=np.bool_)
         adj = adj.tocoo()
         u, v = F.tensor(adj.row), F.tensor(adj.col)
         g = dgl_graph((u, v))


### PR DESCRIPTION
## Description

Replace `np.bool/int` with `np.bool_/int64`. Numpy complains `np.bool/int` are just alias of Python built-in data types (`bool`/`int`), users should either use built-in data types or more specific `np.bool_` and `np.int32/int64`.

Besides, there're many warnings on the use of `np.int` and `np.float` (should be either `np.float32` or `np.float64`) in unit tests and examples, but they are not raised in the core lib so I don't fix them.

## Checklist
Please feel free to remove inapplicable items for your PR.
- [ ] The PR title starts with [$CATEGORY] (such as [NN], [Model], [Doc], [Feature]])
- [ ] I've leverage the [tools](https://docs.google.com/document/d/1iHyj7zlmygKSk5gBPsqIqL5ASPzJSPREaNT_QdsiYA4/edit) to beautify the python and c++ code.
- [ ] The PR is complete and small, read the [Google eng practice (CL equals to PR)](https://google.github.io/eng-practices/review/developer/small-cls.html) to understand more about small PR. In DGL, we consider PRs with less than 200 lines of core code change are small (example, test and documentation could be exempted).
- [ ] All changes have test coverage
- [ ] Code is well-documented
- [ ] To the best of my knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change
- [ ] Related issue is referred in this PR
- [ ] If the PR is for a new model/paper, I've updated the example index [here](../examples/README.md).