### PR TITLE
[Sparse] Add Two Sparse Matrices with Different Sparsity, DiagMatrix.dense, Add SparseMatrix and DiagMatrix

### DIFF
--- a/dgl_sparse/include/sparse/sparse_format.h
+++ b/dgl_sparse/include/sparse/sparse_format.h
@@ -62,6 +62,16 @@ std::shared_ptr<CSR> CSRFromOldDGLCSR(const aten::CSRMatrix& dgl_csr);
 /** @brief Convert a CSR in the sparse library to an old DGL CSR matrix. */
 aten::CSRMatrix CSRToOldDGLCSR(const std::shared_ptr<CSR>& csr);
 
+/**
+ *  @brief Convert a COO and its nonzero values to a Torch COO matrix.
+ *  @param coo The COO format in the sparse library
+ *  @param value Values of the sparse matrix
+ *
+ *  @return Torch Sparse Tensor in COO format
+ */
+torch::Tensor COOToTorchCOO(
+    const std::shared_ptr<COO>& coo, torch::Tensor value);
+
 /** @brief Convert a CSR format to COO format. */
 std::shared_ptr<COO> CSRToCOO(const std::shared_ptr<CSR>& csr);
 

--- a/dgl_sparse/src/sparse_format.cc
+++ b/dgl_sparse/src/sparse_format.cc
@@ -48,6 +48,20 @@ aten::CSRMatrix CSRToOldDGLCSR(const std::shared_ptr<CSR>& csr) {
       csr->num_rows, csr->num_cols, indptr, indices, data, csr->sorted);
 }
 
+torch::Tensor COOToTorchCOO(
+    const std::shared_ptr<COO>& coo, torch::Tensor value) {
+  std::vector<torch::Tensor> indices = {coo->row, coo->col};
+  if (value.ndimension() == 2) {
+    return torch::sparse_coo_tensor(
+      torch::stack(indices), value,
+      {coo->num_rows, coo->num_cols, value.size(1)});
+  } else {
+    return torch::sparse_coo_tensor(
+      torch::stack(indices), value,
+      {coo->num_rows, coo->num_cols});
+  }
+}
+
 std::shared_ptr<COO> CSRToCOO(const std::shared_ptr<CSR>& csr) {
   auto dgl_csr = CSRToOldDGLCSR(csr);
   auto dgl_coo = aten::CSRToCOO(dgl_csr, csr->value_indices.has_value());

--- a/dgl_sparse/src/sparse_format.cc
+++ b/dgl_sparse/src/sparse_format.cc
@@ -53,12 +53,11 @@ torch::Tensor COOToTorchCOO(
   std::vector<torch::Tensor> indices = {coo->row, coo->col};
   if (value.ndimension() == 2) {
     return torch::sparse_coo_tensor(
-      torch::stack(indices), value,
-      {coo->num_rows, coo->num_cols, value.size(1)});
+        torch::stack(indices), value,
+        {coo->num_rows, coo->num_cols, value.size(1)});
   } else {
     return torch::sparse_coo_tensor(
-      torch::stack(indices), value,
-      {coo->num_rows, coo->num_cols});
+        torch::stack(indices), value, {coo->num_rows, coo->num_cols});
   }
 }
 

