### PR TITLE
[Model] Add Node explanations for SubgraphX Explainer Impls.

### DIFF
--- a/python/dgl/nn/pytorch/explain/subgraphx.py
+++ b/python/dgl/nn/pytorch/explain/subgraphx.py
@@ -443,7 +443,7 @@ class SubgraphX(nn.Module):
         sg_feat = feat[sg_nodes]
 
         eg_nodes = self.explain_graph(sg, sg_feat, target_class, **kwargs)
-        original_nodes = sg_nodes[eg_nodes]
+        original_nodes = sg_nodes[eg_nodes.long()]
         return original_nodes
 
 
@@ -988,7 +988,7 @@ class HeteroSubgraphX(nn.Module):
 
         eg_nodes = self.explain_graph(sg, sg_feat, target_class, **kwargs)
         original_nodes = {
-            ntype: sg_nodes[ntype][eg_node_ids]
+            ntype: sg_nodes[ntype][eg_node_ids.long()]
             for ntype, eg_node_ids in eg_nodes.items()
         }
         return original_nodes

--- a/python/dgl/nn/pytorch/explain/subgraphx.py
+++ b/python/dgl/nn/pytorch/explain/subgraphx.py
@@ -6,7 +6,7 @@ import numpy as np
 import torch
 import torch.nn as nn
 
-from .... import to_heterogeneous, to_homogeneous, khop_out_subgraph
+from .... import khop_out_subgraph, to_heterogeneous, to_homogeneous
 from ....base import NID
 from ....convert import to_networkx
 from ....subgraph import node_subgraph

--- a/tests/python/pytorch/nn/test_nn.py
+++ b/tests/python/pytorch/nn/test_nn.py
@@ -1786,12 +1786,13 @@ def test_heterosubgraphx(g, idtype, input_dim, n_classes):
     model = Model(input_dim, n_classes, g.canonical_etypes)
     model = model.to(ctx)
     explainer = nn.HeteroSubgraphX(
-        model, num_hops=1, shapley_steps=20, num_rollouts=5, coef=2.0
+        model, num_hops=2, shapley_steps=20, num_rollouts=5, coef=2.0
     )
     # Explain graph prediction
     explainer.explain_graph(g, feat, target_class=0)
     # Explain node prediction
-    explainer.explain_node(g.ntypes[0], 0, g, feat, target_class=0)
+    # * node_id 0 from g.ntypes[0] will not pass the node_min requirement.
+    explainer.explain_node(g.ntypes[0], 1, g, feat, target_class=0)
 
 
 @parametrize_idtype

--- a/tests/python/pytorch/nn/test_nn.py
+++ b/tests/python/pytorch/nn/test_nn.py
@@ -1791,7 +1791,6 @@ def test_heterosubgraphx(g, idtype, input_dim, n_classes):
     # Explain graph prediction
     explainer.explain_graph(g, feat, target_class=0)
     # Explain node prediction
-    # * node_id 0 from g.ntypes[0] will not pass the node_min requirement.
     explainer.explain_node(g.ntypes[0], 1, g, feat, target_class=0)
 
 

--- a/tests/python/pytorch/nn/test_nn.py
+++ b/tests/python/pytorch/nn/test_nn.py
@@ -1728,7 +1728,10 @@ def test_subgraphx(g, idtype, n_classes):
     explainer = nn.SubgraphX(
         model, num_hops=1, shapley_steps=20, num_rollouts=5, coef=2.0
     )
+    # Explain graph prediction
     explainer.explain_graph(g, feat, target_class=0)
+    # Explain node prediction
+    explainer.explain_node(0, g, feat, target_class=0)
 
 
 @pytest.mark.parametrize("g", get_cases(["hetero"], exclude=["zero-degree"]))
@@ -1785,7 +1788,10 @@ def test_heterosubgraphx(g, idtype, input_dim, n_classes):
     explainer = nn.HeteroSubgraphX(
         model, num_hops=1, shapley_steps=20, num_rollouts=5, coef=2.0
     )
+    # Explain graph prediction
     explainer.explain_graph(g, feat, target_class=0)
+    # Explain node prediction
+    explainer.explain_node(g.ntypes[0], 0, g, feat, target_class=0)
 
 
 @parametrize_idtype


### PR DESCRIPTION
## Description

Implemented Node explanations for SubgraphX Explainer (https://arxiv.org/pdf/2102.05152.pdf) for both Homogeneous and Heterogeneous Graphs. (extending from https://github.com/dmlc/dgl/pull/5530 and https://github.com/dmlc/dgl/pull/5315)

## Checklist
Please feel free to remove inapplicable items for your PR.
- [x] The PR title starts with [$CATEGORY] (such as [NN], [Model], [Doc], [Feature]])
- [x] I've leverage the [tools](https://docs.google.com/document/d/1iHyj7zlmygKSk5gBPsqIqL5ASPzJSPREaNT_QdsiYA4/edit) to beautify the python and c++ code.
- [x] The PR is complete and small, read the [Google eng practice (CL equals to PR)](https://google.github.io/eng-practices/review/developer/small-cls.html) to understand more about small PR. In DGL, we consider PRs with less than 200 lines of core code change are small (example, test and documentation could be exempted).
- [x] All changes have test coverage
- [x] Code is well-documented
- [x] To the best of my knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change
- [x] Related issue is referred in this PR

## Changes

- [x] Added the `explain_node` method for both homogeneous and heterogeneous implementations of SubgraphX Explainer.

The output of the model has been manually verified on MUTAG dataset. Visualization scripts utilizing `explain_node` for both homogeneous ([script ref](https://gist.github.com/ndbaker1/4eec321173fe1dfaff458b957ebc9a1b#file-homo_subgraphx_test-py)) and heterogeneous ([script ref](https://gist.github.com/ndbaker1/4eec321173fe1dfaff458b957ebc9a1b#file-hetero_subgraphx_test-py)) graphs were tested. Unfortunately, there's no ground truth for the explanation except for what is mentioned in the research paper, so we cannot quantify the model's performance. Instead, we manually investigated the results and confirmed that they aligned well with human intuition and findings of the research paper.

Inline documentation is added following the original style, and an example of using the method is included in the documentation.