### PR TITLE
[Build] Change regex pattern to include local versions in update_version.py

### DIFF
--- a/python/update_version.py
+++ b/python/update_version.py
@@ -55,20 +55,20 @@ def main():
     # python path
     update(
         os.path.join(proj_root, "python", "dgl", "_ffi", "libinfo.py"),
-        r"(?<=__version__ = \")[.0-9a-z]+",
+        r"(?<=__version__ = \")[.0-9a-z+_]+",
         __version__,
     )
     # C++ header
     update(
         os.path.join(proj_root, "include", "dgl", "runtime", "c_runtime_api.h"),
-        '(?<=DGL_VERSION ")[.0-9a-z]+',
+        '(?<=DGL_VERSION ")[.0-9a-z+_]+',
         __version__,
     )
     # conda
     for path in ["dgl"]:
         update(
             os.path.join(proj_root, "conda", path, "meta.yaml"),
-            '(?<=version: ")[.0-9a-z]+',
+            '(?<=version: ")[.0-9a-z+_]+',
             __version__,
         )
 


### PR DESCRIPTION
## Description
Starting in 1.0 we will be using local versions to indicate CUDA support (e.g. `1.0.0+cu102`).  However, `update_version.py` did not cover this case.  The consequence is that during nightly builds, if `__version__` already has a local version (e.g. `1.0.0+cu102`), executing `update_version.py` with a new local version like `1.0.0+cu116` will make the version something like `1.0.0+cu116+cu102`, which doesn't make sense.
This PR changes the regex pattern for replacement to include `+` and `_` so that the local version suffixes are properly replaced as well.