### PR TITLE
[BugFix]Enable test for nx conversion

### DIFF
--- a/tests/python/common/function/test_basics.py
+++ b/tests/python/common/function/test_basics.py
@@ -199,7 +199,7 @@ def test_batch_setter_autograd(idtype):
     assert F.array_equal(F.grad(hh)[:, 0], F.tensor([2.0, 2.0, 2.0]))
 
 
-def _test_nx_conversion():
+def test_nx_conversion():
     # check conversion between networkx and DGLGraph
 
     def _check_nx_feature(nxg, nf, ef):
@@ -302,7 +302,7 @@ def _test_nx_conversion():
 
     # Test converting from a networkx graph whose nodes are
     # not labeled with consecutive-integers.
-    nxg = nx.cycle_graph(5)
+    nxg = nx.cycle_graph(5).to_directed()
     nxg.remove_nodes_from([0, 4])
     for u in nxg.nodes():
         nxg.nodes[u]["h"] = F.tensor([u])
@@ -314,9 +314,9 @@ def _test_nx_conversion():
     assert g.num_edges() == 4
     assert g.has_edge_between(0, 1)
     assert g.has_edge_between(1, 2)
-    assert F.allclose(g.ndata["h"], F.tensor([[1.0], [2.0], [3.0]]))
+    assert F.allclose(g.ndata["h"], F.tensor([[1], [2], [3]]))
     assert F.allclose(
-        g.edata["h"], F.tensor([[1.0, 2.0], [1.0, 2.0], [2.0, 3.0], [2.0, 3.0]])
+        g.edata["h"], F.tensor([[1, 2], [2, 1], [2, 3], [3, 2]])
     )
 
 


### PR DESCRIPTION
## Description
- Enable the test for graph conversion from/to networkx graphs.
- Fix a bug in the test function `test_nx_conversion` (`from_networkx` requires a directed graph if `edg_attrs` is specified).

## Checklist
Please feel free to remove inapplicable items for your PR.
- [x] The PR title starts with [$CATEGORY] (such as [NN], [Model], [Doc], [Feature]])
- [x] I've leverage the [tools](https://docs.google.com/document/d/1iHyj7zlmygKSk5gBPsqIqL5ASPzJSPREaNT_QdsiYA4/edit) to beautify the python and c++ code.
- [x] The PR is complete and small, read the [Google eng practice (CL equals to PR)](https://google.github.io/eng-practices/review/developer/small-cls.html) to understand more about small PR. In DGL, we consider PRs with less than 200 lines of core code change are small (example, test and documentation could be exempted).
- [x] All changes have test coverage
- [x] Code is well-documented
- [x] To the best of my knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change
- [x] Related issue is referred in this PR
- [x] If the PR is for a new model/paper, I've updated the example index [here](../examples/README.md).

