### PR TITLE
[Example][Minor] Update README/requirements from sklearn -> scikit-learn

### DIFF
--- a/examples/pytorch/GATNE-T/requirements.txt
+++ b/examples/pytorch/GATNE-T/requirements.txt
@@ -1,6 +1,6 @@
 tqdm
 numpy
-sklearn
+scikit-learn
 networkx
 gensim
 requests

--- a/examples/pytorch/GNN-FiLM/README.md
+++ b/examples/pytorch/GNN-FiLM/README.md
@@ -12,7 +12,7 @@ This example was implemented by [Kounianhua Du](https://github.com/KounianhuaDu)
 Dependencies
 ----------------------
 - numpy 1.19.4
-- sklearn 0.22.1
+- scikit-learn 0.22.1
 - pytorch 1.4.0
 - dgl 0.5.3
 

--- a/examples/pytorch/TAHIN/readme.md
+++ b/examples/pytorch/TAHIN/readme.md
@@ -10,7 +10,7 @@ Dependencies
 ----------------------
 - pytorch 1.7.1
 - dgl 0.6.0
-- sklearn 0.22.1
+- scikit-learn 0.22.1
 
 Datasets
 ---------------------------------------

--- a/examples/pytorch/cluster_gcn/README.md
+++ b/examples/pytorch/cluster_gcn/README.md
@@ -9,7 +9,7 @@ Dependencies
 ------------
 - Python 3.7+(for string formatting features)
 - PyTorch 1.9.0+
-- sklearn
+- scikit-learn
 - TorchMetrics 0.11.4
 
 ## Run Experiments

--- a/examples/pytorch/gatv2/README.md
+++ b/examples/pytorch/gatv2/README.md
@@ -9,7 +9,7 @@ Dependencies
 ------------
 - torch
 - requests
-- sklearn
+- scikit-learn
 
 How to run
 ----------

--- a/examples/pytorch/gin/README.md
+++ b/examples/pytorch/gin/README.md
@@ -6,11 +6,11 @@ Graph Isomorphism Network (GIN)
 
 Dependencies
 ------------
-- sklearn
+- scikit-learn
 
 Install as follows:
 ```bash
-pip install sklearn
+pip install scikit-learn
 ```
 
 How to run

--- a/examples/pytorch/grace/README.md
+++ b/examples/pytorch/grace/README.md
@@ -12,7 +12,7 @@ This example was implemented by [Hengrui Zhang](https://github.com/hengruizhang9
 - Python 3.7
 - PyTorch 1.7.1
 - dgl 0.6.0
-- sklearn 0.22.1
+- scikit-learn 0.22.1
 
 ## Datasets
 

--- a/examples/pytorch/ogb/seal_ogbl/README.md
+++ b/examples/pytorch/ogb/seal_ogbl/README.md
@@ -6,7 +6,7 @@ This is an example of implementing [SEAL](https://arxiv.org/pdf/2010.16103.pdf) 
 
 Requirements
 ------------
-[PyTorch](https://pytorch.org/), [DGL](https://www.dgl.ai/), [OGB](https://ogb.stanford.edu/docs/home/), and other python libraries: numpy, scipy, tqdm, sklearn, etc.
+[PyTorch](https://pytorch.org/), [DGL](https://www.dgl.ai/), [OGB](https://ogb.stanford.edu/docs/home/), and other python libraries: numpy, scipy, tqdm, scikit-learn, etc.
 
 Usages
 ------

--- a/examples/pytorch/stgcn_wave/README.md
+++ b/examples/pytorch/stgcn_wave/README.md
@@ -6,7 +6,7 @@ Spatio-Temporal Graph Convolutional Networks
 - See [this blog](https://towardsdatascience.com/build-your-first-graph-neural-network-model-to-predict-traffic-speed-in-20-minutes-b593f8f838e5) for more details about running the code.
 - Dependencies
   - PyTorch 1.1.0+
-  - sklearn
+  - scikit-learn
   - dgl
   - tables
 


### PR DESCRIPTION
## Description
Now, we have to use scikit-learn in pip requirements files as pip install sklearn is now deprecated. 
source: https://github.com/scikit-learn/sklearn-pypi-package

## Checklist
Please feel free to remove inapplicable items for your PR.
- [x] The PR title starts with [$CATEGORY] (such as [NN], [Model], [Doc], [Feature]])
- [x] I've leverage the [tools](https://docs.google.com/document/d/1iHyj7zlmygKSk5gBPsqIqL5ASPzJSPREaNT_QdsiYA4/edit) to beautify the python and c++ code.
- [x] The PR is complete and small, read the [Google eng practice (CL equals to PR)](https://google.github.io/eng-practices/review/developer/small-cls.html) to understand more about small PR. In DGL, we consider PRs with less than 200 lines of core code change are small (example, test and documentation could be exempted).
- [ ] All changes have test coverage
- [ ] Code is well-documented
- [ ] To the best of my knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change
- [ ] Related issue is referred in this PR
- [ ] If the PR is for a new model/paper, I've updated the example index [here](../examples/README.md).

## Changes
Change `sklearn` --> `scikit-learn`
