### PR TITLE
[Release] Update versioning with local CUDA version suffix

### DIFF
--- a/python/update_version.py
+++ b/python/update_version.py
@@ -12,7 +12,12 @@ import re
 # current version
 # We use the version of the incoming release for code
 # that is under development
-__version__ = "1.0" + os.getenv("DGL_PRERELEASE", "")
+# The environment variable DGL_PRERELEASE is the prerelase suffix
+# (usually "aYYMMDD")
+# The environment variable DGL_VERSION_SUFFIX is the local version label
+# suffix for indicating CPU and CUDA versions as in PEP 440 (e.g. "+cu102")
+__version__ = "1.0" + os.getenv("DGL_PRERELEASE", "") 
+__verison__ += os.getenv("DGL_VERSION_SUFFIX", "")
 print(__version__)
 
 # Implementations


### PR DESCRIPTION
## Description
This adds another environment variable `DGL_VERSION_SUFFIX` to enable attaching [local version identifiers](https://peps.python.org/pep-0440/#local-version-identifiers) for CUDA versions (e.g. `1.0.0` versus `1.0.0+cu102`) in the nightly build and release pipeline.