### PR TITLE
[Feature] Run deepwalk examples with ogbn data

### DIFF
--- a/examples/pytorch/ogb/deepwalk/deepwalk.py
+++ b/examples/pytorch/ogb/deepwalk/deepwalk.py
@@ -3,6 +3,8 @@ import os
 import random
 import time
 
+import dgl
+
 import numpy as np
 import torch
 import torch.multiprocessing as mp
@@ -10,8 +12,6 @@ from model import SkipGramModel
 from reading_data import DeepwalkDataset
 from torch.utils.data import DataLoader
 from utils import shuffle_walks, sum_up_params
-
-import dgl
 
 
 class DeepwalkTrainer:
@@ -31,7 +31,8 @@ class DeepwalkTrainer:
             ogbl_name=args.ogbl_name,
             load_from_ogbl=args.load_from_ogbl,
             ogbn_name=args.ogbn_name,
-            load_from_ogbn=args.load_from_ogbn)
+            load_from_ogbn=args.load_from_ogbn,
+        )
         self.emb_size = self.dataset.G.number_of_nodes()
         self.emb_model = None
 
@@ -311,7 +312,7 @@ if __name__ == "__main__":
         action="store_true",
         help="whether load dataset from ogbn",
     )
-    
+
     # output files
     parser.add_argument(
         "--save_in_txt",

--- a/examples/pytorch/ogb/deepwalk/deepwalk.py
+++ b/examples/pytorch/ogb/deepwalk/deepwalk.py
@@ -30,7 +30,8 @@ class DeepwalkTrainer:
             fast_neg=args.fast_neg,
             ogbl_name=args.ogbl_name,
             load_from_ogbl=args.load_from_ogbl,
-        )
+            ogbn_name=args.ogbn_name,
+            load_from_ogbn=args.load_from_ogbn)
         self.emb_size = self.dataset.G.number_of_nodes()
         self.emb_model = None
 
@@ -301,6 +302,16 @@ if __name__ == "__main__":
         help="whether load dataset from ogbl",
     )
 
