### PR TITLE
[Sparse] Only support scalar or vector values in SparseMatrix creators

### DIFF
--- a/python/dgl/sparse/diag_matrix.py
+++ b/python/dgl/sparse/diag_matrix.py
@@ -366,6 +366,9 @@ def diag(
     >>> mat.nnz
     5
     """
+    assert (
+        val.dim() <= 2
+    ), "The values of a DiagMatrix can only be scalars or vectors."
     # NOTE(Mufei): this may not be needed if DiagMatrix is simple enough
     return DiagMatrix(val, shape)
 

--- a/python/dgl/sparse/sparse_matrix.py
+++ b/python/dgl/sparse/sparse_matrix.py
@@ -697,7 +697,6 @@ def val_like(mat: SparseMatrix, val: torch.Tensor) -> SparseMatrix:
     values=tensor([2, 2, 2]),
     shape=(3, 5), nnz=3)
     """
-
     assert (
         val.dim() <= 2
     ), "The values of a SparseMatrix can only be scalars or vectors."

--- a/python/dgl/sparse/sparse_matrix.py
+++ b/python/dgl/sparse/sparse_matrix.py
@@ -482,6 +482,9 @@ def from_coo(
         shape = (torch.max(row).item() + 1, torch.max(col).item() + 1)
     if val is None:
         val = torch.ones(row.shape[0]).to(row.device)
+    assert (
+        val.dim() <= 2
+    ), "The values of a SparseMatrix can only be scalars or vectors."
 
     return SparseMatrix(torch.ops.dgl_sparse.from_coo(row, col, val, shape))
 
@@ -564,6 +567,10 @@ def from_csr(
         shape = (indptr.shape[0] - 1, torch.max(indices) + 1)
     if val is None:
         val = torch.ones(indices.shape[0]).to(indptr.device)
+
+    assert (
+        val.dim() <= 2
+    ), "The values of a SparseMatrix can only be scalars or vectors."
 
     return SparseMatrix(
         torch.ops.dgl_sparse.from_csr(indptr, indices, val, shape)
@@ -649,6 +656,10 @@ def from_csc(
     if val is None:
         val = torch.ones(indices.shape[0]).to(indptr.device)
 
+    assert (
+        val.dim() <= 2
+    ), "The values of a SparseMatrix can only be scalars or vectors."
+
     return SparseMatrix(
         torch.ops.dgl_sparse.from_csc(indptr, indices, val, shape)
     )
@@ -686,6 +697,11 @@ def val_like(mat: SparseMatrix, val: torch.Tensor) -> SparseMatrix:
     values=tensor([2, 2, 2]),
     shape=(3, 5), nnz=3)
     """
+
+    assert (
+        val.dim() <= 2
+    ), "The values of a SparseMatrix can only be scalars or vectors."
+
     return SparseMatrix(torch.ops.dgl_sparse.val_like(mat.c_sparse_matrix, val))
 
 

--- a/python/dgl/sparse/sparse_matrix.py
+++ b/python/dgl/sparse/sparse_matrix.py
@@ -482,6 +482,7 @@ def from_coo(
         shape = (torch.max(row).item() + 1, torch.max(col).item() + 1)
     if val is None:
         val = torch.ones(row.shape[0]).to(row.device)
+
     assert (
         val.dim() <= 2
     ), "The values of a SparseMatrix can only be scalars or vectors."


### PR DESCRIPTION
## Description
<!-- Brief description. Refer to the related issues if existed.
It'll be great if relevant reviewers can be assigned as well.-->

## Checklist
Please feel free to remove inapplicable items for your PR.
- [ ] The PR title starts with [$CATEGORY] (such as [NN], [Model], [Doc], [Feature]])
- [ ] I've leverage the [tools](https://docs.google.com/document/d/1iHyj7zlmygKSk5gBPsqIqL5ASPzJSPREaNT_QdsiYA4/edit) to beautify the python and c++ code.
- [ ] The PR is complete and small, read the [Google eng practice (CL equals to PR)](https://google.github.io/eng-practices/review/developer/small-cls.html) to understand more about small PR. In DGL, we consider PRs with less than 200 lines of core code change are small (example, test and documentation could be exempted).
- [ ] All changes have test coverage
- [ ] Code is well-documented
- [ ] To the best of my knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change
- [ ] Related issue is referred in this PR
- [ ] If the PR is for a new model/paper, I've updated the example index [here](../examples/README.md).

## Changes
<!-- You could use following template
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)
-->
