### PR TITLE
[DistDGL] keep net_type in public API even it is deprecated

### DIFF
--- a/python/dgl/distributed/dist_context.py
+++ b/python/dgl/distributed/dist_context.py
@@ -12,7 +12,7 @@ import traceback
 from enum import Enum
 
 from .. import utils
-from ..base import DGLError
+from ..base import dgl_warning, DGLError
 from . import rpc
 from .constants import MAX_QUEUE_SIZE
 from .kvstore import close_kvstore, init_kvstore
@@ -208,6 +208,7 @@ class CustomPool:
 def initialize(
     ip_config,
     max_queue_size=MAX_QUEUE_SIZE,
+    net_type=None,
     num_worker_threads=1,
 ):
     """Initialize DGL's distributed module
@@ -226,6 +227,8 @@ def initialize(
 
         Note that the 20 GB is just an upper-bound and DGL uses zero-copy and
         it will not allocate 20GB memory at once.
+    net_type : str, optional
+        [Deprecated] Networking type, can be 'socket' only.
     num_worker_threads: int
         The number of OMP threads in each sampler process.
 
@@ -235,6 +238,10 @@ def initialize(
     distributed API. For example, when used with Pytorch, users have to invoke this function
     before Pytorch's `pytorch.distributed.init_process_group`.
     """
+    if net_type is not None:
+        dgl_warning(
+            "net_type is deprecated and will be removed in future release."
+        )
     if os.environ.get("DGL_ROLE", "client") == "server":
         from .dist_graph import DistGraphServer
 


### PR DESCRIPTION
## Description
<!-- Brief description. Refer to the related issues if existed.
It'll be great if relevant reviewers can be assigned as well.-->

## Checklist
Please feel free to remove inapplicable items for your PR.
- [ ] The PR title starts with [$CATEGORY] (such as [NN], [Model], [Doc], [Feature]])
- [ ] I've leverage the [tools](https://docs.google.com/document/d/1iHyj7zlmygKSk5gBPsqIqL5ASPzJSPREaNT_QdsiYA4/edit) to beautify the python and c++ code.
- [ ] The PR is complete and small, read the [Google eng practice (CL equals to PR)](https://google.github.io/eng-practices/review/developer/small-cls.html) to understand more about small PR. In DGL, we consider PRs with less than 200 lines of core code change are small (example, test and documentation could be exempted).
- [ ] All changes have test coverage
- [ ] Code is well-documented
- [ ] To the best of my knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change
- [ ] Related issue is referred in this PR
- [ ] If the PR is for a new model/paper, I've updated the example index [here](../examples/README.md).

## Changes
<!-- You could use following template
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)
-->
