### PR TITLE
[Sparse] Update code and add unittest for `formats` 

### DIFF
--- a/src/graph/unit_graph.cc
+++ b/src/graph/unit_graph.cc
@@ -1537,13 +1537,9 @@ HeteroGraphPtr UnitGraph::GetGraphInFormat(dgl_format_code_t formats) const {
   // If the intersection of formats and created_formats is not empty.
   // The format(s) in the intersection will be retained.
   if (intersection != 0) {
-    COOPtr coo_ptr = nullptr;
-    CSRPtr in_csr_ptr = nullptr;
-    CSRPtr out_csr_ptr = nullptr;
-
-    if (COO_CODE & intersection) coo_ptr = GetCOO(false);
-    if (CSC_CODE & intersection) in_csr_ptr = GetInCSR(false);
-    if (CSR_CODE & intersection) out_csr_ptr = GetOutCSR(false);
+    COOPtr coo_ptr = COO_CODE & intersection ? GetCOO(false) : nullptr;
+    CSRPtr in_csr_ptr = CSC_CODE & intersection ? GetInCSR(false) : nullptr;
+    CSRPtr out_csr_ptr = CSR_CODE & intersection ? GetOutCSR(false) : nullptr;
 
     return HeteroGraphPtr(
         new UnitGraph(meta_graph_, in_csr_ptr, out_csr_ptr, coo_ptr, formats));

--- a/tests/python/common/test_heterograph-misc.py
+++ b/tests/python/common/test_heterograph-misc.py
@@ -499,6 +499,41 @@ def test_formats():
     finally:
         assert not fail
 
+    # If the intersection of created formats and allowed formats is
+    # not empty, then retain the intersection.
+    # Case1: intersection is not empty and intersected is equal to
+    # created formats.
+    g = g.formats(["coo", "csr"])
+    g.create_formats_()
+    g = g.formats(["coo", "csr", "csc"])
+    assert sorted(g.formats()["created"]) == sorted(["coo", "csr"])
+    assert sorted(g.formats()["not created"]) == sorted(["csc"])
+
+    # Case2: intersection is not empty and intersected is not equal
+    # to created formats.
+    g = g.formats(["coo", "csr"])
+    g.create_formats_()
+    g = g.formats(["coo", "csc"])
+    assert sorted(g.formats()["created"]) == sorted(["coo"])
+    assert sorted(g.formats()["not created"]) == sorted(["csc"])
+
+    # If the intersection of created formats and allowed formats is
+    # empty, then create a format in the order of `coo` -> `csr` ->
+    # `csc`.
+    # Case1: intersection is empty and just one format is allowed.
+    g = g.formats(["coo", "csr"])
+    g.create_formats_()
+    g = g.formats(["csc"])
+    assert sorted(g.formats()["created"]) == sorted(["csc"])
+    assert sorted(g.formats()["not created"]) == sorted([])
+
+    # Case2: intersection is empty and more than one format is allowed.
+    g = g.formats("csc")
+    g.create_formats_()
+    g = g.formats(["csr", "coo"])
+    assert sorted(g.formats()["created"]) == sorted(["coo"])
+    assert sorted(g.formats()["not created"]) == sorted(["csr"])
+
 
 if __name__ == "__main__":
     test_query()


### PR DESCRIPTION
## Description
<!-- Brief description. Refer to the related issues if existed.
It'll be great if relevant reviewers can be assigned as well.-->
Based on the previous [PR#5851 [Sparse] Clean formats function docstring](https://github.com/dmlc/dgl/pull/5851) and [Issue#5846: [Sparse] Standardize the behavior of `formats()`](https://github.com/dmlc/dgl/issues/5846), this PR primarily accomplishes the following:

- [x] Modified the underlying implementation of the `formats()` function within `unit_graph.cc`.
- [x] Added some new, necessary unit tests for the `formats()` function in `tests/python/common/test_heterograph-misc.py`.

With these changes, the behavior of `formats()` will be consistent with its description in `heterograph.py`.
## Checklist
Please feel free to remove inapplicable items for your PR.
- [x] The PR title starts with [$CATEGORY] (such as [NN], [Model], [Doc], [Feature]])
- [x] I've leverage the [tools](https://docs.google.com/document/d/1iHyj7zlmygKSk5gBPsqIqL5ASPzJSPREaNT_QdsiYA4/edit) to beautify the python and c++ code.
- [x] The PR is complete and small, read the [Google eng practice (CL equals to PR)](https://google.github.io/eng-practices/review/developer/small-cls.html) to understand more about small PR. In DGL, we consider PRs with less than 200 lines of core code change are small (example, test and documentation could be exempted).
- [x] All changes have test coverage
- [x] Code is well-documented
- [ ] To the best of my knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change
- [x] Related issue is referred in this PR
- [ ] If the PR is for a new model/paper, I've updated the example index [here](../examples/README.md).

## Changes
<!-- You could use following template
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)
-->
