### PR TITLE
Fix CI Test case for graph partitioning validation script

### DIFF
--- a/tests/tools/test_dist_part.py
+++ b/tests/tools/test_dist_part.py
@@ -26,6 +26,7 @@ from tools.verification_utils import (
     verify_partition_data_types,
     verify_partition_formats,
 )
+from tools.verify_partitions import validate_results
 
 
 def _test_chunk_graph(
@@ -267,11 +268,7 @@ def _test_pipeline(
 
         # check if verify_partitions.py is used for validation.
         if use_verify_partitions:
-            cmd = "python3 tools/verify_partitions.py "
-            cmd += f" --orig-dataset-dir {in_dir}"
-            cmd += f" --part-graph {out_dir}"
-            cmd += f" --partitions-dir {output_dir}"
-            os.system(cmd)
+            validate_results(out_dir, in_dir, partition_dir)
             return
 
         # read original node/edge IDs

--- a/tools/verify_partitions.py
+++ b/tools/verify_partitions.py
@@ -162,29 +162,41 @@ def _read_part_graphs(part_config, part_metafile):
     return part_graph_data
 
 
-def _validate_results(params):
+def validate_results(part_graph_dir, orig_dataset_dir, partitions_dir, log_level="INFO"):
     """Main function to verify the graph partitions
 
     Parameters:
     -----------
-    params : argparser object
-        to access the command line arguments
+    part_graph_dir : string
+        location where partitioned graph objects are stored
+    orig_dataset_dir : string
+        location where input dataset is stored
+    partitions_dir : string
+        location where node partitons files are stored
+    log_level : string [optional]
+        specify the logging level for debugging purposes
     """
+    numeric_level = getattr(logging, log_level, None)
+    logging.basicConfig(
+        level=numeric_level,
+        format=f"[{platform.node()} %(levelname)s %(asctime)s PID:%(process)d] %(message)s",
+    )
+
     logging.info(f"loading config files...")
-    part_config = os.path.join(params.part_graph_dir, "metadata.json")
+    part_config = os.path.join(part_graph_dir, "metadata.json")
     part_schema = read_json(part_config)
     num_parts = part_schema["num_parts"]
 
     logging.info(f"loading config files of the original dataset...")
-    graph_config = os.path.join(params.orig_dataset_dir, "metadata.json")
+    graph_config = os.path.join(orig_dataset_dir, "metadata.json")
     graph_schema = read_json(graph_config)
 
     logging.info(f"loading original ids from the dgl files...")
-    orig_nids = read_orig_ids(params.part_graph_dir, "orig_nids.dgl", num_parts)
-    orig_eids = read_orig_ids(params.part_graph_dir, "orig_eids.dgl", num_parts)
+    orig_nids = read_orig_ids(part_graph_dir, "orig_nids.dgl", num_parts)
+    orig_eids = read_orig_ids(part_graph_dir, "orig_eids.dgl", num_parts)
 
     logging.info(f"loading node to partition-ids from files... ")
-    node_partids = get_node_partids(params.partitions_dir, graph_schema)
+    node_partids = get_node_partids(partitions_dir, graph_schema)
 
     logging.info(f"loading the original dataset...")
     g = _read_graph(graph_schema)
@@ -243,4 +255,6 @@ if __name__ == "__main__":
         format=f"[{platform.node()} %(levelname)s %(asctime)s PID:%(process)d] %(message)s",
     )
 
-    _validate_results(params)
+    validate_results(params.part_graph_dir, params.orig_dataset_dir, params.partitions_dir, params.log_level.upper())
+
+


### PR DESCRIPTION
## Description
<!-- Brief description. Refer to the related issues if existed.
It'll be great if relevant reviewers can be assigned as well.-->

CI Tests for verify_partitions.py script, which is used for validation of partitioned graph objects, was executed using os.system("string") command. This resulted in running the verification script, but as a system command (as a separate process, out of the context of the CI Test process). Because of this reason, even though the verify_partitions.py was failing in the newly spawned process it was NOT caught by the CI Test process leading us to believe that the CI Test passed successfully!. 

This above behavior is corrected now with this PR. In this PR, the verify_partitions.py is NO longer executed as a system command. Now, for the CI test cases it is run directly by invoking the main function from the verify_partitions.py. This will make sure that all the errors happening in verify_partitions.py are correctly caught and reported by the CI test case which is running that function.

## Checklist
Please feel free to remove inapplicable items for your PR.
- [X] The PR title starts with [$CATEGORY] (such as [NN], [Model], [Doc], [Feature]])
- [X] I've leverage the [tools](https://docs.google.com/document/d/1iHyj7zlmygKSk5gBPsqIqL5ASPzJSPREaNT_QdsiYA4/edit) to beautify the python and c++ code.
- [X] The PR is complete and small, read the [Google eng practice (CL equals to PR)](https://google.github.io/eng-practices/review/developer/small-cls.html) to understand more about small PR. In DGL, we consider PRs with less than 200 lines of core code change are small (example, test and documentation could be exempted).
- [X] All changes have test coverage
- [X] Code is well-documented
- [X] To the best of my knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change
- [ ] Related issue is referred in this PR
- [ ] If the PR is for a new model/paper, I've updated the example index [here](../examples/README.md).

## Changes
<!-- You could use following template
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)
-->
