### PR TITLE
[Graphbolt] Dispatch edge ids in neighbor sampling

### DIFF
--- a/graphbolt/src/csc_sampling_graph.cc
+++ b/graphbolt/src/csc_sampling_graph.cc
@@ -150,8 +150,7 @@ c10::intrusive_ptr<SampledSubgraph> CSCSamplingGraph::SampleNeighbors(
             TORCH_CHECK(
                 nid >= 0 && nid < NumNodes(),
                 "The seed nodes' IDs should fall within the range of the "
-                "graph's "
-                "node IDs.");
+                "graph's node IDs.");
             const auto offset = indptr_data[nid];
             const auto num_neighbors = indptr_data[nid + 1] - offset;
 

--- a/graphbolt/src/csc_sampling_graph.cc
+++ b/graphbolt/src/csc_sampling_graph.cc
@@ -144,10 +144,9 @@ c10::intrusive_ptr<SampledSubgraph> CSCSamplingGraph::SampleNeighbors(
   AT_DISPATCH_INTEGRAL_TYPES(
       indptr_.scalar_type(), "parallel_for", ([&] {
         torch::parallel_for(0, num_nodes, 32, [&](scalar_t b, scalar_t e) {
-          const int64_t* nodes_data = nodes.data_ptr<int64_t>();
           const scalar_t* indptr_data = indptr_.data_ptr<scalar_t>();
           for (scalar_t i = b; i < e; ++i) {
-            const auto nid = nodes_data[i];
+            const auto nid = nodes[i].item<int64_t>();
             TORCH_CHECK(
                 nid >= 0 && nid < NumNodes(),
                 "The seed nodes' IDs should fall within the range of the "

--- a/graphbolt/src/csc_sampling_graph.cc
+++ b/graphbolt/src/csc_sampling_graph.cc
@@ -141,37 +141,44 @@ c10::intrusive_ptr<SampledSubgraph> CSCSamplingGraph::SampleNeighbors(
   torch::Tensor num_picked_neighbors_per_node =
       torch::zeros({num_nodes + 1}, indptr_.options());
 
-  torch::parallel_for(0, num_nodes, 32, [&](size_t b, size_t e) {
-    for (size_t i = b; i < e; ++i) {
-      const auto nid = nodes[i].item<int64_t>();
-      TORCH_CHECK(
-          nid >= 0 && nid < NumNodes(),
-          "The seed nodes' IDs should fall within the range of the graph's "
-          "node IDs.");
-      const auto offset = indptr_[nid].item<int64_t>();
-      const auto num_neighbors = indptr_[nid + 1].item<int64_t>() - offset;
+  AT_DISPATCH_INTEGRAL_TYPES(
+      indptr_.scalar_type(), "parallel_for", ([&] {
+        torch::parallel_for(0, num_nodes, 32, [&](scalar_t b, scalar_t e) {
+          const int64_t* nodes_data = nodes.data_ptr<int64_t>();
+          const scalar_t* indptr_data = indptr_.data_ptr<scalar_t>();
+          for (scalar_t i = b; i < e; ++i) {
+            const auto nid = nodes_data[i];
+            TORCH_CHECK(
+                nid >= 0 && nid < NumNodes(),
+                "The seed nodes' IDs should fall within the range of the "
+                "graph's "
+                "node IDs.");
+            const auto offset = indptr_data[nid];
+            const auto num_neighbors = indptr_data[nid + 1] - offset;
 
-      if (num_neighbors == 0) {
-        // Initialization is performed here because all tensors will be
-        // concatenated in the master thread, and having an undefined tensor
-        // during concatenation can result in a crash.
-        picked_neighbors_per_node[i] = torch::tensor({}, indptr_.options());
-        continue;
-      }
+            if (num_neighbors == 0) {
+              // Initialization is performed here because all tensors will be
+              // concatenated in the master thread, and having an undefined
+              // tensor during concatenation can result in a crash.
+              picked_neighbors_per_node[i] =
+                  torch::tensor({}, indptr_.options());
+              continue;
+            }
 
-      if (consider_etype) {
-        picked_neighbors_per_node[i] = PickByEtype(
-            offset, num_neighbors, fanouts, replace, indptr_.options(),
-            type_per_edge_.value(), probs_or_mask);
-      } else {
-        picked_neighbors_per_node[i] = Pick(
-            offset, num_neighbors, fanouts[0], replace, indptr_.options(),
-            probs_or_mask);
-      }
-      num_picked_neighbors_per_node[i + 1] =
-          picked_neighbors_per_node[i].size(0);
-    }
-  });  // End of the thread.
+            if (consider_etype) {
+              picked_neighbors_per_node[i] = PickByEtype(
+                  offset, num_neighbors, fanouts, replace, indptr_.options(),
+                  type_per_edge_.value(), probs_or_mask);
+            } else {
+              picked_neighbors_per_node[i] = Pick(
+                  offset, num_neighbors, fanouts[0], replace, indptr_.options(),
+                  probs_or_mask);
+            }
+            num_picked_neighbors_per_node[i + 1] =
+                picked_neighbors_per_node[i].size(0);
+          }
+        });  // End of the thread.
+      }));
 
   torch::Tensor subgraph_indptr =
       torch::cumsum(num_picked_neighbors_per_node, 0);

--- a/python/dgl/graphbolt/graph_storage/csc_sampling_graph.py
+++ b/python/dgl/graphbolt/graph_storage/csc_sampling_graph.py
@@ -265,6 +265,9 @@ class CSCSamplingGraph:
         """
         # Ensure nodes is 1-D tensor.
         assert nodes.dim() == 1, "Nodes should be 1-D tensor."
+        assert (
+            nodes.dtype == torch.long
+        ), f"Nodes is expected to be of type 'long' but got '{nodes.dtype}'."
         assert fanouts.dim() == 1, "Fanouts should be 1-D tensor."
         if fanouts.size(0) > 1:
             assert (

--- a/python/dgl/graphbolt/graph_storage/csc_sampling_graph.py
+++ b/python/dgl/graphbolt/graph_storage/csc_sampling_graph.py
@@ -265,9 +265,6 @@ class CSCSamplingGraph:
         """
         # Ensure nodes is 1-D tensor.
         assert nodes.dim() == 1, "Nodes should be 1-D tensor."
-        assert (
-            nodes.dtype == torch.long
-        ), f"Nodes is expected to be of type 'long' but got '{nodes.dtype}'."
         assert fanouts.dim() == 1, "Fanouts should be 1-D tensor."
         if fanouts.size(0) > 1:
             assert (


### PR DESCRIPTION
## Description
This PR use torch built-in dispatch macro to dispatch types of edge ids, and change all related data access from 'item()' to raw pointer.
This PR combined with #5890 will improve the performance by around 30%.
## Checklist
Please feel free to remove inapplicable items for your PR.
- [ ] The PR title starts with [$CATEGORY] (such as [NN], [Model], [Doc], [Feature]])
- [ ] I've leverage the [tools](https://docs.google.com/document/d/1iHyj7zlmygKSk5gBPsqIqL5ASPzJSPREaNT_QdsiYA4/edit) to beautify the python and c++ code.
- [ ] The PR is complete and small, read the [Google eng practice (CL equals to PR)](https://google.github.io/eng-practices/review/developer/small-cls.html) to understand more about small PR. In DGL, we consider PRs with less than 200 lines of core code change are small (example, test and documentation could be exempted).
- [ ] All changes have test coverage
- [ ] Code is well-documented
- [ ] To the best of my knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change
- [ ] Related issue is referred in this PR
- [ ] If the PR is for a new model/paper, I've updated the example index [here](../examples/README.md).

## Changes
<!-- You could use following template
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)
-->
