### PR TITLE
[Bugfix] Fix unit test failures on older GPUs

### DIFF
--- a/tests/python/common/ops/test_ops.py
+++ b/tests/python/common/ops/test_ops.py
@@ -410,8 +410,10 @@ def test_gather_mm_idx_b(feat_size, dtype, tol):
         and dtype == torch.float16
         and torch.cuda.get_device_capability() < (7, 0)
     ):
-        pytest.skip(f"FP16 is not supported for atomic operations on GPU with "
-                    f"cuda capability ({torch.cuda.get_device_capability()}).")
+        pytest.skip(
+            f"FP16 is not supported for atomic operations on GPU with "
+            f"cuda capability ({torch.cuda.get_device_capability()})."
+        )
 
     dev = F.ctx()
     # input

--- a/tests/python/common/ops/test_ops.py
+++ b/tests/python/common/ops/test_ops.py
@@ -405,6 +405,13 @@ def test_gather_mm_idx_b(feat_size, dtype, tol):
     ):
         pytest.skip("BF16 is not supported.")
 
+    if (
+        F._default_context_str == "gpu"
+        and dtype == torch.float16
+        and torch.cuda.get_device_capability() < (7, 0)
+    ):
+        pytest.skip("FP16 is not supported for atomic operations on this GPU.")
+
     dev = F.ctx()
     # input
     a = torch.tensor(np.random.rand(100, feat_size)).to(dev).to(dtype)

--- a/tests/python/common/ops/test_ops.py
+++ b/tests/python/common/ops/test_ops.py
@@ -410,7 +410,8 @@ def test_gather_mm_idx_b(feat_size, dtype, tol):
         and dtype == torch.float16
         and torch.cuda.get_device_capability() < (7, 0)
     ):
-        pytest.skip("FP16 is not supported for atomic operations on this GPU.")
+        pytest.skip(f"FP16 is not supported for atomic operations on GPU with "
+                    f"cuda capability ({torch.cuda.get_device_capability()}).")
 
     dev = F.ctx()
     # input


### PR DESCRIPTION
## Description
To fix https://github.com/dmlc/dgl/issues/5571, this PR bypasses the cases if the running GPU does not support atomic operations for half precision.

## Checklist
Please feel free to remove inapplicable items for your PR.
- [x] The PR title starts with [$CATEGORY] (such as [NN], [Model], [Doc], [Feature]])
- [x] I've leverage the [tools](https://docs.google.com/document/d/1iHyj7zlmygKSk5gBPsqIqL5ASPzJSPREaNT_QdsiYA4/edit) to beautify the python and c++ code.
- [x] The PR is complete and small, read the [Google eng practice (CL equals to PR)](https://google.github.io/eng-practices/review/developer/small-cls.html) to understand more about small PR. In DGL, we consider PRs with less than 200 lines of core code change are small (example, test and documentation could be exempted).
- [x] All changes have test coverage
- [ ] Code is well-documented
- [x] To the best of my knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change
- [x] Related issue is referred in this PR
- [ ] If the PR is for a new model/paper, I've updated the example index [here](../examples/README.md).

## Changes
Skip the tests if atomicAdd is not supported for fp16.
