### PR TITLE
[Sparse] formats api doc checkin

### DIFF
--- a/python/dgl/heterograph.py
+++ b/python/dgl/heterograph.py
@@ -6065,6 +6065,88 @@ class DGLGraph(object):
         self._node_frames = old_nframes
         self._edge_frames = old_eframes
 
+    def new_formats(self, allowed_formats=None, create_formats=None):
+        r"""Get a cloned graph with the specified allowed sparse format(s)
+        and create specific sparse matrices allowed for the graph or query
+        for the usage status of sparse formats.
+
+        The API copies both the graph structure and the features.
+
+        If both ``allowed_formats`` and ``create_formats`` are None, the
+        API returns a dict recording the usage status of sparse formats.
+        In any other case, a DGLGraph is returned. The format(s) of the
+        resulting cloned graph is depends on the ``allowed_formats``,
+        ``create_formats`` and the format(s) of the original graph:
+
+        * If ``create_formats`` isn't None, the cloned graph's sparse
+          formats will be consistent with ``create_formats``.
+        * Otherwise:
+          * If the original graph's format is a subset of ``allowed_formats``,
+            the cloned graph's sparse formats will remain consistent with the
+            original.
+          * If a format in the original graph is also in ``allowed_formats``,
+            any formats not in ``allowed_formats`` will be removed in the cloned
+            graph.
+          * If the original graph has no formats in ``allowed_formats``, a new
+            format will be made for the cloned graph. This will be in the order
+            of ``'coo'``, ``'csr'``, ``'csc'``, regardless of the
+            ``allowed_formats`` order.
+
+        Parameters
+        ----------
+        allowed_formats : str or list of str or None
+
+            * If ``allowed_formats`` is None, return the usage status of sparse
+              formats.
+            * Otherwise, it can be a string ``'coo'``, ``'csr'``, or ``'csc'``
+              or a sublist of them, specifying the allowed sparse formats to
+              use.
+
+        create_formats : str or list of str or None
+
+            * If ``create_formats`` is None:
+              * If ``allowed_formats`` is None, return the usage status of
+                sparse formats.
+              * Otherwise, follow the rules above to create sparse matrices for
+                the cloned graph.
+            * Otherwise, it can be ``'coo'``, ``'csr'``, or ``'csc'`` or a
+              sublist of them, specifying the sparse matrices to create. If
+              ``allowed_formats`` is None or there are some formats in the list
+              that are not allowed for the graph, an error will be raised.
+
+        Returns
+        -------
+        dict or DGLGraph
+
+            * If ``allowed_formats`` is None, the result will be a dict
+              recording the usage status of sparse formats.
+            * Otherwise, a DGLGraph will be returned, which is a clone of the
+              original graph with the specified allowed sparse format(s) and
+              created sparse format(s).
+        """
+        pass
+
+    def new_create_formats_(self, create_formats=None):
+        r"""Create specified sparse matrices allowed for the graph.
+
+        By default, sparse matrices for a graph are created only when necessary.
+        In some cases, such as in a multi-process data loader, we may want to
+        create them immediately. This API allows for that.
+
+        Parameters
+        ----------
+        create_formats : str or list of str or None
+
+            * If ``create_formats`` is None, create all sparse matrices allowed
+              for the graph.
+            * Otherwise, it can be ``'coo'``, ``'csr'``, or ``'csc'`` or a
+              sublist of them, specifying the sparse matrices to create. If
+              there are some formats already created, they will be skipped.
+              If there are some formats in the list that are not allowed for
+              the graph, an error will be raised.
+        """
+        pass
+
     def formats(self, formats=None):
         r"""Get a cloned graph with the specified sparse format(s) or query
         for the usage status of sparse formats


### PR DESCRIPTION
## Description
A new API has been designed for the `formats` and `create_formats_` function. This PR first presents the high-level Python design, with the specific design detailed in the function's docstring.

We aim to ensure backward compatibility while enabling:
- `formats` to set `allowed_formats` and designate the `create_formats` for sparse matrices.
- `create_formats_` to also designate the `create_formats` for sparse matrices.

This PR is related to [Issues: DGLGraph.formats with list input doesn't work #5545](https://github.com/dmlc/dgl/issues/5545).

## Checklist
Please feel free to remove inapplicable items for your PR.
- [x] The PR title starts with [$CATEGORY] (such as [NN], [Model], [Doc], [Feature]])
- [x] I've leverage the [tools](https://docs.google.com/document/d/1iHyj7zlmygKSk5gBPsqIqL5ASPzJSPREaNT_QdsiYA4/edit) to beautify the python and c++ code.
- [x] The PR is complete and small, read the [Google eng practice (CL equals to PR)](https://google.github.io/eng-practices/review/developer/small-cls.html) to understand more about small PR. In DGL, we consider PRs with less than 200 lines of core code change are small (example, test and documentation could be exempted).
- [ ] All changes have test coverage
- [x] Code is well-documented
- [ ] To the best of my knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change
- [x] Related issue is referred in this PR
- [ ] If the PR is for a new model/paper, I've updated the example index [here](../examples/README.md).

## Changes
<!-- You could use following template
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)
-->
