### PR TITLE
[Bugfix] Fix duplicate worker_init_fn argument when provided in DataLoader

### DIFF
--- a/python/dgl/dataloading/dataloader.py
+++ b/python/dgl/dataloading/dataloader.py
@@ -1018,7 +1018,7 @@ class DataLoader(torch.utils.data.DataLoader):
         self.use_prefetch_thread = use_prefetch_thread
         self.cpu_affinity_enabled = False
 
-        worker_init_fn = WorkerInitWrapper(kwargs.get("worker_init_fn", None))
+        worker_init_fn = WorkerInitWrapper(kwargs.pop("worker_init_fn", None))
 
         self.other_storages = {}
 

--- a/tests/python/pytorch/dataloading/test_dataloader.py
+++ b/tests/python/pytorch/dataloading/test_dataloader.py
@@ -91,6 +91,7 @@ def test_saint(num_workers, mode):
     for sg in dataloader:
         pass
 
+
 @parametrize_idtype
 @pytest.mark.parametrize(
     "mode", ["cpu", "uva_cuda_indices", "uva_cpu_indices", "pure_gpu"]

--- a/tests/python/pytorch/dataloading/test_dataloader.py
+++ b/tests/python/pytorch/dataloading/test_dataloader.py
@@ -625,6 +625,7 @@ def test_edge_dataloader_excludes(
 def dummy_worker_init_fn(worker_id):
     pass
 
+
 def test_dataloader_worker_init_fn():
     dataset = dgl.data.CoraFullDataset()
     g = dataset[0]

--- a/tests/python/pytorch/dataloading/test_dataloader.py
+++ b/tests/python/pytorch/dataloading/test_dataloader.py
@@ -91,7 +91,6 @@ def test_saint(num_workers, mode):
     for sg in dataloader:
         pass
 
-
 @parametrize_idtype
 @pytest.mark.parametrize(
     "mode", ["cpu", "uva_cuda_indices", "uva_cpu_indices", "pure_gpu"]
@@ -621,6 +620,24 @@ def test_edge_dataloader_excludes(
         if i == 10:
             break
 
+
+def dummy_worker_init_fn(worker_id):
+    pass
+
+def test_dataloader_worker_init_fn():
+    dataset = dgl.data.CoraFullDataset()
+    g = dataset[0]
+    sampler = dgl.dataloading.MultiLayerNeighborSampler([2])
+    dataloader = dgl.dataloading.DataLoader(
+        g,
+        torch.arange(100),
+        sampler,
+        batch_size=4,
+        num_workers=4,
+        worker_init_fn=dummy_worker_init_fn
+    )
+    for _ in dataloader:
+        pass
 
 if __name__ == "__main__":
     # test_node_dataloader(F.int32, 'neighbor', None)

--- a/tests/python/pytorch/dataloading/test_dataloader.py
+++ b/tests/python/pytorch/dataloading/test_dataloader.py
@@ -634,10 +634,11 @@ def test_dataloader_worker_init_fn():
         sampler,
         batch_size=4,
         num_workers=4,
-        worker_init_fn=dummy_worker_init_fn
+        worker_init_fn=dummy_worker_init_fn,
     )
     for _ in dataloader:
         pass
+
 
 if __name__ == "__main__":
     # test_node_dataloader(F.int32, 'neighbor', None)


### PR DESCRIPTION
Addresses one of the problems in #4507 as requested.