### PR TITLE
[GraphBolt] define __len__ for ItemSet/ItemSetDict

### DIFF
--- a/python/dgl/graphbolt/itemset.py
+++ b/python/dgl/graphbolt/itemset.py
@@ -1,6 +1,6 @@
 """GraphBolt Itemset."""
 
-from typing import Dict, Iterable, Iterator, Tuple
+from typing import Dict, Iterable, Iterator, Sized, Tuple
 
 __all__ = ["ItemSet", "ItemSetDict"]
 
@@ -49,9 +49,6 @@ class ItemSet:
 
     def __init__(self, items: Iterable or Tuple[Iterable]) -> None:
         if isinstance(items, tuple):
-            assert all(
-                items[0].size(0) == item.size(0) for item in items
-            ), "Size mismatch between items in tuple."
             self._items = items
         else:
             self._items = (items,)
@@ -63,6 +60,13 @@ class ItemSet:
         zip_items = zip(*self._items)
         for item in zip_items:
             yield tuple(item)
+
+    def __len__(self) -> int:
+        if isinstance(self._items[0], Sized):
+            return len(self._items[0])
+        raise TypeError(
+            f"{type(self).__name__} instance doesn't have valid length."
+        )
 
 
 class ItemSetDict:
@@ -128,3 +132,6 @@ class ItemSetDict:
         for key, itemset in self._itemsets.items():
             for item in itemset:
                 yield {key: item}
+
+    def __len__(self) -> int:
+        return sum(len(itemset) for itemset in self._itemsets.values())


### PR DESCRIPTION
## Description
<!-- Brief description. Refer to the related issues if existed.
It'll be great if relevant reviewers can be assigned as well.-->
1. define `__len__` to enable `len()` if possible. This definition will not result in crash if call with `list(item_set)`. Referred from https://github.com/pytorch/pytorch/blob/6acb8d3d1cf577b63cd11bf88c627d3e86669901/torch/utils/data/datapipes/iter/combinatorics.py#L47-L51 What's more, enabling length could make it possible to do optimization: slice batch of items from original data directly instead of iterating one by one.
2. remove size check for tuple items as `.size()` is available in `torch.Tensor` only, not general enough as `Iterable` is required only for the input items.
## Checklist
Please feel free to remove inapplicable items for your PR.
- [ ] The PR title starts with [$CATEGORY] (such as [NN], [Model], [Doc], [Feature]])
- [ ] I've leverage the [tools](https://docs.google.com/document/d/1iHyj7zlmygKSk5gBPsqIqL5ASPzJSPREaNT_QdsiYA4/edit) to beautify the python and c++ code.
- [ ] The PR is complete and small, read the [Google eng practice (CL equals to PR)](https://google.github.io/eng-practices/review/developer/small-cls.html) to understand more about small PR. In DGL, we consider PRs with less than 200 lines of core code change are small (example, test and documentation could be exempted).
- [ ] All changes have test coverage
- [ ] Code is well-documented
- [ ] To the best of my knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change
- [ ] Related issue is referred in this PR
- [ ] If the PR is for a new model/paper, I've updated the example index [here](../examples/README.md).

## Changes
<!-- You could use following template
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)
-->
