### PR TITLE
[Graphbolt] Improve code quality

### DIFF
--- a/graphbolt/src/shared_memory_utils.cc
+++ b/graphbolt/src/shared_memory_utils.cc
@@ -172,12 +172,9 @@ SharedMemoryTensors LoadTensorsFromSharedMemory(
       metas.push_back({false, {}, torch::ScalarType::Undefined});
     }
   }
-  SharedMemoryPtr data_shm;
-  std::vector<torch::optional<torch::Tensor>> ret_tensors;
-  std::tie(data_shm, ret_tensors) =
-      LoadTensorsDataFromSharedMemory(name + "_data", metas);
-  return std::make_tuple(
-      std::move(meta_shm), std::move(data_shm), std::move(ret_tensors));
+  return std::tuple_cat(
+      std::forward_as_tuple(std::move(meta_shm)),
+      LoadTensorsDataFromSharedMemory(name + "_data", metas));
 }
 
 }  // namespace sampling


### PR DESCRIPTION
## Description

Use `std::tuple_cat` to simplify the code of returning a tuple in a function.

@Rhett-Ying , I don't use variadic template when copy to/load from shared memory because it will make the code too complicated. It requires to write variadic template functions such as `CopyTensorMetaToTorchArchive`, `CopyTensorDataToSharedMemory`, and their loading version. We also need to handle torch tensors and optional tensors in these template functions.

## Checklist
Please feel free to remove inapplicable items for your PR.
- [ ] The PR title starts with [$CATEGORY] (such as [NN], [Model], [Doc], [Feature]])
- [ ] I've leverage the [tools](https://docs.google.com/document/d/1iHyj7zlmygKSk5gBPsqIqL5ASPzJSPREaNT_QdsiYA4/edit) to beautify the python and c++ code.
- [ ] The PR is complete and small, read the [Google eng practice (CL equals to PR)](https://google.github.io/eng-practices/review/developer/small-cls.html) to understand more about small PR. In DGL, we consider PRs with less than 200 lines of core code change are small (example, test and documentation could be exempted).
- [ ] All changes have test coverage
- [ ] Code is well-documented
- [ ] To the best of my knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change
- [ ] Related issue is referred in this PR
- [ ] If the PR is for a new model/paper, I've updated the example index [here](../examples/README.md).

## Changes
<!-- You could use following template
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)
-->
