### PR TITLE
[Sparse] Fix the sddmm backward problem in mock_sparse.

### DIFF
--- a/python/dgl/mock_sparse/sddmm.py
+++ b/python/dgl/mock_sparse/sddmm.py
@@ -54,7 +54,9 @@ def sddmm(
         "scalar values. "
     )
     # PyTorch's sddmm operator only supports CSR format.
-    res = torch.sparse.sampled_addmm(A.adj.to_sparse_csr(), mat1, mat2)
+    res = torch.sparse.sampled_addmm(
+        A.adj.to_sparse_csr(), mat1, mat2
+    ).to_sparse_coo()
     return SparseMatrix(A.row, A.col, res.values(), A.adj.shape)
 
 


### PR DESCRIPTION
## Description
torch_csr_tensor does not have backward for some common operators, so it should be converted to sparse_coo_tensor as soon as possible.

## Checklist
Please feel free to remove inapplicable items for your PR.
- [ ] The PR title starts with [$CATEGORY] (such as [NN], [Model], [Doc], [Feature]])
- [ ] I've leverage the [tools](https://docs.google.com/document/d/1iHyj7zlmygKSk5gBPsqIqL5ASPzJSPREaNT_QdsiYA4/edit) to beautify the python and c++ code.
- [ ] The PR is complete and small, read the [Google eng practice (CL equals to PR)](https://google.github.io/eng-practices/review/developer/small-cls.html) to understand more about small PR. In DGL, we consider PRs with less than 200 lines of core code change are small (example, test and documentation could be exempted).
- [ ] All changes have test coverage
- [ ] Code is well-documented
- [ ] To the best of my knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change
- [ ] Related issue is referred in this PR
- [ ] If the PR is for a new model/paper, I've updated the example index [here](../examples/README.md).

## Changes
<!-- You could use following template
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)
-->