+    parser.add_argument(
+        "--ogbn_name", type=str, help="name of ogbn dataset, e.g. ogbn-proteins"
+    )
+    parser.add_argument(
+        "--load_from_ogbn",
+        default=False,
+        action="store_true",
+        help="whether load dataset from ogbn",
+    )
+    
     # output files
     parser.add_argument(
         "--save_in_txt",

--- a/examples/pytorch/ogb/deepwalk/load_dataset.py
+++ b/examples/pytorch/ogb/deepwalk/load_dataset.py
@@ -6,8 +6,6 @@ import time
 from ogb.linkproppred import DglLinkPropPredDataset
 from ogb.nodeproppred import DglNodePropPredDataset
 
-import dgl
-
 
 def load_from_ogbl_with_name(name):
     choices = ["ogbl-collab", "ogbl-ddi", "ogbl-ppa", "ogbl-citation2"]

--- a/examples/pytorch/ogb/deepwalk/load_dataset.py
+++ b/examples/pytorch/ogb/deepwalk/load_dataset.py
@@ -7,10 +7,22 @@ from ogb.linkproppred import DglLinkPropPredDataset
 
 
 def load_from_ogbl_with_name(name):
-    choices = ["ogbl-collab", "ogbl-ddi", "ogbl-ppa", "ogbl-citation"]
+    choices = ["ogbl-collab", "ogbl-ddi", "ogbl-ppa", "ogbl-citation2"]
     assert name in choices, "name must be selected from " + str(choices)
     dataset = DglLinkPropPredDataset(name)
     return dataset[0]
+
+
+def load_from_ogbn_with_name(name):
+    choices = [
+        "ogbn-products",
+        "ogbn-proteins",
+        "ogbn-arxiv",
+        "ogbn-papers100M",
+    ]
+    assert name in choices, "name must be selected from " + str(choices)
+    dataset, label = DglNodePropPredDataset(name)[0]
+    return dataset
 
 
 if __name__ == "__main__":
@@ -18,7 +30,16 @@ if __name__ == "__main__":
     parser.add_argument(
         "--name",
         type=str,
-        choices=["ogbl-collab", "ogbl-ddi", "ogbl-ppa", "ogbl-citation"],
+        choices=[
+            "ogbl-collab",
+            "ogbl-ddi",
+            "ogbl-ppa",
+            "ogbl-citation",
+            "ogbn-products",
+            "ogbn-proteins",
+            "ogbn-arxiv",
+            "ogbn-papers100M",
+        ],
         default="ogbl-collab",
         help="name of datasets by ogb",
     )
@@ -26,7 +47,10 @@ if __name__ == "__main__":
 
     print("loading graph... it might take some time")
     name = args.name
-    g = load_from_ogbl_with_name(name=name)
+    if name.startswith("ogbl"):
+        g = load_from_ogbl_with_name(name=name)
+    else:
+        g = load_from_ogbn_with_name(name=name)
 
     try:
         w = g.edata["edge_weight"]

--- a/examples/pytorch/ogb/deepwalk/load_dataset.py
+++ b/examples/pytorch/ogb/deepwalk/load_dataset.py
@@ -4,6 +4,9 @@ import argparse
 import time
 
 from ogb.linkproppred import DglLinkPropPredDataset
+from ogb.nodeproppred import DglNodePropPredDataset
+
+import dgl
 
 
 def load_from_ogbl_with_name(name):

--- a/examples/pytorch/ogb/deepwalk/reading_data.py
+++ b/examples/pytorch/ogb/deepwalk/reading_data.py
@@ -148,6 +148,8 @@ class DeepwalkDataset:
         fast_neg=True,
         ogbl_name="",
         load_from_ogbl=False,
+        ogbn_name="",
+        load_from_ogbn=False,
     ):
         """This class has the following functions:
         1. Transform the txt network file into DGL graph;
@@ -180,6 +182,14 @@ class DeepwalkDataset:
             from load_dataset import load_from_ogbl_with_name
 
             self.G = load_from_ogbl_with_name(ogbl_name)
+            self.G = make_undirected(self.G)
+        elif load_from_ogbn:
+            assert (
+                len(gpus) == 1
+            ), "ogb.linkproppred is not compatible with multi-gpu training."
+            from load_dataset import load_from_ogbn_with_name
+
+            self.G = load_from_ogbn_with_name(ogbn_name)
             self.G = make_undirected(self.G)
         else:
             self.net, self.node2id, self.id2node, self.sm = ReadTxtNet(net_file)

--- a/examples/pytorch/ogb/deepwalk/reading_data.py
+++ b/examples/pytorch/ogb/deepwalk/reading_data.py
@@ -3,19 +3,19 @@ import pickle
 import random
 import time
 
+import dgl
+
 import numpy as np
 import scipy.sparse as sp
 import torch
-from torch.utils.data import DataLoader
-from utils import shuffle_walks
-
-import dgl
 from dgl.data.utils import (
     _get_dgl_url,
     download,
     extract_archive,
     get_download_dir,
 )
+from torch.utils.data import DataLoader
+from utils import shuffle_walks
 
 
 def ReadTxtNet(file_path="", undirected=True):


### PR DESCRIPTION
## Description
The [deepwalk example](https://github.com/dmlc/dgl/tree/master/examples/pytorch/ogb/deepwalk) currently only supports [ogbl dataset](https://ogb.stanford.edu/docs/nodeprop/). Actually other algorithms like  [line](https://github.com/dmlc/dgl/tree/master/examples/pytorch/ogb/deepwalk) can run [ogbn dataset](https://ogb.stanford.edu/docs/nodeprop/). So to compare performance of different algorithms against ogb dataset, the deepwalk example should support ogbn dataset. See #5238.

## Checklist
Please feel free to remove inapplicable items for your PR.
- [X] The PR title starts with [$CATEGORY] (such as [NN], [Model], [Doc], [Feature]])
- [X] I've leverage the [tools](https://docs.google.com/document/d/1iHyj7zlmygKSk5gBPsqIqL5ASPzJSPREaNT_QdsiYA4/edit) to beautify the python and c++ code.
- [X] The PR is complete and small, read the [Google eng practice (CL equals to PR)](https://google.github.io/eng-practices/review/developer/small-cls.html) to understand more about small PR. In DGL, we consider PRs with less than 200 lines of core code change are small (example, test and documentation could be exempted).
- [X] All changes have test coverage
- [X] Code is well-documented
- [X] To the best of my knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change
- [X] Related issue is referred in this PR
- [ ] If the PR is for a new model/paper, I've updated the example index [here](../examples/README.md).

## Changes
- Add ogbn dataset following the style of ogbl dataset which is already supported in this example.