### PR TITLE
[GraphBolt] Add common macro

### DIFF
--- a/graphbolt/src/macro.h
+++ b/graphbolt/src/macro.h
@@ -1,0 +1,51 @@
+/**
+ *  Copyright (c) 2023 by Contributors
+ * @file graphbolt/src/macro.h
+ * @brief Common macros for graphbolt package.
+ */
+
+#ifndef GRAPHBOLT_MACRO_H_
+#define GRAPHBOLT_MACRO_H_
+
+#include <torch/torch.h>
+
+/**
+ * Dispatch according to torch scalar type.
+ *
+ * ATEN_ID_TYPE_SWITCH(type_per_edge.dtype(), DataType, {
+ *   // Now DataType is the type corresponding to data type in type_per_edge.
+ *   // For instance, one can do this for a CPU array:
+ *   DataType *data = static_cast<DataType *>(type_per_edge.data_ptr());
+ * });
+ */
+#define ATEN_DATA_TYPE_SWITCH(val, DataType, ...)                           \
+  do {                                                                      \
+    if ((val) == torch::kInt8 || (val) == torch::kUInt8 ||                  \
+        (val) == torch::kBool) {                                            \
+      typedef int8_t DataType;                                              \
+      { __VA_ARGS__ }                                                       \
+    } else if ((val) == torch::kInt16) {                                    \
+      typedef int16_t DataType;                                             \
+      { __VA_ARGS__ }                                                       \
+    } else if ((val) == torch::kInt32) {                                    \
+      typedef uint32_t DataType;                                            \
+      { __VA_ARGS__ }                                                       \
+    } else if ((val) == torch::kInt64) {                                    \
+      typedef uint64_t DataType;                                            \
+      { __VA_ARGS__ }                                                       \
+    }                                                                       \
+  }                                                                         \
+  else if ((val) == torch::kFloat) {                                        \
+    typedef float ProbType;                                                 \
+    { __VA_ARGS__ }                                                         \
+  }                                                                         \
+  else if ((val) == torch::kDouble) {                                       \
+    typedef double ProbType;                                                \
+    { __VA_ARGS__ }                                                         \
+    else {                                                                  \
+      LOG(FATAL) << "Probs can only be bool, uint8, int8, float or double"; \
+    }                                                                       \
+  }                                                                         \
+  while (0)
+
+#endif  // GRAPHBOLT_MACRO_H_


### PR DESCRIPTION
## Description
Add `macro.h` used for common macros in graphbolt, currently only one used to dispatch type.

## Checklist
Please feel free to remove inapplicable items for your PR.
- [ ] The PR title starts with [$CATEGORY] (such as [NN], [Model], [Doc], [Feature]])
- [ ] I've leverage the [tools](https://docs.google.com/document/d/1iHyj7zlmygKSk5gBPsqIqL5ASPzJSPREaNT_QdsiYA4/edit) to beautify the python and c++ code.
- [ ] The PR is complete and small, read the [Google eng practice (CL equals to PR)](https://google.github.io/eng-practices/review/developer/small-cls.html) to understand more about small PR. In DGL, we consider PRs with less than 200 lines of core code change are small (example, test and documentation could be exempted).
- [ ] All changes have test coverage
- [ ] Code is well-documented
- [ ] To the best of my knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change
- [ ] Related issue is referred in this PR
- [ ] If the PR is for a new model/paper, I've updated the example index [here](../examples/README.md).

## Changes
<!-- You could use following template
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)
-->
