### PR TITLE
[Doc] fix doc build error caused by quickstart.ipynb

### DIFF
--- a/notebooks/sparse/quickstart.ipynb
+++ b/notebooks/sparse/quickstart.ipynb
@@ -1255,7 +1255,7 @@
       "cell_type": "code",
       "source": [
         "import torch.nn as nn\n",
-        "import torch.functional as F\n",
+        "import torch.nn.functional as F\n",
         "\n",
         "class SimplifiedGAT(nn.Module):\n",
         "    def __init__(self, in_size, out_size):\n",


### PR DESCRIPTION
## Description
<!-- Brief description. Refer to the related issues if existed.
It'll be great if relevant reviewers can be assigned as well.-->
DGL documentation CI is down due to `'torch.functional' has no attribute 'leaky_relu'`
should be https://pytorch.org/docs/stable/generated/torch.nn.functional.leaky_relu.html#torch.nn.functional.leaky_relu
## Checklist
Please feel free to remove inapplicable items for your PR.
- [ ] The PR title starts with [$CATEGORY] (such as [NN], [Model], [Doc], [Feature]])
- [ ] I've leverage the [tools](https://docs.google.com/document/d/1iHyj7zlmygKSk5gBPsqIqL5ASPzJSPREaNT_QdsiYA4/edit) to beautify the python and c++ code.
- [ ] The PR is complete and small, read the [Google eng practice (CL equals to PR)](https://google.github.io/eng-practices/review/developer/small-cls.html) to understand more about small PR. In DGL, we consider PRs with less than 200 lines of core code change are small (example, test and documentation could be exempted).
- [ ] All changes have test coverage
- [ ] Code is well-documented
- [ ] To the best of my knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change
- [ ] Related issue is referred in this PR
- [ ] If the PR is for a new model/paper, I've updated the example index [here](../examples/README.md).

## Changes
<!-- You could use following template
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)
-->
