### PR TITLE
[Sparse] Support converson to/from torch sparse tensor.

### DIFF
--- a/dgl_sparse/include/sparse/sparse_matrix.h
+++ b/dgl_sparse/include/sparse/sparse_matrix.h
@@ -79,15 +79,14 @@ class SparseMatrix : public torch::CustomClassHolder {
 
   /**
    * @brief Create a SparseMatrix from tensors in COO format.
-   * @param row Row indices of the COO.
-   * @param col Column indices of the COO.
+   * @param indices COO coordinates with shape (2, nnz).
    * @param value Values of the sparse matrix.
    * @param shape Shape of the sparse matrix.
    *
    * @return SparseMatrix
    */
   static c10::intrusive_ptr<SparseMatrix> FromCOO(
-      torch::Tensor row, torch::Tensor col, torch::Tensor value,
+      torch::Tensor indices, torch::Tensor value,
       const std::vector<int64_t>& shape);
 
   /**
@@ -153,6 +152,8 @@ class SparseMatrix : public torch::CustomClassHolder {
 
   /** @return {row, col} tensors in the COO format. */
   std::tuple<torch::Tensor, torch::Tensor> COOTensors();
+  /** @return Stacked row and col tensors in the COO format. */
+  torch::Tensor Indices();
   /** @return {row, col, value_indices} tensors in the CSR format. */
   std::tuple<torch::Tensor, torch::Tensor, torch::optional<torch::Tensor>>
   CSRTensors();

--- a/dgl_sparse/src/elemenwise_op.cc
+++ b/dgl_sparse/src/elemenwise_op.cc
@@ -22,19 +22,10 @@ c10::intrusive_ptr<SparseMatrix> SpSpAdd(
     const c10::intrusive_ptr<SparseMatrix>& A,
     const c10::intrusive_ptr<SparseMatrix>& B) {
   ElementwiseOpSanityCheck(A, B);
-  torch::Tensor sum;
-  {
-    // TODO(#5145) This is a workaround to reduce peak memory usage. It is no
-    // longer needed after we address #5145.
-    auto torch_A = COOToTorchCOO(A->COOPtr(), A->value());
-    auto torch_B = COOToTorchCOO(B->COOPtr(), B->value());
-    sum = torch_A + torch_B;
-  }
-  sum = sum.coalesce();
-  auto indices = sum.indices();
-  auto row = indices[0];
-  auto col = indices[1];
-  return SparseMatrix::FromCOO(row, col, sum.values(), A->shape());
+  auto torch_A = COOToTorchCOO(A->COOPtr(), A->value());
+  auto torch_B = COOToTorchCOO(B->COOPtr(), B->value());
+  auto sum = (torch_A + torch_B).coalesce();
+  return SparseMatrix::FromCOO(sum.indices(), sum.values(), A->shape());
 }
 
 }  // namespace sparse

