### PR TITLE
[Dist] Add argument in dispatch_data.py to allow user-defined metadata JSON filename.

### DIFF
--- a/tools/dispatch_data.py
+++ b/tools/dispatch_data.py
@@ -37,7 +37,7 @@ def get_launch_cmd(args) -> str:
 
 def submit_jobs(args) -> str:
     # read the json file and get the remaining argument here.
-    schema_path = "metadata.json"
+    schema_path = args.metadata_filename
     with open(os.path.join(args.in_dir, schema_path)) as schema:
         schema_map = json.load(schema)
 
@@ -100,6 +100,12 @@ def main():
         "--in-dir",
         type=str,
         help="Location of the input directory where the dataset is located",
+    )
+    parser.add_argument(
+        "--metadata-filename",
+        type=str,
+        default="metadata.json",
+        help="Filename for the metadata JSON file that describes the dataset to be dispatched.",
     )
     parser.add_argument(
         "--partitions-dir",


### PR DESCRIPTION
## Description
Adds an argument to allow custom-named metadata JSON files for `dispatch_data.py`. We provide the previous value as a default to ensure backwards compatibility.

## Checklist
Please feel free to remove inapplicable items for your PR.
- [x] The PR title starts with [$CATEGORY] (such as [NN], [Model], [Doc], [Feature]])
- [x] I've leverage the [tools](https://docs.google.com/document/d/1iHyj7zlmygKSk5gBPsqIqL5ASPzJSPREaNT_QdsiYA4/edit) to beautify the python and c++ code.
- [x] The PR is complete and small, read the [Google eng practice (CL equals to PR)](https://google.github.io/eng-practices/review/developer/small-cls.html) to understand more about small PR. In DGL, we consider PRs with less than 200 lines of core code change are small (example, test and documentation could be exempted).
- [ ] All changes have test coverage
- [x] Code is well-documented
- [x] To the best of my knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change
- [ ] Related issue is referred in this PR
- [ ] If the PR is for a new model/paper, I've updated the example index [here](../examples/README.md).

