### PR TITLE
[NN] Refine the API of GraphormerLayer

### DIFF
--- a/python/dgl/nn/pytorch/gt/graphormer.py
+++ b/python/dgl/nn/pytorch/gt/graphormer.py
@@ -30,6 +30,8 @@ class GraphormerLayer(nn.Module):
         afterwards. Default: False.
     dropout : float, optional
         Dropout probability. Default: 0.1.
+    attn_dropout : float, optional
+        Attention dropout probability. Default: 0.1.
     activation : callable activation layer, optional
         Activation function. Default: nn.ReLU().
 
@@ -60,6 +62,7 @@ class GraphormerLayer(nn.Module):
         attn_bias_type="add",
         norm_first=False,
         dropout=0.1,
+        attn_dropout=0.1,
         activation=nn.ReLU(),
     ):
         super().__init__()
@@ -70,7 +73,7 @@ class GraphormerLayer(nn.Module):
             feat_size=feat_size,
             num_heads=num_heads,
             attn_bias_type=attn_bias_type,
-            attn_drop=dropout,
+            attn_drop=attn_dropout,
         )
         self.ffn = nn.Sequential(
             nn.Linear(feat_size, hidden_size),

--- a/tests/python/pytorch/nn/test_nn.py
+++ b/tests/python/pytorch/nn/test_nn.py
@@ -2322,6 +2322,7 @@ def test_GraphormerLayer(attn_bias_type, norm_first):
         attn_bias_type=attn_bias_type,
         norm_first=norm_first,
         dropout=0.1,
+        attn_dropout=0.1,
         activation=th.nn.ReLU(),
     )
     out = net(nfeat, attn_bias, attn_mask)


### PR DESCRIPTION
## Description
<!-- Brief description. Refer to the related issues if existed.
It'll be great if relevant reviewers can be assigned as well.-->

In common with Graphormer and GraphGPS, we’d like to add `attn_dropout` parameter in `GraphormerLayer` module to distinguish `dropout` and `attn_dropout`, which is convenient for users to set different values of `attn_dropout` and `dropout`. By setting `attn_dropout` individually, users can better control the sparsity of the attention weight matrix.

## Checklist
Please feel free to remove inapplicable items for your PR.
- [x] The PR title starts with [$CATEGORY] (such as [NN], [Model], [Doc], [Feature]])
- [x] I've leverage the [tools](https://docs.google.com/document/d/1iHyj7zlmygKSk5gBPsqIqL5ASPzJSPREaNT_QdsiYA4/edit) to beautify the python and c++ code.
- [x] The PR is complete and small, read the [Google eng practice (CL equals to PR)](https://google.github.io/eng-practices/review/developer/small-cls.html) to understand more about small PR. In DGL, we consider PRs with less than 200 lines of core code change are small (example, test and documentation could be exempted).
- [x] All changes have test coverage
- [x] Code is well-documented
- [x] To the best of my knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

## Changes
<!-- You could use following template
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)
-->
