### PR TITLE
[Feature] Add `state_dict`, `load_state_dict`, `param_groups` to `dgl.optim.SparseGradOptimizer`

### DIFF
--- a/python/dgl/nn/pytorch/sparse_emb.py
+++ b/python/dgl/nn/pytorch/sparse_emb.py
@@ -349,7 +349,12 @@ class NodeEmbedding:  # NodeEmbedding
             th.distributed.barrier()
 
     def _all_get_tensor(self, shared_name, tensor, shape):
-        """A helper function to get model-parallel tensors."""
+        """A helper function to get model-parallel tensors.
+
+        This method must and only need to be called in multi-GPU DDP training.
+        For now, it's only used in ``all_get_embedding`` and
+        ``_all_get_optm_state``.
+        """
         # create a shared memory tensor
         if self._rank == 0:
             # root process creates shared memory
@@ -467,7 +472,6 @@ class NodeEmbedding:  # NodeEmbedding
             # stored in CPU memory
             if self._rank <= 0:
                 for state, new_state in zip(self._optm_state, states):
-                    print(state.shape, new_state.shape)
                     state[:] = F.copy_to(
                         new_state, ctx=F.context(self._tensor)
                     )[:]

--- a/python/dgl/nn/pytorch/sparse_emb.py
+++ b/python/dgl/nn/pytorch/sparse_emb.py
@@ -409,11 +409,11 @@ class NodeEmbedding:  # NodeEmbedding
         if self._partition:
             if self._world_size == 0:
                 # non-multiprocessing
