### PR TITLE
[Sparse] Use NotImplemented to let Python dispatch types

### DIFF
--- a/tests/pytorch/sparse/test_elementwise_op.py
+++ b/tests/pytorch/sparse/test_elementwise_op.py
@@ -1,3 +1,4 @@
+import operator
 import sys
 
 import backend as F
@@ -31,6 +32,11 @@ def test_add_coo(val_shape):
     assert torch.allclose(dense_sum, sum1)
     assert torch.allclose(dense_sum, sum2)
 
+    with pytest.raises(TypeError):
+        A + 2
+    with pytest.raises(TypeError):
+        2 + A
+
 
 @pytest.mark.parametrize("val_shape", [(), (2,)])
 def test_add_csr(val_shape):
@@ -52,6 +58,11 @@ def test_add_csr(val_shape):
     assert torch.allclose(dense_sum, sum1)
     assert torch.allclose(dense_sum, sum2)
 
+    with pytest.raises(TypeError):
+        A + 2
+    with pytest.raises(TypeError):
+        2 + A
+
 
 @pytest.mark.parametrize("val_shape", [(), (2,)])
 def test_add_csc(val_shape):
@@ -72,6 +83,11 @@ def test_add_csc(val_shape):
 
     assert torch.allclose(dense_sum, sum1)
     assert torch.allclose(dense_sum, sum2)
+
+    with pytest.raises(TypeError):
+        A + 2
+    with pytest.raises(TypeError):
+        2 + A
 
 
 @pytest.mark.parametrize("val_shape", [(), (2,)])
@@ -112,3 +128,19 @@ def test_add_sparse_diag(val_shape):
     assert torch.allclose(dense_sum, sum2)
     assert torch.allclose(dense_sum, sum3)
     assert torch.allclose(dense_sum, sum4)
+
+@pytest.mark.parametrize("op", ["mul", "truediv", "pow"])
+def test_error_op_sparse_diag(op):
+    ctx = F.ctx()
+    row = torch.tensor([1, 0, 2]).to(ctx)
+    col = torch.tensor([0, 3, 2]).to(ctx)
+    val = torch.randn(row.shape).to(ctx)
+    A = from_coo(row, col, val)
+
+    shape = (3, 4)
+    D = diag(torch.randn(row.shape[0]).to(ctx), shape=shape)
+
+    with pytest.raises(TypeError):
+        getattr(operator, op)(A, D)
+    with pytest.raises(TypeError):
+        getattr(operator, op)(D, A)

--- a/tests/pytorch/sparse/test_elementwise_op_diag.py
+++ b/tests/pytorch/sparse/test_elementwise_op_diag.py
@@ -60,3 +60,13 @@ def test_diag_op_scalar(v_scalar):
     D2 = power(D1, v_scalar)
     assert torch.allclose(D1.val**v_scalar, D2.val, rtol=1e-4, atol=1e-4)
     assert D1.shape == D2.shape
+
+    with pytest.raises(TypeError):
+        D1 + v_scalar
+    with pytest.raises(TypeError):
+        v_scalar + D1
+
+    with pytest.raises(TypeError):
+        D1 - v_scalar
+    with pytest.raises(TypeError):
+        v_scalar - D1

--- a/tests/pytorch/sparse/test_elementwise_op_sp.py
+++ b/tests/pytorch/sparse/test_elementwise_op_sp.py
@@ -62,3 +62,22 @@ def test_pow(val_shape):
     new_row, new_col = A_new.coo()
     assert torch.allclose(new_row, row)
     assert torch.allclose(new_col, col)
+
+@pytest.mark.parametrize("op", ["add", "sub"])
+@pytest.mark.parametrize("v_scalar", [2, 2.5])
+def test_error_op_scalar(op, v_scalar):
+    ctx = F.ctx()
+    row = torch.tensor([1, 0, 2]).to(ctx)
+    col = torch.tensor([0, 3, 2]).to(ctx)
+    val = torch.randn(len(row)).to(ctx)
+    A = from_coo(row, col, val, shape=(3, 4))
+
+    with pytest.raises(TypeError):
+        A + v_scalar
+    with pytest.raises(TypeError):
+        v_scalar + A
+
+    with pytest.raises(TypeError):
+        A - v_scalar
+    with pytest.raises(TypeError):
+        v_scalar - A


### PR DESCRIPTION
## Description
This is a Sub-PR of #5148 .

## Checklist
Please feel free to remove inapplicable items for your PR.
- [x] The PR title starts with [$CATEGORY] (such as [NN], [Model], [Doc], [Feature]])
- [x] I've leverage the [tools](https://docs.google.com/document/d/1iHyj7zlmygKSk5gBPsqIqL5ASPzJSPREaNT_QdsiYA4/edit) to beautify the python and c++ code.
- [x] The PR is complete and small, read the [Google eng practice (CL equals to PR)](https://google.github.io/eng-practices/review/developer/small-cls.html) to understand more about small PR. In DGL, we consider PRs with less than 200 lines of core code change are small (example, test and documentation could be exempted).
- [x] All changes have test coverage
- [x] Code is well-documented
- [x] To the best of my knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change
- [x] Related issue is referred in this PR
- [x] If the PR is for a new model/paper, I've updated the example index [here](../examples/README.md).