### PR TITLE
[Sparse] Use X to represent dense tensors in sddmm

### DIFF
--- a/python/dgl/sparse/sddmm.py
+++ b/python/dgl/sparse/sddmm.py
@@ -6,31 +6,29 @@ from .sparse_matrix import SparseMatrix
 __all__ = ["sddmm", "bsddmm"]
 
 
-def sddmm(
-    A: SparseMatrix, mat1: torch.Tensor, mat2: torch.Tensor
-) -> SparseMatrix:
+def sddmm(A: SparseMatrix, X1: torch.Tensor, X2: torch.Tensor) -> SparseMatrix:
     r"""Sampled-Dense-Dense Matrix Multiplication (SDDMM).
 
-    ``sddmm`` matrix-multiplies two dense matrices :attr:`mat1` and :attr:`mat2`
+    ``sddmm`` matrix-multiplies two dense matrices :attr:`X1` and :attr:`X2`
     , then elementwise-multiplies the result with sparse matrix :attr:`A` at the
     nonzero locations.
 
     Mathematically ``sddmm`` is formulated as:
 
     .. math::
-        out = (mat1 @ mat2) * A
+        out = (X1 @ X2) * A
 
-    In particular, :attr:`mat1` and :attr:`mat2` can be 1-D, then ``mat1 @
-    mat2`` becomes the out-product of the two vector (which results in a
+    In particular, :attr:`X1` and :attr:`X2` can be 1-D, then ``X1 @
+    X2`` becomes the out-product of the two vector (which results in a
     matrix).
 
     Parameters
     ----------
     A : SparseMatrix
         Sparse matrix of shape ``(M, N)``.
-    mat1 : Tensor
+    X1 : Tensor
         Dense matrix of shape ``(M, K)`` or ``(M,)``
-    mat2 : Tensor
+    X2 : Tensor
         Dense matrix of shape ``(K, N)`` or ``(N,)``
 
     Returns
@@ -45,32 +43,28 @@ def sddmm(
     >>> col = torch.tensor([2, 3, 3])
     >>> val = torch.arange(1, 4).float()
     >>> A = from_coo(row, col, val, (3, 4))
-    >>> mat1 = torch.randn(3, 5)
-    >>> mat2 = torch.randn(5, 4)
-    >>> dgl.sparse.sddmm(A, mat1, mat2)
+    >>> X1 = torch.randn(3, 5)
+    >>> X2 = torch.randn(5, 4)
+    >>> dgl.sparse.sddmm(A, X1, X2)
     SparseMatrix(indices=tensor([[1, 1, 2],
             [2, 3, 3]]),
     values=tensor([ 1.3097, -1.0977,  1.6953]),
     shape=(3, 4), nnz=3)
     """
-    return SparseMatrix(
-        torch.ops.dgl_sparse.sddmm(A.c_sparse_matrix, mat1, mat2)
-    )
+    return SparseMatrix(torch.ops.dgl_sparse.sddmm(A.c_sparse_matrix, X1, X2))
 
 
-def bsddmm(
-    A: SparseMatrix, mat1: torch.Tensor, mat2: torch.Tensor
-) -> SparseMatrix:
+def bsddmm(A: SparseMatrix, X1: torch.Tensor, X2: torch.Tensor) -> SparseMatrix:
     r"""Sampled-Dense-Dense Matrix Multiplication (SDDMM) by batches.
 
-    ``sddmm`` multiplies two dense matrices :attr:`mat1` and :attr:`mat2`
+    ``sddmm`` multiplies two dense matrices :attr:`X1` and :attr:`X2`
     at the nonzero locations of sparse matrix :attr:`A`. Values of :attr:`A`
     is not considered during the computation.
 
     Mathematically ``sddmm`` is formulated as:
 
     .. math::
-        out = (mat1 @ mat2) * A
+        out = (X1 @ X2) * A
 
     The batch dimension is the last dimension for input matrices. In particular,
     if the sparse matrix has scalar non-zero values, it will be broadcasted
@@ -80,9 +74,9 @@ def bsddmm(
     ----------
     A : SparseMatrix
         Sparse matrix of shape ``(M, N)`` or ``(M, N, B)``.
-    mat1 : Tensor
+    X1 : Tensor
         Dense matrix of shape ``(M, K, B)``
-    mat2 : Tensor
+    X2 : Tensor
         Dense matrix of shape ``(K, N, B)``
 
     Returns
@@ -97,9 +91,9 @@ def bsddmm(
     >>> col = torch.tensor([2, 3, 3])
     >>> val = torch.arange(1, 4).float()
     >>> A = from_coo(row, col, val, (3, 4))
-    >>> mat1 = torch.arange(0, 3 * 5 * 2).view(3, 5, 2).float()
-    >>> mat2 = torch.arange(0, 5 * 4 * 2).view(5, 4, 2).float()
-    >>> dgl.sparse.bsddmm(A, mat1, mat2)
+    >>> X1 = torch.arange(0, 3 * 5 * 2).view(3, 5, 2).float()
+    >>> X2 = torch.arange(0, 5 * 4 * 2).view(5, 4, 2).float()
+    >>> dgl.sparse.bsddmm(A, X1, X2)
     SparseMatrix(indices=tensor([[1, 1, 2],
             [2, 3, 3]]),
     values=tensor([[1560., 1735.],
@@ -107,4 +101,4 @@ def bsddmm(
             [8400., 9105.]]),
     shape=(3, 4), nnz=3)
     """
