### PR TITLE
[Fix] Remove curand host functions

### DIFF
--- a/cmake/modules/CUDA.cmake
+++ b/cmake/modules/CUDA.cmake
@@ -315,8 +315,7 @@ macro(dgl_config_cuda out_variable)
   list(APPEND DGL_LINKER_LIBS
     ${CUDA_CUDART_LIBRARY}
     ${CUDA_CUBLAS_LIBRARIES}
-    ${CUDA_cusparse_LIBRARY}
-    ${CUDA_CURAND_LIBRARY})
+    ${CUDA_cusparse_LIBRARY})
 
   set(${out_variable} ${DGL_CUDA_SRC})
 endmacro()

--- a/src/random/random.cc
+++ b/src/random/random.cc
@@ -11,10 +11,6 @@
 #include <dgl/runtime/registry.h>
 #include <dmlc/omp.h>
 
-#ifdef DGL_USE_CUDA
-#include "../runtime/cuda/cuda_common.h"
-#endif  // DGL_USE_CUDA
-
 using namespace dgl::runtime;
 
 namespace dgl {
@@ -28,17 +24,6 @@ DGL_REGISTER_GLOBAL("rng._CAPI_SetSeed")
           RandomEngine::ThreadLocal()->SetSeed(seed);
         }
       });
-#ifdef DGL_USE_CUDA
-      if (DeviceAPI::Get(kDGLCUDA)->IsAvailable()) {
-        auto *thr_entry = CUDAThreadEntry::ThreadLocal();
-        if (!thr_entry->curand_gen) {
-          CURAND_CALL(curandCreateGenerator(
-              &thr_entry->curand_gen, CURAND_RNG_PSEUDO_DEFAULT));
-        }
-        CURAND_CALL(curandSetPseudoRandomGeneratorSeed(
-            thr_entry->curand_gen, static_cast<uint64_t>(seed)));
-      }
-#endif  // DGL_USE_CUDA
     });
 
 DGL_REGISTER_GLOBAL("rng._CAPI_Choice")

--- a/src/runtime/cuda/cuda_common.h
+++ b/src/runtime/cuda/cuda_common.h
@@ -244,8 +244,6 @@ class CUDAThreadEntry {
   cusparseHandle_t cusparse_handle{nullptr};
   /** @brief The cublas handler */
   cublasHandle_t cublas_handle{nullptr};
-  /** @brief The curand generator */
-  curandGenerator_t curand_gen{nullptr};
   /** @brief thread local pool*/
   WorkspacePool pool;
   /** @brief constructor */


### PR DESCRIPTION
## Description

Remove curand host functions and linked library because they're never used.

In DGL, we're using curand device APIs which don't require a generator or linking to the curand library.

## Checklist
Please feel free to remove inapplicable items for your PR.
- [ ] The PR title starts with [$CATEGORY] (such as [NN], [Model], [Doc], [Feature]])
- [ ] I've leverage the [tools](https://docs.google.com/document/d/1iHyj7zlmygKSk5gBPsqIqL5ASPzJSPREaNT_QdsiYA4/edit) to beautify the python and c++ code.
- [ ] The PR is complete and small, read the [Google eng practice (CL equals to PR)](https://google.github.io/eng-practices/review/developer/small-cls.html) to understand more about small PR. In DGL, we consider PRs with less than 200 lines of core code change are small (example, test and documentation could be exempted).
- [ ] All changes have test coverage
- [ ] Code is well-documented
- [ ] To the best of my knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change
- [ ] Related issue is referred in this PR
- [ ] If the PR is for a new model/paper, I've updated the example index [here](../examples/README.md).

