### PR TITLE
[Bugfix] Fix the call of tar.extractall() method

### DIFF
--- a/python/dgl/data/utils.py
+++ b/python/dgl/data/utils.py
@@ -268,7 +268,7 @@ def extract_archive(file, target_dir, overwrite=False):
                     member_path = os.path.join(path, member.name)
                     if not is_within_directory(path, member_path):
                         raise Exception("Attempted Path Traversal in Tar File")
-                tar.extractall(path, members, numeric_owner) 
+                tar.extractall(path, members, numeric_owner=numeric_owner)
             
             safe_extract(archive, path=target_dir)
     elif file.endswith(".gz"):

--- a/python/dgl/data/utils.py
+++ b/python/dgl/data/utils.py
@@ -257,19 +257,22 @@ def extract_archive(file, target_dir, overwrite=False):
         import tarfile
 
         with tarfile.open(file, "r") as archive:
+
             def is_within_directory(directory, target):
                 abs_directory = os.path.abspath(directory)
                 abs_target = os.path.abspath(target)
                 prefix = os.path.commonprefix([abs_directory, abs_target])
                 return prefix == abs_directory
-            
-            def safe_extract(tar, path=".", members=None, *, numeric_owner=False):
+
+            def safe_extract(
+                tar, path=".", members=None, *, numeric_owner=False
+            ):
                 for member in tar.getmembers():
                     member_path = os.path.join(path, member.name)
                     if not is_within_directory(path, member_path):
                         raise Exception("Attempted Path Traversal in Tar File")
                 tar.extractall(path, members, numeric_owner=numeric_owner)
-            
+
             safe_extract(archive, path=target_dir)
     elif file.endswith(".gz"):
         import gzip

--- a/tests/compute/test_data.py
+++ b/tests/compute/test_data.py
@@ -1,18 +1,18 @@
 import gzip
-import tarfile
-import os
 import io
+import os
+import tarfile
 import tempfile
 import unittest
 
 import backend as F
+
+import dgl
+import dgl.data as data
 import numpy as np
 import pandas as pd
 import pytest
 import yaml
-
-import dgl
-import dgl.data as data
 from dgl import DGLError
 
 
@@ -386,14 +386,15 @@ def test_extract_archive():
         tar_file = "tar_archive"
         tar_path = os.path.join(src_dir, tar_file + ".tar")
         # default encode to utf8
-        content = 'test extract archive tar\n'.encode()
-        info = tarfile.TarInfo(name='tar_archive')
+        content = "test extract archive tar\n".encode()
+        info = tarfile.TarInfo(name="tar_archive")
         info.size = len(content)
         with tarfile.open(tar_path, "w") as f:
             f.addfile(info, io.BytesIO(content))
         with tempfile.TemporaryDirectory() as dst_dir:
             data.utils.extract_archive(tar_path, dst_dir, overwrite=True)
             assert os.path.exists(os.path.join(dst_dir, tar_file))
+
 
 def _test_construct_graphs_node_ids():
     from dgl.data.csv_dataset_base import (

--- a/tests/compute/test_data.py
+++ b/tests/compute/test_data.py
@@ -1,5 +1,7 @@
 import gzip
+import tarfile
 import os
+import io
 import tempfile
 import unittest
 
@@ -379,6 +381,19 @@ def test_extract_archive():
             data.utils.extract_archive(gz_path, dst_dir, overwrite=True)
             assert os.path.exists(os.path.join(dst_dir, gz_file))
 
+    # tar
+    with tempfile.TemporaryDirectory() as src_dir:
+        tar_file = "tar_archive"
+        tar_path = os.path.join(src_dir, tar_file + ".tar")
+        # default encode to utf8
+        content = 'test extract archive tar\n'.encode()
+        info = tarfile.TarInfo(name='tar_archive')
+        info.size = len(content)
+        with tarfile.open(tar_path, "w") as f:
+            f.addfile(info, io.BytesIO(content))
+        with tempfile.TemporaryDirectory() as dst_dir:
+            data.utils.extract_archive(tar_path, dst_dir, overwrite=True)
+            assert os.path.exists(os.path.join(dst_dir, tar_file))
 
 def _test_construct_graphs_node_ids():
     from dgl.data.csv_dataset_base import (


### PR DESCRIPTION
## Description
This is to fix https://github.com/dmlc/dgl/issues/5138 and the last argument `numeric_owner` can only be assigned using keyword.
Ref: https://docs.python.org/3/library/tarfile.html#:~:text=TarFile.extractall(path%3D%27.%27%2C%20members%3DNone%2C%20*%2C%20numeric_owner%3DFalse)

This PR also adds an unit test  for `tar.extractall() ` method.
## Checklist
Please feel free to remove inapplicable items for your PR.
- [x] The PR title starts with [$CATEGORY] (such as [NN], [Model], [Doc], [Feature]])
- [x] I've leverage the [tools](https://docs.google.com/document/d/1iHyj7zlmygKSk5gBPsqIqL5ASPzJSPREaNT_QdsiYA4/edit) to beautify the python and c++ code.
- [x] The PR is complete and small, read the [Google eng practice (CL equals to PR)](https://google.github.io/eng-practices/review/developer/small-cls.html) to understand more about small PR. In DGL, we consider PRs with less than 200 lines of core code change are small (example, test and documentation could be exempted).
- [x] All changes have test coverage
- [ ] Code is well-documented
- [ ] To the best of my knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change
- [x] Related issue is referred in this PR
- [ ] If the PR is for a new model/paper, I've updated the example index [here](../examples/README.md).


