### PR TITLE
[Sparse] Add more complete elementwise op

### DIFF
--- a/python/dgl/sparse/elementwise_op.py
+++ b/python/dgl/sparse/elementwise_op.py
@@ -251,4 +251,4 @@ def power(
     DiagMatrix(val=tensor([1, 4, 9]),
                shape=(3, 3))
     """
-    return A ** scalar
+    return A**scalar

--- a/python/dgl/sparse/elementwise_op.py
+++ b/python/dgl/sparse/elementwise_op.py
@@ -1,6 +1,9 @@
 # pylint: disable=anomalous-backslash-in-string
 """DGL elementwise operator module."""
+from numbers import Number
 from typing import Union
+
+import torch
 
 from .diag_matrix import DiagMatrix
 from .sparse_matrix import SparseMatrix
@@ -96,8 +99,8 @@ def sub(
     >>> A - B
     SparseMatrix(indices=tensor([[0, 0, 1, 1, 2],
                                  [0, 1, 0, 1, 2]]),
-    values=tensor([-1, 20, 10,  -2, 27]),
-    shape=(3, 3), nnz=5)
+                 values=tensor([-1, 20, 10,  -2, 27]),
+                 shape=(3, 3), nnz=5)
     """
     return A - B
 
@@ -205,7 +208,7 @@ def div(
 
 
 def power(
-    A: Union[SparseMatrix, DiagMatrix], scalar: Union[float, int]
+    A: Union[SparseMatrix, DiagMatrix], scalar: Union[Number, torch.Tensor]
 ) -> Union[SparseMatrix, DiagMatrix]:
     r"""Elementwise exponentiation for ``DiagMatrix`` and ``SparseMatrix``,
     equivalent to ``A ** scalar``.

--- a/python/dgl/sparse/elementwise_op.py
+++ b/python/dgl/sparse/elementwise_op.py
@@ -55,7 +55,9 @@ def add(
     return A + B
 
 
-def sub(A: Union[DiagMatrix], B: Union[DiagMatrix]) -> Union[DiagMatrix]:
+def sub(
+    A: Union[DiagMatrix, SparseMatrix], B: Union[DiagMatrix, SparseMatrix]
+) -> Union[DiagMatrix, SparseMatrix]:
     r"""Elementwise subtraction for ``DiagMatrix`` and ``SparseMatrix``,
     equivalent to ``A - B``.
 
@@ -64,32 +66,38 @@ def sub(A: Union[DiagMatrix], B: Union[DiagMatrix]) -> Union[DiagMatrix]:
     +--------------+------------+--------------+--------+
     |    A \\ B    | DiagMatrix | SparseMatrix | scalar |
     +--------------+------------+--------------+--------+
-    |  DiagMatrix  |     ✅     |      🚫      |   🚫   |
+    |  DiagMatrix  |     ✅     |      ✅      |   🚫   |
     +--------------+------------+--------------+--------+
-    | SparseMatrix |     🚫     |      🚫      |   🚫   |
+    | SparseMatrix |     ✅     |      ✅      |   🚫   |
     +--------------+------------+--------------+--------+
     |    scalar    |     🚫     |      🚫      |   🚫   |
     +--------------+------------+--------------+--------+
 
     Parameters
     ----------
-    A : DiagMatrix
-        Diagonal matrix
-    B : DiagMatrix
-        Diagonal matrix
+    A : DiagMatrix or SparseMatrix
+        Diagonal matrix or sparse matrix
+    B : DiagMatrix or SparseMatrix
+        Diagonal matrix or sparse matrix
 
     Returns
     -------
-    DiagMatrix
-        Diagonal matrix
+    DiagMatrix or SparseMatrix
+        Diagonal matrix if both :attr:`A` and :attr:`B` are diagonal matrices,
+        sparse matrix otherwise
 
     Examples
     --------
-    >>> A = diag(torch.arange(1, 4))
-    >>> B = diag(torch.arange(10, 13))
-    >>> sub(A, B)
-    DiagMatrix(val=tensor([-9, -9, -9]),
-               shape=(3, 3))
+    >>> row = torch.tensor([1, 0, 2])
+    >>> col = torch.tensor([0, 1, 2])
+    >>> val = torch.tensor([10, 20, 30])
+    >>> A = from_coo(row, col, val)
+    >>> B = diag(torch.arange(1, 4))
+    >>> A - B
+    SparseMatrix(indices=tensor([[0, 0, 1, 1, 2],
+                                 [0, 1, 0, 1, 2]]),
+    values=tensor([-1, 20, 10,  -2, 27]),
+    shape=(3, 3), nnz=5)
     """
     return A - B
 
@@ -243,4 +251,4 @@ def power(
     DiagMatrix(val=tensor([1, 4, 9]),
                shape=(3, 3))
     """
-    return A**scalar
+    return A ** scalar

--- a/python/dgl/sparse/elementwise_op_diag.py
+++ b/python/dgl/sparse/elementwise_op_diag.py
@@ -17,6 +17,7 @@ from .utils import is_scalar
 # See also:
 # https://docs.python.org/3/reference/datamodel.html#emulating-numeric-types
 
+
 def diag_add(
     D1: DiagMatrix, D2: Union[DiagMatrix, SparseMatrix]
 ) -> Union[DiagMatrix, SparseMatrix]:
@@ -273,7 +274,9 @@ def diag_power(
     DiagMatrix(val=tensor([1, 4, 9]),
     shape=(3, 3))
     """
-    return diag(D.val ** scalar, D.shape) if is_scalar(scalar) else NotImplemented
+    return (
+        diag(D.val**scalar, D.shape) if is_scalar(scalar) else NotImplemented
+    )
 
 
 DiagMatrix.__add__ = diag_add

--- a/python/dgl/sparse/elementwise_op_diag.py
+++ b/python/dgl/sparse/elementwise_op_diag.py
@@ -8,15 +8,6 @@ from .diag_matrix import diag, DiagMatrix
 from .sparse_matrix import SparseMatrix
 from .utils import is_scalar
 
-# Since these functions are never exposed but instead used for implementing
-# the builtin operators, we can return NotImplemented to (1) raise TypeError
-# for invalid value types, (2) not handling the first argument not being
-# a DiagMatrix object but instead delegate it to DiagMatrix.__radd__ etc, (3)
-# allow others to implement their own class that operates with DiagMatrix
-# objects.
-# See also:
-# https://docs.python.org/3/reference/datamodel.html#emulating-numeric-types
-
 
 def diag_add(
     D1: DiagMatrix, D2: Union[DiagMatrix, SparseMatrix]
@@ -41,7 +32,7 @@ def diag_add(
     >>> D2 = diag(torch.arange(10, 13))
     >>> D1 + D2
     DiagMatrix(val=tensor([11, 13, 15]),
-    shape=(3, 3))
+               shape=(3, 3))
     """
     if isinstance(D1, DiagMatrix) and isinstance(D2, DiagMatrix):
         assert D1.shape == D2.shape, (
@@ -56,6 +47,8 @@ def diag_add(
         )
         D1 = D1.as_sparse()
         return D1 + D2
+    # Python falls back to D2.__radd__(D1) then TypeError when NotImplemented
+    # is returned.
     return NotImplemented
 
 
@@ -87,8 +80,10 @@ def diag_sub(
     >>> D2 = diag(torch.arange(10, 13))
     >>> D1 - D2
     DiagMatrix(val=tensor([-9, -9, -9]),
-    shape=(3, 3))
+               shape=(3, 3))
     """
+    # Python falls back to D2.__rsub__(D1) then TypeError when NotImplemented
+    # is returned.
     return D1 + (-D2)
 
 
@@ -120,8 +115,9 @@ def diag_rsub(
     >>> D2 = diag(torch.arange(10, 13))
     >>> D2 - D1
     DiagMatrix(val=tensor([9, 9, 9]),
-    shape=(3, 3))
+               shape=(3, 3))
     """
+    # Python falls back to TypeError when NotImplemented is returned.
     return (-D1) + D2
 
 
@@ -147,10 +143,10 @@ def diag_mul(
     >>> D = diag(torch.arange(1, 4))
     >>> D * 2.5
     DiagMatrix(val=tensor([2.5000, 5.0000, 7.5000]),
-    shape=(3, 3))
+               shape=(3, 3))
     >>> 2 * D
     DiagMatrix(val=tensor([2, 4, 6]),
-    shape=(3, 3))
+               shape=(3, 3))
     """
     if isinstance(D2, DiagMatrix):
         assert D1.shape == D2.shape, (
@@ -161,6 +157,8 @@ def diag_mul(
     elif is_scalar(D2):
         return diag(D1.val * D2, D1.shape)
     else:
+        # Python falls back to D2.__rmul__(D1) then TypeError when
+        # NotImplemented is returned.
         return NotImplemented
 
 
@@ -188,10 +186,10 @@ def diag_div(
     >>> D2 = diag(torch.arange(10, 13))
     >>> D1 / D2
     DiagMatrix(val=tensor([0.1000, 0.1818, 0.2500]),
-    shape=(3, 3))
+               shape=(3, 3))
     >>> D1 / 2.5
     DiagMatrix(val=tensor([0.4000, 0.8000, 1.2000]),
-    shape=(3, 3))
+               shape=(3, 3))
     """
     if isinstance(D2, DiagMatrix):
         assert D1.shape == D2.shape, (
@@ -203,6 +201,8 @@ def diag_div(
         assert D2 != 0, "Division by zero is not allowed."
         return diag(D1.val / D2, D1.shape)
     else:
+        # Python falls back to D2.__rtruediv__(D1) then TypeError when
+        # NotImplemented is returned.
         return NotImplemented
 
 
@@ -230,10 +230,10 @@ def diag_rdiv(
     >>> D2 = diag(torch.arange(10, 13))
     >>> D2 / D1
     DiagMatrix(val=tensor([10.0000, 5.5000, 4.0000]),
-    shape=(3, 3))
+               shape=(3, 3))
     >>> 2.5 / D1
     DiagMatrix(val=tensor([0.2500, 0.2273, 0.2083]),
-    shape=(3, 3))
+               shape=(3, 3))
     """
     if isinstance(D2, DiagMatrix):
         assert D1.shape == D2.shape, (
@@ -245,6 +245,7 @@ def diag_rdiv(
         assert D2 != 0, "Division by zero is not allowed."
         return diag(D2 / D1.val, D1.shape)
     else:
+        # Python falls back to TypeError when NotImplemented is returned.
         return NotImplemented
 
 
@@ -272,8 +273,10 @@ def diag_power(
     >>> D = diag(torch.arange(1, 4))
     >>> D ** 2
     DiagMatrix(val=tensor([1, 4, 9]),
-    shape=(3, 3))
+               shape=(3, 3))
     """
+    # Python falls back to scalar.__rpow__ then TypeError when NotImplemented
+    # is returned.
     return (
         diag(D.val**scalar, D.shape) if is_scalar(scalar) else NotImplemented
     )

--- a/python/dgl/sparse/elementwise_op_sp.py
+++ b/python/dgl/sparse/elementwise_op_sp.py
@@ -4,7 +4,6 @@ from numbers import Number
 
 import torch
 
-from .diag_matrix import DiagMatrix
 from .sparse_matrix import SparseMatrix, val_like
 from .utils import is_scalar
 

--- a/python/dgl/sparse/elementwise_op_sp.py
+++ b/python/dgl/sparse/elementwise_op_sp.py
@@ -15,6 +15,7 @@ def spsp_add(A, B):
         torch.ops.dgl_sparse.spsp_add(A.c_sparse_matrix, B.c_sparse_matrix)
     )
 
+
 # Since these functions are never exposed but instead used for implementing
 # the builtin operators, we can return NotImplemented to (1) raise TypeError
 # for invalid value types, (2) not handling DiagMatrix in SparseMatrix
@@ -22,6 +23,7 @@ def spsp_add(A, B):
 # others to implement their own class that operates with SparseMatrix objects.
 # See also:
 # https://docs.python.org/3/reference/datamodel.html#emulating-numeric-types
+
 
 def sp_add(A: SparseMatrix, B: SparseMatrix) -> SparseMatrix:
     """Elementwise addition
@@ -87,9 +89,7 @@ def sp_sub(A: SparseMatrix, B: SparseMatrix) -> SparseMatrix:
     return A + (-B)
 
 
-def sp_mul(
-    A: SparseMatrix, B: Union[Number, torch.Tensor]
-) -> SparseMatrix:
+def sp_mul(A: SparseMatrix, B: Union[Number, torch.Tensor]) -> SparseMatrix:
     """Elementwise multiplication
 
     Parameters
@@ -127,9 +127,7 @@ def sp_mul(
     return val_like(A, A.val * B) if is_scalar(B) else NotImplemented
 
 
-def sp_div(
-    A: SparseMatrix, B: Union[Number, torch.Tensor]
-) -> SparseMatrix:
+def sp_div(A: SparseMatrix, B: Union[Number, torch.Tensor]) -> SparseMatrix:
     """Elementwise division
 
     Parameters
@@ -191,7 +189,7 @@ def sp_power(
     values=tensor([100, 400, 900]),
     shape=(3, 4), nnz=3)
     """
-    return val_like(A, A.val ** scalar) if is_scalar(scalar) else NotImplemented
+    return val_like(A, A.val**scalar) if is_scalar(scalar) else NotImplemented
 
 
 SparseMatrix.__add__ = sp_add

--- a/python/dgl/sparse/elementwise_op_sp.py
+++ b/python/dgl/sparse/elementwise_op_sp.py
@@ -1,10 +1,12 @@
 """DGL elementwise operators for sparse matrix module."""
 from typing import Union
+from numbers import Number
 
 import torch
 
 from .diag_matrix import DiagMatrix
 from .sparse_matrix import SparseMatrix, val_like
+from .utils import is_scalar
 
 
 def spsp_add(A, B):
@@ -13,16 +15,23 @@ def spsp_add(A, B):
         torch.ops.dgl_sparse.spsp_add(A.c_sparse_matrix, B.c_sparse_matrix)
     )
 
+# Since these functions are never exposed but instead used for implementing
+# the builtin operators, we can return NotImplemented to (1) raise TypeError
+# for invalid value types, (2) not handling DiagMatrix in SparseMatrix
+# functions but instead delegate it to DiagMatrix.__radd__ etc, (3) allow
+# others to implement their own class that operates with SparseMatrix objects.
+# See also:
+# https://docs.python.org/3/reference/datamodel.html#emulating-numeric-types
 
-def sp_add(A: SparseMatrix, B: Union[DiagMatrix, SparseMatrix]) -> SparseMatrix:
+def sp_add(A: SparseMatrix, B: SparseMatrix) -> SparseMatrix:
     """Elementwise addition
 
     Parameters
     ----------
     A : SparseMatrix
         Sparse matrix
-    B : DiagMatrix or SparseMatrix
-        Diagonal matrix or sparse matrix
+    B : SparseMatrix
+        The other sparse matrix
 
     Returns
     -------
@@ -42,27 +51,53 @@ def sp_add(A: SparseMatrix, B: Union[DiagMatrix, SparseMatrix]) -> SparseMatrix:
     values=tensor([40, 20, 60]),
     shape=(3, 4), nnz=3)
     """
-    if isinstance(B, DiagMatrix):
-        B = B.as_sparse()
-    if isinstance(A, SparseMatrix) and isinstance(B, SparseMatrix):
-        return spsp_add(A, B)
-    raise RuntimeError(
-        "Elementwise addition between {} and {} is not "
-        "supported.".format(type(A), type(B))
-    )
+    return spsp_add(A, B) if isinstance(B, SparseMatrix) else NotImplemented
+
+
+def sp_sub(A: SparseMatrix, B: SparseMatrix) -> SparseMatrix:
+    """Elementwise subtraction
+
+    Parameters
+    ----------
+    A : SparseMatrix
+        Sparse matrix
+    B : SparseMatrix
+        The other sparse matrix
+
+    Returns
+    -------
+    SparseMatrix
+        Sparse matrix
+
+    Examples
+    --------
+
+    >>> row = torch.tensor([1, 0, 2])
+    >>> col = torch.tensor([0, 3, 2])
+    >>> val = torch.tensor([10, 20, 30])
+    >>> val2 = torch.tensor([5, 10, 15])
+    >>> A = from_coo(row, col, val, shape=(3, 4))
+    >>> B = from_coo(row, col, val2, shape=(3, 4))
+    >>> A - B
+    SparseMatrix(indices=tensor([[0, 1, 2],
+            [3, 0, 2]]),
+    values=tensor([10, 5, 15]),
+    shape=(3, 4), nnz=3)
+    """
+    return A + (-B)
 
 
 def sp_mul(
-    A: Union[SparseMatrix, float, int], B: Union[SparseMatrix, float, int]
+    A: SparseMatrix, B: Union[Number, torch.Tensor]
 ) -> SparseMatrix:
     """Elementwise multiplication
 
     Parameters
     ----------
-    A : SparseMatrix or float or int
+    A : SparseMatrix
         First operand
-    B : SparseMatrix or float or int
-        Second operand
+    B : Number or torch.Tensor
+        Second operand.  Must be a scalar.
 
     Returns
     -------
@@ -89,17 +124,46 @@ def sp_mul(
     values=tensor([2, 4, 6]),
     shape=(3, 4), nnz=3)
     """
-    if isinstance(A, SparseMatrix) and isinstance(B, (float, int)):
-        return val_like(A, A.val * B)
-    elif isinstance(A, (float, int)) and isinstance(B, SparseMatrix):
-        return val_like(B, A * B.val)
-    raise RuntimeError(
-        "Elementwise multiplication between "
-        f"{type(A)} and {type(B)} is not supported."
-    )
+    return val_like(A, A.val * B) if is_scalar(B) else NotImplemented
 
 
-def sp_power(A: SparseMatrix, scalar: Union[float, int]) -> SparseMatrix:
+def sp_div(
+    A: SparseMatrix, B: Union[Number, torch.Tensor]
+) -> SparseMatrix:
+    """Elementwise division
+
+    Parameters
+    ----------
+    A : SparseMatrix
+        First operand
+    B : Number or torch.Tensor
+        Second operand.  Must be a scalar.
+
+    Returns
+    -------
+    SparseMatrix
+        Result of A / B
+
+    Examples
+    --------
+
+    >>> row = torch.tensor([1, 0, 2])
+    >>> col = torch.tensor([0, 3, 2])
+    >>> val = torch.tensor([1, 2, 3])
+    >>> A = from_coo(row, col, val, shape=(3, 4))
+
+    >>> A / 2
+    SparseMatrix(indices=tensor([[1, 0, 2],
+            [0, 3, 2]]),
+    values=tensor([0.5000, 1.0000, 1.5000]),
+    shape=(3, 4), nnz=3)
+    """
+    return val_like(A, A.val / B) if is_scalar(B) else NotImplemented
+
+
+def sp_power(
+    A: SparseMatrix, scalar: Union[Number, torch.Tensor]
+) -> SparseMatrix:
     """Take the power of each nonzero element and return a sparse matrix with
     the result.
 
@@ -107,8 +171,8 @@ def sp_power(A: SparseMatrix, scalar: Union[float, int]) -> SparseMatrix:
     ----------
     A : SparseMatrix
         Sparse matrix
-    scalar : float or int
-        Exponent
+    scalar : Number or torch.Tensor
+        Exponent.  Must be a scalar.
 
     Returns
     -------
@@ -127,32 +191,12 @@ def sp_power(A: SparseMatrix, scalar: Union[float, int]) -> SparseMatrix:
     values=tensor([100, 400, 900]),
     shape=(3, 4), nnz=3)
     """
-    if isinstance(scalar, (float, int)):
-        return val_like(A, A.val**scalar)
-
-    raise RuntimeError(
-        f"Raising a sparse matrix to exponent {type(scalar)} is not allowed."
-    )
-
-
-def sp_rpower(A: SparseMatrix, scalar: Union[float, int]):
-    """Function for preventing raising a scalar to a sparse matrix exponent
-
-    Parameters
-    ----------
-    A : SparseMatrix
-        Sparse matrix
-    scalar : float or int
-        Scalar
-    """
-    raise RuntimeError(
-        f"Raising {type(scalar)} to a sparse matrix component is not allowed."
-    )
+    return val_like(A, A.val ** scalar) if is_scalar(scalar) else NotImplemented
 
 
 SparseMatrix.__add__ = sp_add
-SparseMatrix.__radd__ = sp_add
+SparseMatrix.__sub__ = sp_sub
 SparseMatrix.__mul__ = sp_mul
 SparseMatrix.__rmul__ = sp_mul
+SparseMatrix.__truediv__ = sp_div
 SparseMatrix.__pow__ = sp_power
-SparseMatrix.__rpow__ = sp_rpower

--- a/python/dgl/sparse/utils.py
+++ b/python/dgl/sparse/utils.py
@@ -1,0 +1,8 @@
+"""DGL sparse utility module."""
+from numbers import Number
+import torch
+
+def is_scalar(x):
+    """Check if the input is a scalar.
+    """
+    return isinstance(x, Number) or (torch.is_tensor(x) and x.dim() == 0)

--- a/python/dgl/sparse/utils.py
+++ b/python/dgl/sparse/utils.py
@@ -2,7 +2,7 @@
 from numbers import Number
 import torch
 
+
 def is_scalar(x):
-    """Check if the input is a scalar.
-    """
+    """Check if the input is a scalar."""
     return isinstance(x, Number) or (torch.is_tensor(x) and x.dim() == 0)

--- a/tests/pytorch/sparse/test_elementwise_op.py
+++ b/tests/pytorch/sparse/test_elementwise_op.py
@@ -1,10 +1,12 @@
 import sys
+import operator
 
 import backend as F
 import pytest
 import torch
 
-from dgl.sparse import add, diag, from_coo, from_csc, from_csr
+import dgl.sparse
+from dgl.sparse import add, sub, diag, from_coo, from_csc, from_csr
 
 # TODO(#4818): Skipping tests on win.
 if not sys.platform.startswith("linux"):
@@ -12,7 +14,8 @@ if not sys.platform.startswith("linux"):
 
 
 @pytest.mark.parametrize("val_shape", [(), (2,)])
-def test_add_coo(val_shape):
+@pytest.mark.parametrize("op", ["add", "sub"])
+def test_add_coo(val_shape, op):
     ctx = F.ctx()
     row = torch.tensor([1, 0, 2]).to(ctx)
     col = torch.tensor([0, 3, 2]).to(ctx)
@@ -24,16 +27,17 @@ def test_add_coo(val_shape):
     val = torch.randn(row.shape + val_shape).to(ctx)
     B = from_coo(row, col, val, shape=A.shape)
 
-    sum1 = (A + B).dense()
-    sum2 = add(A, B).dense()
-    dense_sum = A.dense() + B.dense()
+    C1 = getattr(operator, op)(A, B).dense()
+    C2 = getattr(dgl.sparse, op)(A, B).dense()
+    dense_C = getattr(operator, op)(A.dense(), B.dense())
 
-    assert torch.allclose(dense_sum, sum1)
-    assert torch.allclose(dense_sum, sum2)
+    assert torch.allclose(dense_C, C1)
+    assert torch.allclose(dense_C, C2)
 
 
 @pytest.mark.parametrize("val_shape", [(), (2,)])
-def test_add_csr(val_shape):
+@pytest.mark.parametrize("op", ["add", "sub"])
+def test_add_csr(val_shape, op):
     ctx = F.ctx()
     indptr = torch.tensor([0, 1, 2, 3]).to(ctx)
     indices = torch.tensor([3, 0, 2]).to(ctx)
@@ -45,16 +49,17 @@ def test_add_csr(val_shape):
     val = torch.randn(indices.shape + val_shape).to(ctx)
     B = from_csr(indptr, indices, val, shape=A.shape)
 
-    sum1 = (A + B).dense()
-    sum2 = add(A, B).dense()
-    dense_sum = A.dense() + B.dense()
+    C1 = getattr(operator, op)(A, B).dense()
+    C2 = getattr(dgl.sparse, op)(A, B).dense()
+    dense_C = getattr(operator, op)(A.dense(), B.dense())
 
-    assert torch.allclose(dense_sum, sum1)
-    assert torch.allclose(dense_sum, sum2)
+    assert torch.allclose(dense_C, C1)
+    assert torch.allclose(dense_C, C2)
 
 
 @pytest.mark.parametrize("val_shape", [(), (2,)])
-def test_add_csc(val_shape):
+@pytest.mark.parametrize("op", ["add", "sub"])
+def test_add_csc(val_shape, op):
     ctx = F.ctx()
     indptr = torch.tensor([0, 1, 1, 2, 3]).to(ctx)
     indices = torch.tensor([1, 2, 0]).to(ctx)
@@ -66,28 +71,29 @@ def test_add_csc(val_shape):
     val = torch.randn(indices.shape + val_shape).to(ctx)
     B = from_csc(indptr, indices, val, shape=A.shape)
 
-    sum1 = (A + B).dense()
-    sum2 = add(A, B).dense()
-    dense_sum = A.dense() + B.dense()
+    C1 = getattr(operator, op)(A, B).dense()
+    C2 = getattr(dgl.sparse, op)(A, B).dense()
+    dense_C = getattr(operator, op)(A.dense(), B.dense())
 
-    assert torch.allclose(dense_sum, sum1)
-    assert torch.allclose(dense_sum, sum2)
+    assert torch.allclose(dense_C, C1)
+    assert torch.allclose(dense_C, C2)
 
 
 @pytest.mark.parametrize("val_shape", [(), (2,)])
-def test_add_diag(val_shape):
+@pytest.mark.parametrize("op", ["add", "sub"])
+def test_add_diag(val_shape, op):
     ctx = F.ctx()
     shape = (3, 4)
     val_shape = (shape[0],) + val_shape
     D1 = diag(torch.randn(val_shape).to(ctx), shape=shape)
     D2 = diag(torch.randn(val_shape).to(ctx), shape=shape)
 
-    sum1 = (D1 + D2).dense()
-    sum2 = add(D1, D2).dense()
-    dense_sum = D1.dense() + D2.dense()
+    C1 = getattr(operator, op)(D1, D2).dense()
+    C2 = getattr(dgl.sparse, op)(D1, D2).dense()
+    dense_C = getattr(operator, op)(D1.dense(), D2.dense())
 
-    assert torch.allclose(dense_sum, sum1)
-    assert torch.allclose(dense_sum, sum2)
+    assert torch.allclose(dense_C, C1)
+    assert torch.allclose(dense_C, C2)
 
 
 @pytest.mark.parametrize("val_shape", [(), (2,)])
@@ -112,3 +118,27 @@ def test_add_sparse_diag(val_shape):
     assert torch.allclose(dense_sum, sum2)
     assert torch.allclose(dense_sum, sum3)
     assert torch.allclose(dense_sum, sum4)
+
+
+@pytest.mark.parametrize("val_shape", [(), (2,)])
+def test_sub_sparse_diag(val_shape):
+    ctx = F.ctx()
+    row = torch.tensor([1, 0, 2]).to(ctx)
+    col = torch.tensor([0, 3, 2]).to(ctx)
+    val = torch.randn(row.shape + val_shape).to(ctx)
+    A = from_coo(row, col, val)
+
+    shape = (3, 4)
+    val_shape = (shape[0],) + val_shape
+    D = diag(torch.randn(val_shape).to(ctx), shape=shape)
+
+    diff1 = (A - D).dense()
+    diff2 = (D - A).dense()
+    diff3 = sub(A, D).dense()
+    diff4 = sub(D, A).dense()
+    dense_diff = A.dense() - D.dense()
+
+    assert torch.allclose(dense_diff, diff1)
+    assert torch.allclose(-dense_diff, diff2)
+    assert torch.allclose(dense_diff, diff3)
+    assert torch.allclose(-dense_diff, diff4)

--- a/tests/pytorch/sparse/test_elementwise_op_diag.py
+++ b/tests/pytorch/sparse/test_elementwise_op_diag.py
@@ -18,8 +18,9 @@ def all_close_sparse(A, B):
     assert A.shape == B.shape
 
 
-@pytest.mark.parametrize("op", [operator.sub, operator.mul, operator.truediv])
-def test_diag_op_diag(op):
+@pytest.mark.parametrize("opname", ["add", "sub", "mul", "truediv"])
+def test_diag_op_diag(opname):
+    op = getattr(operator, opname)
     ctx = F.ctx()
     shape = (3, 4)
     D1 = diag(torch.arange(1, 4).to(ctx), shape=shape)
@@ -48,6 +49,11 @@ def test_diag_op_scalar(v_scalar):
     # D / v
     D2 = D1 / v_scalar
     assert torch.allclose(D1.val / v_scalar, D2.val, rtol=1e-4, atol=1e-4)
+    assert D1.shape == D2.shape
+
+    # v / D
+    D2 = v_scalar / D1
+    assert torch.allclose(v_scalar / D1.val, D2.val, rtol=1e-4, atol=1e-4)
     assert D1.shape == D2.shape
 
     # D ^ v

--- a/tests/pytorch/sparse/test_elementwise_op_diag.py
+++ b/tests/pytorch/sparse/test_elementwise_op_diag.py
@@ -30,7 +30,7 @@ def test_diag_op_diag(opname):
     assert result.shape == D1.shape
 
 
-@pytest.mark.parametrize("v_scalar", [2, 2.5])
+@pytest.mark.parametrize("v_scalar", [2, 2.5, torch.tensor(2), torch.tensor(2.5)])
 def test_diag_op_scalar(v_scalar):
     ctx = F.ctx()
     shape = (3, 4)

--- a/tests/pytorch/sparse/test_elementwise_op_sp.py
+++ b/tests/pytorch/sparse/test_elementwise_op_sp.py
@@ -20,7 +20,7 @@ def all_close_sparse(A, row, col, val, shape):
     assert A.shape == shape
 
 
-@pytest.mark.parametrize("v_scalar", [2, 2.5])
+@pytest.mark.parametrize("v_scalar", [2, 2.5, torch.tensor(2), torch.tensor(2.5)])
 def test_mul_scalar(v_scalar):
     ctx = F.ctx()
     row = torch.tensor([1, 0, 2]).to(ctx)
@@ -39,15 +39,29 @@ def test_mul_scalar(v_scalar):
     assert A1.shape == A2.shape
 
 
+@pytest.mark.parametrize("v_scalar", [2, 2.5, torch.tensor(2), torch.tensor(2.5)])
+def test_div_scalar(v_scalar):
+    ctx = F.ctx()
+    row = torch.tensor([1, 0, 2]).to(ctx)
+    col = torch.tensor([0, 3, 2]).to(ctx)
+    val = torch.randn(len(row)).to(ctx)
+    A1 = from_coo(row, col, val, shape=(3, 4))
+
+    # A / v
+    A2 = A1 / v_scalar
+    assert torch.allclose(A1.val / v_scalar, A2.val, rtol=1e-4, atol=1e-4, equal_nan=True)
+    assert A1.shape == A2.shape
+
+
 @pytest.mark.parametrize("val_shape", [(3,), (3, 2)])
-def test_pow(val_shape):
+@pytest.mark.parametrize("exponent", [2, torch.tensor(2)])
+def test_pow(val_shape, exponent):
     # A ** v
     ctx = F.ctx()
     row = torch.tensor([1, 0, 2]).to(ctx)
     col = torch.tensor([0, 3, 2]).to(ctx)
     val = torch.randn(val_shape).to(ctx)
     A = from_coo(row, col, val, shape=(3, 4))
-    exponent = 2
     A_new = A**exponent
     assert torch.allclose(A_new.val, val**exponent)
     assert A_new.shape == A.shape


### PR DESCRIPTION
## Description
This completes the following:
* Support sparse matrix subtraction: `A - B`
* Support scalar operands that are PyTorch scalar tensors instead of Python numbers in `*`, `/` and `**`.
* Support scalar operand dividing a diagonal: `v / D`.

## Checklist
Please feel free to remove inapplicable items for your PR.
- [x] The PR title starts with [$CATEGORY] (such as [NN], [Model], [Doc], [Feature]])
- [x] I've leverage the [tools](https://docs.google.com/document/d/1iHyj7zlmygKSk5gBPsqIqL5ASPzJSPREaNT_QdsiYA4/edit) to beautify the python and c++ code.
- [x] The PR is complete and small, read the [Google eng practice (CL equals to PR)](https://google.github.io/eng-practices/review/developer/small-cls.html) to understand more about small PR. In DGL, we consider PRs with less than 200 lines of core code change are small (example, test and documentation could be exempted).
- [x] All changes have test coverage
- [x] Code is well-documented
- [x] To the best of my knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change