### PR TITLE
[BugFix] Fix khop_adj

### DIFF
--- a/python/dgl/transforms/functional.py
+++ b/python/dgl/transforms/functional.py
@@ -1152,21 +1152,22 @@ def khop_adj(g, k):
     >>> import dgl
     >>> g = dgl.graph(([0,1,2,3,4,0,1,2,3,4], [0,1,2,3,4,1,2,3,4,0]))
     >>> dgl.khop_adj(g, 1)
-    tensor([[1., 0., 0., 0., 1.],
-            [1., 1., 0., 0., 0.],
+    tensor([[1., 1., 0., 0., 0.],
             [0., 1., 1., 0., 0.],
             [0., 0., 1., 1., 0.],
-            [0., 0., 0., 1., 1.]])
+            [0., 0., 0., 1., 1.],
+            [1., 0., 0., 0., 1.]])
     >>> dgl.khop_adj(g, 3)
-    tensor([[1., 0., 1., 3., 3.],
+    tensor([[1., 3., 3., 1., 0.],
+            [0., 1., 3., 3., 1.],
+            [1., 0., 1., 3., 3.],
             [3., 1., 0., 1., 3.],
-            [3., 3., 1., 0., 1.],
-            [1., 3., 3., 1., 0.],
-            [0., 1., 3., 3., 1.]])
+            [3., 3., 1., 0., 1.]])
     """
     assert g.is_homogeneous, "only homogeneous graph is supported"
     adj_k = (
-        g.adj_external(transpose=True, scipy_fmt=g.formats()["created"][0]) ** k
+        g.adj_external(transpose=False, scipy_fmt=g.formats()["created"][0])
+        ** k
     )
     return F.tensor(adj_k.todense().astype(np.float32))
 

--- a/tests/python/common/transforms/test_transform.py
+++ b/tests/python/common/transforms/test_transform.py
@@ -649,7 +649,7 @@ def test_khop_graph():
 def test_khop_adj():
     N = 20
     feat = F.randn((N, 5))
-    g = dgl.DGLGraph(nx.erdos_renyi_graph(N, 0.3))
+    g = dgl.DGLGraph(nx.erdos_renyi_graph(N, 0.3, directed=True))
     for k in range(3):
         adj = F.tensor(F.swapaxes(dgl.khop_adj(g, k), 0, 1))
         # use original graph to do message passing for k times.


### PR DESCRIPTION
## Description
Current `khop_adj` api wrongly includes a transpose operation when accessing adjacency matrix. Fix the bug.

## Checklist
Please feel free to remove inapplicable items for your PR.
- [x] The PR title starts with [$CATEGORY] (such as [NN], [Model], [Doc], [Feature]])
- [x] I've leverage the [tools](https://docs.google.com/document/d/1iHyj7zlmygKSk5gBPsqIqL5ASPzJSPREaNT_QdsiYA4/edit) to beautify the python and c++ code.
- [x] The PR is complete and small, read the [Google eng practice (CL equals to PR)](https://google.github.io/eng-practices/review/developer/small-cls.html) to understand more about small PR. In DGL, we consider PRs with less than 200 lines of core code change are small (example, test and documentation could be exempted).
- [x] All changes have test coverage
- [x] Code is well-documented
- [x] To the best of my knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change
- [x] Related issue is referred in this PR
- [ ] If the PR is for a new model/paper, I've updated the example index [here](../examples/README.md).
