### PR TITLE
[Build] Fix build for multiple pytorch versions

### DIFF
--- a/dgl_sparse/build.sh
+++ b/dgl_sparse/build.sh
@@ -23,8 +23,12 @@ if [ $# -eq 0 ]; then
 	cp -v $CPSOURCE $BINDIR/dgl_sparse
 else
 	for PYTHON_INTERP in $@; do
-		$CMAKE_COMMAND $CMAKE_FLAGS -DPYTHON_INTERP=$PYTHON_INTERP ..
+		TORCH_VER=$($PYTHON_INTERP -c 'import torch; print(torch.__version__.split("+")[0])')
+		mkdir -p $TORCH_VER
+		cd $TORCH_VER
+		$CMAKE_COMMAND $CMAKE_FLAGS -DPYTHON_INTERP=$PYTHON_INTERP ../..
 		make -j
 		cp -v $CPSOURCE $BINDIR/dgl_sparse
+		cd ..
 	done
 fi

--- a/tensoradapter/pytorch/build.sh
+++ b/tensoradapter/pytorch/build.sh
@@ -20,8 +20,12 @@ if [ $# -eq 0 ]; then
 	cp -v $CPSOURCE $BINDIR/tensoradapter/pytorch
 else
 	for PYTHON_INTERP in $@; do
-		$CMAKE_COMMAND $CMAKE_FLAGS -DPYTHON_INTERP=$PYTHON_INTERP ..
+		TORCH_VER=$($PYTHON_INTERP -c 'import torch; print(torch.__version__.split("+")[0])')
+		mkdir -p $TORCH_VER
+		cd $TORCH_VER
+		$CMAKE_COMMAND $CMAKE_FLAGS -DPYTHON_INTERP=$PYTHON_INTERP ../..
 		make -j
 		cp -v $CPSOURCE $BINDIR/tensoradapter/pytorch
+		cd ..
 	done
 fi


### PR DESCRIPTION
## Description
Previously I approved that `rm -rf build` in the build scripts of `tensoradapter` and `dgl_sparse` is unnecessary.  This is actually wrong since during release the `build` directory is reused multiple times for different PyTorch versions.

This PR makes a separate subdirectory for every PyTorch version and build the binaries there, to avoid rebuilding the libraries from scratch and allow building multiple versions at the same time.