### PR TITLE
[Bug] Merge rather replace when find reverse eids

### DIFF
--- a/python/dgl/dataloading/base.py
+++ b/python/dgl/dataloading/base.py
@@ -281,17 +281,9 @@ def _find_exclude_eids_with_reverse_types(g, eids, reverse_etype_map):
     }
     exclude_eids.update(
         {
-            v: F.unique(
-                F.cat(
-                    (
-                        exclude_eids[k],
-                        exclude_eids.get(
-                            v, F.tensor([], dtype=exclude_eids[k].dtype)
-                        ),
-                    ),
-                    dim=0,
-                )
-            )
+            v: F.unique(F.cat((exclude_eids[k], exclude_eids[v]), dim=0))
+            if v in exclude_eids
+            else exclude_eids[k]
             for k, v in reverse_etype_map.items()
             if k in exclude_eids
         }

--- a/python/dgl/dataloading/base.py
+++ b/python/dgl/dataloading/base.py
@@ -279,13 +279,16 @@ def _find_exclude_eids_with_reverse_types(g, eids, reverse_etype_map):
         g.to_canonical_etype(k): g.to_canonical_etype(v)
         for k, v in reverse_etype_map.items()
     }
-    exclude_eids.update(
-        {
-            reverse_etype_map[k]: v
-            for k, v in exclude_eids.items()
-            if k in reverse_etype_map
-        }
-    )
+    reverse_exclude_eids = {
+        reverse_etype_map[k]: v for k, v in exclude_eids.items()
+    }
+    for etype, eid in reverse_exclude_eids.items():
+        if etype in exclude_eids:
+            exclude_eids[etype] = F.unique(
+                F.cat((exclude_eids[etype], eid), dim=0)
+            )
+        else:
+            exclude_eids[etype] = eid
     return exclude_eids
 
 

--- a/python/dgl/dataloading/base.py
+++ b/python/dgl/dataloading/base.py
@@ -279,15 +279,14 @@ def _find_exclude_eids_with_reverse_types(g, eids, reverse_etype_map):
         g.to_canonical_etype(k): g.to_canonical_etype(v)
         for k, v in reverse_etype_map.items()
     }
-    exclude_eids.update(
-        {
-            v: F.unique(F.cat((exclude_eids[k], exclude_eids[v]), dim=0))
-            if v in exclude_eids
-            else exclude_eids[k]
-            for k, v in reverse_etype_map.items()
-            if k in exclude_eids
-        }
-    )
+    for k, v in reverse_etype_map.items():
+        if k in exclude_eids:
+            if v in exclude_eids:
+                exclude_eids[v] = F.unique(
+                    F.cat((exclude_eids[k], exclude_eids[v]), dim=0)
+                )
+            else:
+                exclude_eids[v] = exclude_eids[k]
     return exclude_eids
 
 

--- a/python/dgl/dataloading/base.py
+++ b/python/dgl/dataloading/base.py
@@ -279,16 +279,23 @@ def _find_exclude_eids_with_reverse_types(g, eids, reverse_etype_map):
         g.to_canonical_etype(k): g.to_canonical_etype(v)
         for k, v in reverse_etype_map.items()
     }
-    reverse_exclude_eids = {
-        reverse_etype_map[k]: v for k, v in exclude_eids.items()
-    }
-    for etype, eid in reverse_exclude_eids.items():
-        if etype in exclude_eids:
-            exclude_eids[etype] = F.unique(
-                F.cat((exclude_eids[etype], eid), dim=0)
+    exclude_eids.update(
+        {
+            v: F.unique(
+                F.cat(
+                    (
+                        exclude_eids[k],
+                        exclude_eids.get(
+                            v, F.tensor([], dtype=exclude_eids[k].dtype)
+                        ),
+                    ),
+                    dim=0,
+                )
             )
-        else:
-            exclude_eids[etype] = eid
+            for k, v in reverse_etype_map.items()
+            if k in exclude_eids
+        }
+    )
     return exclude_eids
 
 


### PR DESCRIPTION
## Description
When calling `as_edge_prediction_sampler` with `exclude=reverse_types`, both original eids and reverse eids should be removed from latest MFG, but currently only  reverse eids are removed, so this PR is used to fix this bug.

## Checklist
Please feel free to remove inapplicable items for your PR.
- [ ] The PR title starts with [$CATEGORY] (such as [NN], [Model], [Doc], [Feature]])
- [ ] I've leverage the [tools](https://docs.google.com/document/d/1iHyj7zlmygKSk5gBPsqIqL5ASPzJSPREaNT_QdsiYA4/edit) to beautify the python and c++ code.
- [ ] The PR is complete and small, read the [Google eng practice (CL equals to PR)](https://google.github.io/eng-practices/review/developer/small-cls.html) to understand more about small PR. In DGL, we consider PRs with less than 200 lines of core code change are small (example, test and documentation could be exempted).
- [ ] All changes have test coverage
- [ ] Code is well-documented
- [ ] To the best of my knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change
- [ ] Related issue is referred in this PR
- [ ] If the PR is for a new model/paper, I've updated the example index [here](../examples/README.md).

## Changes
<!-- You could use following template
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)
-->
