### PR TITLE
[Bugfix] Fix worker division in the dataloader

### DIFF
--- a/python/dgl/dataloading/dataloader.py
+++ b/python/dgl/dataloading/dataloader.py
@@ -125,7 +125,7 @@ def _divide_by_worker(dataset, batch_size, drop_last):
         segments = []
         for i in range(worker_info.id, num_batches, worker_info.num_workers):
             segments.append(dataset[i * batch_size : (i + 1) * batch_size])
-        dataset = torch.concat(segments)
+        dataset = torch.cat(segments) if segments else dataset[0:0]
     return dataset
 
 


### PR DESCRIPTION
## Description

Resolves https://github.com/dmlc/dgl/issues/5068.

`shuffle=False` and `num_workers>0` should give ordered results now.

## Checklist
Please feel free to remove inapplicable items for your PR.
- [x] The PR title starts with [$CATEGORY] (such as [NN], [Model], [Doc], [Feature]])
- [x] I've leverage the [tools](https://docs.google.com/document/d/1iHyj7zlmygKSk5gBPsqIqL5ASPzJSPREaNT_QdsiYA4/edit) to beautify the python and c++ code.
- [x] The PR is complete and small, read the [Google eng practice (CL equals to PR)](https://google.github.io/eng-practices/review/developer/small-cls.html) to understand more about small PR. In DGL, we consider PRs with less than 200 lines of core code change are small (example, test and documentation could be exempted).
- [ ] All changes have test coverage
- [ ] Code is well-documented
- [x] To the best of my knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change
- [x] Related issue is referred in this PR
- [ ] If the PR is for a new model/paper, I've updated the example index [here](../examples/README.md).
