### PR TITLE
[Bugfix] `dgl.linkx_homophily` calculation fails when all class homophily=0

### DIFF
--- a/python/dgl/homophily.py
+++ b/python/dgl/homophily.py
@@ -177,7 +177,7 @@ def linkx_homophily(graph, y):
         num_nodes = graph.num_nodes()
         num_classes = y.max(dim=0).values.item() + 1
 
-        value = 0
+        value = torch.tensor(0.0)
         for k in range(num_classes):
             # Get the nodes that belong to class k.
             class_mask = y == k

--- a/python/dgl/homophily.py
+++ b/python/dgl/homophily.py
@@ -177,7 +177,7 @@ def linkx_homophily(graph, y):
         num_nodes = graph.num_nodes()
         num_classes = y.max(dim=0).values.item() + 1
 
-        value = torch.tensor(0.0)
+        value = torch.tensor(0.0).to(graph.device)
         for k in range(num_classes):
             # Get the nodes that belong to class k.
             class_mask = y == k

--- a/tests/python/common/test_homophily.py
+++ b/tests/python/common/test_homophily.py
@@ -48,3 +48,6 @@ def test_linkx_homophily(idtype):
     graph = dgl.graph(([0, 1, 2, 3], [1, 2, 0, 4]), device=device)
     y = F.tensor([0, 0, 0, 0, 1])
     assert math.isclose(dgl.linkx_homophily(graph, y), 0.19999998807907104)
+
+    y = F.tensor([0, 1, 2, 3, 4])
+    assert math.isclose(dgl.linkx_homophily(graph, y), 0.0000000000000000)


### PR DESCRIPTION
## Description
<!-- Brief description. Refer to the related issues if existed.
It'll be great if relevant reviewers can be assigned as well.-->

Fail to calculate `dgl.linkx_homophily` when all class homophily = 0 due to inpropriate type of initial value.

![image](https://github.com/dmlc/dgl/assets/65325063/21b125bc-4c81-42ed-8785-291e174a4fd9)

```log
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "${path_to_venv}/.venv/lib/python3.7/site-packages/dgl/homophily.py", line 189, in linkx_homophily
    return value.item() / (num_classes - 1)
AttributeError: 'int' object has no attribute 'item'
```

Check issue #5710 for details.

## Checklist
Please feel free to remove inapplicable items for your PR.
- [x] The PR title starts with [$CATEGORY] (such as [NN], [Model], [Doc], [Feature]])
- [x] I've leverage the [tools](https://docs.google.com/document/d/1iHyj7zlmygKSk5gBPsqIqL5ASPzJSPREaNT_QdsiYA4/edit) to beautify the python and c++ code.
- [x] The PR is complete and small, read the [Google eng practice (CL equals to PR)](https://google.github.io/eng-practices/review/developer/small-cls.html) to understand more about small PR. In DGL, we consider PRs with less than 200 lines of core code change are small (example, test and documentation could be exempted).
- [x] All changes have test coverage
- [x] Code is well-documented
- [x] To the best of my knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change
- [x] Related issue is referred in this PR
- [x] If the PR is for a new model/paper, I've updated the example index [here](../examples/README.md).

## Changes
<!-- You could use following template
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)
-->

- [x] Fix1: Change the initial value from `int(0)` to `torch.tensor(0.0)`. As the `homophily` module has already tried to import torch, it feels safe to user `torch.tensor` as the initial value.
- [x] Test1: Add unit test for the fix.
