### PR TITLE
Replace global cudaStream in Filter with runtime calls (fix #5153)

### DIFF
--- a/src/array/cuda/cuda_filter.cu
+++ b/src/array/cuda/cuda_filter.cu
@@ -18,8 +18,6 @@ namespace array {
 
 namespace {
 
-cudaStream_t cudaStream = runtime::getCurrentCUDAStream();
-
 template <typename IdType, bool include>
 __global__ void _IsInKernel(
     DeviceOrderedHashTable<IdType> table, const IdType* const array,
@@ -46,6 +44,7 @@ IdArray _PerformFilter(const OrderedHashTable<IdType>& table, IdArray test) {
   const auto& ctx = test->ctx;
   auto device = runtime::DeviceAPI::Get(ctx);
   const int64_t size = test->shape[0];
+  cudaStream_t cudaStream = runtime::getCurrentCUDAStream();
 
   if (size == 0) {
     return test;
@@ -108,7 +107,8 @@ template <typename IdType>
 class CudaFilterSet : public Filter {
  public:
   explicit CudaFilterSet(IdArray array)
-      : table_(array->shape[0], array->ctx, cudaStream) {
+      : table_(array->shape[0], array->ctx, runtime::getCurrentCUDAStream()) {
+    cudaStream_t cudaStream = runtime::getCurrentCUDAStream();
     table_.FillWithUnique(
         static_cast<const IdType*>(array->data), array->shape[0], cudaStream);
   }

--- a/tests/compute/test_filter.py
+++ b/tests/compute/test_filter.py
@@ -89,8 +89,6 @@ def test_filter_multistream(idtype):
             x = F.randint([30000], dtype=idtype, ctx=F.ctx(), low=0, high=50000)
             xi = f.find_included_indices(x)
 
-
-
 if __name__ == "__main__":
     test_graph_filter()
     test_array_filter()

--- a/tests/compute/test_filter.py
+++ b/tests/compute/test_filter.py
@@ -1,11 +1,11 @@
 import unittest
 
 import backend as F
-import numpy as np
-from test_utils import parametrize_idtype
 
 import dgl
+import numpy as np
 from dgl.utils import Filter
+from test_utils import parametrize_idtype
 
 
 def test_graph_filter():
@@ -70,24 +70,28 @@ def test_array_filter(idtype):
     ye_exp = F.copy_to(F.tensor([1, 3, 4, 6], dtype=idtype), F.ctx())
     assert F.array_equal(ye_act, ye_exp)
 
+
 @unittest.skipIf(
-    dgl.backend.backend_name != "pytorch", reason="Multiple streams are only " \
-        "supported by pytorch backend"
+    dgl.backend.backend_name != "pytorch",
+    reason="Multiple streams are only supported by pytorch backend",
+)
+@unittest.skipIf(
+    F._default_context_str == "cpu", reason="CPU not yet supported"
 )
 @parametrize_idtype
 def test_filter_multistream(idtype):
     # this is a smoke test to ensure we do not trip any internal assertions
     import torch
+
     s = torch.cuda.Stream(device=F.ctx())
     with torch.cuda.stream(s):
         # we must do multiple runs such that the stream is busy as we launch
         # work
         for i in range(10):
-            f = Filter(
-                F.arange(1000, 4000, dtype=idtype, ctx=F.ctx())
-            )
+            f = Filter(F.arange(1000, 4000, dtype=idtype, ctx=F.ctx()))
             x = F.randint([30000], dtype=idtype, ctx=F.ctx(), low=0, high=50000)
             xi = f.find_included_indices(x)
+
 
 if __name__ == "__main__":
     test_graph_filter()

--- a/tests/compute/test_filter.py
+++ b/tests/compute/test_filter.py
@@ -70,6 +70,26 @@ def test_array_filter(idtype):
     ye_exp = F.copy_to(F.tensor([1, 3, 4, 6], dtype=idtype), F.ctx())
     assert F.array_equal(ye_act, ye_exp)
 
+@unittest.skipIf(
+    dgl.backend.backend_name != "pytorch", reason="Multiple streams are only " \
+        "supported by pytorch backend"
+)
+@parametrize_idtype
+def test_filter_multistream(idtype):
+    # this is a smoke test to ensure we do not trip any internal assertions
+    import torch
+    s = torch.cuda.Stream(device=F.ctx())
+    with torch.cuda.stream(s):
+        # we must do multiple runs such that the stream is busy as we launch
+        # work
+        for i in range(10):
+            f = Filter(
+                F.arange(1000, 4000, dtype=idtype, ctx=F.ctx())
+            )
+            x = F.randint([30000], dtype=idtype, ctx=F.ctx(), low=0, high=50000)
+            xi = f.find_included_indices(x)
+
+
 
 if __name__ == "__main__":
     test_graph_filter()


### PR DESCRIPTION
## Description
Fix #5153 by determining the stream at function invocation

## Checklist
Please feel free to remove inapplicable items for your PR.
- [x] The PR title starts with [$CATEGORY] (such as [NN], [Model], [Doc], [Feature]])
- [x] I've leverage the [tools](https://docs.google.com/document/d/1iHyj7zlmygKSk5gBPsqIqL5ASPzJSPREaNT_QdsiYA4/edit) to beautify the python and c++ code.
- [x] The PR is complete and small, read the [Google eng practice (CL equals to PR)](https://google.github.io/eng-practices/review/developer/small-cls.html) to understand more about small PR. In DGL, we consider PRs with less than 200 lines of core code change are small (example, test and documentation could be exempted).
- [x] All changes have test coverage
- [x] Code is well-documented
- [x] To the best of my knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change
- [x] Related issue is referred in this PR

