### PR TITLE
[Sparse] Add coalesce and has_duplicate to SparseMatrix

### DIFF
--- a/dgl_sparse/include/sparse/sparse_matrix.h
+++ b/dgl_sparse/include/sparse/sparse_matrix.h
@@ -116,6 +116,23 @@ class SparseMatrix : public torch::CustomClassHolder {
    */
   c10::intrusive_ptr<SparseMatrix> Transpose() const;
 
+  /**
+   * @brief Return a new coalesced matrix.
+   *
+   * A coalesced sparse matrix satisfies the following properties:
+   *   - the indices of the non-zero elements are unique,
+   *   - the indices are sorted in lexicographical order.
+   *
+   * @return A coalesced sparse matrix.
+   */
+  c10::intrusive_ptr<SparseMatrix> Coalesce();
+
+  /**
+   * @brief Return true if this sparse matrix contains duplicate indices.
+   * @return A bool flag.
+   */
+  bool HasDuplicate();
+
  private:
   /** @brief Create the COO format for the sparse matrix internally */
   void _CreateCOO();

--- a/dgl_sparse/src/python_binding.cc
+++ b/dgl_sparse/src/python_binding.cc
@@ -28,7 +28,9 @@ TORCH_LIBRARY(dgl_sparse, m) {
       .def("coo", &SparseMatrix::COOTensors)
       .def("csr", &SparseMatrix::CSRTensors)
       .def("csc", &SparseMatrix::CSCTensors)
-      .def("transpose", &SparseMatrix::Transpose);
+      .def("transpose", &SparseMatrix::Transpose)
+      .def("coalesce", &SparseMatrix::Coalesce)
+      .def("has_duplicate", &SparseMatrix::HasDuplicate);
   m.def("create_from_coo", &CreateFromCOO)
       .def("create_from_csr", &CreateFromCSR)
       .def("create_from_csc", &CreateFromCSC)

--- a/dgl_sparse/src/sparse_matrix.cc
+++ b/dgl_sparse/src/sparse_matrix.cc
@@ -32,7 +32,8 @@ SparseMatrix::SparseMatrix(
     CHECK_EQ(coo->row.dim(), 1);
     CHECK_EQ(coo->col.dim(), 1);
     CHECK_EQ(coo->row.size(0), coo->col.size(0));
-    CHECK_EQ(coo->row.size(0), value.size(0));
+    //CHECK_EQ(coo->row.size(0), value.size(0));
+    TORCH_CHECK(coo->row.size(0) == value.size(0), "Error");
     CHECK_EQ(coo->row.device(), value.device());
     CHECK_EQ(coo->col.device(), value.device());
   }

--- a/dgl_sparse/src/sparse_matrix.cc
+++ b/dgl_sparse/src/sparse_matrix.cc
@@ -32,8 +32,7 @@ SparseMatrix::SparseMatrix(
     CHECK_EQ(coo->row.dim(), 1);
     CHECK_EQ(coo->col.dim(), 1);
     CHECK_EQ(coo->row.size(0), coo->col.size(0));
-    //CHECK_EQ(coo->row.size(0), value.size(0));
-    TORCH_CHECK(coo->row.size(0) == value.size(0), "Error");
+    CHECK_EQ(coo->row.size(0), value.size(0));
     CHECK_EQ(coo->row.device(), value.device());
     CHECK_EQ(coo->col.device(), value.device());
   }

--- a/dgl_sparse/src/sparse_matrix_coalesce.cc
+++ b/dgl_sparse/src/sparse_matrix_coalesce.cc
@@ -1,0 +1,39 @@
+/**
+ *  Copyright (c) 2022 by Contributors
+ * @file elementwise_op.cc
+ * @brief DGL C++ sparse elementwise operator implementation.
+ */
+// clang-format off
+#include <sparse/dgl_headers.h>
+// clang-format on
+
+#include <sparse/sparse_matrix.h>
+
+#include "./utils.h"
+
+namespace dgl {
+namespace sparse {
+
+c10::intrusive_ptr<SparseMatrix> SparseMatrix::Coalesce() {
+  auto torch_coo = COOToTorchCOO(this->COOPtr(), this->value());
+  auto coalesced_coo = torch_coo.coalesce();
+  torch::Tensor indices = coalesced_coo.indices();
+  torch::Tensor row = indices[0];
+  torch::Tensor col = indices[1];
+  return CreateFromCOO(row, col, coalesced_coo.values(), this->shape());
+}
+
+bool SparseMatrix::HasDuplicate() {
+  aten::CSRMatrix dgl_csr;
+  // The format for calculation will be chosen in the following order: CSR,
+  // CSC. CSR is created if the sparse matrix only has CSC format.
+  if (HasCSR() || !HasCSC()) {
+    dgl_csr = CSRToOldDGLCSR(CSRPtr());
+  } else {
+    dgl_csr = CSRToOldDGLCSR(CSCPtr());
+  }
+  return aten::CSRHasDuplicate(dgl_csr);
+}
+
+}  // namespace sparse
+}  // namespace dgl

--- a/dgl_sparse/src/sparse_matrix_coalesce.cc
+++ b/dgl_sparse/src/sparse_matrix_coalesce.cc
@@ -1,7 +1,7 @@
 /**
  *  Copyright (c) 2022 by Contributors
- * @file elementwise_op.cc
- * @brief DGL C++ sparse elementwise operator implementation.
+ * @file sparse_matrix_coalesce.cc
+ * @brief Operators related to sparse matrix coalescing.
  */
 // clang-format off
 #include <sparse/dgl_headers.h>

--- a/dgl_sparse/src/spspmm.cc
+++ b/dgl_sparse/src/spspmm.cc
@@ -44,18 +44,18 @@ void _SpSpMMSanityCheck(
       "SpSpMM: the value shape of rhs_mat should be 1-D");
   TORCH_CHECK(
       lhs_mat->device() == rhs_mat->device(),
-      "SpSpMM: lhs_mat and rhs_mat should on the same device");
+      "SpSpMM: lhs_mat and rhs_mat should be on the same device");
   TORCH_CHECK(
       lhs_mat->dtype() == rhs_mat->dtype(),
       "SpSpMM: lhs_mat and rhs_mat should have the same dtype");
   TORCH_CHECK(
       !lhs_mat->HasDuplicate(),
       "SpSpMM does not support lhs_mat with duplicate indices. ",
-      "Call coalesce() to dedup first.");
+      "Call A = A.coalesce() to dedup first.");
   TORCH_CHECK(
       !rhs_mat->HasDuplicate(),
       "SpSpMM does not support rhs_mat with duplicate indices. ",
-      "Call coalesce() to dedup first.");
+      "Call A = A.coalesce() to dedup first.");
 }
 
 // Mask select value of `mat` by `sub_mat`.

