### PR TITLE
[BugFix] fix unexpected exception when agg_type is GCN and bias disabled

### DIFF
--- a/python/dgl/nn/pytorch/conv/sageconv.py
+++ b/python/dgl/nn/pytorch/conv/sageconv.py
@@ -129,6 +129,8 @@ class SAGEConv(nn.Module):
             self.fc_self = nn.Linear(self._in_dst_feats, out_feats, bias=bias)
         elif bias:
             self.bias = nn.parameter.Parameter(torch.zeros(self._out_feats))
+        else:
+            self.bias = None
 
         self.reset_parameters()
 

--- a/python/dgl/nn/pytorch/conv/sageconv.py
+++ b/python/dgl/nn/pytorch/conv/sageconv.py
@@ -130,7 +130,7 @@ class SAGEConv(nn.Module):
         elif bias:
             self.bias = nn.parameter.Parameter(torch.zeros(self._out_feats))
         else:
-            self.bias = None
+            self.register_buffer("bias", None)
 
         self.reset_parameters()
 


### PR DESCRIPTION


## Description
<!-- Brief description. Refer to the related issues if existed.
It'll be great if relevant reviewers can be assigned as well.-->
without this fix, below exception is thrown:

```
File "/asv/dgl/benchmarks/env/06715dc6ea55f2b02b6ebc21bca7e34a/lib/python3.10/site-packages/dgl-1.0-py3.10-linux-x86_64.egg/dgl/nn/pytorch/conv/sageconv.py", line 258, in forward
              if self.bias is not None:

                File "/asv/dgl/benchmarks/env/06715dc6ea55f2b02b6ebc21bca7e34a/lib/python3.10/site-packages/torch/nn/modules/module.py", line 1269, in __getattr__
              raise AttributeError("'
{}
' object has no attribute '
{}
'".format(

              AttributeError: 'SAGEConv' object has no attribute 'bias'
```
## Checklist
Please feel free to remove inapplicable items for your PR.
- [ ] The PR title starts with [$CATEGORY] (such as [NN], [Model], [Doc], [Feature]])
- [ ] I've leverage the [tools](https://docs.google.com/document/d/1iHyj7zlmygKSk5gBPsqIqL5ASPzJSPREaNT_QdsiYA4/edit) to beautify the python and c++ code.
- [ ] The PR is complete and small, read the [Google eng practice (CL equals to PR)](https://google.github.io/eng-practices/review/developer/small-cls.html) to understand more about small PR. In DGL, we consider PRs with less than 200 lines of core code change are small (example, test and documentation could be exempted).
- [ ] All changes have test coverage
- [ ] Code is well-documented
- [ ] To the best of my knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change
- [ ] Related issue is referred in this PR
- [ ] If the PR is for a new model/paper, I've updated the example index [here](../examples/README.md).

## Changes
<!-- You could use following template
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)
-->