--- a/dgl_sparse/src/python_binding.cc
+++ b/dgl_sparse/src/python_binding.cc
@@ -27,6 +27,7 @@ TORCH_LIBRARY(dgl_sparse, m) {
       .def("device", &SparseMatrix::device)
       .def("shape", &SparseMatrix::shape)
       .def("coo", &SparseMatrix::COOTensors)
+      .def("indices", &SparseMatrix::Indices)
       .def("csr", &SparseMatrix::CSRTensors)
       .def("csc", &SparseMatrix::CSCTensors)
       .def("transpose", &SparseMatrix::Transpose)

--- a/dgl_sparse/src/sparse_matrix.cc
+++ b/dgl_sparse/src/sparse_matrix.cc
@@ -72,10 +72,10 @@ c10::intrusive_ptr<SparseMatrix> SparseMatrix::FromCSCPointer(
 }
 
 c10::intrusive_ptr<SparseMatrix> SparseMatrix::FromCOO(
-    torch::Tensor row, torch::Tensor col, torch::Tensor value,
+    torch::Tensor indices, torch::Tensor value,
     const std::vector<int64_t>& shape) {
-  auto coo = std::make_shared<COO>(
-      COO{shape[0], shape[1], torch::stack({row, col}), false, false});
+  auto coo =
+      std::make_shared<COO>(COO{shape[0], shape[1], indices, false, false});
   return SparseMatrix::FromCOOPointer(coo, value, shape);
 }
 
@@ -138,8 +138,12 @@ std::shared_ptr<CSR> SparseMatrix::CSCPtr() {
 
 std::tuple<torch::Tensor, torch::Tensor> SparseMatrix::COOTensors() {
   auto coo = COOPtr();
-  auto val = value();
   return std::make_tuple(coo->indices.index({0}), coo->indices.index({1}));
+}
+
+torch::Tensor SparseMatrix::Indices() {
+  auto coo = COOPtr();
+  return coo->indices;
 }
 
 std::tuple<torch::Tensor, torch::Tensor, torch::optional<torch::Tensor>>

--- a/dgl_sparse/src/sparse_matrix_coalesce.cc
+++ b/dgl_sparse/src/sparse_matrix_coalesce.cc
@@ -17,10 +17,8 @@ namespace sparse {
 c10::intrusive_ptr<SparseMatrix> SparseMatrix::Coalesce() {
   auto torch_coo = COOToTorchCOO(this->COOPtr(), this->value());
   auto coalesced_coo = torch_coo.coalesce();
-  torch::Tensor indices = coalesced_coo.indices();
-  torch::Tensor row = indices[0];
-  torch::Tensor col = indices[1];
-  return SparseMatrix::FromCOO(row, col, coalesced_coo.values(), this->shape());
+  return SparseMatrix::FromCOO(
+      coalesced_coo.indices(), coalesced_coo.values(), this->shape());
 }
 
 bool SparseMatrix::HasDuplicate() {

--- a/python/dgl/sparse/sparse_matrix.py
+++ b/python/dgl/sparse/sparse_matrix.py
@@ -890,8 +890,8 @@ def from_torch_sparse(torch_sparse_tensor: torch.Tensor) -> SparseMatrix:
         torch.sparse_csr,
         torch.sparse_csc,
     ), (
-        f"Cannot convert Pytorch sparse tensor"
-        f"{torch_sparse_tensor} to DGL sparse."
+        f"Cannot convert Pytorch sparse tensor with layout "
+        f"{torch_sparse_tensor.layout} to DGL sparse."
     )
     if torch_sparse_tensor.layout == torch.sparse_coo:
         # Use ._indices() and ._values() to access uncoalesced indices and

--- a/tests/python/pytorch/sparse/test_sparse_matrix.py
+++ b/tests/python/pytorch/sparse/test_sparse_matrix.py
@@ -548,17 +548,13 @@ def test_torch_sparse_coo_conversion(row, col, nz_dim, shape):
 
 @pytest.mark.parametrize("indptr", [(0, 0, 1, 4), (0, 1, 2, 4)])
 @pytest.mark.parametrize("indices", [(0, 1, 2, 3), (1, 2, 3, 4)])
-@pytest.mark.parametrize("nz_dim", [None, 2])
 @pytest.mark.parametrize("shape", [(3, 5), (3, 7)])
-def test_torch_sparse_csr_conversion(indptr, indices, nz_dim, shape):
+def test_torch_sparse_csr_conversion(indptr, indices, shape):
     dev = F.ctx()
     indptr = torch.tensor(indptr).to(dev)
     indices = torch.tensor(indices).to(dev)
     torch_sparse_shape = shape
     val_shape = (indices.shape[0],)
-    if nz_dim is not None:
-        torch_sparse_shape += (nz_dim,)
-        val_shape += (nz_dim,)
     val = torch.randn(val_shape).to(dev)
     torch_sparse_csr = torch.sparse_csr_tensor(
         indptr, indices, val, torch_sparse_shape
@@ -583,17 +579,13 @@ def test_torch_sparse_csr_conversion(indptr, indices, nz_dim, shape):
 
 @pytest.mark.parametrize("indptr", [(0, 0, 1, 4), (0, 1, 2, 4)])
 @pytest.mark.parametrize("indices", [(0, 1, 2, 3), (1, 2, 3, 4)])
-@pytest.mark.parametrize("nz_dim", [None, 2])
 @pytest.mark.parametrize("shape", [(8, 3), (5, 3)])
-def test_torch_sparse_csc_conversion(indptr, indices, nz_dim, shape):
+def test_torch_sparse_csc_conversion(indptr, indices, shape):
     dev = F.ctx()
     indptr = torch.tensor(indptr).to(dev)
     indices = torch.tensor(indices).to(dev)
     torch_sparse_shape = shape
     val_shape = (indices.shape[0],)
-    if nz_dim is not None:
-        torch_sparse_shape += (nz_dim,)
-        val_shape += (nz_dim,)
     val = torch.randn(val_shape).to(dev)
     torch_sparse_csc = torch.sparse_csc_tensor(
         indptr, indices, val, torch_sparse_shape


### PR DESCRIPTION
## Description
Resolve #5373, #5145.

* Support conversions to/from torch sparse tensor.
* Use the stacked row and column tensor in C++ FromCOO.
* Fix typos in the from_coo, from_csr, from_csc docstrings.

## Checklist
Please feel free to remove inapplicable items for your PR.
- [ ] The PR title starts with [$CATEGORY] (such as [NN], [Model], [Doc], [Feature]])
- [ ] I've leverage the [tools](https://docs.google.com/document/d/1iHyj7zlmygKSk5gBPsqIqL5ASPzJSPREaNT_QdsiYA4/edit) to beautify the python and c++ code.
- [ ] The PR is complete and small, read the [Google eng practice (CL equals to PR)](https://google.github.io/eng-practices/review/developer/small-cls.html) to understand more about small PR. In DGL, we consider PRs with less than 200 lines of core code change are small (example, test and documentation could be exempted).
- [ ] All changes have test coverage
- [ ] Code is well-documented
- [ ] To the best of my knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change
- [ ] Related issue is referred in this PR
- [ ] If the PR is for a new model/paper, I've updated the example index [here](../examples/README.md).

## Changes
<!-- You could use following template
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)
-->
