### PR TITLE
[Feature] Enable bfloat16 convert functions in Python API

### DIFF
--- a/examples/pytorch/gat/train.py
+++ b/examples/pytorch/gat/train.py
@@ -1,5 +1,6 @@
 import argparse
 
+import dgl
 import dgl.nn as dglnn
 
 import torch
@@ -88,6 +89,12 @@ if __name__ == "__main__":
         default="cora",
         help="Dataset name ('cora', 'citeseer', 'pubmed').",
     )
+    parser.add_argument(
+        "--dt",
+        type=str,
+        default="float",
+        help="data type(float, bfloat16)",
+    )
     args = parser.parse_args()
     print(f"Training with DGL built-in GATConv module.")
 
@@ -114,6 +121,12 @@ if __name__ == "__main__":
     in_size = features.shape[1]
     out_size = data.num_classes
     model = GAT(in_size, 8, out_size, heads=[8, 1]).to(device)
+
+    # convert model and graph to bfloat16 if needed
+    if args.dt == "bfloat16":
+        g = dgl.to_bfloat16(g)
+        features = features.to(dtype=torch.bfloat16)
+        model = model.to(dtype=torch.bfloat16)
 
     # model training
     print("Training...")

--- a/examples/pytorch/gcn/train.py
+++ b/examples/pytorch/gcn/train.py
@@ -72,6 +72,12 @@ if __name__ == "__main__":
         default="cora",
         help="Dataset name ('cora', 'citeseer', 'pubmed').",
     )
+    parser.add_argument(
+        "--dt",
+        type=str,
+        default="float",
+        help="data type(float, bfloat16)",
+    )
     args = parser.parse_args()
     print(f"Training with DGL built-in GraphConv module.")
 
@@ -98,6 +104,12 @@ if __name__ == "__main__":
     in_size = features.shape[1]
     out_size = data.num_classes
     model = GCN(in_size, 16, out_size).to(device)
+
+    # convert model and graph to bfloat16 if needed
+    if args.dt == "bfloat16":
+        g = dgl.to_bfloat16(g)
+        features = features.to(dtype=torch.bfloat16)
+        model = model.to(dtype=torch.bfloat16)
 
     # model training
     print("Training...")

--- a/examples/pytorch/graphsage/train_full.py
+++ b/examples/pytorch/graphsage/train_full.py
@@ -1,5 +1,6 @@
 import argparse
 
+import dgl
 import dgl.nn as dglnn
 
 import torch
@@ -69,6 +70,12 @@ if __name__ == "__main__":
         default="cora",
         help="Dataset name ('cora', 'citeseer', 'pubmed')",
     )
+    parser.add_argument(
+        "--dt",
+        type=str,
+        default="float",
+        help="data type(float, bfloat16)",
+    )
     args = parser.parse_args()
     print(f"Training with DGL built-in GraphSage module")
 
@@ -95,6 +102,12 @@ if __name__ == "__main__":
     in_size = features.shape[1]
     out_size = data.num_classes
     model = SAGE(in_size, 16, out_size).to(device)
+
+    # convert model and graph to bfloat16 if needed
+    if args.dt == "bfloat16":
+        g = dgl.to_bfloat16(g)
+        features = features.to(dtype=torch.bfloat16)
+        model = model.to(dtype=torch.bfloat16)
 
     # model training
     print("Training...")

--- a/python/dgl/backend/backend.py
+++ b/python/dgl/backend/backend.py
@@ -21,6 +21,7 @@ def data_type_dict():
     """Returns a dictionary from data type string to the data type.
 
     The dictionary should include at least:
+    bfloat16
     float16
     float32
     float64

--- a/python/dgl/backend/pytorch/tensor.py
+++ b/python/dgl/backend/pytorch/tensor.py
@@ -18,6 +18,7 @@ if version.parse(th.__version__) < version.parse("1.12.0"):
 
 def data_type_dict():
     return {
+        "bfloat16": th.bfloat16,
         "float16": th.float16,
         "float32": th.float32,
         "float64": th.float64,

--- a/python/dgl/backend/tensorflow/tensor.py
+++ b/python/dgl/backend/tensorflow/tensor.py
@@ -30,6 +30,7 @@ def zerocopy_from_dlpack(dlpack_tensor):
 
 def data_type_dict():
     return {
+        "bfloat16": tf.bfloat16,
         "float16": tf.float16,
         "float32": tf.float32,
         "float64": tf.float64,

--- a/python/dgl/frame.py
+++ b/python/dgl/frame.py
@@ -990,17 +990,28 @@ class Frame(MutableMapping):
             F.float64,
             F.float32,
             F.float16,
+            F.bfloat16,
         ], "'new_type' must be floating-point type: %s" % str(new_type)
         newframe = self.clone()
         new_columns = {}
         for name, column in self._columns.items():
             dtype = column.dtype
-            if dtype != new_type and dtype in [F.float64, F.float32, F.float16]:
+            if dtype != new_type and dtype in [
+                F.float64,
+                F.float32,
+                F.float16,
+                F.bfloat16,
+            ]:
                 new_columns[name] = column.astype(new_type)
             else:
                 new_columns[name] = column
         newframe._columns = new_columns
         return newframe
+
+    def bfloat16(self):
+        """Return a new frame with all floating-point columns converted
+        to bfloat16"""
+        return self._astype_float(F.bfloat16)
 
     def half(self):
         """Return a new frame with all floating-point columns converted

