### PR TITLE
[DistDGL][Robustness]Use appropriate delimiter when reading edge files.

### DIFF
--- a/tools/distpartitioning/dataset_utils.py
+++ b/tools/distpartitioning/dataset_utils.py
@@ -546,7 +546,11 @@ def get_dataset(
                     block_size=4096,
                     autogenerate_column_names=True,
                 )
-                parse_options = pyarrow.csv.ParseOptions(delimiter=" ")
+                parse_options = pyarrow.csv.ParseOptions(
+                    delimiter=etype_info[constants.STR_FORMAT][
+                        constants.STR_FORMAT_DELIMITER
+                    ]
+                )
                 with pyarrow.csv.open_csv(
                     edge_file,
                     read_options=read_options,


### PR DESCRIPTION
## Description
<!-- Brief description. Refer to the related issues if existed.
It'll be great if relevant reviewers can be assigned as well.-->

Webgraph dataset edge files have '\t' as the delimiter. But the pipeline, by default assumes ' ' as the delimiter because of which it fails to read webgraph files.

## Checklist
Please feel free to remove inapplicable items for your PR.
- [X] The PR title starts with [$CATEGORY] (such as [NN], [Model], [Doc], [Feature]])
- [X] I've leverage the [tools](https://docs.google.com/document/d/1iHyj7zlmygKSk5gBPsqIqL5ASPzJSPREaNT_QdsiYA4/edit) to beautify the python and c++ code.
- [X] The PR is complete and small, read the [Google eng practice (CL equals to PR)](https://google.github.io/eng-practices/review/developer/small-cls.html) to understand more about small PR. In DGL, we consider PRs with less than 200 lines of core code change are small (example, test and documentation could be exempted).
- [X] All changes have test coverage
- [X] Code is well-documented
- [X] To the best of my knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change
- [ ] Related issue is referred in this PR
- [ ] If the PR is for a new model/paper, I've updated the example index [here](../examples/README.md).

## Changes
<!-- You could use following template
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)
-->
