### PR TITLE
Distributed Lookup Service Robustness

### DIFF
--- a/tools/distpartitioning/dist_lookup.py
+++ b/tools/distpartitioning/dist_lookup.py
@@ -185,8 +185,13 @@ class DistLookupService:
             ]
 
             # Find the process where global_nid --> partition-id(owner) is stored.
-            ntype_ids, type_nids = self.id_map(global_nids)
-            ntype_ids, type_nids = ntype_ids.numpy(), type_nids.numpy()
+            if len(global_nids) > 0:
+                ntype_ids, type_nids = self.id_map(global_nids)
+                ntype_ids, type_nids = ntype_ids.numpy(), type_nids.numpy()
+            else:
+                ntype_ids = np.array([], dtype=np.int64)
+                type_nids = np.array([], dtype=np.int64)
+
             assert len(ntype_ids) == len(global_nids)
 
             # For each node-type, the per-type-node-id <-> partition-id mappings are
@@ -294,9 +299,11 @@ class DistLookupService:
 
             # Order according to the requesting order.
             # Owner_resp_list is the list of owner-ids for global_nids (function argument).
-            owner_ids = torch.cat(
-                [x for x in owner_resp_list if x is not None]
-            ).numpy()
+            owner_ids = [x for x in owner_resp_list if x is not None]
+            if len(owner_ids) > 0:
+                owner_ids = torch.cat(owner_ids).numpy()
+            else:
+                owner_ids = np.array([], dtype=np.int64)
             assert len(owner_ids) == len(global_nids)
 
             global_nids_order = np.concatenate(indices_list)
@@ -305,8 +312,9 @@ class DistLookupService:
             global_nids_order = global_nids_order[sort_order_idx]
             assert np.all(np.arange(len(global_nids)) == global_nids_order)
 
-            # Store the partition-ids for the current split
-            agg_partition_ids.append(owner_ids)
+            if len(owner_ids) > 0:
+                # Store the partition-ids for the current split
+                agg_partition_ids.append(owner_ids)
 
         # Stitch the list of partition-ids and return to the caller
         if len(agg_partition_ids) > 0:


### PR DESCRIPTION
Handling corner cases in the distributed lookup service. When the get partition ids function is invoked with empty request. This is needed because we are using alltoall function in the get_partition_ids function.

Functions like torch.cat() will fail when empty arguments are passed. This is checked and appropriate action is taken. 

Unit Test cases, is blocked by the following PR - https://github.com/dmlc/dgl/pull/5365
This corner case will be covered in the above mentioned unit test cases PR. 

## Description
<!-- Brief description. Refer to the related issues if existed.
It'll be great if relevant reviewers can be assigned as well.-->

## Checklist
Please feel free to remove inapplicable items for your PR.
- [X] The PR title starts with [$CATEGORY] (such as [NN], [Model], [Doc], [Feature]])
- [X] I've leverage the [tools](https://docs.google.com/document/d/1iHyj7zlmygKSk5gBPsqIqL5ASPzJSPREaNT_QdsiYA4/edit) to beautify the python and c++ code.
- [X] The PR is complete and small, read the [Google eng practice (CL equals to PR)](https://google.github.io/eng-practices/review/developer/small-cls.html) to understand more about small PR. In DGL, we consider PRs with less than 200 lines of core code change are small (example, test and documentation could be exempted).
- [X] All changes have test coverage
- [X] Code is well-documented
- [X] To the best of my knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change
- [X] Related issue is referred in this PR
- [ ] If the PR is for a new model/paper, I've updated the example index [here](../examples/README.md).

## Changes
<!-- You could use following template
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)
-->