--- a/python/dgl/transforms/functional.py
+++ b/python/dgl/transforms/functional.py
@@ -86,6 +86,7 @@ __all__ = [
     "random_walk_pe",
     "laplacian_pe",
     "lap_pe",
+    "to_bfloat16",
     "to_half",
     "to_float",
     "to_double",
@@ -3709,6 +3710,24 @@ def laplacian_pe(g, k, padding=False, return_eigval=False):
     r"""Alias of `dgl.lap_pe`."""
     dgl_warning("dgl.laplacian_pe will be deprecated. Use dgl.lap_pe please.")
     return lap_pe(g, k, padding, return_eigval)
+
+
+def to_bfloat16(g):
+    r"""Cast this graph to use bfloat16 for any
+    floating-point edge and node feature data.
+
+    A shallow copy is returned so that the original graph is not modified.
+    Feature tensors that are not floating-point will not be modified.
+
+    Returns
+    -------
+    DGLGraph
+        Clone of graph with the feature data converted to float16.
+    """
+    ret = copy.copy(g)
+    ret._edge_frames = [frame.bfloat16() for frame in ret._edge_frames]
+    ret._node_frames = [frame.bfloat16() for frame in ret._node_frames]
+    return ret
 
 
 def to_half(g):

--- a/tests/python/common/test_heterograph.py
+++ b/tests/python/common/test_heterograph.py
@@ -2443,7 +2443,7 @@ def test_dtype_cast(idtype):
 
 
 def test_float_cast():
-    for t in [F.float16, F.float32, F.float64]:
+    for t in [F.bfloat16, F.float16, F.float32, F.float64]:
         idtype = F.int32
         g = dgl.heterograph(
             {
@@ -2469,6 +2469,7 @@ def test_float_cast():
             ("c", F.float64),
             ("d", F.int32),
             ("e", F.int64),
+            ("f", F.bfloat16),
         ]
         for name, type in dataNamesTypes:
             g.nodes["user"].data[name] = F.copy_to(
@@ -2487,6 +2488,8 @@ def test_float_cast():
                 F.tensor(pvalues, dtype=type), ctx=F.ctx()
             )
 
+        if t == F.bfloat16:
+            g = dgl.transforms.functional.to_bfloat16(g)
         if t == F.float16:
             g = dgl.transforms.functional.to_half(g)
         if t == F.float32:
@@ -2498,7 +2501,7 @@ def test_float_cast():
             # integer tensors shouldn't be converted
             reqType = (
                 t
-                if (origType in [F.float16, F.float32, F.float64])
+                if (origType in [F.bfloat16, F.float16, F.float32, F.float64])
                 else origType
             )
 


### PR DESCRIPTION
## Description
<!-- Brief description. Refer to the related issues if existed.
It'll be great if relevant reviewers can be assigned as well.-->
Added functions to support bfloat16 graph conversion.
<!-- ## Checklist
Please feel free to remove inapplicable items for your PR.
- [ ] The PR title starts with [$CATEGORY] (such as [NN], [Model], [Doc], [Feature]])
- [ ] I've leverage the [tools](https://docs.google.com/document/d/1iHyj7zlmygKSk5gBPsqIqL5ASPzJSPREaNT_QdsiYA4/edit) to beautify the python and c++ code.
- [ ] The PR is complete and small, read the [Google eng practice (CL equals to PR)](https://google.github.io/eng-practices/review/developer/small-cls.html) to understand more about small PR. In DGL, we consider PRs with less than 200 lines of core code change are small (example, test and documentation could be exempted).
- [ ] All changes have test coverage
- [ ] Code is well-documented
- [ ] To the best of my knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change
- [ ] Related issue is referred in this PR
- [ ] If the PR is for a new model/paper, I've updated the example index [here](../examples/README.md).
-->
## Benchmark results
<!-- You could use following template
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)
-->
Performance collected on Intel(R) Xeon(R) Platinum 8480+ (4th Generation Xeon, which supports [AMX](https://en.wikipedia.org/wiki/Advanced_Matrix_Extensions) instruction)

| #threads     |               | 16            |          |                    | full socket   |          |                    |
|--------------|---------------|---------------|----------|--------------------|---------------|----------|--------------------|
| example      | dataset       | Test accuracy |          | perf diff % | Test accuracy |          | perf diff % |
|              |               | float         | bf16 |                    | float         | bf16 |                    |
| gat          | citeseer      | 0.706         | 0.707    | 1.500155075        | 0.71          | 0.697    | 1.012161345        |
|              | cora          | 0.823         | 0.806    | 1.252912319        | 0.829         | 0.827    | 0.841738173        |
|              | pubmed        | 0.781         | 0.779    | 1.159851665        | 0.778         | 0.779    | 0.896904753        |
| gcn          | citeseer      | 0.708         | 0.702    | 2.286722333        | 0.704         | 0.715    | 3.055408728        |
|              | cora          | 0.813         | 0.804    | 0.96189143         | 0.813         | 0.802    | 0.508002998        |
|              | pubmed        | 0.787         | 0.8      | 1.309534617        | 0.792         | 0.793    | 2.812601222        |
| graphsage-mb | ogbn-products | 0.7635        | 0.7395   | 1.414979496        | 0.766         | 0.7388   | 1.251275365        |
| graphsage    | citeseer      | 0.718         | 0.694    | 1.53384672         | 0.714         | 0.707    | 2.786746044        |
|              | cora          | 0.827         | 0.812    | 1.648600844        | 0.818         | 0.801    | 0.998175618        |
|              | pubmed        | 0.785         | 0.786    | 1.352056641        | 0.788         | 0.788    | 3.026328587        |


![image](https://github.com/dmlc/dgl/assets/54678650/6a18fd50-1226-4553-b144-7459f05d8a7d)
![image](https://github.com/dmlc/dgl/assets/54678650/260aa02b-41a1-4249-bedc-fb215bfcf435)