-    return sddmm(A, mat1, mat2)
+    return sddmm(A, X1, X2)

--- a/python/dgl/sparse/sddmm.py
+++ b/python/dgl/sparse/sddmm.py
@@ -6,6 +6,7 @@ from .sparse_matrix import SparseMatrix
 __all__ = ["sddmm", "bsddmm"]
 
 
+# pylint: disable=invalid-name
 def sddmm(A: SparseMatrix, X1: torch.Tensor, X2: torch.Tensor) -> SparseMatrix:
     r"""Sampled-Dense-Dense Matrix Multiplication (SDDMM).
 
@@ -53,6 +54,7 @@ def sddmm(A: SparseMatrix, X1: torch.Tensor, X2: torch.Tensor) -> SparseMatrix:
     return SparseMatrix(torch.ops.dgl_sparse.sddmm(A.c_sparse_matrix, X1, X2))
 
 
+# pylint: disable=invalid-name
 def bsddmm(A: SparseMatrix, X1: torch.Tensor, X2: torch.Tensor) -> SparseMatrix:
     r"""Sampled-Dense-Dense Matrix Multiplication (SDDMM) by batches.
 

--- a/python/dgl/sparse/sddmm.py
+++ b/python/dgl/sparse/sddmm.py
@@ -9,8 +9,8 @@ __all__ = ["sddmm", "bsddmm"]
 def sddmm(A: SparseMatrix, X1: torch.Tensor, X2: torch.Tensor) -> SparseMatrix:
     r"""Sampled-Dense-Dense Matrix Multiplication (SDDMM).
 
-    ``sddmm`` matrix-multiplies two dense matrices :attr:`X1` and :attr:`X2`
-    , then elementwise-multiplies the result with sparse matrix :attr:`A` at the
+    ``sddmm`` matrix-multiplies two dense matrices :attr:`X1` and :attr:`X2`,
+    then elementwise-multiplies the result with sparse matrix :attr:`A` at the
     nonzero locations.
 
     Mathematically ``sddmm`` is formulated as:
@@ -18,9 +18,8 @@ def sddmm(A: SparseMatrix, X1: torch.Tensor, X2: torch.Tensor) -> SparseMatrix:
     .. math::
         out = (X1 @ X2) * A
 
-    In particular, :attr:`X1` and :attr:`X2` can be 1-D, then ``X1 @
-    X2`` becomes the out-product of the two vector (which results in a
-    matrix).
+    In particular, :attr:`X1` and :attr:`X2` can be 1-D, then ``X1 @ X2``
+    becomes the out-product of the two vector (which results in a matrix).
 
     Parameters
     ----------
@@ -57,9 +56,9 @@ def sddmm(A: SparseMatrix, X1: torch.Tensor, X2: torch.Tensor) -> SparseMatrix:
 def bsddmm(A: SparseMatrix, X1: torch.Tensor, X2: torch.Tensor) -> SparseMatrix:
     r"""Sampled-Dense-Dense Matrix Multiplication (SDDMM) by batches.
 
-    ``sddmm`` multiplies two dense matrices :attr:`X1` and :attr:`X2`
-    at the nonzero locations of sparse matrix :attr:`A`. Values of :attr:`A`
-    is not considered during the computation.
+    ``sddmm`` multiplies two dense matrices :attr:`X1` and :attr:`X2` at the
+    nonzero locations of sparse matrix :attr:`A`. Values of :attr:`A` is not
+    considered during the computation.
 
     Mathematically ``sddmm`` is formulated as:
 


### PR DESCRIPTION
## Description
<!-- Brief description. Refer to the related issues if existed.
It'll be great if relevant reviewers can be assigned as well.-->

## Checklist
Please feel free to remove inapplicable items for your PR.
- [ ] The PR title starts with [$CATEGORY] (such as [NN], [Model], [Doc], [Feature]])
- [ ] I've leverage the [tools](https://docs.google.com/document/d/1iHyj7zlmygKSk5gBPsqIqL5ASPzJSPREaNT_QdsiYA4/edit) to beautify the python and c++ code.
- [ ] The PR is complete and small, read the [Google eng practice (CL equals to PR)](https://google.github.io/eng-practices/review/developer/small-cls.html) to understand more about small PR. In DGL, we consider PRs with less than 200 lines of core code change are small (example, test and documentation could be exempted).
- [ ] All changes have test coverage
- [ ] Code is well-documented
- [ ] To the best of my knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change
- [ ] Related issue is referred in this PR
- [ ] If the PR is for a new model/paper, I've updated the example index [here](../examples/README.md).

## Changes
<!-- You could use following template
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)
-->
