### PR TITLE
Memory Robustness code refactoring to increase capacity and reduce memory footprint

### DIFF
--- a/tools/distpartitioning/convert_partition.py
+++ b/tools/distpartitioning/convert_partition.py
@@ -175,6 +175,433 @@ def _get_unique_invidx(srcids, dstids, nids):
     return uniques, idxes, srcids, dstids
 
 
+def _process_node_data(
+    schema, part_id, node_data, node_typecounts
+):
+    """
+    This is an auxiliary function used to process data relating to the nodes
+    of the current partition and prepares the data needed to create the dgl
+    graph object. The data accumulated from the beginning of the pipeline
+    after this processing step will be deleted to free up the memory footprint
+    of the pipeline.
+
+    Parameters:
+    -----------
+    schema : json dictionary
+        dictionary object created by reading the metadata.json file for the
+        current dataset
+    part_id : integer
+        specifies the partition id of the current partition
+    node_data : dictionary
+        dictionary object where data related to the nodes of the graph are
+        stored as numpy arrays
+    node_typecounts : dictionary
+        dictionary specifying the total no. of nodes per node type in the
+        input graph
+
+    Returns:
+    --------
+    numpy array :
+        shuffle_global_nids, assigned after the data-shuffling phase, for the
+        nodes in the current partition
+    tuple :
+        tuple specifying the range of the shuffle_global_nids for the current
+        partitioned graph object
+    dictionary :
+        dictionary where keys are node types and values are list of two
+        integers (specifying the range of shuffle_global_nids for the nodes
+        which belong to a given node type)
+    dictionary :
+        dictionary which maps a given node type, string, to an integer, which
+        is the node_type_id used for internal processing like filters,
+        conditions for numpy arrays
+    numpy array :
+        list of unique numbers which are the original global nids of the nodes
+        in the current partition
+    dictionary :
+        dictionary object where keys are ntypes, strings, and values are
+        type_node_ids of the `inner_nodes` in the current partition. This
+        dictionary is populated only when the input parameter, return_orig_nids
+        , is specified as True
+    dgl.distributed.PartitionBook :
+        an object of the PartitionBook class, created for the input graph
+        dataset
+    """
+    # create auxiliary data structures from the schema object
+    memory_snapshot("CreateDGLObj_ProcessNodeDataEnd", part_id)
+    _, global_nid_ranges = get_idranges(
+        schema[constants.STR_NODE_TYPE], node_typecounts
+    )
+
+    id_map = dgl.distributed.id_map.IdMap(global_nid_ranges)
+
+    ntypes = [(key, global_nid_ranges[key][0, 0]) for key in global_nid_ranges]
+    ntypes.sort(key=lambda e: e[1])
+    ntype_offset_np = np.array([e[1] for e in ntypes])
+    ntypes = [e[0] for e in ntypes]
+    ntypes_map = {e: i for i, e in enumerate(ntypes)}
+    node_map_val = {ntype: [] for ntype in ntypes}
+
+    shuffle_global_nids = node_data[constants.SHUFFLE_GLOBAL_NID]
+    node_data.pop(constants.SHUFFLE_GLOBAL_NID)
+
+    ntype_ids = node_data[constants.NTYPE_ID]
+    node_data.pop(constants.NTYPE_ID)
+
+    global_type_nid = node_data[constants.GLOBAL_TYPE_NID]
+    node_data.pop(constants.GLOBAL_TYPE_NID)
+    node_data = None
+
+    global_homo_nid = ntype_offset_np[ntype_ids] + global_type_nid
+    assert np.all(shuffle_global_nids[1:] - shuffle_global_nids[:-1] == 1)
+    shuffle_global_nid_range = (shuffle_global_nids[0], shuffle_global_nids[-1])
+
+    # Determine the node ID ranges of different node types.
+    for ntype_name in global_nid_ranges:
+        ntype_id = ntypes_map[ntype_name]
+        type_nids = shuffle_global_nids[ntype_ids == ntype_id]
+        node_map_val[ntype_name].append(
+            [int(type_nids[0]), int(type_nids[-1]) + 1]
+        )
+
+    '''
+    orig_nids = None
+    if return_orig_nids:
+        orig_nids = {}
+        for ntype, ntype_id in ntypes_map.items():
+            mask = th.logical_and(
+                part_graph.ndata[dgl.NTYPE] == ntype_id,
+                part_graph.ndata["inner_node"],
+            )
+            orig_nids[ntype] = th.as_tensor(per_type_ids[mask])
+    '''
+
+    memory_snapshot("CreateDGLObj_ProcessNodeDataEnd", part_id)
+    return (
+        shuffle_global_nids,
+        shuffle_global_nid_range,
+        node_map_val,
+        ntypes_map,
+        global_homo_nid,
+        id_map,
+    )
+
+
+def _process_edge_data(
+    schema,
+    part_id,
+    edge_data,
+    edgeid_offset,
+    edge_typecounts,
+    global_homo_nid,
+    shuffle_global_nid_range,
+    id_map,
+):
+    """
+    Auxiliary function used to process edge data and return the data needed
+    to create dgl graph object for the current partition. This enables us
+    to delete the `edge_data` dictionary object which stores all the edge
+    data stored until this point.
+
+    Parameters:
+    ----------
+    schema : json dictionary
+        dictionary object created by reading the metadata of the input dataset
+    part_id : integer
+        specifying the partition id of the current partitioned graph object
+    edge_data : dictionary
+        which stored the information related to the edges
+    edgeid_offset : integer
+        starting value, used as offset, to assign global edge ids to the edges
+        in the current graph partition
+    edge_typecounts : dictionary
+        dictionary which maps edgetypes, strings, to the total no. of edges
+        for a given edgetype
+    global_homo_nid : numpy array
+        a list of unique numbers specifying the global node ids of the nodes
+        in the current partition
+    shuffle_global_nid_range : tuple
+        tuple of integers specifying the range of shuffle global node ids of
+        the nodes in the current graph partition
+    id_map : dgl.distributed.PartitionBook object
+        an object of the PartitionBook class, created for the input graph
+        dataset
+
+    Returns:
+    --------
+    numpy array :
+        local node ids, of the source end points of edges in the current graph
+        partition
+    numpy array :
+        local node ids, of the destination end points of edges in the current
+        graph partition
+    numpy array :
+        edge type ids of all the edges in the current graph partition
+    numpy array :
+        node type ids of all the nodes in the current graph partition
+    numpy array :
+        a list of unique nodes ids, in the context of current graph partition
+    numpy boolean array :
+        boolean array indicating whether a node is an `inner node` or not for
+        the current graph partition
+    dictionary :
+        specifying the range of shuffle global edge ids for all the edge types
+        in the current graph
+    dictionary :
+        used to map canonical edge types, tuple of strings, to corresponding
+        integers for internal processing
+    dictionary :
+        used to store the original, global, edge ids for all the edges in the
+        current graph partition, determined by the user specified command line
+        option
+    """
+    memory_snapshot("CreateDGLObj_ProcessEdgesBegin: ", part_id)
+    _, global_eid_ranges = get_idranges(
+        schema[constants.STR_EDGE_TYPE], edge_typecounts
+    )
+
+    etypes = [(key, global_eid_ranges[key][0, 0]) for key in global_eid_ranges]
+    etypes.sort(key=lambda e: e[1])
+    etypes = [e[0] for e in etypes]
+    etypes_map = {_etype_str_to_tuple(e): i for i, e in enumerate(etypes)}
+    edge_map_val = {_etype_str_to_tuple(etype): [] for etype in etypes}
+
+    # process edges
+    shuffle_global_src_id = edge_data[constants.SHUFFLE_GLOBAL_SRC_ID]
+    edge_data[constants.SHUFFLE_GLOBAL_SRC_ID] = None
+    edge_data.pop(constants.SHUFFLE_GLOBAL_SRC_ID)
+
+    shuffle_global_dst_id = edge_data[constants.SHUFFLE_GLOBAL_DST_ID]
+    edge_data[constants.SHUFFLE_GLOBAL_DST_ID] = None
+    edge_data.pop(constants.SHUFFLE_GLOBAL_DST_ID)
+
+    global_src_id = edge_data[constants.GLOBAL_SRC_ID]
+    edge_data[constants.GLOBAL_SRC_ID] = None
+    edge_data.pop(constants.GLOBAL_SRC_ID)
+
+    global_dst_id = edge_data[constants.GLOBAL_DST_ID]
+    edge_data[constants.GLOBAL_DST_ID] = None
+    edge_data.pop(constants.GLOBAL_DST_ID)
+
+    global_edge_id = edge_data[constants.GLOBAL_TYPE_EID]
+    edge_data[constants.GLOBAL_TYPE_EID] = None
+    edge_data.pop(constants.GLOBAL_TYPE_EID)
+
+    etype_ids = edge_data[constants.ETYPE_ID]
+    edge_data[constants.ETYPE_ID] = None
+    edge_data.pop(constants.ETYPE_ID)
+    edge_data = None
+    logging.info(
+        f"[Rank: {part_id}] There are {len(shuffle_global_src_id)} edges in partition {part_id}"
+    )
+
+    # It's not guaranteed that the edges are sorted based on edge type.
+    # Let's sort edges and all attributes on the edges.
+    if not np.all(np.diff(etype_ids) >= 0):
+        sort_idx = np.argsort(etype_ids)
+        (
+            shuffle_global_src_id,
+            shuffle_global_dst_id,
+            global_src_id,
+            global_dst_id,
+            global_edge_id,
+            etype_ids,
+        ) = (
+            shuffle_global_src_id[sort_idx],
+            shuffle_global_dst_id[sort_idx],
+            global_src_id[sort_idx],
+            global_dst_id[sort_idx],
+            global_edge_id[sort_idx],
+            etype_ids[sort_idx],
+        )
+        assert np.all(np.diff(etype_ids) >= 0)
+    else:
+        print(f"[Rank: {part_id} Edge data is already sorted !!!")
+
+    # Determine the edge ID range of different edge types.
+    edge_id_start = edgeid_offset
+    for etype_name in global_eid_ranges:
+        etype = _etype_str_to_tuple(etype_name)
+        assert len(etype) == 3
+        etype_id = etypes_map[etype]
+        edge_map_val[etype].append(
+            [edge_id_start, edge_id_start + np.sum(etype_ids == etype_id)]
+        )
+        edge_id_start += np.sum(etype_ids == etype_id)
+
+    uniq_ids, idx, part_local_src_id, part_local_dst_id = _get_unique_invidx(
+        shuffle_global_src_id,
+        shuffle_global_dst_id,
+        np.arange(shuffle_global_nid_range[0], shuffle_global_nid_range[1] + 1),
+    )
+    shuffle_global_src_id = None
+    shuffle_global_dst_id = None
+
+    # inner nodes
+    inner_nodes = th.as_tensor(
+        np.logical_and(
+            uniq_ids >= shuffle_global_nid_range[0],
+            uniq_ids <= shuffle_global_nid_range[1],
+        )
+    )
+
+    # get the list of indices, from inner_nodes, which will sort inner_nodes
+    # as [True, True, ...., False, False, ...]
+    # essentially local nodes will be placed before non-local nodes.
+    reshuffle_nodes = th.arange(len(uniq_ids))
+    reshuffle_nodes = th.cat(
+        [reshuffle_nodes[inner_nodes.bool()], reshuffle_nodes[inner_nodes == 0]]
+    )
+
+    # compute per_type_ids and ntype for all the nodes in the graph.
+    global_ids = np.concatenate([global_src_id, global_dst_id, global_homo_nid])
+    part_global_ids = global_ids[idx]
+    part_global_ids = part_global_ids[reshuffle_nodes]
+    ntype, per_type_ids = id_map(part_global_ids)
+
+    # create the mappings to generate mapped part_local_src_id and
+    # part_local_dst_id. This map will map from unshuffled node-ids
+    # to reshuffled-node-ids (which are ordered to prioritize locally owned
+    # nodes).
+    nid_map = np.zeros(
+        (
+            len(
+                reshuffle_nodes,
+            )
+        )
+    )
+    nid_map[reshuffle_nodes] = np.arange(len(reshuffle_nodes))
+
+    # Now map the edge end points to reshuffled_values.
+    part_local_src_id, part_local_dst_id = (
+        nid_map[part_local_src_id],
+        nid_map[part_local_dst_id],
+    )
+    '''
+    orig_eids = None
+    if return_orig_eids:
+        orig_eids = {}
+        for etype, etype_id in etypes_map.items():
+            mask = th.logical_and(
+                part_graph.edata[dgl.ETYPE] == etype_id,
+                part_graph.edata["inner_edge"],
+            )
+            orig_eids[_etype_tuple_to_str(etype)] = th.as_tensor(
+                global_edge_id[mask]
+            )
+    '''
+
+    shuffle_global_src_id = None
+    shuffle_global_dst_id = None
+    global_src_id = None
+    global_dst_id = None
+    #global_edge_id = None
+    memory_snapshot("CreateDGLObj_ProcessEdgesEnd: ", part_id)
+
+    return (
+        part_local_src_id,
+        part_local_dst_id,
+        global_edge_id,
+        etype_ids,
+        ntype,
+        per_type_ids,
+        uniq_ids[reshuffle_nodes],
+        inner_nodes[reshuffle_nodes],
+        edge_map_val,
+        etypes_map,
+    )
+
+
+def _create_graph(
+    part_local_src_id,
+    part_local_dst_id,
+    edgeid_offset,
+    etype_ids,
+    ntype,
+    uniq_ids,
+    inner_nodes,
+    part_id,
+):
+    """
+    Function used to create an instance of DGL graph object for the
+    current graph partition.
+
+    Parameters:
+    -----------
+    part_local_src_id : numpy array
+        local node ids, of the source end points of edges in the current graph
+        partition
+    part_local_dst_id : numpy array
+        local node ids, of the destination end points of edges in the current
+        graph partition
+    edgeid_offset : integer
+        used to specify the offset value from which point edge ids will be
+        assigned in the current graph partition
+    ntype : numpy array
+        node type ids of all the nodes in the current graph partition
+    uniq_ids : numpy array
+        a list of unique nodes ids, in the context of current graph partition
+    inner_nodes : numpy boolean array
+        boolean array indicating whether a node is an `inner node` or not for
+        the current graph partition
+    part_id : integer
+        specifying the partition id of the current graph partition
+
+    Returns:
+    --------
+    DGL graph object :
+        instance of the dgl graph object created using the input data to this
+        function
+    """
+
+    # create the graph here now.
+    memory_snapshot("CreateDGLObj_GraphBegin", part_id)
+    part_graph = dgl.graph(
+        data=(part_local_src_id, part_local_dst_id), num_nodes=len(uniq_ids)
+    )
+
+    del part_local_src_id
+    part_local_src_id = None
+    del part_local_dst_id
+    part_local_dst_id = None
+
+    part_graph.edata[dgl.EID] = th.arange(
+        edgeid_offset,
+        edgeid_offset + part_graph.number_of_edges(),
+        dtype=th.int64,
+    )
+
+    part_graph.edata[dgl.ETYPE] = th.as_tensor(
+        etype_ids, dtype=RESERVED_FIELD_DTYPE[dgl.ETYPE]
+    )
+    del etype_ids
+    etype_ids = None
+
+    part_graph.edata["inner_edge"] = th.ones(
+        part_graph.number_of_edges(), dtype=RESERVED_FIELD_DTYPE["inner_edge"]
+    )
+
+    # continue with the graph creation
+    part_graph.ndata[dgl.NTYPE] = th.as_tensor(
+        ntype, dtype=RESERVED_FIELD_DTYPE[dgl.NTYPE]
+    )
+    del ntype
+    ntype = None
+
+    part_graph.ndata[dgl.NID] = th.as_tensor(uniq_ids)
+    del uniq_ids
+    uniq_ids = None
+
+    part_graph.ndata["inner_node"] = th.as_tensor(
+        inner_nodes, dtype=RESERVED_FIELD_DTYPE["inner_node"]
+    )
+    del inner_nodes
+    inner_nodes = None
+    memory_snapshot("CreateDGLObj_GraphObj", part_id)
+
+    return part_graph
+
+
 def create_dgl_object(
     schema,
     part_id,
@@ -187,50 +614,14 @@ def create_dgl_object(
     return_orig_eids=False,
 ):
     """
-    This function creates dgl objects for a given graph partition, as in function
-    arguments.
 
-    The "schema" argument is a dictionary, which contains the metadata related to node ids
-    and edge ids. It contains two keys: "nid" and "eid", whose value is also a dictionary
-    with the following structure.
-
-    1. The key-value pairs in the "nid" dictionary has the following format.
-       "ntype-name" is the user assigned name to this node type. "format" describes the
-       format of the contents of the files. and "data" is a list of lists, each list has
-       3 elements: file-name, start_id and end_id. File-name can be either absolute or
-       relative path to this file and starting and ending ids are type ids of the nodes
-       which are contained in this file. These type ids are later used to compute global ids
-       of these nodes which are used throughout the processing of this pipeline.
-        "ntype-name" : {
-            "format" : "csv",
-            "data" : [
-                    [ <path-to-file>/ntype0-name-0.csv, start_id0, end_id0],
-                    [ <path-to-file>/ntype0-name-1.csv, start_id1, end_id1],
-                    ...
-                    [ <path-to-file>/ntype0-name-<p-1>.csv, start_id<p-1>, end_id<p-1>],
-            ]
-        }
-
-    2. The key-value pairs in the "eid" dictionary has the following format.
-       As described for the "nid" dictionary the "eid" dictionary is similarly structured
-       except that these entries are for edges.
-        "etype-name" : {
-            "format" : "csv",
-            "data" : [
-                    [ <path-to-file>/etype0-name-0, start_id0, end_id0],
-                    [ <path-to-file>/etype0-name-1 start_id1, end_id1],
-                    ...
-                    [ <path-to-file>/etype0-name-1 start_id<p-1>, end_id<p-1>]
-            ]
-        }
-
-    In "nid" dictionary, the type_nids are specified that
-    should be assigned to nodes which are read from the corresponding nodes file.
-    Along the same lines dictionary for the key "eid" is used for edges in the
-    input graph.
-
-    These type ids, for nodes and edges, are used to compute global ids for nodes
-    and edges which are stored in the graph object.
+    Creating DGL graph object function is broken into three functions, namely
+        > _create_graph
+        > _process_node_data
+        > _process_edge_data
+    primarily for memory efficiency and readability.
+    These above function will be used here, to create the instance of DGL
+    graph partition for the current graph partition.
 
     Parameters:
     -----------
@@ -270,229 +661,63 @@ def create_dgl_object(
         and value is a 1D tensor mapping between shuffled edge IDs and the original edge
         IDs for each edge type. Otherwise, ``None`` is returned.
     """
-    # create auxiliary data structures from the schema object
-    memory_snapshot("CreateDGLObj_Begin", part_id)
-    _, global_nid_ranges = get_idranges(
-        schema[constants.STR_NODE_TYPE], node_typecounts
+    memory_snapshot("CreateDGLObj_GraphPartBegin", part_id)
+    (
+        shuffle_global_nids,
+        shuffle_global_nid_range,
+        node_map_val,
+        ntypes_map,
+        global_homo_nid,
+        id_map,
+    ) = _process_node_data(
+        schema, part_id, node_data, node_typecounts
     )
-    _, global_eid_ranges = get_idranges(
-        schema[constants.STR_EDGE_TYPE], edge_typecounts
-    )
-
-    id_map = dgl.distributed.id_map.IdMap(global_nid_ranges)
-
-    ntypes = [(key, global_nid_ranges[key][0, 0]) for key in global_nid_ranges]
-    ntypes.sort(key=lambda e: e[1])
-    ntype_offset_np = np.array([e[1] for e in ntypes])
-    ntypes = [e[0] for e in ntypes]
-    ntypes_map = {e: i for i, e in enumerate(ntypes)}
-    etypes = [(key, global_eid_ranges[key][0, 0]) for key in global_eid_ranges]
-    etypes.sort(key=lambda e: e[1])
-    etypes = [e[0] for e in etypes]
-    etypes_map = {_etype_str_to_tuple(e): i for i, e in enumerate(etypes)}
-
-    node_map_val = {ntype: [] for ntype in ntypes}
-    edge_map_val = {_etype_str_to_tuple(etype): [] for etype in etypes}
-
-    memory_snapshot("CreateDGLObj_AssignNodeData", part_id)
-    shuffle_global_nids = node_data[constants.SHUFFLE_GLOBAL_NID]
-    node_data.pop(constants.SHUFFLE_GLOBAL_NID)
-    gc.collect()
-
-    ntype_ids = node_data[constants.NTYPE_ID]
-    node_data.pop(constants.NTYPE_ID)
-    gc.collect()
-
-    global_type_nid = node_data[constants.GLOBAL_TYPE_NID]
-    node_data.pop(constants.GLOBAL_TYPE_NID)
     node_data = None
-    gc.collect()
+    memory_snapshot("CreateDGLObj_NodesDone", part_id)
 
-    global_homo_nid = ntype_offset_np[ntype_ids] + global_type_nid
-    assert np.all(shuffle_global_nids[1:] - shuffle_global_nids[:-1] == 1)
-    shuffle_global_nid_range = (shuffle_global_nids[0], shuffle_global_nids[-1])
-
-    # Determine the node ID ranges of different node types.
-    for ntype_name in global_nid_ranges:
-        ntype_id = ntypes_map[ntype_name]
-        type_nids = shuffle_global_nids[ntype_ids == ntype_id]
-        node_map_val[ntype_name].append(
-            [int(type_nids[0]), int(type_nids[-1]) + 1]
-        )
-
-    # process edges
-    memory_snapshot("CreateDGLObj_AssignEdgeData: ", part_id)
-    shuffle_global_src_id = edge_data[constants.SHUFFLE_GLOBAL_SRC_ID]
-    edge_data.pop(constants.SHUFFLE_GLOBAL_SRC_ID)
-    gc.collect()
-
-    shuffle_global_dst_id = edge_data[constants.SHUFFLE_GLOBAL_DST_ID]
-    edge_data.pop(constants.SHUFFLE_GLOBAL_DST_ID)
-    gc.collect()
-
-    global_src_id = edge_data[constants.GLOBAL_SRC_ID]
-    edge_data.pop(constants.GLOBAL_SRC_ID)
-    gc.collect()
-
-    global_dst_id = edge_data[constants.GLOBAL_DST_ID]
-    edge_data.pop(constants.GLOBAL_DST_ID)
-    gc.collect()
-
-    global_edge_id = edge_data[constants.GLOBAL_TYPE_EID]
-    edge_data.pop(constants.GLOBAL_TYPE_EID)
-    gc.collect()
-
-    etype_ids = edge_data[constants.ETYPE_ID]
-    edge_data.pop(constants.ETYPE_ID)
-    edge_data = None
-    gc.collect()
-    logging.info(
-        f"There are {len(shuffle_global_src_id)} edges in partition {part_id}"
-    )
-
-    # It's not guaranteed that the edges are sorted based on edge type.
-    # Let's sort edges and all attributes on the edges.
-    if not np.all(np.diff(etype_ids) >= 0):
-        sort_idx = np.argsort(etype_ids)
-        (
-            shuffle_global_src_id,
-            shuffle_global_dst_id,
-            global_src_id,
-            global_dst_id,
-            global_edge_id,
-            etype_ids,
-        ) = (
-            shuffle_global_src_id[sort_idx],
-            shuffle_global_dst_id[sort_idx],
-            global_src_id[sort_idx],
-            global_dst_id[sort_idx],
-            global_edge_id[sort_idx],
-            etype_ids[sort_idx],
-        )
-        assert np.all(np.diff(etype_ids) >= 0)
-    else:
-        print(f"[Rank: {part_id} Edge data is already sorted !!!")
-
-    # Determine the edge ID range of different edge types.
-    edge_id_start = edgeid_offset
-    for etype_name in global_eid_ranges:
-        etype = _etype_str_to_tuple(etype_name)
-        assert len(etype) == 3
-        etype_id = etypes_map[etype]
-        edge_map_val[etype].append(
-            [edge_id_start, edge_id_start + np.sum(etype_ids == etype_id)]
-        )
-        edge_id_start += np.sum(etype_ids == etype_id)
-    memory_snapshot("CreateDGLObj_UniqueNodeIds: ", part_id)
-
-    # get the edge list in some order and then reshuffle.
-    # Here the order of nodes is defined by the sorted order.
-    uniq_ids, idx, part_local_src_id, part_local_dst_id = _get_unique_invidx(
-        shuffle_global_src_id,
-        shuffle_global_dst_id,
-        np.arange(shuffle_global_nid_range[0], shuffle_global_nid_range[1] + 1),
-    )
-
-    inner_nodes = th.as_tensor(
-        np.logical_and(
-            uniq_ids >= shuffle_global_nid_range[0],
-            uniq_ids <= shuffle_global_nid_range[1],
-        )
-    )
-
-    # get the list of indices, from inner_nodes, which will sort inner_nodes as [True, True, ...., False, False, ...]
-    # essentially local nodes will be placed before non-local nodes.
-    reshuffle_nodes = th.arange(len(uniq_ids))
-    reshuffle_nodes = th.cat(
-        [reshuffle_nodes[inner_nodes.bool()], reshuffle_nodes[inner_nodes == 0]]
-    )
-
-    """
-    Following procedure is used to map the part_local_src_id, part_local_dst_id to account for
-    reshuffling of nodes (to order localy owned nodes prior to non-local nodes in a partition)
-    1. Form a node_map, in this case a numpy array, which will be used to map old node-ids (pre-reshuffling)
-    to post-reshuffling ids.
-    2. Once the map is created, use this map to map all the node-ids in the part_local_src_id 
-    and part_local_dst_id list to their appropriate `new` node-ids (post-reshuffle order).
-    3. Since only the node's order is changed, we will have to re-order nodes related information when
-    creating dgl object: this includes dgl.NTYPE, dgl.NID and inner_node.
-    4. Edge's order is not changed. At this point in the execution path edges are still ordered by their etype-ids.
-    5. Create the dgl object appropriately and return the dgl object.
-    
-    Here is a  simple example to understand the above flow better.
-
-    part_local_nids = [0, 1, 2, 3, 4, 5]
-    part_local_src_ids = [0, 0, 0, 0, 2, 3, 4]
-    part_local_dst_ids = [1, 2, 3, 4, 4, 4, 5]
-
-    Assume that nodes {1, 5} are halo-nodes, which are not owned by this partition.
-
-    reshuffle_nodes = [0, 2, 3, 4, 1, 5]
-
-    A node_map, which maps node-ids from old to reshuffled order is as follows:
-    node_map = np.zeros((len(reshuffle_nodes,)))
-    node_map[reshuffle_nodes] = np.arange(len(reshuffle_nodes))
-
-    Using the above map, we have mapped part_local_src_ids and part_local_dst_ids as follows:
-    part_local_src_ids = [0, 0, 0, 0, 1, 2, 3]
-    part_local_dst_ids = [4, 1, 2, 3, 3, 3, 5]
-
-    In this graph above, note that nodes {0, 1, 2, 3} are inner_nodes and {4, 5} are NON-inner-nodes
-
-    Since the edge are re-ordered in any way, there is no reordering required for edge related data
-    during the DGL object creation.
-    """
-    # create the mappings to generate mapped part_local_src_id and part_local_dst_id
-    # This map will map from unshuffled node-ids to reshuffled-node-ids (which are ordered to prioritize
-    # locally owned nodes).
-    nid_map = np.zeros(
-        (
-            len(
-                reshuffle_nodes,
-            )
-        )
-    )
-    nid_map[reshuffle_nodes] = np.arange(len(reshuffle_nodes))
-
-    # Now map the edge end points to reshuffled_values.
-    part_local_src_id, part_local_dst_id = (
-        nid_map[part_local_src_id],
-        nid_map[part_local_dst_id],
-    )
-
-    # create the graph here now.
-    part_graph = dgl.graph(
-        data=(part_local_src_id, part_local_dst_id), num_nodes=len(uniq_ids)
-    )
-    part_graph.edata[dgl.EID] = th.arange(
+    (
+        part_local_src_id,
+        part_local_dst_id,
+        global_edge_id,
+        etype_ids,
+        ntype,
+        per_type_ids,
+        uniq_ids,
+        inner_nodes,
+        edge_map_val,
+        etypes_map,
+    ) = _process_edge_data(
+        schema,
+        part_id,
+        edge_data,
         edgeid_offset,
-        edgeid_offset + part_graph.number_of_edges(),
-        dtype=th.int64,
+        edge_typecounts,
+        global_homo_nid,
+        shuffle_global_nid_range,
+        id_map,
     )
-    part_graph.edata[dgl.ETYPE] = th.as_tensor(
-        etype_ids, dtype=RESERVED_FIELD_DTYPE[dgl.ETYPE]
-    )
-    part_graph.edata["inner_edge"] = th.ones(
-        part_graph.number_of_edges(), dtype=RESERVED_FIELD_DTYPE["inner_edge"]
-    )
+    edge_data = None
+    del global_homo_nid
+    memory_snapshot("CreateDGLObj_EdgesDone", part_id)
 
-    # compute per_type_ids and ntype for all the nodes in the graph.
-    global_ids = np.concatenate([global_src_id, global_dst_id, global_homo_nid])
-    part_global_ids = global_ids[idx]
-    part_global_ids = part_global_ids[reshuffle_nodes]
-    ntype, per_type_ids = id_map(part_global_ids)
-
-    # continue with the graph creation
-    part_graph.ndata[dgl.NTYPE] = th.as_tensor(
-        ntype, dtype=RESERVED_FIELD_DTYPE[dgl.NTYPE]
+    part_graph = _create_graph(
+        part_local_src_id,
+        part_local_dst_id,
+        edgeid_offset,
+        etype_ids,
+        ntype,
+        uniq_ids,
+        inner_nodes,
+        part_id,
     )
-    part_graph.ndata[dgl.NID] = th.as_tensor(uniq_ids[reshuffle_nodes])
-    part_graph.ndata["inner_node"] = th.as_tensor(
-        inner_nodes[reshuffle_nodes], dtype=RESERVED_FIELD_DTYPE["inner_node"]
-    )
+    del part_local_src_id
+    del part_local_dst_id
+    del etype_ids
+    del ntype
+    del uniq_ids
+    memory_snapshot("CreateDGLObj_GraphPartDone", part_id)
 
     orig_nids = None
-    orig_eids = None
     if return_orig_nids:
         orig_nids = {}
         for ntype, ntype_id in ntypes_map.items():
@@ -501,6 +726,8 @@ def create_dgl_object(
                 part_graph.ndata["inner_node"],
             )
             orig_nids[ntype] = th.as_tensor(per_type_ids[mask])
+
+    orig_eids = None
     if return_orig_eids:
         orig_eids = {}
         for etype, etype_id in etypes_map.items():

--- a/tools/distpartitioning/data_shuffle.py
+++ b/tools/distpartitioning/data_shuffle.py
@@ -1265,10 +1265,17 @@ def gen_dist_partitions(rank, world_size, params):
 
     def prepare_local_data(src_data, local_part_id):
         local_data = {}
+        keys = []
         for k, v in src_data.items():
             tokens = k.split("/")
             if tokens[len(tokens) - 1] == str(local_part_id):
+                keys.append(k)
                 local_data["/".join(tokens[:-1])] = v
+
+        for k in keys:
+            src_data[k] = None
+            src_data.pop(k)
+
         return local_data
 
     # create dgl objects here

--- a/tools/distpartitioning/dataset_utils.py
+++ b/tools/distpartitioning/dataset_utils.py
@@ -12,13 +12,30 @@ import torch
 import torch.distributed as dist
 from gloo_wrapper import alltoallv_cpu
 from utils import (
-    DATA_TYPE_ID,
     generate_read_list,
     get_gid_offsets,
     get_idranges,
     map_partid_rank,
-    REV_DATA_TYPE_ID,
 )
+
+DATA_TYPE_ID = {
+    data_type: id
+    for id, data_type in enumerate(
+        [
+            torch.float32,
+            torch.float64,
+            torch.float16,
+            torch.uint8,
+            torch.int8,
+            torch.int16,
+            torch.int32,
+            torch.int64,
+            torch.bool,
+        ]
+    )
+}
+
+REV_DATA_TYPE_ID = {id: data_type for data_type, id in DATA_TYPE_ID.items()}
 
 
 def _broadcast_shape(


### PR DESCRIPTION
## Description
<!-- Brief description. Refer to the related issues if existed.
It'll be great if relevant reviewers can be assigned as well.-->

With benchmarking felarge/webgraph/searchctr graphs, it is observed that the memory bottleneck is because of dgl graph creation, in the convert_partition.py module. Currently we can only partition felarge graph no less than 12 partitions and webgraph no less than 32 partitions.

To overcome this issue, so as to increase the size of the graph partition per node following code changes are made using this PR: 
1. refactor the code in the convert_partition::create_dgl_object into smaller functions so that we can accomplish the following. 
2. numpy's buffers are more reliably free'ed by the pythons' garbage collector when wrapper into a function. This means that upon functions exit, it appears that garbage collector seems to work the best and the buffers will become available for use by the system. 
3. The large function, to create DGL object, is refactored into 3 smaller functions. Each of these functions process the data and returns processed data which is later used for creating dgl graph object. After each of these functions, appropriate data can be deleted and their memory freed up to become available to the system. 

No additional (unit) test cases are instrumented to this PR because all the existing end-to-end test cases in the unit test framework will be sufficient to test this functional refactoring of the code. 

## Checklist
Please feel free to remove inapplicable items for your PR.
- [X] The PR title starts with [$CATEGORY] (such as [NN], [Model], [Doc], [Feature]])
- [X] I've leverage the [tools](https://docs.google.com/document/d/1iHyj7zlmygKSk5gBPsqIqL5ASPzJSPREaNT_QdsiYA4/edit) to beautify the python and c++ code.
- [X] The PR is complete and small, read the [Google eng practice (CL equals to PR)](https://google.github.io/eng-practices/review/developer/small-cls.html) to understand more about small PR. In DGL, we consider PRs with less than 200 lines of core code change are small (example, test and documentation could be exempted).
- [X] All changes have test coverage
- [X] Code is well-documented
- [X] To the best of my knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change
- [ ] Related issue is referred in this PR
- [ ] If the PR is for a new model/paper, I've updated the example index [here](../examples/README.md).

## Changes
<!-- You could use following template
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)
-->
