### PR TITLE
[Misc]Improving the output of the DCRNN training script.

### DIFF
--- a/examples/pytorch/dtgrnn/train.py
+++ b/examples/pytorch/dtgrnn/train.py
@@ -87,7 +87,7 @@ def train(
             scheduler.step()
         total_loss.append(float(loss))
         batch_cnt[0] += 1
-        print("Batch: ", i)
+        print("\rBatch: ", i, end="")
     return np.mean(total_loss)
 
 
@@ -284,7 +284,7 @@ if __name__ == "__main__":
             dcrnn, g, test_loader, normalizer, loss_fn, device, args
         )
         print(
-            "Epoch: {} Train Loss: {} Valid Loss: {} Test Loss: {}".format(
+            "\rEpoch: {} Train Loss: {} Valid Loss: {} Test Loss: {}".format(
                 e, train_loss, valid_loss, test_loss
             )
         )


### PR DESCRIPTION
## Description
<!-- Brief description. Refer to the related issues if existed.
It'll be great if relevant reviewers can be assigned as well.-->
By printing the messages: `Batch: XYZ` on the same line on the screen, we make the output of the training script much better:
```
Epoch: 0 Train Loss: 3.7948007539113364 Valid Loss: 2.795261863809866 Test Loss: 3.0333544105707206
Epoch: 1 Train Loss: 2.7208512636820474 Valid Loss: 2.720377560393147 Test Loss: 2.9376083156443222
Epoch: 2 Train Loss: 2.6939743881225584 Valid Loss: 2.725586600032616 Test Loss: 2.9333534335773077
Epoch: 3 Train Loss: 2.6862449487050375 Valid Loss: 2.693360625590208 Test Loss: 2.915788319969165
Epoch: 4 Train Loss: 2.683133149464925 Valid Loss: 2.6903926561599554 Test Loss: 2.944984791167583
Epoch: 5 Train Loss: 2.679369389851888 Valid Loss: 2.6951579150301144 Test Loss: 2.9178620783741143
Epoch: 6 Train Loss: 2.675840035120646 Valid Loss: 2.7057937984609755 Test Loss: 2.9143207424945548
Epoch: 7 Train Loss: 2.670881732940674 Valid Loss: 2.6831955642307665 Test Loss: 2.9126363726332776
Epoch: 8 Train Loss: 2.669891906738281 Valid Loss: 2.710183073477305 Test Loss: 2.9222461769841694
Epoch: 9 Train Loss: 2.6638503761291505 Valid Loss: 2.7223289136806814 Test Loss: 2.905425327243179
```

Previously, between every two lines with epoch losses, the training script generated 374 lines with batch numbers:
```
Epoch: N Train Loss: . . .
Batch: 0
...
Batch: XYZ
....
Batch: 374
Epoch: N+1 Train Loss: . . .
```
## Checklist
Please feel free to remove inapplicable items for your PR.
- [ ] The PR title starts with [$CATEGORY] (such as [NN], [Model], [Doc], [Feature]])
- [ ] The PR is complete and small, read the [Google eng practice (CL equals to PR)](https://google.github.io/eng-practices/review/developer/small-cls.html) to understand more about small PR. In DGL, we consider PRs with less than 200 lines of core code change are small (example, test and documentation could be exempted).
- [ ] All changes have test coverage
- [ ] Code is well-documented
- [ ] To the best of my knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

## Changes
<!-- You could use following template
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)
-->
