### PR TITLE
[Doc] Labor sampling improvement

### DIFF
--- a/python/dgl/dataloading/labor_sampler.py
+++ b/python/dgl/dataloading/labor_sampler.py
@@ -53,7 +53,9 @@ class LaborSampler(BlockSampler):
     prob : str, optional
         If given, the probability of each neighbor being sampled is proportional
         to the edge feature value with the given name in ``g.edata``.
-        The feature must be a scalar on each edge.
+        The feature must be a scalar on each edge. In this case, the returned
+        blocks edata include ``'edge_weights'`` that needs to be used in the
+        message passing operation.
     importance_sampling : int, default ``0``
         Whether to use importance sampling or uniform sampling, use of negative
         values optimizes importance sampling probabilities until convergence

--- a/python/dgl/dataloading/labor_sampler.py
+++ b/python/dgl/dataloading/labor_sampler.py
@@ -58,7 +58,9 @@ class LaborSampler(BlockSampler):
         Whether to use importance sampling or uniform sampling, use of negative
         values optimizes importance sampling probabilities until convergence
         while use of positive values runs optimization steps that many times.
-        If the value is i, then LABOR-i variant is used.
+        If the value is i, then LABOR-i variant is used. When used with a
+        nonzero parameter, the returned blocks edata include ``'edge_weights'``
+        that needs to be used in the message passing operation.
     layer_dependency : bool, default ``False``
         Specifies whether different layers should use same random variates.
         Results into a reduction in the number of vertices sampled, but may


### PR DESCRIPTION
## Description
When importance sampling option is used, the returned blocks include edge weights that need to be used during the message passing operation. So, I am including this in the documentation.

## Checklist
Please feel free to remove inapplicable items for your PR.
- [x] The PR title starts with [$CATEGORY] (such as [NN], [Model], [Doc], [Feature]])
- [x] The PR is complete and small, read the [Google eng practice (CL equals to PR)](https://google.github.io/eng-practices/review/developer/small-cls.html) to understand more about small PR. In DGL, we consider PRs with less than 200 lines of core code change are small (example, test and documentation could be exempted).
