### PR TITLE
[Fix] np.asscalar deprecated usage

### DIFF
--- a/tests/python/common/test_heterograph.py
+++ b/tests/python/common/test_heterograph.py
@@ -1313,8 +1313,8 @@ def test_convert(idtype):
         dsttype = hg.ntypes[ntype_id[dst[i]]]
         etype = hg.etypes[etype_id[i]]
         src_i, dst_i = hg.find_edges([eid[i]], (srctype, etype, dsttype))
-        assert np.asscalar(F.asnumpy(src_i)) == nid[src[i]]
-        assert np.asscalar(F.asnumpy(dst_i)) == nid[dst[i]]
+        assert F.asnumpy(src_i).item() == nid[src[i]]
+        assert F.asnumpy(dst_i).item() == nid[dst[i]]
 
     mg = nx.MultiDiGraph(
         [


### PR DESCRIPTION
## Description

Closes #5555 

Fixed the bug reported in this issue, https://github.com/dmlc/dgl/issues/5555,  by replacing the deprecated API with the recommended one.

## Checklist
Please feel free to remove inapplicable items for your PR.
- [x] The PR title starts with [$CATEGORY] (such as [NN], [Model], [Doc], [Feature]])
- [x] I've leverage the [tools](https://docs.google.com/document/d/1iHyj7zlmygKSk5gBPsqIqL5ASPzJSPREaNT_QdsiYA4/edit) to beautify the python and c++ code.
- [x] The PR is complete and small, read the [Google eng practice (CL equals to PR)](https://google.github.io/eng-practices/review/developer/small-cls.html) to understand more about small PR. In DGL, we consider PRs with less than 200 lines of core code change are small (example, test and documentation could be exempted).
- [x] All changes have test coverage
- [x] Code is well-documented
- [x] To the best of my knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change
- [x] [Related bug report is referred in this PR](https://github.com/dmlc/dgl/issues/5555)


## Changes
* replaced `numpy.asscalar()` with `.item()`