### PR TITLE
[Fix] np.float and np.int deprecated usage

### DIFF
--- a/tests/python/common/data/test_data.py
+++ b/tests/python/common/data/test_data.py
@@ -693,12 +693,12 @@ def _test_construct_graphs_multiple():
     num_edges = 1000
     num_graphs = 10
     num_dims = 3
-    node_ids = np.array([], dtype=np.int)
-    src_ids = np.array([], dtype=np.int)
-    dst_ids = np.array([], dtype=np.int)
-    ngraph_ids = np.array([], dtype=np.int)
-    egraph_ids = np.array([], dtype=np.int)
-    u_indices = np.array([], dtype=np.int)
+    node_ids = np.array([], dtype=int)
+    src_ids = np.array([], dtype=int)
+    dst_ids = np.array([], dtype=int)
+    ngraph_ids = np.array([], dtype=int)
+    egraph_ids = np.array([], dtype=int)
+    u_indices = np.array([], dtype=int)
     for i in range(num_graphs):
         l_node_ids = np.random.choice(
             np.arange(num_nodes * 2), size=num_nodes, replace=False
@@ -1579,7 +1579,7 @@ def _test_NodeEdgeGraphData():
 
     # NodeData basics
     num_nodes = 100
-    node_ids = np.arange(num_nodes, dtype=np.float)
+    node_ids = np.arange(num_nodes, dtype=float)
     ndata = NodeData(node_ids, {})
     assert np.array_equal(ndata.id, node_ids)
     assert len(ndata.data) == 0
@@ -1619,8 +1619,8 @@ def _test_NodeEdgeGraphData():
     assert len(edata.data) == 0
     assert np.array_equal(edata.graph_id, np.full(num_edges, 0))
     # EdageData more
-    src_ids = np.random.randint(num_nodes, size=num_edges).astype(np.float)
-    dst_ids = np.random.randint(num_nodes, size=num_edges).astype(np.float)
+    src_ids = np.random.randint(num_nodes, size=num_edges).astype(float)
+    dst_ids = np.random.randint(num_nodes, size=num_edges).astype(float)
     data = {"feat": np.random.rand(num_edges, 3)}
     etype = ("user", "like", "item")
     graph_ids = np.arange(num_edges)
@@ -1653,7 +1653,7 @@ def _test_NodeEdgeGraphData():
     assert np.array_equal(gdata.graph_id, graph_ids)
     assert len(gdata.data) == 0
     # GraphData more
-    graph_ids = np.arange(num_graphs).astype(np.float)
+    graph_ids = np.arange(num_graphs).astype(float)
     data = {"feat": np.random.rand(num_graphs, 3)}
     gdata = GraphData(graph_ids, data)
     assert np.array_equal(gdata.graph_id, graph_ids)

--- a/tests/python/common/test_heterograph.py
+++ b/tests/python/common/test_heterograph.py
@@ -1313,8 +1313,8 @@ def test_convert(idtype):
         dsttype = hg.ntypes[ntype_id[dst[i]]]
         etype = hg.etypes[etype_id[i]]
         src_i, dst_i = hg.find_edges([eid[i]], (srctype, etype, dsttype))
-        assert np.asscalar(F.asnumpy(src_i)) == nid[src[i]]
-        assert np.asscalar(F.asnumpy(dst_i)) == nid[dst[i]]
+        assert F.asnumpy(src_i).item() == nid[src[i]]
+        assert F.asnumpy(dst_i).item() == nid[dst[i]]
 
     mg = nx.MultiDiGraph(
         [


### PR DESCRIPTION
## Description

Closes #5562

Fixed the bug reported in this issue, https://github.com/dmlc/dgl/issues/5562,  by replacing the deprecated API with the recommended one.

## Checklist
Please feel free to remove inapplicable items for your PR.
- [x] The PR title starts with [$CATEGORY] (such as [NN], [Model], [Doc], [Feature]])
- [x] I've leverage the [tools](https://docs.google.com/document/d/1iHyj7zlmygKSk5gBPsqIqL5ASPzJSPREaNT_QdsiYA4/edit) to beautify the python and c++ code.
- [x] The PR is complete and small, read the [Google eng practice (CL equals to PR)](https://google.github.io/eng-practices/review/developer/small-cls.html) to understand more about small PR. In DGL, we consider PRs with less than 200 lines of core code change are small (example, test and documentation could be exempted).
- [x] All changes have test coverage
- [x] Code is well-documented
- [x] To the best of my knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change
- [x] [Related bug report is referred in this PR](https://github.com/dmlc/dgl/issues/5562)


## Changes
* replaced `numpy.float` with `float`
* replaced `numpy.int` with `int`