### PR TITLE
[BugFix] Tensorflow examples fix

### DIFF
--- a/examples/tensorflow/dgi/train.py
+++ b/examples/tensorflow/dgi/train.py
@@ -51,7 +51,7 @@ def main(args):
         test_mask = g.ndata["test_mask"]
         in_feats = features.shape[1]
         n_classes = data.num_labels
-        n_edges = data.graph.number_of_edges()
+        n_edges = g.number_of_edges()
 
         # add self loop
         if args.self_loop:

--- a/examples/tensorflow/gat/train.py
+++ b/examples/tensorflow/gat/train.py
@@ -67,7 +67,7 @@ def main(args):
         test_mask = g.ndata["test_mask"]
         num_feats = features.shape[1]
         n_classes = data.num_labels
-        n_edges = data.graph.number_of_edges()
+        n_edges = g.number_of_edges()
         print(
             """----Data statistics------'
         #Edges %d

--- a/examples/tensorflow/gcn/train.py
+++ b/examples/tensorflow/gcn/train.py
@@ -44,7 +44,7 @@ def main(args):
         test_mask = g.ndata["test_mask"]
         in_feats = features.shape[1]
         n_classes = data.num_labels
-        n_edges = data.graph.number_of_edges()
+        n_edges = g.number_of_edges()
         print(
             """----Data statistics------'
         #Edges %d


### PR DESCRIPTION
## Description
Some of the examples in _examples/tensorflow_ were raising the following error:
![error_tensorflow](https://user-images.githubusercontent.com/61557665/223376021-900b1009-1492-4d32-a945-f966770ae374.png)
after the change, the examples work properly:
![working_test_tensorflow](https://user-images.githubusercontent.com/61557665/223376129-eacb7845-f535-40ce-a3a0-8ac5d599cd66.png)


## Checklist
- [x] The PR title starts with [$CATEGORY] (such as [NN], [Model], [Doc], [Feature]])
- [x] The PR is complete and small, read the [Google eng practice (CL equals to PR)](https://google.github.io/eng-practices/review/developer/small-cls.html) to understand more about small PR. In DGL, we consider PRs with less than 200 lines of core code change are small (example, test and documentation could be exempted).


