### PR TITLE
[GraphBolt] add support for load and save CSCSamplingGraph

### DIFF
--- a/graphbolt/include/csc_sampling_graph.h
+++ b/graphbolt/include/csc_sampling_graph.h
@@ -4,6 +4,9 @@
  * @brief Header file of csc sampling graph.
  */
 
+#ifndef GRAPHBOLT_INCLUDE_CSCSAMPLINGGRAPH_H_
+#define GRAPHBOLT_INCLUDE_CSCSAMPLINGGRAPH_H_
+
 #include <torch/custom_class.h>
 #include <torch/torch.h>
 
@@ -94,6 +97,9 @@ struct HeteroInfo {
  */
 class CSCSamplingGraph : public torch::CustomClassHolder {
  public:
+  /** @brief Default constructor. */
+  CSCSamplingGraph() = default;
+
   /**
    * @brief Constructor for CSC with data.
    * @param num_nodes The number of nodes in the graph.
@@ -201,32 +207,4 @@ class CSCSamplingGraph : public torch::CustomClassHolder {
 }  // namespace sampling
 }  // namespace graphbolt
 
-/**
- * @brief Overload stream operator to enable `torch::save()` and `torch.load()`
- * for CSCSamplingGraph.
- */
-namespace torch {
-
-/**
- * @brief Overload input stream operator for CSCSamplingGraph deserialization.
- * @param archive Input stream for deserializing.
- * @param graph CSCSamplingGraph.
- *
- * @return archive
- */
-inline serialize::InputArchive& operator>>(
-    serialize::InputArchive& archive,
-    graphbolt::sampling::CSCSamplingGraph& graph);
-
-/**
- * @brief Overload output stream operator for CSCSamplingGraph serialization.
- * @param archive Output stream for serializing.
- * @param graph CSCSamplingGraph.
- *
- * @return archive
- */
-inline serialize::OutputArchive& operator<<(
-    serialize::OutputArchive& archive,
-    const graphbolt::sampling::CSCSamplingGraph& graph);
-
-}  // namespace torch
+#endif  // GRAPHBOLT_INCLUDE_CSCSAMPLINGGRAPH_H_

--- a/graphbolt/include/serialize.h
+++ b/graphbolt/include/serialize.h
@@ -12,134 +12,69 @@
 #include <string>
 #include <vector>
 
+#include "csc_sampling_graph.h"
+
+/**
+ * @brief Overload stream operator to enable `torch::save()` and `torch.load()`
+ * for CSCSamplingGraph.
+ */
+namespace torch {
+
+/**
+ * @brief Overload input stream operator for CSCSamplingGraph deserialization.
+ * @param archive Input stream for deserializing.
+ * @param graph CSCSamplingGraph.
+ *
+ * @return archive
+ */
+inline serialize::InputArchive& operator>>(
+    serialize::InputArchive& archive,
+    graphbolt::sampling::CSCSamplingGraph& graph);
+
+/**
+ * @brief Overload output stream operator for CSCSamplingGraph serialization.
+ * @param archive Output stream for serializing.
+ * @param graph CSCSamplingGraph.
+ *
+ * @return archive
+ */
+inline serialize::OutputArchive& operator<<(
+    serialize::OutputArchive& archive,
+    const graphbolt::sampling::CSCSamplingGraph& graph);
+
+}  // namespace torch
+
 namespace graphbolt {
-namespace utils {
 
 /**
- * @brief Utility function to write to archive.
- * @param archive Output archive.
- * @param key Key name used in saving.
- * @param data Data that could be constructed as `torch::IValue`.
+ * @brief Load CSCSamplingGraph from file.
+ * @param filename File name to read.
+ *
+ * @return CSCSamplingGraph.
  */
-template <typename DataT>
-void write_to_archive(
-    torch::serialize::OutputArchive& archive, const std::string& key,
-    const DataT& data) {
-  archive.write(key, data);
-}
+c10::intrusive_ptr<sampling::CSCSamplingGraph> LoadCSCSamplingGraph(
+    const std::string& filename);
 
 /**
- * @brief Specialization utility function to save string vector.
- * @param archive Output archive.
- * @param key Key name used in saving.
- * @param data Vector of string.
+ * @brief Save CSCSamplingGraph to file.
+ * @param graph CSCSamplingGraph to save.
+ * @param filename File name to save.
+ *
  */
-template <>
-void write_to_archive<std::vector<std::string>>(
-    torch::serialize::OutputArchive& archive, const std::string& key,
-    const std::vector<std::string>& data) {
-  archive.write(
-      key + "/size", torch::tensor(static_cast<int64_t>(data.size())));
-  for (const auto index : c10::irange(data.size())) {
-    archive.write(key + "/" + std::to_string(index), data[index]);
-  }
-}
+void SaveCSCSamplingGraph(
+    c10::intrusive_ptr<sampling::CSCSamplingGraph> graph,
+    const std::string& filename);
 
 /**
- * @brief Utility function to read from archive.
+ * @brief Read data from archive.
  * @param archive Input archive.
- * @param key Key name used in reading.
- * @param data Data that could be constructed as `torch::IValue`.
+ * @param key Key name of data.
+ *
+ * @return data.
  */
-template <typename DataT = torch::IValue>
-void read_from_archive(
-    torch::serialize::InputArchive& archive, const std::string& key,
-    DataT& data) {
-  archive.read(key, data);
-}
+torch::IValue read_from_archive(
+    torch::serialize::InputArchive& archive, const std::string& key);
 
-/**
- * @brief Specialization utility function to read from archive.
- * @param archive Input archive.
- * @param key Key name used in reading.
- * @param data Data that is `bool`.
- */
-template <>
-void read_from_archive<bool>(
-    torch::serialize::InputArchive& archive, const std::string& key,
-    bool& data) {
-  torch::IValue iv_data;
-  archive.read(key, iv_data);
-  data = iv_data.toBool();
-}
-
-/**
- * @brief Specialization utility function to read from archive.
- * @param archive Input archive.
- * @param key Key name used in reading.
- * @param data Data that is `int64_t`.
- */
-template <>
-void read_from_archive<int64_t>(
-    torch::serialize::InputArchive& archive, const std::string& key,
-    int64_t& data) {
-  torch::IValue iv_data;
-  archive.read(key, iv_data);
-  data = iv_data.toInt();
-}
-
-/**
- * @brief Specialization utility function to read from archive.
- * @param archive Input archive.
- * @param key Key name used in reading.
- * @param data Data that is `std::string`.
- */
-template <>
-void read_from_archive<std::string>(
-    torch::serialize::InputArchive& archive, const std::string& key,
-    std::string& data) {
-  torch::IValue iv_data;
-  archive.read(key, iv_data);
-  data = iv_data.toString();
-}
-
-/**
- * @brief Specialization utility function to read from archive.
- * @param archive Input archive.
- * @param key Key name used in reading.
- * @param data Data that is `torch::Tensor`.
- */
-template <>
-void read_from_archive<torch::Tensor>(
-    torch::serialize::InputArchive& archive, const std::string& key,
-    torch::Tensor& data) {
-  torch::IValue iv_data;
-  archive.read(key, iv_data);
-  data = iv_data.toTensor();
-}
-
-/**
- * @brief Specialization utility function to read to string vector.
- * @param archive Output archive.
- * @param key Key name used in saving.
- * @param data Vector of string.
- */
-template <>
-void read_from_archive<std::vector<std::string>>(
-    torch::serialize::InputArchive& archive, const std::string& key,
-    std::vector<std::string>& data) {
-  int64_t size = 0;
-  read_from_archive<int64_t>(archive, key + "/size", size);
-  data.resize(static_cast<size_t>(size));
-  std::string element;
-  for (int64_t index = 0; index < size; ++index) {
-    read_from_archive<std::string>(
-        archive, key + "/" + std::to_string(index), element);
-    data[index] = element;
-  }
-}
-
-}  // namespace utils
 }  // namespace graphbolt
 
 #endif  // GRAPHBOLT_INCLUDE_SERIALIZE_H_

--- a/graphbolt/src/csc_sampling_graph.cc
+++ b/graphbolt/src/csc_sampling_graph.cc
@@ -17,10 +17,10 @@ void HeteroInfo::Load(torch::serialize::InputArchive& archive) {
   TORCH_CHECK(
       magic_num == kHeteroInfoSerializeMagic,
       "Magic numbers mismatch when loading HeteroInfo.");
-  node_types =
-      read_from_archive(archive, "HeteroInfo/node_types").to<StringList>();
-  edge_types =
-      read_from_archive(archive, "HeteroInfo/edge_types").to<StringList>();
+  node_types = read_from_archive(archive, "HeteroInfo/node_types")
+                   .to<decltype(node_types)>();
+  edge_types = read_from_archive(archive, "HeteroInfo/edge_types")
+                   .to<decltype(edge_types)>();
   node_type_offset =
       read_from_archive(archive, "HeteroInfo/node_type_offset").toTensor();
   type_per_edge =

--- a/graphbolt/src/csc_sampling_graph.cc
+++ b/graphbolt/src/csc_sampling_graph.cc
@@ -12,26 +12,27 @@ namespace graphbolt {
 namespace sampling {
 
 void HeteroInfo::Load(torch::serialize::InputArchive& archive) {
-  int64_t magic_num = 0x0;
-  utils::read_from_archive(archive, "HeteroInfo/magic_num", magic_num);
+  const int64_t magic_num =
+      read_from_archive(archive, "HeteroInfo/magic_num").toInt();
   TORCH_CHECK(
       magic_num == kHeteroInfoSerializeMagic,
       "Magic numbers mismatch when loading HeteroInfo.");
-  utils::read_from_archive(archive, "HeteroInfo/node_types", node_types);
-  utils::read_from_archive(archive, "HeteroInfo/edge_types", edge_types);
-  utils::read_from_archive(
-      archive, "HeteroInfo/node_type_offset", node_type_offset);
-  utils::read_from_archive(archive, "HeteroInfo/type_per_edge", type_per_edge);
+  node_types =
+      read_from_archive(archive, "HeteroInfo/node_types").to<StringList>();
+  edge_types =
+      read_from_archive(archive, "HeteroInfo/edge_types").to<StringList>();
+  node_type_offset =
+      read_from_archive(archive, "HeteroInfo/node_type_offset").toTensor();
+  type_per_edge =
+      read_from_archive(archive, "HeteroInfo/type_per_edge").toTensor();
 }
 
 void HeteroInfo::Save(torch::serialize::OutputArchive& archive) const {
-  utils::write_to_archive(
-      archive, "HeteroInfo/magic_num", kHeteroInfoSerializeMagic);
-  utils::write_to_archive(archive, "HeteroInfo/node_types", node_types);
-  utils::write_to_archive(archive, "HeteroInfo/edge_types", edge_types);
-  utils::write_to_archive(
-      archive, "HeteroInfo/node_type_offset", node_type_offset);
-  utils::write_to_archive(archive, "HeteroInfo/type_per_edge", type_per_edge);
+  archive.write("HeteroInfo/magic_num", kHeteroInfoSerializeMagic);
+  archive.write("HeteroInfo/node_types", node_types);
+  archive.write("HeteroInfo/edge_types", edge_types);
+  archive.write("HeteroInfo/node_type_offset", node_type_offset);
+  archive.write("HeteroInfo/type_per_edge", type_per_edge);
 }
 
 CSCSamplingGraph::CSCSamplingGraph(
@@ -74,17 +75,16 @@ c10::intrusive_ptr<CSCSamplingGraph> CSCSamplingGraph::FromCSCWithHeteroInfo(
 }
 
 void CSCSamplingGraph::Load(torch::serialize::InputArchive& archive) {
-  int64_t magic_num = 0x0;
-  utils::read_from_archive(archive, "CSCSamplingGraph/magic_num", magic_num);
+  const int64_t magic_num =
+      read_from_archive(archive, "CSCSamplingGraph/magic_num").toInt();
   TORCH_CHECK(
       magic_num == kCSCSamplingGraphSerializeMagic,
       "Magic numbers mismatch when loading CSCSamplingGraph.");
-  utils::read_from_archive(archive, "CSCSamplingGraph/num_nodes", num_nodes_);
-  utils::read_from_archive(archive, "CSCSamplingGraph/indptr", indptr_);
-  utils::read_from_archive(archive, "CSCSamplingGraph/indices", indices_);
-  bool is_heterogeneous = false;
-  utils::read_from_archive(
-      archive, "CSCSamplingGraph/is_hetero", is_heterogeneous);
+  num_nodes_ = read_from_archive(archive, "CSCSamplingGraph/num_nodes").toInt();
+  indptr_ = read_from_archive(archive, "CSCSamplingGraph/indptr").toTensor();
+  indices_ = read_from_archive(archive, "CSCSamplingGraph/indices").toTensor();
+  const bool is_heterogeneous =
+      read_from_archive(archive, "CSCSamplingGraph/is_hetero").toBool();
   if (is_heterogeneous) {
     hetero_info_ = std::make_shared<HeteroInfo>();
     hetero_info_->Load(archive);
@@ -92,13 +92,11 @@ void CSCSamplingGraph::Load(torch::serialize::InputArchive& archive) {
 }
 
 void CSCSamplingGraph::Save(torch::serialize::OutputArchive& archive) const {
-  archive.write(
-      "CSCSamplingGraph/magic_num",
-      torch::IValue(kCSCSamplingGraphSerializeMagic));
-  archive.write("CSCSamplingGraph/num_nodes", torch::IValue(num_nodes_));
+  archive.write("CSCSamplingGraph/magic_num", kCSCSamplingGraphSerializeMagic);
+  archive.write("CSCSamplingGraph/num_nodes", num_nodes_);
   archive.write("CSCSamplingGraph/indptr", indptr_);
   archive.write("CSCSamplingGraph/indices", indices_);
-  archive.write("CSCSamplingGraph/is_hetero", torch::IValue(IsHeterogeneous()));
+  archive.write("CSCSamplingGraph/is_hetero", IsHeterogeneous());
   if (IsHeterogeneous()) {
     hetero_info_->Save(archive);
   }
@@ -106,21 +104,3 @@ void CSCSamplingGraph::Save(torch::serialize::OutputArchive& archive) const {
 
 }  // namespace sampling
 }  // namespace graphbolt
-
-namespace torch {
-
-serialize::InputArchive& operator>>(
-    serialize::InputArchive& archive,
-    graphbolt::sampling::CSCSamplingGraph& graph) {
-  graph.Load(archive);
-  return archive;
-}
-
-serialize::OutputArchive& operator<<(
-    serialize::OutputArchive& archive,
-    const graphbolt::sampling::CSCSamplingGraph& graph) {
-  graph.Save(archive);
-  return archive;
-}
-
-}  // namespace torch

--- a/graphbolt/src/python_binding.cc
+++ b/graphbolt/src/python_binding.cc
@@ -1,0 +1,31 @@
+/**
+ *  Copyright (c) 2023 by Contributors
+ * @file python_binding.cc
+ * @brief Graph bolt library Python binding.
+ */
+
+#include "csc_sampling_graph.h"
+#include "serialize.h"
+
+namespace graphbolt {
+namespace sampling {
+
+TORCH_LIBRARY(graphbolt, m) {
+  m.class_<CSCSamplingGraph>("CSCSamplingGraph")
+      .def("num_nodes", &CSCSamplingGraph::NumNodes)
+      .def("num_edges", &CSCSamplingGraph::NumEdges)
+      .def("csc_indptr", &CSCSamplingGraph::CSCIndptr)
+      .def("indices", &CSCSamplingGraph::Indices)
+      .def("is_heterogeneous", &CSCSamplingGraph::IsHeterogeneous)
+      .def("node_types", &CSCSamplingGraph::NodeTypes)
+      .def("edge_types", &CSCSamplingGraph::EdgeTypes)
+      .def("node_type_offset", &CSCSamplingGraph::NodeTypeOffset)
+      .def("type_per_edge", &CSCSamplingGraph::TypePerEdge);
+  m.def("from_csc", &CSCSamplingGraph::FromCSC);
+  m.def("from_csc_with_hetero_info", &CSCSamplingGraph::FromCSCWithHeteroInfo);
+  m.def("load_csc_sampling_graph", &LoadCSCSamplingGraph);
+  m.def("save_csc_sampling_graph", &SaveCSCSamplingGraph);
+}
+
+}  // namespace sampling
+}  // namespace graphbolt

--- a/graphbolt/src/serialize.cc
+++ b/graphbolt/src/serialize.cc
@@ -1,0 +1,49 @@
+/**
+ *  Copyright (c) 2023 by Contributors
+ * @file graphbolt/src/serialize.cc
+ * @brief Source file of serialize.
+ */
+
+#include "serialize.h"
+
+namespace torch {
+
+serialize::InputArchive& operator>>(
+    serialize::InputArchive& archive,
+    graphbolt::sampling::CSCSamplingGraph& graph) {
+  graph.Load(archive);
+  return archive;
+}
+
+serialize::OutputArchive& operator<<(
+    serialize::OutputArchive& archive,
+    const graphbolt::sampling::CSCSamplingGraph& graph) {
+  graph.Save(archive);
+  return archive;
+}
+
+}  // namespace torch
+
+namespace graphbolt {
+
+c10::intrusive_ptr<sampling::CSCSamplingGraph> LoadCSCSamplingGraph(
+    const std::string& filename) {
+  auto&& graph = c10::make_intrusive<sampling::CSCSamplingGraph>();
+  torch::load(*graph, filename);
+  return graph;
+}
+
+void SaveCSCSamplingGraph(
+    c10::intrusive_ptr<sampling::CSCSamplingGraph> graph,
+    const std::string& filename) {
+  torch::save(*graph, filename);
+}
+
+torch::IValue read_from_archive(
+    torch::serialize::InputArchive& archive, const std::string& key) {
+  torch::IValue data;
+  archive.read(key, data);
+  return data;
+}
+
+}  // namespace graphbolt

--- a/python/dgl/__init__.py
+++ b/python/dgl/__init__.py
@@ -19,7 +19,6 @@ from . import (
     container,
     cuda,
     dataloading,
-    dataloading2,
     distributed,
     function,
     ops,
@@ -48,7 +47,6 @@ from .dataloading import (
     set_node_lazy_features,
     set_src_lazy_features,
 )
-from .dataloading2 import *
 from .heterograph import (  # pylint: disable=reimported
     DGLGraph,
     DGLGraph as DGLHeteroGraph,

--- a/python/dgl/dataloading2/__init__.py
+++ b/python/dgl/dataloading2/__init__.py
@@ -1,3 +1,43 @@
 """GraphBolt"""
 
+import os
+import sys
+
+import torch
+
+from .._ffi import libinfo
+from .data_fetcher import *
+from .graph_storage import *
+from .minibatch_sampler import *
+from .negative_sampler import *
+from .subgraph_sampler import *
 from .itemset import *
+
+
+def load_graphbolt():
+    """Load Graphbolt C++ library"""
+    version = torch.__version__.split("+", maxsplit=1)[0]
+
+    if sys.platform.startswith("linux"):
+        basename = f"libgraphbolt_pytorch_{version}.so"
+    elif sys.platform.startswith("darwin"):
+        basename = f"libgraphbolt_pytorch_{version}.dylib"
+    elif sys.platform.startswith("win"):
+        basename = f"graphbolt_pytorch_{version}.dll"
+    else:
+        raise NotImplementedError("Unsupported system: %s" % sys.platform)
+
+    dirname = os.path.dirname(libinfo.find_lib_path()[0])
+    path = os.path.join(dirname, "graphbolt", basename)
+    if not os.path.exists(path):
+        raise FileNotFoundError(
+            f"Cannot find DGL C++ graphbolt library at {path}"
+        )
+
+    try:
+        torch.classes.load_library(path)
+    except Exception:  # pylint: disable=W0703
+        raise ImportError("Cannot load Graphbolt C++ library")
+
+
+load_graphbolt()

--- a/python/dgl/dataloading2/graph_storage/__init__.py
+++ b/python/dgl/dataloading2/graph_storage/__init__.py
@@ -1,0 +1,2 @@
+"""Graphbolt graph module."""
+from .csc_sampling_graph import *

--- a/python/dgl/dataloading2/graph_storage/csc_sampling_graph.py
+++ b/python/dgl/dataloading2/graph_storage/csc_sampling_graph.py
@@ -1,0 +1,318 @@
+"""Csc format sampling graph."""
+# pylint: disable= invalid-name
+from typing import List, Optional, Tuple
+
+import torch
+
+
+HeteroInfo = Tuple[List[str], List[str], torch.tensor, torch.tensor]
+
+
+class CSCSamplingGraph:
+    r"""Class for Csc sampling graph."""
+
+    def __repr__(self):
+        return _csc_sampling_graph_str(self)
+
+    def __init__(self, c_csc_graph: torch.ScriptObject):
+        self.c_csc_graph = c_csc_graph
+
+    def save(self, filename):
+        self.c_csc_graph.save(filename)
+    
+    @property
+    def num_nodes(self) -> int:
+        """Returns the number of nodes in the graph.
+
+        Returns
+        -------
+        int
+            The number of rows in the dense format
+        """
+        return self.c_csc_graph.num_nodes()
+
+    @property
+    def num_edges(self) -> int:
+        """Returns the number of edges in the graph.
+
+        Returns
+        -------
+        int
+            The number of edges in the graph
+        """
+        return self.c_csc_graph.num_edges()
+
+    @property
+    def csc_indptr(self) -> torch.tensor:
+        """Returns the indices pointer in the Csc graph.
+
+        Returns
+        -------
+        int
+            The indices pointer in the Csc graph
+        """
+        return self.c_csc_graph.csc_indptr()
+
+    @property
+    def indices(self) -> torch.tensor:
+        """Returns the indices in the Csc graph.
+
+        Returns
+        -------
+        int
+            The indices in the Csc graph
+        """
+        return self.c_csc_graph.indices()
+
+    @property
+    def is_heterogeneous(self) -> bool:
+        """Returns if the graph is heterogeneous.
+
+        Returns
+        -------
+        bool
+            True if the graph is heterogeneous, False otherwise.
+        """
+        return self.c_csc_graph.is_heterogeneous()
+
+    @property
+    def node_types(self) -> Optional[torch.Tensor]:
+        """Returns the type of each node in the graph.
+
+        Returns
+        -------
+        torch.Tensor or None
+            If the graph is heterogeneous, returns a 1D tensor of size num_nodes,
+            containing the type of each node in the graph. If the graph is homogeneous,
+            returns None.
+        """
+        return (
+            self.c_csc_graph.node_types()
+            if self.c_csc_graph.is_heterogeneous()
+            else None
+        )
+
+    @property
+    def edge_types(self) -> Optional[torch.Tensor]:
+        """Returns the type of each edge in the graph.
+
+        Returns
+        -------
+        torch.Tensor or None
+            If the graph is heterogeneous, returns a 1D tensor of size num_edges,
+            containing the type of each edge in the graph. If the graph is homogeneous,
+            returns None.
+        """
+        return (
+            self.c_csc_graph.edge_types()
+            if self.c_csc_graph.is_heterogeneous()
+            else None
+        )
+
+    @property
+    def node_type_offset(self) -> Optional[torch.Tensor]:
+        """Returns the node type offset tensor for a heterogeneous graph.
+
+        Returns
+        -------
+        torch.Tensor or None
+            If the graph is heterogeneous, returns a 1D tensor of size num_node_types + 1,
+            where num_node_types is the number of unique node types in the graph.
+            The i-th element of the tensor indicates the index in the node type tensor
+            where nodes of type i start. If the graph is homogeneous, returns None.
+        """
+        return (
+            self.c_csc_graph.node_type_offset()
+            if self.c_csc_graph.is_heterogeneous()
+            else None
+        )
+
+    @property
+    def type_per_edge(self) -> Optional[torch.Tensor]:
+        """Returns the edge type tensor for a heterogeneous graph.
+
+        Returns
+        -------
+        torch.Tensor or None
+            If the graph is heterogeneous, returns a 1D tensor of size num_edges,
+            containing the type of each edge in the graph. If the graph is homogeneous,
+            returns None.
+        """
+        return (
+            self.c_csc_graph.type_per_edge()
+            if self.c_csc_graph.is_heterogeneous()
+            else None
+        )
+
+def from_csc(
+    csc_indptr: torch.Tensor,
+    indices: torch.Tensor,
+    etype_sorted: bool = True,
+    num_nodes: Optional[int] = None,
+    hetero_info: Optional[HeteroInfo] = None,
+) -> CSCSamplingGraph:
+    """
+    Create a CSCSamplingGraph object from a CSC representation.
+
+    Parameters
+    ----------
+    csc_indptr : torch.Tensor
+        Pointer to the start of each row in the `indices`.
+    indices : torch.Tensor
+        Column indices of the non-zero elements in the CSC graph.
+    etype_sorted : bool
+        A hint telling whether neighbors of each node are already sorted by edge type ID,
+        it is only meaningful when graph is heterogeneous, by default True.
+    num_nodes : int, optional
+        Number of nodes in the graph, by default None.
+    hetero_info : Optional[HeteroInfo], optional
+        Heterogeneous graph metadata, by default None.
+        Indicates whether the graph is homogeneous or heterogeneous.
+
+    Returns
+    -------
+    CSCSamplingGraph
+        The created CSCSamplingGraph object.
+
+    Examples
+    --------
+    >>> csc_indptr = torch.tensor([0, 2, 5, 7])
+    >>> indices = torch.tensor([1, 3, 0, 1, 2, 0, 3])
+    >>> num_nodes = 3
+    >>> ntypes, etypes = ['n1', 'n2'], ['e1', 'e2']
+    >>> hetero_info = (ntypes, etypes, torch.tensor([0, 2]), torch.tensor([0, 1, 0, 1, 1, 0, 0]))
+    >>> graph = from_csc(csc_indptr, indices, num_nodes, hetero_info)
+    >>> print(graph)
+    CSCSamplingGraph(csc_indptr=tensor([0, 2, 5, 7]),
+                    indices=tensor([1, 3, 0, 1, 2, 0, 3]),
+                    num_nodes=3, num_edges=7, is_heterogeneous=True)
+    """
+    if num_nodes is None:
+        num_nodes = csc_indptr.shape[0] - 1
+
+    assert csc_indptr.shape[0] == num_nodes + 1
+    assert torch.max(indices) < num_nodes
+    if hetero_info is None:
+        return CSCSamplingGraph(
+            torch.ops.graphbolt.from_csc(num_nodes, csc_indptr, indices)
+        )
+    else:
+        if etype_sorted is False:
+            ntypes, etypes, node_type_offset, type_per_edge = hetero_info
+            # sort neighbors by edge type id for each node
+            sorted_etype = []
+            sorted_indices = []
+            for s, e in zip(csc_indptr[:-1], csc_indptr[1:]):
+                neighbor_etype, index = torch.sort(type_per_edge[s:e])
+                sorted_etype.append(neighbor_etype)
+                sorted_indices.append(indices[s:e][index])
+            type_per_edge = torch.cat(sorted_etype, dim=0)
+            indices = torch.cat(sorted_indices, dim=0)
+            hetero_info = (ntypes, etypes, node_type_offset, type_per_edge)
+
+        return CSCSamplingGraph(
+            torch.ops.graphbolt.from_csc_with_hetero_info(
+                num_nodes, csc_indptr, indices, *hetero_info
+            )
+        )
+
+
+def from_coo(
+    coo: torch.Tensor,
+    num_nodes: Optional[int] = None,
+    hetero_info: Optional[HeteroInfo] = None,
+) -> CSCSamplingGraph:
+    """
+    Create a CSCSamplingGraph object from a COO representation.
+
+    Parameters
+    ----------
+    coo : torch.Tensor
+        COO format graph.
+    num_nodes : int, optional
+        Number of nodes in the graph, by default None.
+    hetero_info : Optional[HeteroInfo], optional
+        Heterogeneous graph metadata, by default None. Indicates whether the graph is
+        homogeneous or heterogeneous.
+
+    Returns
+    -------
+    CSCSamplingGraph
+        The created CSCSamplingGraph object.
+
+    Examples
+    --------
+    >>> coo = torch.tensor([[0, 1, 2, 2, 3, 3],
+    ...                     [1, 2, 0, 3, 1, 3]])
+    >>> ntypes, etypes = ['n1', 'n2', 'n3'], ['e1', 'e2']
+    >>> hetero_info = (ntypes, etypes, torch.tensor([0, 2, 5]), torch.tensor([0, 1, 0, 1, 0, 1]))
+    >>> graph = dataloading2.from_coo(coo, hetero_info)
+    >>> print(graph)
+    CSCSamplingGraph(csc_indptr=tensor([0, 1, 3, 4, 6]),
+                    indices=tensor([2, 0, 3, 1, 2, 3]),
+                    num_nodes=4, num_edges=6, is_heterogeneous=True)
+    """
+    assert coo.dim() == 2
+
+    if num_nodes is None:
+        num_nodes = torch.max(coo) + (1 if coo.size(1) > 0 else 0)
+    rol = coo[1]
+    _, indices = torch.sort(rol)
+
+    row, col = torch.index_select(coo, 1, indices)
+    csc_indptr = torch.cumsum(torch.bincount(col, minlength=num_nodes), dim=0)
+    csc_indptr = torch.cat(
+        (torch.zeros((1,), dtype=csc_indptr.dtype), csc_indptr), dim=0
+    )
+    if hetero_info is not None:
+        ntypes, etypes, node_type_offset, type_per_edge = hetero_info
+        type_per_edge = type_per_edge[indices]
+        hetero_info = (ntypes, etypes, node_type_offset, type_per_edge)
+
+    return from_csc(
+        csc_indptr,
+        row,
+        etype_sorted=False,
+        num_nodes=num_nodes,
+        hetero_info=hetero_info,
+    )
+
+
+def _csc_sampling_graph_str(graph: CSCSamplingGraph) -> str:
+    """Internal function for converting a csc sampling graph to string
+    representation.
+    """
+    csc_indptr_str = str(graph.csc_indptr)
+    indices_str = str(graph.indices)
+    meta_str = (
+        f"num_nodes={graph.num_nodes}, num_edges={graph.num_edges}"
+        f", is_heterogeneous={graph.is_heterogeneous}"
+    )
+    prefix = f"{type(graph).__name__}("
+
+    def _add_indent(_str, indent):
+        lines = _str.split("\n")
+        lines = [lines[0]] + [" " * indent + line for line in lines[1:]]
+        return "\n".join(lines)
+
+    final_str = (
+        "csc_indptr="
+        + _add_indent(csc_indptr_str, len("csc_indptr="))
+        + ",\n"
+        + "indices="
+        + _add_indent(indices_str, len("indices="))
+        + ",\n"
+        + meta_str
+        + ")"
+    )
+
+    final_str = prefix + _add_indent(final_str, len(prefix))
+    return final_str
+
+def load_csc_sampling_graph(filename):
+    """ Load CSCSamplingGraph from file. """
+    return CSCSamplingGraph(torch.ops.graphbolt.load_csc_sampling_graph(filename))
+
+def save_csc_sampling_graph(graph, filename):
+    """ Save CSCSamplingGraph to file. """
+    torch.ops.graphbolt.save_csc_sampling_graph(graph.c_csc_graph, filename)

--- a/tests/python/pytorch/dataloading2/test_csc_sampling_graph.py
+++ b/tests/python/pytorch/dataloading2/test_csc_sampling_graph.py
@@ -1,0 +1,144 @@
+import unittest
+
+import backend as F
+
+import numpy as np
+import pytest
+import torch
+import tempfile
+import os
+
+from dgl.dataloading2 import *
+
+
+def random_heterogeneous_graph_from_csc(num_nodes, num_ntypes, num_etypes):
+    # assume each node has 0 ~ 10 neighbors
+    csc_indptr = torch.randint(0, 10, (num_nodes,))
+    csc_indptr = torch.cumsum(csc_indptr, dim=0)
+    csc_indptr = torch.cat((torch.tensor([0]), csc_indptr), dim=0)
+    num_edges = csc_indptr[-1].item()
+    indices = torch.randint(0, num_nodes, (num_edges,))
+    ntypes = [f"n{i}" for i in range(num_ntypes)]
+    etypes = [f"e{i}" for i in range(num_etypes)]
+    # random get node type split point
+    node_type_offset = torch.sort(torch.randperm(num_nodes)[:num_ntypes])[0]
+    node_type_offset[0] = 0
+    type_per_edge = torch.randint(0, num_etypes, (num_edges,))
+    return (
+        from_csc(
+            csc_indptr,
+            indices,
+            etype_sorted=False,
+            hetero_info=(ntypes, etypes, node_type_offset, type_per_edge),
+        ),
+        csc_indptr,
+        indices,
+        type_per_edge,
+    )
+
+
+def random_heterogeneous_graph_from_coo(
+    num_nodes, num_edges, num_ntypes, num_etypes
+):
+    coo = torch.randint(0, num_nodes, (2, num_edges))
+    ntypes = [f"n{i}" for i in range(num_ntypes)]
+    etypes = [f"e{i}" for i in range(num_etypes)]
+    type_per_edge = torch.randint(0, num_etypes, (num_edges,))
+    node_type_offset = torch.sort(torch.randperm(num_nodes)[:num_ntypes])[0]
+    node_type_offset[0] = 0
+    return (
+        from_coo(
+            coo,
+            hetero_info=(ntypes, etypes, node_type_offset, type_per_edge),
+        ),
+        torch.cat([coo, type_per_edge.unsqueeze(dim=0)], dim=0),
+    )
+
+
+def sort_coo(coo: torch.tensor):
+    row, col, etype = coo
+    indices = torch.from_numpy(
+        np.lexsort((etype.numpy(), row.numpy(), col.numpy()))
+    )
+    return torch.index_select(coo, 1, indices)
+
+
+@unittest.skipIf(
+    F._default_context_str == "gpu",
+    reason="Graph is CPU only at present.",
+)
+@pytest.mark.parametrize("num_nodes", [10, 50, 1000, 10000])
+def test_from_csc(num_nodes, num_ntypes, num_etypes):
+    (
+        graph,
+        orig_csc_indptr,
+        orig_indices,
+        orig_type_per_edge,
+    ) = random_heterogeneous_graph_from_csc(num_nodes, num_ntypes, num_etypes)
+
+    csc_indptr = graph.csc_indptr
+    indices = graph.indices
+    type_per_edge = graph.type_per_edge
+
+    assert torch.equal(csc_indptr, orig_csc_indptr)
+    assert torch.equal(
+        torch.sort(type_per_edge).values, torch.sort(orig_type_per_edge).values
+    )
+    assert torch.equal(
+        torch.sort(indices).values, torch.sort(orig_indices).values
+    )
+    # check if the etype is sorted for each node
+    for s, e in zip(csc_indptr[:-1], csc_indptr[1:]):
+        etype = type_per_edge[s:e]
+        assert torch.equal(etype, torch.sort(etype).values)
+
+
+@unittest.skipIf(
+    F._default_context_str == "gpu",
+    reason="Graph is CPU only at present.",
+)
+@pytest.mark.parametrize(
+    "num_nodes,num_edges", [(10, 20), (50, 300), (1000, 500000)]
+)
+def test_from_coo(num_nodes, num_edges, num_ntypes=3, num_etypes=5):
+    graph, orig_coo = random_heterogeneous_graph_from_coo(
+        num_nodes, num_edges, num_ntypes, num_etypes
+    )
+
+    csc_indptr = graph.csc_indptr
+    indices = graph.indices
+    type_per_edge = graph.type_per_edge
+
+    col = csc_indptr[1:] - csc_indptr[:-1]
+    col_indices = torch.nonzero(col).squeeze()
+    col = col_indices.repeat_interleave(col[col_indices])
+    coo = torch.stack([indices, col, type_per_edge], dim=0)
+    orig_coo, coo = sort_coo(orig_coo), sort_coo(coo)
+
+    assert graph.num_nodes == num_nodes
+    assert graph.num_edges == num_edges
+    assert coo.shape == orig_coo.shape
+    assert torch.equal(orig_coo, coo)
+
+
+@unittest.skipIf(
+    F._default_context_str == "gpu",
+    reason="Graph is CPU only at present.",
+)
+@pytest.mark.parametrize("num_nodes,num_ntypes,num_etypes", [(10, 1, 1), (50, 2, 2), (1000, 3, 5), (10000, 8, 10)])
+def test_load_save_graph(num_nodes, num_ntypes, num_etypes):
+    graph, _, _, _ = random_heterogeneous_graph_from_csc(num_nodes, num_ntypes, num_etypes)
+
+    with tempfile.TemporaryDirectory() as test_dir:
+        filename = os.path.join(test_dir, "csc_sampling_graph.pt")
+        save_csc_sampling_graph(graph, filename)
+        graph2 = load_csc_sampling_graph(filename)
+
+        assert graph.num_nodes == graph2.num_nodes
+        assert torch.equal(graph.csc_indptr, graph2.csc_indptr)
+        assert torch.equal(graph.indices, graph2.indices)
+        assert graph.is_heterogeneous == graph2.is_heterogeneous
+        assert graph.node_types == graph2.node_types
+        assert graph.edge_types == graph2.edge_types
+        assert torch.equal(graph.node_type_offset, graph2.node_type_offset)
+        assert torch.equal(graph.type_per_edge, graph2.type_per_edge)


### PR DESCRIPTION
## Description
<!-- Brief description. Refer to the related issues if existed.
It'll be great if relevant reviewers can be assigned as well.-->

**This PR is supposed to be based on #5700 so please focus on the key part of load/save graph. To be re-based.** 

what changed in this PR:
1. optimize load/save code in c++: `serialize.h/cc`.
2. add interface in python level: `load_csc_sampling_graph()`, `save_csc_sampling_graph()`.
3. add tests for python interfaces: `test_load_save_graph()`.

Note: Unit tests pass in local run. It's expected to fail on CI due to some CI issue we're still working on.

## Checklist
Please feel free to remove inapplicable items for your PR.
- [ ] The PR title starts with [$CATEGORY] (such as [NN], [Model], [Doc], [Feature]])
- [ ] I've leverage the [tools](https://docs.google.com/document/d/1iHyj7zlmygKSk5gBPsqIqL5ASPzJSPREaNT_QdsiYA4/edit) to beautify the python and c++ code.
- [ ] The PR is complete and small, read the [Google eng practice (CL equals to PR)](https://google.github.io/eng-practices/review/developer/small-cls.html) to understand more about small PR. In DGL, we consider PRs with less than 200 lines of core code change are small (example, test and documentation could be exempted).
- [ ] All changes have test coverage
- [ ] Code is well-documented
- [ ] To the best of my knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change
- [ ] Related issue is referred in this PR
- [ ] If the PR is for a new model/paper, I've updated the example index [here](../examples/README.md).

## Changes
<!-- You could use following template
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)
-->