-                return (
+                return tuple(
                     state.to(th.device("cpu")) for state in self._optm_state
                 )
             else:
-                return (
+                return tuple(
                     self._all_get_tensor(
                         f"state_gather_{i}",
                         state,
@@ -433,7 +433,7 @@ class NodeEmbedding:  # NodeEmbedding
                 ),
                 F.context(states[0]),
             )
-            self._optm_state = (
+            self._optm_state = tuple(
                 F.copy_to(
                     F.gather_row(state, idxs), ctx=F.context(self._tensor)
                 )
@@ -442,7 +442,7 @@ class NodeEmbedding:  # NodeEmbedding
         else:
             # stored in CPU memory
             if self._rank <= 0:
-                self._optm_state = (
+                self._optm_state = tuple(
                     F.copy_to(state, ctx=F.context(self._tensor))
                     for state in states
                 )

--- a/python/dgl/nn/pytorch/sparse_emb.py
+++ b/python/dgl/nn/pytorch/sparse_emb.py
@@ -406,7 +406,7 @@ class NodeEmbedding:  # NodeEmbedding
             # already stored in CPU memory
             return self._tensor
 
-    def all_get_optm_state(self):
+    def _all_get_optm_state(self):
         """Return a copy of the whole optimizer states stored in CPU memory.
         If this is a multi-processing instance, the states will be returned in
         shared memory. If the embedding is currently stored on multiple GPUs,
@@ -439,7 +439,7 @@ class NodeEmbedding:  # NodeEmbedding
             # already stored in CPU memory
             return self._optm_state
 
-    def all_set_optm_state(self, states):
+    def _all_set_optm_state(self, states):
         """Set the optimizer states of the embedding. This method must be
         called by all processes sharing the embedding with identical
         :attr:`states`.

--- a/python/dgl/nn/pytorch/sparse_emb.py
+++ b/python/dgl/nn/pytorch/sparse_emb.py
@@ -460,7 +460,7 @@ class NodeEmbedding:  # NodeEmbedding
         if self._partition:
             idxs = F.copy_to(
                 self._partition.get_local_indices(
-                    self._comm.rank(), ctx=F.context(self._tensor)
+                    max(self._rank, 0), ctx=F.context(self._tensor)
                 ),
                 F.context(states[0]),
             )

--- a/python/dgl/nn/pytorch/sparse_emb.py
+++ b/python/dgl/nn/pytorch/sparse_emb.py
@@ -459,18 +459,17 @@ class NodeEmbedding:  # NodeEmbedding
                 ),
                 F.context(states[0]),
             )
-            self._optm_state = tuple(
-                F.copy_to(
-                    F.gather_row(state, idxs), ctx=F.context(self._tensor)
-                )
-                for state in states
-            )
+            for state, new_state in zip(self._optm_state, states):
+                state[:] = F.copy_to(
+                    F.gather_row(new_state, idxs), ctx=F.context(self._tensor)
+                )[:]
         else:
             # stored in CPU memory
             if self._rank <= 0:
-                self._optm_state = tuple(
-                    F.copy_to(state, ctx=F.context(self._tensor))
-                    for state in states
-                )
+                for state, new_state in zip(self._optm_state, states):
+                    print(state.shape, new_state.shape)
+                    state[:] = F.copy_to(
+                        new_state, ctx=F.context(self._tensor)
+                    )[:]
         if th.distributed.is_initialized():
             th.distributed.barrier()

--- a/python/dgl/nn/pytorch/sparse_emb.py
+++ b/python/dgl/nn/pytorch/sparse_emb.py
@@ -429,7 +429,7 @@ class NodeEmbedding:  # NodeEmbedding
             else:
                 return tuple(
                     self._all_get_tensor(
-                        f"state_gather_{i}",
+                        f"state_gather_{self._name}_{i}",
                         state,
                         (self._num_embeddings, *state.shape[1:]),
                     )

--- a/python/dgl/optim/pytorch/sparse_optim.py
+++ b/python/dgl/optim/pytorch/sparse_optim.py
@@ -466,7 +466,7 @@ class SparseGradOptimizer(abc.ABC):
         dictionary of optimizer states
             The optimizer states stored in CPU memory.
         """
-        return {emb.name: emb.all_get_optm_state() for emb in self._params}
+        return {emb.name: emb._all_get_optm_state() for emb in self._params}
 
     def load_state_dict(self, state_dict, **kwargs):
         """Load the optimizer states. This method must be called by all
@@ -482,7 +482,7 @@ class SparseGradOptimizer(abc.ABC):
             The global states to pull values from.
         """
         for emb in self._params:
-            emb.all_set_optm_state(state_dict[emb.name])
+            emb._all_set_optm_state(state_dict[emb.name])
 
 
 class SparseAdagrad(SparseGradOptimizer):

--- a/python/dgl/optim/pytorch/sparse_optim.py
+++ b/python/dgl/optim/pytorch/sparse_optim.py
@@ -538,7 +538,7 @@ class SparseAdagrad(SparseGradOptimizer):
                     dtype=th.float32,
                     device=emb.weight.device,
                 ).zero_()
-            emb.set_optm_state(state)
+            emb.set_optm_state((state,))
 
     def update(self, idx, grad, emb):
         """Update embeddings in a sparse manner
@@ -568,7 +568,7 @@ class SparseAdagrad(SparseGradOptimizer):
         grad_values = grad_values / cnt.unsqueeze(1)
 
         grad_sum = grad_values * grad_values
-        state = emb.optm_state
+        state, = emb.optm_state
         state_dev = state.device
         state_idx = grad_indices.to(state_dev)
         grad_state = state[state_idx].to(grad.device)

--- a/python/dgl/optim/pytorch/sparse_optim.py
+++ b/python/dgl/optim/pytorch/sparse_optim.py
@@ -453,11 +453,11 @@ class SparseGradOptimizer(abc.ABC):
         self._clean_grad = True
 
     def state_dict(self, **kwargs):
-        return {emb.name: emb.all_get_optim_state() for emb in self._params}
+        return {emb.name: emb.all_get_optm_state() for emb in self._params}
 
     def load_state_dict(self, state_dict, **kwargs):
         for emb in self._params:
-            emb.all_set_optim_state(state_dict[emb.name])
+            emb.all_set_optm_state(state_dict[emb.name])
 
 class SparseAdagrad(SparseGradOptimizer):
     r"""Node embedding optimizer using the Adagrad algorithm.

--- a/python/dgl/optim/pytorch/sparse_optim.py
+++ b/python/dgl/optim/pytorch/sparse_optim.py
@@ -452,7 +452,7 @@ class SparseGradOptimizer(abc.ABC):
         """clean grad cache"""
         self._clean_grad = True
 
-    def state_dict(self, **kwargs):
+    def state_dict(self, **kwargs):  # pylint: disable=unused-argument
         """Return a copy of the whole optimizer states stored in CPU memory.
         If this is a multi-processing instance, the states will be returned in
         shared memory. If the underlying embedding is currently stored on
@@ -468,7 +468,9 @@ class SparseGradOptimizer(abc.ABC):
         """
         return {emb.name: emb._all_get_optm_state() for emb in self._params}
 
-    def load_state_dict(self, state_dict, **kwargs):
+    def load_state_dict(
+        self, state_dict, **kwargs
+    ):  # pylint: disable=unused-argument
         """Load the optimizer states. This method must be called by all
         processes sharing the underlying embedding with identical
         :attr:`state_dict`.

--- a/python/dgl/optim/pytorch/sparse_optim.py
+++ b/python/dgl/optim/pytorch/sparse_optim.py
@@ -452,6 +452,12 @@ class SparseGradOptimizer(abc.ABC):
         """clean grad cache"""
         self._clean_grad = True
 
+    def state_dict(self, **kwargs):
+        return {emb.name: emb.all_get_optim_state() for emb in self._params}
+
+    def load_state_dict(self, state_dict, **kwargs):
+        for emb in self._params:
+            emb.all_set_optim_state(state_dict[emb.name])
 
 class SparseAdagrad(SparseGradOptimizer):
     r"""Node embedding optimizer using the Adagrad algorithm.

--- a/tests/python/pytorch/nn/test_sparse_emb.py
+++ b/tests/python/pytorch/nn/test_sparse_emb.py
@@ -33,6 +33,7 @@ def check_all_set_all_get_optm_state(
     emb_dim = state_mem.shape[1]
     dgl_emb = NodeEmbedding(num_embs, emb_dim, "test", device=device)
     optm = SparseAdam(params=[dgl_emb], lr=0.01)
+    optm.setup(optm._params)
 
     dgl_emb._all_set_optm_state((state_step, state_mem, state_power))
 
@@ -99,7 +100,7 @@ def test_multiprocess_sparse_emb_get_set_optm_state(num_workers):
     worker_list = []
 
     num_embs, emb_dim = 1000, 8
-    state_step = th.randint(1000, (num_embs, emb_dim))
+    state_step = th.randint(1000, (num_embs,))
     state_mem = th.rand((num_embs, emb_dim))
     state_power = th.rand((num_embs, emb_dim))
 

--- a/tests/python/pytorch/nn/test_sparse_emb.py
+++ b/tests/python/pytorch/nn/test_sparse_emb.py
@@ -33,7 +33,6 @@ def check_all_set_all_get_optm_state(
     emb_dim = state_mem.shape[1]
     dgl_emb = NodeEmbedding(num_embs, emb_dim, "test", device=device)
     optm = SparseAdam(params=[dgl_emb], lr=0.01)
-    optm.setup(optm._params)
 
     dgl_emb._all_set_optm_state((state_step, state_mem, state_power))
 
@@ -125,10 +124,10 @@ def test_multiprocess_sparse_emb_get_set_optm_state(num_workers):
 
 
 if __name__ == "__main__":
-    test_multiprocess_sparse_emb_get_set(1)
-    test_multiprocess_sparse_emb_get_set(2)
-    test_multiprocess_sparse_emb_get_set(3)
+    # test_multiprocess_sparse_emb_get_set(1)
+    # test_multiprocess_sparse_emb_get_set(2)
+    # test_multiprocess_sparse_emb_get_set(3)
 
     test_multiprocess_sparse_emb_get_set_optm_state(1)
-    test_multiprocess_sparse_emb_get_set_optm_state(2)
-    test_multiprocess_sparse_emb_get_set_optm_state(3)
+    # test_multiprocess_sparse_emb_get_set_optm_state(2)
+    # test_multiprocess_sparse_emb_get_set_optm_state(3)

--- a/tests/python/pytorch/nn/test_sparse_emb.py
+++ b/tests/python/pytorch/nn/test_sparse_emb.py
@@ -7,6 +7,7 @@ import pytest
 import torch as th
 
 from dgl.nn import NodeEmbedding
+from dgl.optim import SparseAdam
 
 
 def initializer(emb):
@@ -15,7 +16,7 @@ def initializer(emb):
     return emb
 
 
-def check_all_set_all_get_func(device, init_emb):
+def check_all_set_all_get_emb(device, init_emb):
     num_embs = init_emb.shape[0]
     emb_dim = init_emb.shape[1]
     dgl_emb = NodeEmbedding(num_embs, emb_dim, "test", device=device)
@@ -23,6 +24,23 @@ def check_all_set_all_get_func(device, init_emb):
 
     out_emb = dgl_emb.all_get_embedding()
     assert F.allclose(init_emb, out_emb)
+
+
+def check_all_set_all_get_optm_state(
+    device, state_step, state_mem, state_power
+):
+    num_embs = state_mem.shape[0]
+    emb_dim = state_mem.shape[1]
+    dgl_emb = NodeEmbedding(num_embs, emb_dim, "test", device=device)
+    optm = SparseAdam(params=[dgl_emb], lr=0.01)
+
+    dgl_emb.all_set_optm_state((state_step, state_mem, state_power))
+
+    out_step, out_mem, out_power = dgl_emb.all_get_optm_state()
+
+    assert F.allclose(state_step, out_step)
+    assert F.allclose(state_mem, out_mem)
+    assert F.allclose(state_power, out_power)
 
 
 def start_sparse_worker(rank, world_size, test, args):
@@ -44,6 +62,7 @@ def start_sparse_worker(rank, world_size, test, args):
 
     test(device, *args)
     th.distributed.barrier()
+    th.distributed.destroy_process_group()
 
 
 @unittest.skipIf(os.name == "nt", reason="Do not support windows yet")
@@ -60,7 +79,40 @@ def test_multiprocess_sparse_emb_get_set(num_workers):
     for i in range(num_workers):
         p = ctx.Process(
             target=start_sparse_worker,
-            args=(i, num_workers, check_all_set_all_get_func, (init_emb,)),
+            args=(i, num_workers, check_all_set_all_get_emb, (init_emb,)),
+        )
+        p.start()
+        worker_list.append(p)
+
+    for p in worker_list:
+        p.join()
+    for p in worker_list:
+        assert p.exitcode == 0
+
+
+@unittest.skipIf(os.name == "nt", reason="Do not support windows yet")
+@pytest.mark.parametrize("num_workers", [1, 2, 3])
+def test_multiprocess_sparse_emb_get_set_optm_state(num_workers):
+    if F.ctx().type == "cuda" and th.cuda.device_count() < num_workers:
+        pytest.skip("Not enough GPUs to run test.")
+
+    worker_list = []
+
+    num_embs, emb_dim = 1000, 8
+    state_step = th.randint(1000, (num_embs, emb_dim))
+    state_mem = th.rand((num_embs, emb_dim))
+    state_power = th.rand((num_embs, emb_dim))
+
+    ctx = mp.get_context("spawn")
+    for i in range(num_workers):
+        p = ctx.Process(
+            target=start_sparse_worker,
+            args=(
+                i,
+                num_workers,
+                check_all_set_all_get_optm_state,
+                (state_step, state_mem, state_power),
+            ),
         )
         p.start()
         worker_list.append(p)
@@ -72,6 +124,10 @@ def test_multiprocess_sparse_emb_get_set(num_workers):
 
 
 if __name__ == "__main__":
-    test_sparse_emb_get_set(1)
-    test_sparse_emb_get_set(2)
-    test_sparse_emb_get_set(3)
+    test_multiprocess_sparse_emb_get_set(1)
+    test_multiprocess_sparse_emb_get_set(2)
+    test_multiprocess_sparse_emb_get_set(3)
+
+    test_multiprocess_sparse_emb_get_set_optm_state(1)
+    test_multiprocess_sparse_emb_get_set_optm_state(2)
+    test_multiprocess_sparse_emb_get_set_optm_state(3)

--- a/tests/python/pytorch/nn/test_sparse_emb.py
+++ b/tests/python/pytorch/nn/test_sparse_emb.py
@@ -34,9 +34,9 @@ def check_all_set_all_get_optm_state(
     dgl_emb = NodeEmbedding(num_embs, emb_dim, "test", device=device)
     optm = SparseAdam(params=[dgl_emb], lr=0.01)
 
-    dgl_emb.all_set_optm_state((state_step, state_mem, state_power))
+    dgl_emb._all_set_optm_state((state_step, state_mem, state_power))
 
-    out_step, out_mem, out_power = dgl_emb.all_get_optm_state()
+    out_step, out_mem, out_power = dgl_emb._all_get_optm_state()
 
     assert F.allclose(state_step, out_step)
     assert F.allclose(state_mem, out_mem)


### PR DESCRIPTION
## Description

Resolves #5270

1. Add `state_dict`, `load_state_dict` to `dgl.optim.SparseGradOptimizer`
2. Add `param_groups` to `dgl.optim.SparseGradOptimizer`. Note that different from torch's optimizer, our `param_groups` doesn't contain parameters because getting the whole embedding is very expensive. It still contains other attributes, e.g., lr, betas, eps, for debugging.
3. To support the above functionalities, we further add `_all_get_optm_state` and `_all_set_optm_state` to `dgl.nn.NodeEmbedding`. Ideally, the optimizer states should be attached to the optimizer instead of the embedding, however, to gather multi-GPU states, we have to leverage the TCPStore and communicator of the embedding, so I just follow the current design.
4. Add unit tests.

## Checklist
Please feel free to remove inapplicable items for your PR.
- [x] The PR title starts with [$CATEGORY] (such as [NN], [Model], [Doc], [Feature]])
- [x] I've leverage the [tools](https://docs.google.com/document/d/1iHyj7zlmygKSk5gBPsqIqL5ASPzJSPREaNT_QdsiYA4/edit) to beautify the python and c++ code.
- [x] The PR is complete and small, read the [Google eng practice (CL equals to PR)](https://google.github.io/eng-practices/review/developer/small-cls.html) to understand more about small PR. In DGL, we consider PRs with less than 200 lines of core code change are small (example, test and documentation could be exempted).
- [x] All changes have test coverage
- [x] Code is well-documented
- [x] To the best of my knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change
- [x] Related issue is referred in this PR
