### PR TITLE
[Sparse] New print for SparseMatrix and DiagMatrix

### DIFF
--- a/python/dgl/mock_sparse2/diag_matrix.py
+++ b/python/dgl/mock_sparse2/diag_matrix.py
@@ -3,7 +3,7 @@ from typing import Optional, Tuple
 
 import torch
 
-from .sparse_matrix import SparseMatrix, create_from_coo
+from .sparse_matrix import create_from_coo, SparseMatrix
 
 
 class DiagMatrix:
@@ -286,7 +286,7 @@ def identity(
     return diag(val, shape)
 
 
-def _diag_matrix_str(spmat : DiagMatrix) -> str:
+def _diag_matrix_str(spmat: DiagMatrix) -> str:
     """Internal function for converting a diagonal matrix to string representation."""
     values_str = str(spmat.val)
     meta_str = f"size={spmat.shape}"
@@ -294,14 +294,18 @@ def _diag_matrix_str(spmat : DiagMatrix) -> str:
         val_size = tuple(spmat.val.shape[1:])
         meta_str += f", val_size={val_size}"
     prefix = f"{type(spmat).__name__}("
+
     def _add_indent(_str, indent):
-        lines = _str.split('\n')
-        lines = [lines[0]] + [' ' * indent + line for line in lines[1:]]
-        return '\n'.join(lines)
-    final_str = ("values="
-            + _add_indent(values_str, len("values="))
-            + ",\n"
-            + meta_str
-            + ")")
+        lines = _str.split("\n")
+        lines = [lines[0]] + [" " * indent + line for line in lines[1:]]
+        return "\n".join(lines)
+
+    final_str = (
+        "values="
+        + _add_indent(values_str, len("values="))
+        + ",\n"
+        + meta_str
+        + ")"
+    )
     final_str = prefix + _add_indent(final_str, len(prefix))
     return final_str

--- a/python/dgl/mock_sparse2/diag_matrix.py
+++ b/python/dgl/mock_sparse2/diag_matrix.py
@@ -62,7 +62,7 @@ class DiagMatrix:
         return self._shape
 
     def __repr__(self):
-        return f"DiagMatrix(val={self.val}, \nshape={self.shape})"
+        return _diag_matrix_str(self)
 
     @property
     def nnz(self) -> int:
@@ -284,3 +284,24 @@ def identity(
         val_shape = (len_val, d)
     val = torch.ones(val_shape, dtype=dtype, device=device)
     return diag(val, shape)
+
+
+def _diag_matrix_str(spmat : DiagMatrix) -> str:
+    """Internal function for converting a diagonal matrix to string representation."""
+    values_str = str(spmat.val)
+    meta_str = f"size={spmat.shape}"
+    if spmat.val.dim() > 1:
+        val_size = tuple(spmat.val.shape[1:])
+        meta_str += f", val_size={val_size}"
+    prefix = f"{type(spmat).__name__}("
+    def _add_indent(_str, indent):
+        lines = _str.split('\n')
+        lines = [lines[0]] + [' ' * indent + line for line in lines[1:]]
+        return '\n'.join(lines)
+    final_str = ("values="
+            + _add_indent(values_str, len("values="))
+            + ",\n"
+            + meta_str
+            + ")")
+    final_str = prefix + _add_indent(final_str, len(prefix))
+    return final_str

--- a/python/dgl/mock_sparse2/sparse_matrix.py
+++ b/python/dgl/mock_sparse2/sparse_matrix.py
@@ -522,7 +522,7 @@ def val_like(mat: SparseMatrix, val: torch.Tensor) -> SparseMatrix:
     return SparseMatrix(torch.ops.dgl_sparse.val_like(mat.c_sparse_matrix, val))
 
 
-def _sparse_matrix_str(spmat : SparseMatrix) -> str:
+def _sparse_matrix_str(spmat: SparseMatrix) -> str:
     """Internal function for converting a sparse matrix to string representation."""
     indices_str = str(spmat.indices("COO"))
     values_str = str(spmat.val)
@@ -531,17 +531,21 @@ def _sparse_matrix_str(spmat : SparseMatrix) -> str:
         val_size = tuple(spmat.val.shape[1:])
         meta_str += f", val_size={val_size}"
     prefix = f"{type(spmat).__name__}("
+
     def _add_indent(_str, indent):
-        lines = _str.split('\n')
-        lines = [lines[0]] + [' ' * indent + line for line in lines[1:]]
-        return '\n'.join(lines)
-    final_str = ("indices="
-            + _add_indent(indices_str, len("indices="))
-            + ",\n"
-            + "values="
-            + _add_indent(values_str, len("values="))
-            + ",\n"
-            + meta_str
-            + ")")
+        lines = _str.split("\n")
+        lines = [lines[0]] + [" " * indent + line for line in lines[1:]]
+        return "\n".join(lines)
+
+    final_str = (
+        "indices="
+        + _add_indent(indices_str, len("indices="))
+        + ",\n"
+        + "values="
+        + _add_indent(values_str, len("values="))
+        + ",\n"
+        + meta_str
+        + ")"
+    )
     final_str = prefix + _add_indent(final_str, len(prefix))
     return final_str

--- a/tests/pytorch/mock_sparse2/test_diag.py
+++ b/tests/pytorch/mock_sparse2/test_diag.py
@@ -1,6 +1,7 @@
 import pytest
 import torch
 import sys
+import backend as F
 
 from dgl.mock_sparse2 import diag, identity, DiagMatrix
 
@@ -12,8 +13,9 @@ if not sys.platform.startswith("linux"):
 @pytest.mark.parametrize("val_shape", [(3,), (3, 2)])
 @pytest.mark.parametrize("mat_shape", [None, (3, 5), (5, 3)])
 def test_diag(val_shape, mat_shape):
+    ctx = F.ctx()
     # creation
-    val = torch.randn(val_shape)
+    val = torch.randn(val_shape).to(ctx)
     mat = diag(val, mat_shape)
 
     # val, shape attributes
@@ -22,8 +24,7 @@ def test_diag(val_shape, mat_shape):
         mat_shape = (val_shape[0], val_shape[0])
     assert mat.shape == mat_shape
 
-    # __call__
-    val = torch.randn(val_shape)
+    val = torch.randn(val_shape).to(ctx)
 
     # nnz
     assert mat.nnz == val.shape[0]
@@ -54,6 +55,7 @@ def test_diag(val_shape, mat_shape):
 @pytest.mark.parametrize("shape", [(3, 3), (3, 5), (5, 3)])
 @pytest.mark.parametrize("d", [None, 2])
 def test_identity(shape, d):
+    ctx = F.ctx()
     # creation
     mat = identity(shape, d)
     # type
@@ -68,3 +70,17 @@ def test_identity(shape, d):
         val_shape = (len_val, d)
     val = torch.ones(val_shape)
     assert torch.allclose(val, mat.val)
+
+
+def test_print():
+    ctx = F.ctx()
+
+    # basic
+    val = torch.tensor([1., 1., 2.]).to(ctx)
+    A = diag(val)
+    print(A)
+
+    # vector-shape non zero
+    val = torch.randn(3, 2).to(ctx)
+    A = diag(val)
+    print(A)

--- a/tests/pytorch/mock_sparse2/test_diag.py
+++ b/tests/pytorch/mock_sparse2/test_diag.py
@@ -1,9 +1,10 @@
+import sys
+
+import backend as F
 import pytest
 import torch
-import sys
-import backend as F
 
-from dgl.mock_sparse2 import diag, identity, DiagMatrix
+from dgl.mock_sparse2 import diag, DiagMatrix, identity
 
 # TODO(#4818): Skipping tests on win.
 if not sys.platform.startswith("linux"):
@@ -76,7 +77,7 @@ def test_print():
     ctx = F.ctx()
 
     # basic
-    val = torch.tensor([1., 1., 2.]).to(ctx)
+    val = torch.tensor([1.0, 1.0, 2.0]).to(ctx)
     A = diag(val)
     print(A)
 

--- a/tests/pytorch/mock_sparse2/test_sparse_matrix.py
+++ b/tests/pytorch/mock_sparse2/test_sparse_matrix.py
@@ -418,3 +418,21 @@ def test_has_duplicate():
     indptr, indices, _ = coo_A.csc()
     csc_A = create_from_csc(indptr, indices, val, shape)
     assert csc_A.has_duplicate()
+
+
+def test_print():
+    ctx = F.ctx()
+
+    # basic
+    row = torch.tensor([1, 1, 3]).to(ctx)
+    col = torch.tensor([2, 1, 3]).to(ctx)
+    val = torch.tensor([1., 1., 2.]).to(ctx)
+    A = create_from_coo(row, col, val)
+    print(A)
+
+    # vector-shape non zero
+    row = torch.tensor([1, 1, 3]).to(ctx)
+    col = torch.tensor([2, 1, 3]).to(ctx)
+    val = torch.randn(3, 2).to(ctx)
+    A = create_from_coo(row, col, val)
+    print(A)

--- a/tests/pytorch/mock_sparse2/test_sparse_matrix.py
+++ b/tests/pytorch/mock_sparse2/test_sparse_matrix.py
@@ -426,7 +426,7 @@ def test_print():
     # basic
     row = torch.tensor([1, 1, 3]).to(ctx)
     col = torch.tensor([2, 1, 3]).to(ctx)
-    val = torch.tensor([1., 1., 2.]).to(ctx)
+    val = torch.tensor([1.0, 1.0, 2.0]).to(ctx)
     A = create_from_coo(row, col, val)
     print(A)
 


### PR DESCRIPTION
## Description
<!-- Brief description. Refer to the related issues if existed.
It'll be great if relevant reviewers can be assigned as well.-->

Part of #4962 . Remaining task is to refactor all the docstrings/docpages.

Print a `SparseMatrix`:
```
SparseMatrix(indices=tensor([[1, 1, 3],
                             [2, 1, 3]]),
             values=tensor([1., 1., 2.]),
             size=(4, 4), nnz=3)
```

Print a CUDA `SparseMatrix`:
```
SparseMatrix(indices=tensor([[1, 1, 3],
                             [2, 1, 3]], device='cuda:0'),
             values=tensor([1., 1., 2.], device='cuda:0'),
             size=(4, 4), nnz=3)
```

Print a CUDA `SparseMatrix` that requires grad for its values:
```
SparseMatrix(indices=tensor([[1, 1, 3],
                             [2, 1, 3]], device='cuda:0'),
             values=tensor([1., 1., 2.], device='cuda:0', grad_fn=<ToCopyBackward0>),
             size=(4, 4), nnz=3)
```

Print a CUDA `SparseMatrix` with vector-shape values:
```
SparseMatrix(indices=tensor([[1, 1, 3],
                             [2, 1, 3]], device='cuda:0'),
             values=tensor([[ 0.2468, -0.7525],
                            [ 0.7526, -0.4141],
                            [ 0.9317, -0.9911]], device='cuda:0', grad_fn=<ToCopyBackward0>),
             size=(4, 4), nnz=3, val_size=(2,))
```

Print `DiagMatrix`:
```
DiagMatrix(values=tensor([1., 1., 2.]),
           size=(3, 3))
```

Print `DiagMatrix` with vector shape values:
```
DiagMatrix(values=tensor([[-0.8178,  0.2647],
                          [ 0.8745, -1.5404],
                          [ 0.9366, -0.8272]]),
           size=(3, 3), val_size=(2,))
```


## Checklist
Please feel free to remove inapplicable items for your PR.
- [x] The PR title starts with [$CATEGORY] (such as [NN], [Model], [Doc], [Feature]])
- [x] I've leverage the [tools](https://docs.google.com/document/d/1iHyj7zlmygKSk5gBPsqIqL5ASPzJSPREaNT_QdsiYA4/edit) to beautify the python and c++ code.
- [x] The PR is complete and small, read the [Google eng practice (CL equals to PR)](https://google.github.io/eng-practices/review/developer/small-cls.html) to understand more about small PR. In DGL, we consider PRs with less than 200 lines of core code change are small (example, test and documentation could be exempted).
- [x] All changes have test coverage
- [x] Code is well-documented
- [x] To the best of my knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change
- [x] Related issue is referred in this PR