### PR TITLE
[Dataloading] Ignore edge types without reverse types in edge dataloader

### DIFF
--- a/python/dgl/dataloading/base.py
+++ b/python/dgl/dataloading/base.py
@@ -280,7 +280,11 @@ def _find_exclude_eids_with_reverse_types(g, eids, reverse_etype_map):
         for k, v in reverse_etype_map.items()
     }
     exclude_eids.update(
-        {reverse_etype_map[k]: v for k, v in exclude_eids.items() if k in reverse_etype_map}
+        {
+            reverse_etype_map[k]: v
+            for k, v in exclude_eids.items()
+            if k in reverse_etype_map
+        }
     )
     return exclude_eids
 

--- a/python/dgl/dataloading/base.py
+++ b/python/dgl/dataloading/base.py
@@ -280,7 +280,7 @@ def _find_exclude_eids_with_reverse_types(g, eids, reverse_etype_map):
         for k, v in reverse_etype_map.items()
     }
     exclude_eids.update(
-        {reverse_etype_map[k]: v for k, v in exclude_eids.items()}
+        exclude_eids.update({reverse_etype_map[k]: v for k, v in exclude_eids.items() if k in reverse_etype_map})
     )
     return exclude_eids
 

--- a/python/dgl/dataloading/base.py
+++ b/python/dgl/dataloading/base.py
@@ -280,7 +280,7 @@ def _find_exclude_eids_with_reverse_types(g, eids, reverse_etype_map):
         for k, v in reverse_etype_map.items()
     }
     exclude_eids.update(
-        exclude_eids.update({reverse_etype_map[k]: v for k, v in exclude_eids.items() if k in reverse_etype_map})
+        {reverse_etype_map[k]: v for k, v in exclude_eids.items() if k in reverse_etype_map}
     )
     return exclude_eids
 

--- a/tests/python/pytorch/dataloading/test_dataloader.py
+++ b/tests/python/pytorch/dataloading/test_dataloader.py
@@ -623,35 +623,39 @@ def test_edge_dataloader_excludes(
 
 
 def test_edge_dataloader_exclusion_without_all_reverses():
-    data_dict = {('A','AB','B'): (torch.tensor([0,1]),torch.tensor([0,1])),
-             ('B','BA','A'): (torch.tensor([0,1]),torch.tensor([0,1])),
-            ('B','BC','C'):(torch.tensor([0]),torch.tensor([0])),
-            ('C','CA','A'): (torch.tensor([0,1]),torch.tensor([0,1]))}
+    data_dict = {
+        ("A", "AB", "B"): (torch.tensor([0, 1]), torch.tensor([0, 1])),
+        ("B", "BA", "A"): (torch.tensor([0, 1]), torch.tensor([0, 1])),
+        ("B", "BC", "C"): (torch.tensor([0]), torch.tensor([0])),
+        ("C", "CA", "A"): (torch.tensor([0, 1]), torch.tensor([0, 1])),
+    }
     g = dgl.heterograph(data_dict=data_dict)
     block_sampler = dgl.dataloading.MultiLayerNeighborSampler(
-                fanouts=[1],
-                replace=True)
+        fanouts=[1], replace=True
+    )
     block_sampler = dgl.dataloading.as_edge_prediction_sampler(
-                block_sampler,
-                exclude="reverse_types",
-                reverse_etypes={'AB':'BA'},
-
-            )
+        block_sampler,
+        exclude="reverse_types",
+        reverse_etypes={"AB": "BA"},
+    )
     d = dgl.dataloading.DataLoader(
-                graph=g,
-                indices={'AB':torch.tensor([0]),'BC':torch.tensor([0]),},
-                graph_sampler=block_sampler,
-                batch_size=2,
-                shuffle=True,
-                drop_last=False,
-                num_workers=0,
-                device='cuda',
-                use_ddp=False,
-                use_uva=True,
-            )
+        graph=g,
+        indices={
+            "AB": torch.tensor([0]),
+            "BC": torch.tensor([0]),
+        },
+        graph_sampler=block_sampler,
+        batch_size=2,
+        shuffle=True,
+        drop_last=False,
+        num_workers=0,
+        device=F.ctx(),
+        use_ddp=False,
+    )
 
     next(iter(d))
-    
+
+
 def dummy_worker_init_fn(worker_id):
     pass
 
@@ -670,6 +674,7 @@ def test_dataloader_worker_init_fn():
     )
     for _ in dataloader:
         pass
+
 
 if __name__ == "__main__":
     # test_node_dataloader(F.int32, 'neighbor', None)


### PR DESCRIPTION
## Description
Fixes https://github.com/dmlc/dgl/issues/5410


## Checklist
Please feel free to remove inapplicable items for your PR.
- [x] The PR title starts with [$CATEGORY] (such as [NN], [Model], [Doc], [Feature]])
- [x] I've leverage the [tools](https://docs.google.com/document/d/1iHyj7zlmygKSk5gBPsqIqL5ASPzJSPREaNT_QdsiYA4/edit) to beautify the python and c++ code.
- [x] The PR is complete and small, read the [Google eng practice (CL equals to PR)](https://google.github.io/eng-practices/review/developer/small-cls.html) to understand more about small PR. In DGL, we consider PRs with less than 200 lines of core code change are small (example, test and documentation could be exempted).
- [x] All changes have test coverage
- [x] Code is well-documented
- [x] To the best of my knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change
- [x] Related issue is referred in this PR


