### PR TITLE
[Build] Bump nightly version

### DIFF
--- a/conda/dgl/meta.yaml
+++ b/conda/dgl/meta.yaml
@@ -1,6 +1,6 @@
 package:
   name: dgl{{ environ.get('DGL_PACKAGE_SUFFIX', '') }}
-  version: 1.1{{ environ.get('DGL_VERSION_SUFFIX', '') }}
+  version: 1.2{{ environ.get('DGL_VERSION_SUFFIX', '') }}
 
 source:
   git_rev: {{ environ.get('DGL_RELEASE_BRANCH', 'master') }}

--- a/include/dgl/runtime/c_runtime_api.h
+++ b/include/dgl/runtime/c_runtime_api.h
@@ -33,7 +33,7 @@
 #endif
 
 // DGL version
-#define DGL_VERSION "1.1"
+#define DGL_VERSION "1.2"
 
 #ifdef __cplusplus
 extern "C" {

--- a/python/dgl/_ffi/libinfo.py
+++ b/python/dgl/_ffi/libinfo.py
@@ -105,4 +105,4 @@ def find_lib_path(name=None, search_path=None, optional=False):
 # We use the version of the incoming release for code
 # that is under development.
 # The following line is set by dgl/python/update_version.py
-__version__ = "1.1"
+__version__ = "1.2"

--- a/python/update_version.py
+++ b/python/update_version.py
@@ -16,7 +16,7 @@ import re
 # (usually "aYYMMDD")
 # The environment variable DGL_VERSION_SUFFIX is the local version label
 # suffix for indicating CPU and CUDA versions as in PEP 440 (e.g. "+cu102")
-__version__ = "1.1" + os.getenv("DGL_PRERELEASE", "")
+__version__ = "1.2" + os.getenv("DGL_PRERELEASE", "")
 __version__ += os.getenv("DGL_VERSION_SUFFIX", "")
 print(__version__)
 


### PR DESCRIPTION
After each release we should bump the nightly version on the master branch to let the nightly build continue.  I have updated the release build guide accordingly as well.  @czkkkkkk 