### PR TITLE
[Bugfix] Fix the uninitialized pin_memory flag for empty graph

### DIFF
--- a/include/dgl/aten/coo.h
+++ b/include/dgl/aten/coo.h
@@ -158,7 +158,6 @@ struct COOMatrix {
              "with the above stacktrace.";
       return new_coo;
     }
-    is_pinned = true;
     return *this;
   }
 

--- a/include/dgl/aten/coo.h
+++ b/include/dgl/aten/coo.h
@@ -158,6 +158,7 @@ struct COOMatrix {
              "with the above stacktrace.";
       return new_coo;
     }
+    is_pinned = true;
     return *this;
   }
 

--- a/include/dgl/aten/coo.h
+++ b/include/dgl/aten/coo.h
@@ -64,8 +64,7 @@ struct COOMatrix {
         data(darr),
         row_sorted(rsorted),
         col_sorted(csorted) {
-    if (!aten::IsNullArray(row) || !aten::IsNullArray(col) ||
-        !aten::IsNullArray(data)) {
+    if (!IsEmpty()) {
       is_pinned = (aten::IsNullArray(row) || row.IsPinned()) &&
                   (aten::IsNullArray(col) || col.IsPinned()) &&
                   (aten::IsNullArray(data) || data.IsPinned());
@@ -130,6 +129,11 @@ struct COOMatrix {
     CHECK_NO_OVERFLOW(row->dtype, num_cols);
   }
 
+  inline bool IsEmpty() const {
+    return aten::IsNullArray(row) && aten::IsNullArray(col) &&
+           aten::IsNullArray(data);
+  }
+
   /** @brief Return a copy of this matrix on the give device context. */
   inline COOMatrix CopyTo(const DGLContext& ctx) const {
     if (ctx == row->ctx) return *this;
@@ -141,8 +145,7 @@ struct COOMatrix {
 
   /** @brief Return a copy of this matrix in pinned (page-locked) memory. */
   inline COOMatrix PinMemory() {
-    if (!aten::IsNullArray(row) || !aten::IsNullArray(col) ||
-        !aten::IsNullArray(data)) {
+    if (!IsEmpty()) {
       if (is_pinned) return *this;
       auto new_coo = COOMatrix(
           num_rows, num_cols, row.PinMemory(), col.PinMemory(),
@@ -168,8 +171,7 @@ struct COOMatrix {
    *       The context check is deferred to pinning the NDArray.
    */
   inline void PinMemory_() {
-    if (!aten::IsNullArray(row) || !aten::IsNullArray(col) ||
-        !aten::IsNullArray(data)) {
+    if (!IsEmpty()) {
       if (is_pinned) return;
       row.PinMemory_();
       col.PinMemory_();
@@ -190,8 +192,7 @@ struct COOMatrix {
    *       The context check is deferred to unpinning the NDArray.
    */
   inline void UnpinMemory_() {
-    if (!aten::IsNullArray(row) || !aten::IsNullArray(col) ||
-        !aten::IsNullArray(data)) {
+    if (!IsEmpty()) {
       if (!is_pinned) return;
       row.UnpinMemory_();
       col.UnpinMemory_();

--- a/include/dgl/aten/coo.h
+++ b/include/dgl/aten/coo.h
@@ -64,9 +64,11 @@ struct COOMatrix {
         data(darr),
         row_sorted(rsorted),
         col_sorted(csorted) {
-    is_pinned = (aten::IsNullArray(row) || row.IsPinned()) &&
+    if (!aten::IsNullArray(row) || !aten::IsNullArray(col) || !aten::IsNullArray(data)) {
+      is_pinned = (aten::IsNullArray(row) || row.IsPinned()) &&
                 (aten::IsNullArray(col) || col.IsPinned()) &&
                 (aten::IsNullArray(data) || data.IsPinned());
+    }
     CheckValidity();
   }
 
@@ -138,16 +140,20 @@ struct COOMatrix {
 
   /** @brief Return a copy of this matrix in pinned (page-locked) memory. */
   inline COOMatrix PinMemory() {
-    if (is_pinned) return *this;
-    auto new_coo = COOMatrix(
-        num_rows, num_cols, row.PinMemory(), col.PinMemory(),
-        aten::IsNullArray(data) ? data : data.PinMemory(), row_sorted,
-        col_sorted);
-    CHECK(new_coo.is_pinned)
-        << "An internal DGL error has occured while trying to pin a COO "
-           "matrix. Please file a bug at 'https://github.com/dmlc/dgl/issues' "
-           "with the above stacktrace.";
-    return new_coo;
+    if (!aten::IsNullArray(row) || !aten::IsNullArray(col) || !aten::IsNullArray(data)) {
+      if (is_pinned) return *this;
+      auto new_coo = COOMatrix(
+          num_rows, num_cols, row.PinMemory(), col.PinMemory(),
+          aten::IsNullArray(data) ? data : data.PinMemory(), row_sorted,
+          col_sorted);
+      CHECK(new_coo.is_pinned)
+          << "An internal DGL error has occured while trying to pin a COO "
+             "matrix. Please file a bug at 'https://github.com/dmlc/dgl/issues' "
+             "with the above stacktrace.";
+      return new_coo;
+    }
+    is_pinned = true;
+    return *this;
   }
 
   /**
@@ -159,13 +165,17 @@ struct COOMatrix {
    *       The context check is deferred to pinning the NDArray.
    */
   inline void PinMemory_() {
-    if (is_pinned) return;
-    row.PinMemory_();
-    col.PinMemory_();
-    if (!aten::IsNullArray(data)) {
-      data.PinMemory_();
+    if (!aten::IsNullArray(row) || !aten::IsNullArray(col) || !aten::IsNullArray(data)) {
+      if (is_pinned) return;
+      row.PinMemory_();
+      col.PinMemory_();
+      if (!aten::IsNullArray(data)) {
+        data.PinMemory_();
+      }
+      is_pinned = true;
     }
     is_pinned = true;
+    return;
   }
 
   /**
@@ -176,13 +186,17 @@ struct COOMatrix {
    *       The context check is deferred to unpinning the NDArray.
    */
   inline void UnpinMemory_() {
-    if (!is_pinned) return;
-    row.UnpinMemory_();
-    col.UnpinMemory_();
-    if (!aten::IsNullArray(data)) {
-      data.UnpinMemory_();
+    if (!aten::IsNullArray(row) || !aten::IsNullArray(col) || !aten::IsNullArray(data)) {
+      if (!is_pinned) return;
+      row.UnpinMemory_();
+      col.UnpinMemory_();
+      if (!aten::IsNullArray(data)) {
+        data.UnpinMemory_();
+      }
+      is_pinned = false;
     }
     is_pinned = false;
+    return;
   }
 
   /**

--- a/include/dgl/aten/coo.h
+++ b/include/dgl/aten/coo.h
@@ -64,10 +64,11 @@ struct COOMatrix {
         data(darr),
         row_sorted(rsorted),
         col_sorted(csorted) {
-    if (!aten::IsNullArray(row) || !aten::IsNullArray(col) || !aten::IsNullArray(data)) {
+    if (!aten::IsNullArray(row) || !aten::IsNullArray(col) ||
+        !aten::IsNullArray(data)) {
       is_pinned = (aten::IsNullArray(row) || row.IsPinned()) &&
-                (aten::IsNullArray(col) || col.IsPinned()) &&
-                (aten::IsNullArray(data) || data.IsPinned());
+                  (aten::IsNullArray(col) || col.IsPinned()) &&
+                  (aten::IsNullArray(data) || data.IsPinned());
     }
     CheckValidity();
   }
@@ -140,7 +141,8 @@ struct COOMatrix {
 
   /** @brief Return a copy of this matrix in pinned (page-locked) memory. */
   inline COOMatrix PinMemory() {
-    if (!aten::IsNullArray(row) || !aten::IsNullArray(col) || !aten::IsNullArray(data)) {
+    if (!aten::IsNullArray(row) || !aten::IsNullArray(col) ||
+        !aten::IsNullArray(data)) {
       if (is_pinned) return *this;
       auto new_coo = COOMatrix(
           num_rows, num_cols, row.PinMemory(), col.PinMemory(),
@@ -148,7 +150,8 @@ struct COOMatrix {
           col_sorted);
       CHECK(new_coo.is_pinned)
           << "An internal DGL error has occured while trying to pin a COO "
-             "matrix. Please file a bug at 'https://github.com/dmlc/dgl/issues' "
+             "matrix. Please file a bug at "
+             "'https://github.com/dmlc/dgl/issues' "
              "with the above stacktrace.";
       return new_coo;
     }
@@ -165,7 +168,8 @@ struct COOMatrix {
    *       The context check is deferred to pinning the NDArray.
    */
   inline void PinMemory_() {
-    if (!aten::IsNullArray(row) || !aten::IsNullArray(col) || !aten::IsNullArray(data)) {
+    if (!aten::IsNullArray(row) || !aten::IsNullArray(col) ||
+        !aten::IsNullArray(data)) {
       if (is_pinned) return;
       row.PinMemory_();
       col.PinMemory_();
@@ -186,7 +190,8 @@ struct COOMatrix {
    *       The context check is deferred to unpinning the NDArray.
    */
   inline void UnpinMemory_() {
-    if (!aten::IsNullArray(row) || !aten::IsNullArray(col) || !aten::IsNullArray(data)) {
+    if (!aten::IsNullArray(row) || !aten::IsNullArray(col) ||
+        !aten::IsNullArray(data)) {
       if (!is_pinned) return;
       row.UnpinMemory_();
       col.UnpinMemory_();

--- a/include/dgl/aten/csr.h
+++ b/include/dgl/aten/csr.h
@@ -150,7 +150,6 @@ struct CSRMatrix {
              "with the above stacktrace.";
       return new_csr;
     }
-    is_pinned = true;
     return *this;
   }
 

--- a/include/dgl/aten/csr.h
+++ b/include/dgl/aten/csr.h
@@ -150,6 +150,7 @@ struct CSRMatrix {
              "with the above stacktrace.";
       return new_csr;
     }
+    is_pinned = true;
     return *this;
   }
 

--- a/include/dgl/aten/csr.h
+++ b/include/dgl/aten/csr.h
@@ -60,8 +60,7 @@ struct CSRMatrix {
         indices(iarr),
         data(darr),
         sorted(sorted_flag) {
-    if (!aten::IsNullArray(indptr) || !aten::IsNullArray(indices) ||
-        !aten::IsNullArray(data)) {
+    if (!IsEmpty()) {
       is_pinned = (aten::IsNullArray(indptr) || indptr.IsPinned()) &&
                   (aten::IsNullArray(indices) || indices.IsPinned()) &&
                   (aten::IsNullArray(data) || data.IsPinned());
@@ -124,6 +123,11 @@ struct CSRMatrix {
     CHECK_EQ(indptr->shape[0], num_rows + 1);
   }
 
+  inline bool IsEmpty() const {
+    return aten::IsNullArray(indptr) && aten::IsNullArray(indices) &&
+           aten::IsNullArray(data);
+  }
+
   /** @brief Return a copy of this matrix on the give device context. */
   inline CSRMatrix CopyTo(const DGLContext& ctx) const {
     if (ctx == indptr->ctx) return *this;
@@ -134,8 +138,7 @@ struct CSRMatrix {
 
   /** @brief Return a copy of this matrix in pinned (page-locked) memory. */
   inline CSRMatrix PinMemory() {
-    if (!aten::IsNullArray(indptr) || !aten::IsNullArray(indices) ||
-        !aten::IsNullArray(data)) {
+    if (!IsEmpty()) {
       if (is_pinned) return *this;
       auto new_csr = CSRMatrix(
           num_rows, num_cols, indptr.PinMemory(), indices.PinMemory(),
@@ -160,8 +163,7 @@ struct CSRMatrix {
    *       The context check is deferred to pinning the NDArray.
    */
   inline void PinMemory_() {
-    if (!aten::IsNullArray(indptr) || !aten::IsNullArray(indices) ||
-        !aten::IsNullArray(data)) {
+    if (!IsEmpty()) {
       if (is_pinned) return;
       indptr.PinMemory_();
       indices.PinMemory_();
@@ -182,8 +184,7 @@ struct CSRMatrix {
    *       The context check is deferred to unpinning the NDArray.
    */
   inline void UnpinMemory_() {
-    if (!aten::IsNullArray(indptr) || !aten::IsNullArray(indices) ||
-        !aten::IsNullArray(data)) {
+    if (!IsEmpty()) {
       if (!is_pinned) return;
       indptr.UnpinMemory_();
       indices.UnpinMemory_();

--- a/include/dgl/aten/csr.h
+++ b/include/dgl/aten/csr.h
@@ -60,7 +60,8 @@ struct CSRMatrix {
         indices(iarr),
         data(darr),
         sorted(sorted_flag) {
-    if (!aten::IsNullArray(indptr) || !aten::IsNullArray(indices) || !aten::IsNullArray(data)) {
+    if (!aten::IsNullArray(indptr) || !aten::IsNullArray(indices) ||
+        !aten::IsNullArray(data)) {
       is_pinned = (aten::IsNullArray(indptr) || indptr.IsPinned()) &&
                   (aten::IsNullArray(indices) || indices.IsPinned()) &&
                   (aten::IsNullArray(data) || data.IsPinned());
@@ -133,14 +134,16 @@ struct CSRMatrix {
 
   /** @brief Return a copy of this matrix in pinned (page-locked) memory. */
   inline CSRMatrix PinMemory() {
-    if (!aten::IsNullArray(indptr) || !aten::IsNullArray(indices) || !aten::IsNullArray(data)) {
+    if (!aten::IsNullArray(indptr) || !aten::IsNullArray(indices) ||
+        !aten::IsNullArray(data)) {
       if (is_pinned) return *this;
       auto new_csr = CSRMatrix(
           num_rows, num_cols, indptr.PinMemory(), indices.PinMemory(),
           aten::IsNullArray(data) ? data : data.PinMemory(), sorted);
       CHECK(new_csr.is_pinned)
           << "An internal DGL error has occured while trying to pin a CSR "
-             "matrix. Please file a bug at 'https://github.com/dmlc/dgl/issues' "
+             "matrix. Please file a bug at "
+             "'https://github.com/dmlc/dgl/issues' "
              "with the above stacktrace.";
       return new_csr;
     }
@@ -157,7 +160,8 @@ struct CSRMatrix {
    *       The context check is deferred to pinning the NDArray.
    */
   inline void PinMemory_() {
-    if (!aten::IsNullArray(indptr) || !aten::IsNullArray(indices) || !aten::IsNullArray(data)) {
+    if (!aten::IsNullArray(indptr) || !aten::IsNullArray(indices) ||
+        !aten::IsNullArray(data)) {
       if (is_pinned) return;
       indptr.PinMemory_();
       indices.PinMemory_();
@@ -178,7 +182,8 @@ struct CSRMatrix {
    *       The context check is deferred to unpinning the NDArray.
    */
   inline void UnpinMemory_() {
-    if (!aten::IsNullArray(indptr) || !aten::IsNullArray(indices) || !aten::IsNullArray(data)) {
+    if (!aten::IsNullArray(indptr) || !aten::IsNullArray(indices) ||
+        !aten::IsNullArray(data)) {
       if (!is_pinned) return;
       indptr.UnpinMemory_();
       indices.UnpinMemory_();

--- a/src/runtime/config.cc
+++ b/src/runtime/config.cc
@@ -6,7 +6,9 @@
 
 #include <dgl/runtime/config.h>
 #include <dgl/runtime/registry.h>
+#if !defined(_WIN32) && defined(USE_LIBXSMM)
 #include <libxsmm_cpuid.h>
+#endif
 
 using namespace dgl::runtime;
 

--- a/tests/python/common/test_heterograph-index.py
+++ b/tests/python/common/test_heterograph-index.py
@@ -68,6 +68,7 @@ def test_pin_memory(idtype):
 
     # Test pinning an empty homograph
     g2 = dgl.graph(([], []))
+    assert not g2.is_pinned()
     g2._graph = g2._graph.pin_memory()
     assert g2.is_pinned()
 

--- a/tests/python/common/test_heterograph.py
+++ b/tests/python/common/test_heterograph.py
@@ -1259,6 +1259,7 @@ def test_pin_memory_(idtype):
 
     # test pin empty homograph
     g2 = dgl.graph(([], []))
+    assert not g2.is_pinned()
     g2.pin_memory_()
     assert g2.is_pinned()
     g2.unpin_memory_()


### PR DESCRIPTION
## Description
This is to fix https://github.com/dmlc/dgl/issues/5592. For future/own reference, I will detail the root cause in the following.

The root cause is when the first relational graph is empty, the entire heterograph could return `is_pinned() = true` even if they are never being pinned by DGL or PyTorch at all. 

This is because (1) the empty unit graph would return `is_pinned = True` due to the following init. logic: https://github.com/dmlc/dgl/blob/ae8cbde5cfa699ff8d9e774ae6acd2cb8f7b451a/include/dgl/aten/coo.h#L67-L69 and (2) the first relational graph determines if the entire hetero-graph is pinned. 
https://github.com/dmlc/dgl/blob/ae8cbde5cfa699ff8d9e774ae6acd2cb8f7b451a/src/graph/heterograph.h#L58

As a result, when the sub-graph is pickled/unpickled by workers/main process after sampling, the code will always try to pin the (sub)graph as long as its `relation_graphs_[0]` is an empty graph (`coo.data`, `coo.row` and `coo.col` are NullArray). See here https://github.com/dmlc/dgl/blob/ae8cbde5cfa699ff8d9e774ae6acd2cb8f7b451a/src/graph/pickle.cc#L64 is for sub-graph pickling, which will always write `True` if `graph->relation_graphs_[0]` is empty. And then here https://github.com/dmlc/dgl/blob/ae8cbde5cfa699ff8d9e774ae6acd2cb8f7b451a/src/graph/pickle.cc#L156-L158 will pin the unpickled graph even if it never gets pinned before.

## Checklist
Please feel free to remove inapplicable items for your PR.
- [x] The PR title starts with [$CATEGORY] (such as [NN], [Model], [Doc], [Feature]])
- [x] I've leverage the [tools](https://docs.google.com/document/d/1iHyj7zlmygKSk5gBPsqIqL5ASPzJSPREaNT_QdsiYA4/edit) to beautify the python and c++ code.
- [x] The PR is complete and small, read the [Google eng practice (CL equals to PR)](https://google.github.io/eng-practices/review/developer/small-cls.html) to understand more about small PR. In DGL, we consider PRs with less than 200 lines of core code change are small (example, test and documentation could be exempted).
- [x] All changes have test coverage
- [ ] Code is well-documented
- [ ] To the best of my knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change
- [x] Related issue is referred in this PR
- [ ] If the PR is for a new model/paper, I've updated the example index [here](../examples/README.md).

## Changes
- If its a null/empty graph, always init. the `is_pinned` to false
- Update tests to cover this case
 