--- a/dgl_sparse/src/sparse_matrix.cc
+++ b/dgl_sparse/src/sparse_matrix.cc
@@ -119,7 +119,8 @@ c10::intrusive_ptr<SparseMatrix> SparseMatrix::Transpose() const {
   if (HasCOO()) {
     auto coo = COOTranspose(coo_);
     return SparseMatrix::FromCOO(coo, value, shape);
-  } else if (HasCSR()) {
+  }
+   if (HasCSR()) {
     return SparseMatrix::FromCSC(csr_, value, shape);
   } else {
     return SparseMatrix::FromCSR(csc_, value, shape);

--- a/dgl_sparse/src/sparse_matrix.cc
+++ b/dgl_sparse/src/sparse_matrix.cc
@@ -119,8 +119,7 @@ c10::intrusive_ptr<SparseMatrix> SparseMatrix::Transpose() const {
   if (HasCOO()) {
     auto coo = COOTranspose(coo_);
     return SparseMatrix::FromCOO(coo, value, shape);
-  }
-   if (HasCSR()) {
+  } else if (HasCSR()) {
     return SparseMatrix::FromCSC(csr_, value, shape);
   } else {
     return SparseMatrix::FromCSR(csc_, value, shape);

--- a/python/dgl/mock_sparse2/__init__.py
+++ b/python/dgl/mock_sparse2/__init__.py
@@ -7,6 +7,8 @@ import torch
 from .._ffi import libinfo
 from .diag_matrix import *
 from .elementwise_op import *
+from .elementwise_op_diag import *
+from .elementwise_op_sp import *
 from .sparse_matrix import *
 from .unary_op_diag import *
 from .unary_op_sp import *

--- a/python/dgl/mock_sparse2/diag_matrix.py
+++ b/python/dgl/mock_sparse2/diag_matrix.py
@@ -121,6 +121,22 @@ class DiagMatrix:
         row = col = torch.arange(len(self.val)).to(self.device)
         return create_from_coo(row=row, col=col, val=self.val, shape=self.shape)
 
+    def dense(self) -> torch.Tensor:
+        """Return a dense representation of the matrix.
+
+        Returns
+        -------
+        torch.Tensor
+            Dense representation of the diagonal matrix.
+        """
+        val = self.val
+        device = self.device
+        shape = self.shape + val.shape[1:]
+        mat = torch.zeros(shape, device=device, dtype=self.dtype)
+        row = col = torch.arange(len(val)).to(device)
+        mat[row, col] = val
+        return mat
+
     def t(self):
         """Alias of :meth:`transpose()`"""
         return self.transpose()

--- a/python/dgl/mock_sparse2/elementwise_op.py
+++ b/python/dgl/mock_sparse2/elementwise_op.py
@@ -10,12 +10,32 @@ __all__ = ["add", "power"]
 
 
 def add(
-    A: Union[SparseMatrix, DiagMatrix], B: Union[SparseMatrix, DiagMatrix]
-) -> Union[SparseMatrix, DiagMatrix]:
-    """Elementwise addition"""
-    if isinstance(A, DiagMatrix) and isinstance(B, DiagMatrix):
-        return diag_add(A, B)
-    return sp_add(A, B)
+    A: Union[DiagMatrix, SparseMatrix], B: Union[DiagMatrix, SparseMatrix]
+) -> Union[DiagMatrix, SparseMatrix]:
+    """Elementwise addition
+
+    Parameters
+    ----------
+    A : DiagMatrix or SparseMatrix
+        Diagonal matrix or sparse matrix
+    B : DiagMatrix or SparseMatrix
+        Diagonal matrix or sparse matrix
+
+    Returns
+    -------
+    DiagMatrix or SparseMatrix
+        Diagonal matrix if both :attr:`A` and :attr:`B` are diagonal matrices,
+        sparse matrix otherwise
+
+    Examples
+    --------
+    >>> row = torch.tensor([1, 0, 2])
+    >>> col = torch.tensor([0, 1, 2])
+    >>> val = torch.tensor([10, 20, 30])
+    >>> A = create_from_coo(row, col, val)
+    >>> B = diag(torch.arange(1, 4))
+    """
+    return A + B
 
 
 def power(

--- a/python/dgl/mock_sparse2/elementwise_op.py
+++ b/python/dgl/mock_sparse2/elementwise_op.py
@@ -32,6 +32,11 @@ def add(
     >>> val = torch.tensor([10, 20, 30])
     >>> A = create_from_coo(row, col, val)
     >>> B = diag(torch.arange(1, 4))
+    >>> A + B
+    SparseMatrix(indices=tensor([[0, 0, 1, 1, 2],
+            [0, 1, 0, 1, 2]]),
+    values=tensor([ 1, 20, 10,  2, 33]),
+    shape=(3, 3), nnz=5)
     """
     return A + B
 

--- a/python/dgl/mock_sparse2/elementwise_op.py
+++ b/python/dgl/mock_sparse2/elementwise_op.py
@@ -2,8 +2,6 @@
 from typing import Union
 
 from .diag_matrix import DiagMatrix
-from .elementwise_op_diag import diag_add
-from .elementwise_op_sp import sp_add
 from .sparse_matrix import SparseMatrix
 
 __all__ = ["add", "power"]

--- a/python/dgl/mock_sparse2/elementwise_op_diag.py
+++ b/python/dgl/mock_sparse2/elementwise_op_diag.py
@@ -1,14 +1,15 @@
 """DGL elementwise operators for diagonal matrix module."""
 from typing import Union
 
-from .diag_matrix import diag, DiagMatrix
+from .diag_matrix import DiagMatrix, diag
 from .sparse_matrix import SparseMatrix
 
 __all__ = ["diag_add", "diag_sub", "diag_mul", "diag_div", "diag_power"]
 
 
-def diag_add(D1: DiagMatrix, D2: Union[DiagMatrix, SparseMatrix])\
-    -> Union[DiagMatrix, SparseMatrix]:
+def diag_add(
+    D1: DiagMatrix, D2: Union[DiagMatrix, SparseMatrix]
+) -> Union[DiagMatrix, SparseMatrix]:
     """Elementwise addition
 
     Parameters

--- a/python/dgl/mock_sparse2/elementwise_op_diag.py
+++ b/python/dgl/mock_sparse2/elementwise_op_diag.py
@@ -2,24 +2,26 @@
 from typing import Union
 
 from .diag_matrix import diag, DiagMatrix
+from .sparse_matrix import SparseMatrix
 
 __all__ = ["diag_add", "diag_sub", "diag_mul", "diag_div", "diag_power"]
 
 
-def diag_add(D1: DiagMatrix, D2: DiagMatrix) -> DiagMatrix:
+def diag_add(D1: DiagMatrix, D2: Union[DiagMatrix, SparseMatrix])\
+    -> Union[DiagMatrix, SparseMatrix]:
     """Elementwise addition
 
     Parameters
     ----------
     D1 : DiagMatrix
         Diagonal matrix
-    D2 : DiagMatrix
-        Diagonal matrix
+    D2 : DiagMatrix or SparseMatrix
+        Diagonal matrix or sparse matrix
 
     Returns
     -------
-    DiagMatrix
-        Diagonal matrix
+    DiagMatrix or SparseMatrix
+        Diagonal matrix or sparse matrix, same as D2
 
     Examples
     --------
@@ -35,6 +37,13 @@ def diag_add(D1: DiagMatrix, D2: DiagMatrix) -> DiagMatrix:
             f"{D1.shape} and D2 {D2.shape} must match."
         )
         return diag(D1.val + D2.val, D1.shape)
+    elif isinstance(D1, DiagMatrix) and isinstance(D2, SparseMatrix):
+        assert D1.shape == D2.shape, (
+            "The shape of diagonal matrix D1 "
+            f"{D1.shape} and sparse matrix D2 {D2.shape} must match."
+        )
+        D1 = D1.as_sparse()
+        return D1 + D2
     raise RuntimeError(
         "Elementwise addition between "
         f"{type(D1)} and {type(D2)} is not supported."

--- a/python/dgl/mock_sparse2/elementwise_op_sp.py
+++ b/python/dgl/mock_sparse2/elementwise_op_sp.py
@@ -16,8 +16,7 @@ def spsp_add(A, B):
     )
 
 
-def sp_add(A: SparseMatrix, B: Union[DiagMatrix, SparseMatrix])\
-    -> SparseMatrix:
+def sp_add(A: SparseMatrix, B: Union[DiagMatrix, SparseMatrix]) -> SparseMatrix:
     """Elementwise addition
 
     Parameters

--- a/python/dgl/mock_sparse2/elementwise_op_sp.py
+++ b/python/dgl/mock_sparse2/elementwise_op_sp.py
@@ -3,6 +3,7 @@ from typing import Union
 
 import torch
 
+from .diag_matrix import DiagMatrix
 from .sparse_matrix import SparseMatrix, val_like
 
 __all__ = ["sp_add", "sp_power"]
@@ -15,15 +16,16 @@ def spsp_add(A, B):
     )
 
 
-def sp_add(A: SparseMatrix, B: SparseMatrix) -> SparseMatrix:
-    """Elementwise addition.
+def sp_add(A: SparseMatrix, B: Union[DiagMatrix, SparseMatrix])\
+    -> SparseMatrix:
+    """Elementwise addition
 
     Parameters
     ----------
     A : SparseMatrix
         Sparse matrix
-    B : SparseMatrix
-        Sparse matrix
+    B : DiagMatrix or SparseMatrix
+        Diagonal matrix or sparse matrix
 
     Returns
     -------
@@ -43,6 +45,8 @@ def sp_add(A: SparseMatrix, B: SparseMatrix) -> SparseMatrix:
     values=tensor([40, 20, 60]),
     shape=(3, 4), nnz=3)
     """
+    if isinstance(B, DiagMatrix):
+        B = B.as_sparse()
     if isinstance(A, SparseMatrix) and isinstance(B, SparseMatrix):
         return spsp_add(A, B)
     raise RuntimeError(

--- a/python/dgl/mock_sparse2/sparse_matrix.py
+++ b/python/dgl/mock_sparse2/sparse_matrix.py
@@ -136,7 +136,7 @@ class SparseMatrix:
         row, col = self.coo()
         val = self.val
         shape = self.shape + val.shape[1:]
-        mat = torch.zeros(shape, device=self.device)
+        mat = torch.zeros(shape, device=self.device, dtype=self.dtype)
         mat[row, col] = val
         return mat
 

--- a/tests/pytorch/mock_sparse2/test_elementwise_op.py
+++ b/tests/pytorch/mock_sparse2/test_elementwise_op.py
@@ -2,12 +2,15 @@ import sys
 
 import backend as F
 import pytest
+import torch
 
-from dgl.mock_sparse2 import *
+from dgl.mock_sparse2 import (add, create_from_coo, create_from_csc,
+                              create_from_csr, diag)
 
 # TODO(#4818): Skipping tests on win.
 if not sys.platform.startswith("linux"):
     pytest.skip("skipping tests on win", allow_module_level=True)
+
 
 @pytest.mark.parametrize("val_shape", [(), (2,)])
 def test_add_coo(val_shape):
@@ -29,6 +32,7 @@ def test_add_coo(val_shape):
     assert torch.allclose(dense_sum, sum1)
     assert torch.allclose(dense_sum, sum2)
 
+
 @pytest.mark.parametrize("val_shape", [(), (2,)])
 def test_add_csr(val_shape):
     ctx = F.ctx()
@@ -48,6 +52,7 @@ def test_add_csr(val_shape):
 
     assert torch.allclose(dense_sum, sum1)
     assert torch.allclose(dense_sum, sum2)
+
 
 @pytest.mark.parametrize("val_shape", [(), (2,)])
 def test_add_csc(val_shape):
@@ -69,6 +74,7 @@ def test_add_csc(val_shape):
     assert torch.allclose(dense_sum, sum1)
     assert torch.allclose(dense_sum, sum2)
 
+
 @pytest.mark.parametrize("val_shape", [(), (2,)])
 def test_add_diag(val_shape):
     ctx = F.ctx()
@@ -83,6 +89,7 @@ def test_add_diag(val_shape):
 
     assert torch.allclose(dense_sum, sum1)
     assert torch.allclose(dense_sum, sum2)
+
 
 @pytest.mark.parametrize("val_shape", [(), (2,)])
 def test_add_sparse_diag(val_shape):

--- a/tests/pytorch/mock_sparse2/test_elementwise_op.py
+++ b/tests/pytorch/mock_sparse2/test_elementwise_op.py
@@ -1,0 +1,108 @@
+import sys
+
+import backend as F
+import pytest
+
+from dgl.mock_sparse2 import *
+
+# TODO(#4818): Skipping tests on win.
+if not sys.platform.startswith("linux"):
+    pytest.skip("skipping tests on win", allow_module_level=True)
+
+@pytest.mark.parametrize("val_shape", [(), (2,)])
+def test_add_coo(val_shape):
+    ctx = F.ctx()
+    row = torch.tensor([1, 0, 2]).to(ctx)
+    col = torch.tensor([0, 3, 2]).to(ctx)
+    val = torch.randn(row.shape + val_shape).to(ctx)
+    A = create_from_coo(row, col, val)
+
+    row = torch.tensor([1, 0]).to(ctx)
+    col = torch.tensor([0, 2]).to(ctx)
+    val = torch.randn(row.shape + val_shape).to(ctx)
+    B = create_from_coo(row, col, val, shape=A.shape)
+
+    sum1 = (A + B).dense()
+    sum2 = add(A, B).dense()
+    dense_sum = A.dense() + B.dense()
+
+    assert torch.allclose(dense_sum, sum1)
+    assert torch.allclose(dense_sum, sum2)
+
+@pytest.mark.parametrize("val_shape", [(), (2,)])
+def test_add_csr(val_shape):
+    ctx = F.ctx()
+    indptr = torch.tensor([0, 1, 2, 3]).to(ctx)
+    indices = torch.tensor([3, 0, 2]).to(ctx)
+    val = torch.randn(indices.shape + val_shape).to(ctx)
+    A = create_from_csr(indptr, indices, val)
+
+    indptr = torch.tensor([0, 1, 2, 2]).to(ctx)
+    indices = torch.tensor([2, 0]).to(ctx)
+    val = torch.randn(indices.shape + val_shape).to(ctx)
+    B = create_from_csr(indptr, indices, val, shape=A.shape)
+
+    sum1 = (A + B).dense()
+    sum2 = add(A, B).dense()
+    dense_sum = A.dense() + B.dense()
+
+    assert torch.allclose(dense_sum, sum1)
+    assert torch.allclose(dense_sum, sum2)
+
+@pytest.mark.parametrize("val_shape", [(), (2,)])
+def test_add_csc(val_shape):
+    ctx = F.ctx()
+    indptr = torch.tensor([0, 1, 1, 2, 3]).to(ctx)
+    indices = torch.tensor([1, 2, 0]).to(ctx)
+    val = torch.randn(indices.shape + val_shape).to(ctx)
+    A = create_from_csc(indptr, indices, val)
+
+    indptr = torch.tensor([0, 1, 1, 2, 2]).to(ctx)
+    indices = torch.tensor([1, 0]).to(ctx)
+    val = torch.randn(indices.shape + val_shape).to(ctx)
+    B = create_from_csc(indptr, indices, val, shape=A.shape)
+
+    sum1 = (A + B).dense()
+    sum2 = add(A, B).dense()
+    dense_sum = A.dense() + B.dense()
+
+    assert torch.allclose(dense_sum, sum1)
+    assert torch.allclose(dense_sum, sum2)
+
+@pytest.mark.parametrize("val_shape", [(), (2,)])
+def test_add_diag(val_shape):
+    ctx = F.ctx()
+    shape = (3, 4)
+    val_shape = (shape[0],) + val_shape
+    D1 = diag(torch.randn(val_shape).to(ctx), shape=shape)
+    D2 = diag(torch.randn(val_shape).to(ctx), shape=shape)
+
+    sum1 = (D1 + D2).dense()
+    sum2 = add(D1, D2).dense()
+    dense_sum = D1.dense() + D2.dense()
+
+    assert torch.allclose(dense_sum, sum1)
+    assert torch.allclose(dense_sum, sum2)
+
+@pytest.mark.parametrize("val_shape", [(), (2,)])
+def test_add_sparse_diag(val_shape):
+    ctx = F.ctx()
+    row = torch.tensor([1, 0, 2]).to(ctx)
+    col = torch.tensor([0, 3, 2]).to(ctx)
+    val = torch.randn(row.shape + val_shape).to(ctx)
+    A = create_from_coo(row, col, val)
+
+    shape = (3, 4)
+    val_shape = (shape[0],) + val_shape
+    D = diag(torch.randn(val_shape).to(ctx), shape=shape)
+
+    sum1 = (A + D).dense()
+    sum2 = (D + A).dense()
+    sum3 = add(A, D).dense()
+    sum4 = add(D, A).dense()
+    dense_sum = A.dense() + D.dense()
+
+    assert torch.allclose(dense_sum, sum1)
+    assert torch.allclose(dense_sum, sum2)
+    assert torch.allclose(dense_sum, sum3)
+    assert torch.allclose(dense_sum, sum4)

--- a/tests/pytorch/mock_sparse2/test_elementwise_op_diag.py
+++ b/tests/pytorch/mock_sparse2/test_elementwise_op_diag.py
@@ -19,7 +19,7 @@ def all_close_sparse(A, B):
 
 
 @pytest.mark.parametrize(
-    "op", [operator.add, operator.sub, operator.mul, operator.truediv]
+    "op", [operator.sub, operator.mul, operator.truediv]
 )
 def test_diag_op_diag(op):
     ctx = F.ctx()

--- a/tests/pytorch/mock_sparse2/test_elementwise_op_sp.py
+++ b/tests/pytorch/mock_sparse2/test_elementwise_op_sp.py
@@ -21,22 +21,6 @@ def all_close_sparse(A, row, col, val, shape):
     assert A.shape == shape
 
 
-@pytest.mark.parametrize("op", [operator.add])
-def test_sparse_op_sparse(op):
-    ctx = F.ctx()
-    rowA = torch.tensor([1, 0, 2, 7, 1]).to(ctx)
-    colA = torch.tensor([0, 49, 2, 1, 7]).to(ctx)
-    valA = torch.rand(len(rowA)).to(ctx)
-    A = create_from_coo(rowA, colA, valA, shape=(10, 50))
-    w = torch.rand(len(rowA)).to(ctx)
-    A1 = create_from_coo(rowA, colA, w, shape=(10, 50))
-
-    def _test():
-        all_close_sparse(op(A, A1), rowA, colA, valA + w, (10, 50))
-
-    _test()
-
-
 @pytest.mark.parametrize("val_shape", [(3,), (3, 2)])
 def test_pow(val_shape):
     # A ** v


### PR DESCRIPTION
## Description
### Major
- `A1 + A2`: Add two sparse matrices with different sparsity using PyTorch's implementation for COO matrices. The CSR support of PyTorch is still in beta phase, so I think it's better to wait for a few more versions.
- `D + A` and `A + D` using `A1 + A2`
### Minor
- `DiagMatrix.dense`
- Fix of `SparseMatrix.dense` to handle dtypes other than float

## Checklist
Please feel free to remove inapplicable items for your PR.
- [x] The PR title starts with [$CATEGORY] (such as [NN], [Model], [Doc], [Feature]])
- [x] I've leverage the [tools](https://docs.google.com/document/d/1iHyj7zlmygKSk5gBPsqIqL5ASPzJSPREaNT_QdsiYA4/edit) to beautify the python and c++ code.
- [x] The PR is complete and small, read the [Google eng practice (CL equals to PR)](https://google.github.io/eng-practices/review/developer/small-cls.html) to understand more about small PR. In DGL, we consider PRs with less than 200 lines of core code change are small (example, test and documentation could be exempted).
- [x] All changes have test coverage
- [x] Code is well-documented
- [x] To the best of my knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change
- [ ] Related issue is referred in this PR
- [ ] If the PR is for a new model/paper, I've updated the example index [here](../examples/README.md).