### PR TITLE
[GraphBolt] add InSubgraph() for CSCSamplingGraph in c++ level

### DIFF
--- a/graphbolt/include/graphbolt/csc_sampling_graph.h
+++ b/graphbolt/include/graphbolt/csc_sampling_graph.h
@@ -111,7 +111,7 @@ class CSCSamplingGraph : public torch::CustomClassHolder {
    * @brief Extract induced subgraph of given nodes.
    * @param nodes Type agnostic node IDs to form the subgraph.
    *
-   * @return CSCSamplingGraph.
+   * @return SampledSubgraph.
    */
   c10::intrusive_ptr<SampledSubgraph> InSubgraph(
       const torch::Tensor& nodes) const;

--- a/graphbolt/include/graphbolt/csc_sampling_graph.h
+++ b/graphbolt/include/graphbolt/csc_sampling_graph.h
@@ -105,6 +105,15 @@ class CSCSamplingGraph : public torch::CustomClassHolder {
    */
   void Save(torch::serialize::OutputArchive& archive) const;
 
+  /**
+   * @brief Extract induced subgraph of given nodes.
+   * @param nodes Type agnostic node IDs to form the subgraph.
+   *
+   * @return CSCSamplingGraph.
+   */
+  c10::intrusive_ptr<sampling::CSCSamplingGraph> InSubgraph(
+      const torch::Tensor& nodes) const;
+
  private:
   /** @brief CSC format index pointer array. */
   torch::Tensor indptr_;

--- a/graphbolt/include/graphbolt/csc_sampling_graph.h
+++ b/graphbolt/include/graphbolt/csc_sampling_graph.h
@@ -12,6 +12,8 @@
 #include <string>
 #include <vector>
 
+#include "sampled_subgraph.h"
+
 namespace graphbolt {
 namespace sampling {
 
@@ -111,7 +113,7 @@ class CSCSamplingGraph : public torch::CustomClassHolder {
    *
    * @return CSCSamplingGraph.
    */
-  c10::intrusive_ptr<sampling::CSCSamplingGraph> InSubgraph(
+  c10::intrusive_ptr<SampledSubgraph> InSubgraph(
       const torch::Tensor& nodes) const;
 
  private:

--- a/graphbolt/include/graphbolt/csc_sampling_graph.h
+++ b/graphbolt/include/graphbolt/csc_sampling_graph.h
@@ -108,7 +108,7 @@ class CSCSamplingGraph : public torch::CustomClassHolder {
   void Save(torch::serialize::OutputArchive& archive) const;
 
   /**
-   * @brief Extract induced subgraph of given nodes.
+   * @brief Return the subgraph induced on the inbound edges of the given nodes.
    * @param nodes Type agnostic node IDs to form the subgraph.
    *
    * @return SampledSubgraph.

--- a/graphbolt/src/csc_sampling_graph.cc
+++ b/graphbolt/src/csc_sampling_graph.cc
@@ -78,5 +78,34 @@ void CSCSamplingGraph::Save(torch::serialize::OutputArchive& archive) const {
   }
 }
 
+c10::intrusive_ptr<sampling::CSCSamplingGraph> CSCSamplingGraph::InSubgraph(
+    const torch::Tensor& nodes) const {
+  const int32_t kDefaultGrainSize = 100;
+  torch::Tensor indptr = torch::zeros_like(indptr_);
+  const size_t num_seeds = nodes.size(0);
+  std::vector<torch::Tensor> indices_arr(num_seeds);
+  std::vector<torch::Tensor> type_per_edge_arr(num_seeds);
+  torch::parallel_for(
+      0, num_seeds, kDefaultGrainSize, [&](size_t start, size_t end) {
+        for (size_t i = start; i < end; ++i) {
+          const int64_t node_id = nodes[i].item<int64_t>();
+          const int64_t start_idx = indptr_[node_id].item<int64_t>();
+          const int64_t end_idx = indptr_[node_id + 1].item<int64_t>();
+          indptr[node_id + 1] = end_idx - start_idx;
+          indices_arr[i] = indices_.slice(0, start_idx, end_idx);
+          if (type_per_edge_) {
+            type_per_edge_arr[i] =
+                type_per_edge_.value().slice(0, start_idx, end_idx);
+          }
+        }
+      });
+
+  return FromCSC(
+      indptr.cumsum(0), torch::cat(indices_arr), node_type_offset_,
+      type_per_edge_
+          ? torch::optional<torch::Tensor>{torch::cat(type_per_edge_arr)}
+          : torch::nullopt);
+}
+
 }  // namespace sampling
 }  // namespace graphbolt

--- a/graphbolt/src/csc_sampling_graph.cc
+++ b/graphbolt/src/csc_sampling_graph.cc
@@ -78,12 +78,14 @@ void CSCSamplingGraph::Save(torch::serialize::OutputArchive& archive) const {
   }
 }
 
-c10::intrusive_ptr<sampling::CSCSamplingGraph> CSCSamplingGraph::InSubgraph(
+c10::intrusive_ptr<SampledSubgraph> CSCSamplingGraph::InSubgraph(
     const torch::Tensor& nodes) const {
+  using namespace torch::indexing;
   const int32_t kDefaultGrainSize = 100;
   torch::Tensor indptr = torch::zeros_like(indptr_);
   const size_t num_seeds = nodes.size(0);
   std::vector<torch::Tensor> indices_arr(num_seeds);
+  std::vector<torch::Tensor> edge_ids_arr(num_seeds);
   std::vector<torch::Tensor> type_per_edge_arr(num_seeds);
   torch::parallel_for(
       0, num_seeds, kDefaultGrainSize, [&](size_t start, size_t end) {
@@ -93,6 +95,7 @@ c10::intrusive_ptr<sampling::CSCSamplingGraph> CSCSamplingGraph::InSubgraph(
           const int64_t end_idx = indptr_[node_id + 1].item<int64_t>();
           indptr[node_id + 1] = end_idx - start_idx;
           indices_arr[i] = indices_.slice(0, start_idx, end_idx);
+          edge_ids_arr[i] = torch::arange(start_idx, end_idx);
           if (type_per_edge_) {
             type_per_edge_arr[i] =
                 type_per_edge_.value().slice(0, start_idx, end_idx);
@@ -100,8 +103,13 @@ c10::intrusive_ptr<sampling::CSCSamplingGraph> CSCSamplingGraph::InSubgraph(
         }
       });
 
-  return FromCSC(
-      indptr.cumsum(0), torch::cat(indices_arr), node_type_offset_,
+  const auto& nonzero_idx = torch::nonzero(indptr).reshape(-1);
+  torch::Tensor compact_indptr =
+      torch::zeros({nonzero_idx.size(0) + 1}, indptr_.dtype());
+  compact_indptr.index_put_({Slice(1, None)}, indptr.index({nonzero_idx}));
+  return c10::make_intrusive<SampledSubgraph>(
+      compact_indptr.cumsum(0), torch::cat(indices_arr), nonzero_idx,
+      torch::arange(0, NumNodes()), torch::cat(edge_ids_arr),
       type_per_edge_
           ? torch::optional<torch::Tensor>{torch::cat(type_per_edge_arr)}
           : torch::nullopt);


### PR DESCRIPTION
## Description
<!-- Brief description. Refer to the related issues if existed.
It'll be great if relevant reviewers can be assigned as well.-->
add support for extracting induced subgraph from parent graph.
## Checklist
Please feel free to remove inapplicable items for your PR.
- [ ] The PR title starts with [$CATEGORY] (such as [NN], [Model], [Doc], [Feature]])
- [ ] I've leverage the [tools](https://docs.google.com/document/d/1iHyj7zlmygKSk5gBPsqIqL5ASPzJSPREaNT_QdsiYA4/edit) to beautify the python and c++ code.
- [ ] The PR is complete and small, read the [Google eng practice (CL equals to PR)](https://google.github.io/eng-practices/review/developer/small-cls.html) to understand more about small PR. In DGL, we consider PRs with less than 200 lines of core code change are small (example, test and documentation could be exempted).
- [ ] All changes have test coverage
- [ ] Code is well-documented
- [ ] To the best of my knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change
- [ ] Related issue is referred in this PR
- [ ] If the PR is for a new model/paper, I've updated the example index [here](../examples/README.md).

## Changes
<!-- You could use following template
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)
-->
