### PR TITLE
[Dev] enable to specify torch version when create conda env

### DIFF
--- a/script/create_dev_conda_env.sh
+++ b/script/create_dev_conda_env.sh
@@ -27,7 +27,7 @@ OPTIONS:
   -p           Create dev environment based on specified python version.
   -s           Run silently which indicates always 'yes' for any confirmation.
   -t           Create dev environment based on specified PyTorch version such
-                as '1.13.0'.
+               as '1.13.0'.
 EOF
 }
 

--- a/script/create_dev_conda_env.sh
+++ b/script/create_dev_conda_env.sh
@@ -26,7 +26,8 @@ OPTIONS:
   -o           Save environment YAML file to specified path.
   -p           Create dev environment based on specified python version.
   -s           Run silently which indicates always 'yes' for any confirmation.
-  -t           Create dev environment based on specified PyTorch version such as '1.13.0'.
+  -t           Create dev environment based on specified PyTorch version such
+                as '1.13.0'.
 EOF
 }
 

--- a/script/create_dev_conda_env.sh
+++ b/script/create_dev_conda_env.sh
@@ -11,6 +11,7 @@ examples:
   bash $0 -c
   bash $0 -g 11.7
   bash $0 -g 11.7 -p 3.8
+  bash $0 -g 11.7 -p 3.8 -t 1.13.0
 
 Create a developement environment for DGL developers.
 
@@ -25,6 +26,7 @@ OPTIONS:
   -o           Save environment YAML file to specified path.
   -p           Create dev environment based on specified python version.
   -s           Run silently which indicates always 'yes' for any confirmation.
+  -t           Create dev environment based on specified PyTorch version such as '1.13.0'.
 EOF
 }
 
@@ -48,7 +50,7 @@ confirm() {
 }
 
 # Parse flags.
-while getopts "cdfg:ho:p:s" flag; do
+while getopts "cdfg:ho:p:st:" flag; do
   case "${flag}" in
     c)
       cpu=1
@@ -75,6 +77,9 @@ while getopts "cdfg:ho:p:s" flag; do
     s)
       always_yes=1
       ;;
+    t)
+      torch_version=${OPTARG}
+      ;;
     :)
       echo "Error: -${OPTARG} requires an argument."
       exit 1
@@ -96,9 +101,13 @@ if [[ -z ${cuda_version} && -z ${cpu} ]]; then
   exit 1
 fi
 
+if [[ -z "${torch_version}" ]]; then
+  torch_version=${TORCH_VERSION}
+fi
+
 # Set up CPU mode.
 if [[ ${cpu} -eq 1 ]]; then
-  torchversion=${TORCH_VERSION}"+cpu"
+  torchversion=${torch_version}"+cpu"
   name="dgl-dev-cpu"
 fi
 
@@ -113,7 +122,7 @@ if [[ -n ${cuda_version} ]]; then
   echo "Confirm the installed CUDA version matches the specified one."
   [[ -n "${always_yes}" ]] || confirm
 
-  torchversion=${TORCH_VERSION}"+cu"${cuda_version//[-._]/}
+  torchversion=${torch_version}"+cu"${cuda_version//[-._]/}
   name="dgl-dev-gpu"
 fi
 


### PR DESCRIPTION
## Description
<!-- Brief description. Refer to the related issues if existed.
It'll be great if relevant reviewers can be assigned as well.-->
The default torch version `1.12.0` does not support `cu117`, so sometimes we need to specify torch version.
## Checklist
Please feel free to remove inapplicable items for your PR.
- [ ] The PR title starts with [$CATEGORY] (such as [NN], [Model], [Doc], [Feature]])
- [ ] I've leverage the [tools](https://docs.google.com/document/d/1iHyj7zlmygKSk5gBPsqIqL5ASPzJSPREaNT_QdsiYA4/edit) to beautify the python and c++ code.
- [ ] The PR is complete and small, read the [Google eng practice (CL equals to PR)](https://google.github.io/eng-practices/review/developer/small-cls.html) to understand more about small PR. In DGL, we consider PRs with less than 200 lines of core code change are small (example, test and documentation could be exempted).
- [ ] All changes have test coverage
- [ ] Code is well-documented
- [ ] To the best of my knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change
- [ ] Related issue is referred in this PR
- [ ] If the PR is for a new model/paper, I've updated the example index [here](../examples/README.md).

## Changes
<!-- You could use following template
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)
-->