--- a/dgl_sparse/src/spspmm.cc
+++ b/dgl_sparse/src/spspmm.cc
@@ -32,21 +32,28 @@ void _SpSpMMSanityCheck(
     const c10::intrusive_ptr<SparseMatrix>& rhs_mat) {
   const auto& lhs_shape = lhs_mat->shape();
   const auto& rhs_shape = rhs_mat->shape();
-  TORCH_CHECK(lhs_shape[1] == rhs_shape[0],
+  TORCH_CHECK(
+      lhs_shape[1] == rhs_shape[0],
       "SpSpMM: the second dim of lhs_mat should be equal to the first dim ",
       "of the second matrix");
-  TORCH_CHECK(lhs_mat->value().dim() == 1,
+  TORCH_CHECK(
+      lhs_mat->value().dim() == 1,
       "SpSpMM: the value shape of lhs_mat should be 1-D");
-  TORCH_CHECK(rhs_mat->value().dim() == 1,
+  TORCH_CHECK(
+      rhs_mat->value().dim() == 1,
       "SpSpMM: the value shape of rhs_mat should be 1-D");
-  TORCH_CHECK(lhs_mat->device() == rhs_mat->device(),
+  TORCH_CHECK(
+      lhs_mat->device() == rhs_mat->device(),
       "SpSpMM: lhs_mat and rhs_mat should on the same device");
-  TORCH_CHECK(lhs_mat->dtype() == rhs_mat->dtype(),
+  TORCH_CHECK(
+      lhs_mat->dtype() == rhs_mat->dtype(),
       "SpSpMM: lhs_mat and rhs_mat should have the same dtype");
-  TORCH_CHECK(!lhs_mat->HasDuplicate(),
+  TORCH_CHECK(
+      !lhs_mat->HasDuplicate(),
       "SpSpMM does not support lhs_mat with duplicate indices. ",
       "Call coalesce() to dedup first.");
-  TORCH_CHECK(!rhs_mat->HasDuplicate(),
+  TORCH_CHECK(
+      !rhs_mat->HasDuplicate(),
       "SpSpMM does not support rhs_mat with duplicate indices. ",
       "Call coalesce() to dedup first.");
 }

--- a/dgl_sparse/src/spspmm.cc
+++ b/dgl_sparse/src/spspmm.cc
@@ -32,17 +32,23 @@ void _SpSpMMSanityCheck(
     const c10::intrusive_ptr<SparseMatrix>& rhs_mat) {
   const auto& lhs_shape = lhs_mat->shape();
   const auto& rhs_shape = rhs_mat->shape();
-  CHECK_EQ(lhs_shape[1], rhs_shape[0])
-      << "SpSpMM: the second dim of lhs_mat should be equal to the first dim "
-         "of the second matrix";
-  CHECK_EQ(lhs_mat->value().dim(), 1)
-      << "SpSpMM: the value shape of lhs_mat should be 1-D";
-  CHECK_EQ(rhs_mat->value().dim(), 1)
-      << "SpSpMM: the value shape of rhs_mat should be 1-D";
-  CHECK_EQ(lhs_mat->device(), rhs_mat->device())
-      << "SpSpMM: lhs_mat and rhs_mat should on the same device";
-  CHECK_EQ(lhs_mat->dtype(), rhs_mat->dtype())
-      << "SpSpMM: lhs_mat and rhs_mat should have the same dtype";
+  TORCH_CHECK(lhs_shape[1] == rhs_shape[0],
+      "SpSpMM: the second dim of lhs_mat should be equal to the first dim ",
+      "of the second matrix");
+  TORCH_CHECK(lhs_mat->value().dim() == 1,
+      "SpSpMM: the value shape of lhs_mat should be 1-D");
+  TORCH_CHECK(rhs_mat->value().dim() == 1,
+      "SpSpMM: the value shape of rhs_mat should be 1-D");
+  TORCH_CHECK(lhs_mat->device() == rhs_mat->device(),
+      "SpSpMM: lhs_mat and rhs_mat should on the same device");
+  TORCH_CHECK(lhs_mat->dtype() == rhs_mat->dtype(),
+      "SpSpMM: lhs_mat and rhs_mat should have the same dtype");
+  TORCH_CHECK(!lhs_mat->HasDuplicate(),
+      "SpSpMM does not support lhs_mat with duplicate indices. ",
+      "Call coalesce() to dedup first.");
+  TORCH_CHECK(!rhs_mat->HasDuplicate(),
+      "SpSpMM does not support rhs_mat with duplicate indices. ",
+      "Call coalesce() to dedup first.");
 }
 
 // Mask select value of `mat` by `sub_mat`.

--- a/python/dgl/mock_sparse2/sparse_matrix.py
+++ b/python/dgl/mock_sparse2/sparse_matrix.py
@@ -198,7 +198,7 @@ class SparseMatrix:
     def coalesce(self):
         """Return a coalesced sparse matrix.
 
-        A coalesced sparse matrix satisfies the following properties::
+        A coalesced sparse matrix satisfies the following properties:
 
           - the indices of the non-zero elements are unique,
           - the indices are sorted in lexicographical order.

--- a/python/dgl/mock_sparse2/sparse_matrix.py
+++ b/python/dgl/mock_sparse2/sparse_matrix.py
@@ -206,6 +206,8 @@ class SparseMatrix:
         The coalescing process will accumulate the non-zero values of the same
         indices by summation.
 
+        The function does not support autograd.
+
         Returns
         -------
         SparseMatrix

--- a/python/dgl/mock_sparse2/sparse_matrix.py
+++ b/python/dgl/mock_sparse2/sparse_matrix.py
@@ -88,7 +88,6 @@ class SparseMatrix:
         """
         return self.coo()[1]
 
-
     def indices(
         self, fmt: str, return_shuffle=False
     ) -> Tuple[torch.Tensor, ...]:

--- a/python/dgl/mock_sparse2/sparse_matrix.py
+++ b/python/dgl/mock_sparse2/sparse_matrix.py
@@ -66,6 +66,29 @@ class SparseMatrix:
         """
         return self.c_sparse_matrix.device()
 
+    @property
+    def row(self) -> torch.Tensor:
+        """Get the row indices of the nonzero elements.
+
+        Returns
+        -------
+        tensor
+            Row indices of the nonzero elements
+        """
+        return self.coo()[0]
+
+    @property
+    def col(self) -> torch.Tensor:
+        """Get the column indices of the nonzero elements.
+
+        Returns
+        -------
+        tensor
+            Column indices of the nonzero elements
+        """
+        return self.coo()[1]
+
+
     def indices(
         self, fmt: str, return_shuffle=False
     ) -> Tuple[torch.Tensor, ...]:
@@ -172,6 +195,58 @@ class SparseMatrix:
         shape=(4, 4), nnz=3)
         """
         return SparseMatrix(self.c_sparse_matrix.transpose())
+
+    def coalesce(self):
+        """Return a coalesced sparse matrix.
+
+        A coalesced sparse matrix satisfies the following properties::
+
+          - the indices of the non-zero elements are unique,
+          - the indices are sorted in lexicographical order.
+
+        The coalescing process will accumulate the non-zero values of the same
+        indices by summation.
+
+        Returns
+        -------
+        SparseMatrix
+            The coalesced sparse matrix.
+
+        Examples
+        --------
+        >>> row = torch.tensor([1, 0, 0, 0, 1])
+        >>> col = torch.tensor([1, 1, 1, 2, 2])
+        >>> val = torch.tensor([0, 1, 2, 3, 4])
+        >>> A = create_from_coo(row, col, val)
+        >>> A = A.coalesce()
+        >>> print(A)
+        SparseMatrix(indices=tensor([[0, 0, 1, 1],
+                [1, 2, 1, 2]]),
+        values=tensor([3, 3, 0, 4]),
+        shape=(2, 3), nnz=4)
+        """
+        return SparseMatrix(self.c_sparse_matrix.coalesce())
+
+    def has_duplicate(self):
+        """Return whether this sparse matrix contains duplicate indices.
+
+        Returns
+        -------
+        bool
+            True if this sparse matrix contains duplicate indices.
+
+        Examples
+        --------
+        >>> row = torch.tensor([1, 0, 0, 0, 1])
+        >>> col = torch.tensor([1, 1, 1, 2, 2])
+        >>> val = torch.tensor([0, 1, 2, 3, 4])
+        >>> A = create_from_coo(row, col, val)
+        >>> print(A.has_duplicate())
+        True
+        >>> print(A.coalesce().has_duplicate())
+        False
+        """
+        return self.c_sparse_matrix.has_duplicate()
 
 
 def create_from_coo(

--- a/tests/pytorch/mock_sparse2/test_matmul.py
+++ b/tests/pytorch/mock_sparse2/test_matmul.py
@@ -4,7 +4,7 @@ import backend as F
 import pytest
 import torch
 
-from dgl.mock_sparse2 import val_like, create_from_coo
+from dgl.mock_sparse2 import create_from_coo, val_like
 
 from .utils import (
     clone_detach_and_grad,

--- a/tests/pytorch/mock_sparse2/test_matmul.py
+++ b/tests/pytorch/mock_sparse2/test_matmul.py
@@ -59,9 +59,7 @@ def test_spmm(create_func, shape, nnz, out_dim):
 @pytest.mark.parametrize("shape_k", [3, 4])
 @pytest.mark.parametrize("nnz1", [1, 10])
 @pytest.mark.parametrize("nnz2", [1, 10])
-def test_spspmm(
-    create_func1, create_func2, shape_n_m, shape_k, nnz1, nnz2
-):
+def test_spspmm(create_func1, create_func2, shape_n_m, shape_k, nnz1, nnz2):
     dev = F.ctx()
     shape1 = shape_n_m
     shape2 = (shape_n_m[1], shape_k)
@@ -89,6 +87,7 @@ def test_spspmm(
             torch_A2.grad.to_dense(),
             atol=1e-05,
         )
+
 
 def test_spspmm_duplicate():
     dev = F.ctx()

--- a/tests/pytorch/mock_sparse2/test_sparse_matrix.py
+++ b/tests/pytorch/mock_sparse2/test_sparse_matrix.py
@@ -4,7 +4,12 @@ import sys
 
 import backend as F
 
-from dgl.mock_sparse2 import create_from_coo, create_from_csr, create_from_csc, val_like
+from dgl.mock_sparse2 import (
+    create_from_coo,
+    create_from_csr,
+    create_from_csc,
+    val_like,
+)
 
 # TODO(#4818): Skipping tests on win.
 if not sys.platform.startswith("linux"):
@@ -337,6 +342,7 @@ def test_csr_to_csc(dense_dim, indptr, indices, shape):
     assert torch.allclose(mat_indptr, indptr)
     assert torch.allclose(mat_indices, indices)
 
+
 @pytest.mark.parametrize("val_shape", [(3), (3, 2)])
 @pytest.mark.parametrize("shape", [(3, 5), (5, 5)])
 def test_val_like(val_shape, shape):
@@ -369,6 +375,7 @@ def test_val_like(val_shape, shape):
     csc_B = val_like(csc_A, new_val)
     check_val_like(csc_A, csc_B)
 
+
 def test_coalesce():
     ctx = F.ctx()
 
@@ -388,6 +395,7 @@ def test_coalesce():
     # Values of duplicate indices are added together.
     assert list(A_coalesced.val) == [3, 3, 0, 4]
     assert not A_coalesced.has_duplicate()
+
 
 def test_has_duplicate():
     ctx = F.ctx()

--- a/tests/pytorch/mock_sparse2/test_sparse_matrix.py
+++ b/tests/pytorch/mock_sparse2/test_sparse_matrix.py
@@ -368,3 +368,45 @@ def test_val_like(val_shape, shape):
     csc_A = create_from_csc(indptr, indices, val, shape)
     csc_B = val_like(csc_A, new_val)
     check_val_like(csc_A, csc_B)
+
+def test_coalesce():
+    ctx = F.ctx()
+
+    row = torch.tensor([1, 0, 0, 0, 1]).to(ctx)
+    col = torch.tensor([1, 1, 1, 2, 2]).to(ctx)
+    val = torch.arange(len(row)).to(ctx)
+    A = create_from_coo(row, col, val, (4, 4))
+
+    assert A.has_duplicate()
+
+    A_coalesced = A.coalesce()
+
+    assert A_coalesced.nnz == 4
+    assert A_coalesced.shape == (4, 4)
+    assert list(A_coalesced.row) == [0, 0, 1, 1]
+    assert list(A_coalesced.col) == [1, 2, 1, 2]
+    # Values of duplicate indices are added together.
+    assert list(A_coalesced.val) == [3, 3, 0, 4]
+    assert not A_coalesced.has_duplicate()
+
+def test_has_duplicate():
+    ctx = F.ctx()
+
+    row = torch.tensor([1, 0, 0, 0, 1]).to(ctx)
+    col = torch.tensor([1, 1, 1, 2, 2]).to(ctx)
+    val = torch.arange(len(row)).to(ctx)
+    shape = (4, 4)
+
+    # COO
+    coo_A = create_from_coo(row, col, val, shape)
+    assert coo_A.has_duplicate()
+
+    # CSR
+    indptr, indices, _ = coo_A.csr()
+    csr_A = create_from_csr(indptr, indices, val, shape)
+    assert csr_A.has_duplicate()
+
+    # CSC
+    indptr, indices, _ = coo_A.csc()
+    csc_A = create_from_csc(indptr, indices, val, shape)
+    assert csc_A.has_duplicate()

--- a/tests/pytorch/mock_sparse2/test_sparse_matrix.py
+++ b/tests/pytorch/mock_sparse2/test_sparse_matrix.py
@@ -1,13 +1,13 @@
-import pytest
-import torch
 import sys
 
 import backend as F
+import pytest
+import torch
 
 from dgl.mock_sparse2 import (
     create_from_coo,
-    create_from_csr,
     create_from_csc,
+    create_from_csr,
     val_like,
 )
 


### PR DESCRIPTION
## Description
<!-- Brief description. Refer to the related issues if existed.
It'll be great if relevant reviewers can be assigned as well.-->

Closes #5072 
Follow up of #5050

* Add two methods `coalesce()` and `has_duplicate` to the `SparseMatrix` class.
* Add two properties `row()` and `col()` for accessing row and column indices more easily.
* Add check for duplicate values in `spspmm` to avoid unfriendly CUDA errors.

## Checklist
Please feel free to remove inapplicable items for your PR.
- [x] The PR title starts with [$CATEGORY] (such as [NN], [Model], [Doc], [Feature]])
- [x] I've leverage the [tools](https://docs.google.com/document/d/1iHyj7zlmygKSk5gBPsqIqL5ASPzJSPREaNT_QdsiYA4/edit) to beautify the python and c++ code.
- [x] The PR is complete and small, read the [Google eng practice (CL equals to PR)](https://google.github.io/eng-practices/review/developer/small-cls.html) to understand more about small PR. In DGL, we consider PRs with less than 200 lines of core code change are small (example, test and documentation could be exempted).
- [x] All changes have test coverage
- [x] Code is well-documented
- [x] To the best of my knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change
- [x] Related issue is referred in this PR
- [ ] If the PR is for a new model/paper, I've updated the example index [here](../examples/README.md).
