### PR TITLE
[Performance] Use binary search in rowwise pick

### DIFF
--- a/src/array/cpu/rowwise_pick.h
+++ b/src/array/cpu/rowwise_pick.h
@@ -257,7 +257,6 @@ COOMatrix CSRRowWisePerEtypePick(
       CHECK_LT(rid, mat.num_rows);
       const IdxType off = indptr[rid];
       const IdxType len = indptr[rid + 1] - off;
-
       // do something here
       if (len == 0) {
         picked_rows[i] = NewIdArray(0, ctx, sizeof(IdxType) * 8);
@@ -310,101 +309,124 @@ COOMatrix CSRRowWisePerEtypePick(
         std::vector<IdxType> cols;
         std::vector<IdxType> idx;
 
-        std::vector<IdxType> et(len);
+        std::vector<IdxType> et;
         std::vector<IdxType> et_idx(len);
-        std::vector<IdxType> et_eid(len);
+        std::vector<IdxType> et_eid;
         std::iota(et_idx.begin(), et_idx.end(), 0);
-        for (int64_t j = 0; j < len; ++j) {
-          const IdxType homogenized_eid = eid ? eid[off + j] : off + j;
-          auto it = std::upper_bound(
-              eid2etype_offset.begin(), eid2etype_offset.end(),
-              homogenized_eid);
-          const IdxType heterogenized_etype = it - eid2etype_offset.begin() - 1;
-          const IdxType heterogenized_eid =
-              homogenized_eid - eid2etype_offset[heterogenized_etype];
-          et[j] = heterogenized_etype;
-          et_eid[j] = heterogenized_eid;
+        // heterogenized eid is needed when :
+        // 1. neighbors of each node is not sorted.
+        // 2. probs_or_mask is not empty as it is indexed by heterogenized eid.
+        if (!rowwise_etype_sorted || has_probs) {
+          et.resize(len);
+          et_eid.resize(len);
+          for (int64_t j = 0; j < len; ++j) {
+            const IdxType homogenized_eid = eid ? eid[off + j] : off + j;
+            auto it = std::upper_bound(
+                eid2etype_offset.begin(), eid2etype_offset.end(),
+                homogenized_eid);
+            const IdxType heterogenized_etype =
+                it - eid2etype_offset.begin() - 1;
+            const IdxType heterogenized_eid =
+                homogenized_eid - eid2etype_offset[heterogenized_etype];
+            et[j] = heterogenized_etype;
+            et_eid[j] = heterogenized_eid;
+          }
+          if (!rowwise_etype_sorted)  // the edge type is sorted, not need to
+                                      // sort it
+            std::sort(
+                et_idx.begin(), et_idx.end(),
+                [&et](IdxType i1, IdxType i2) { return et[i1] < et[i2]; });
+          CHECK_LT(et[et_idx[len - 1]], num_etypes)
+              << "etype values exceed the number of fanouts";
         }
-        if (!rowwise_etype_sorted)  // the edge type is sorted, not need to sort
-                                    // it
-          std::sort(
-              et_idx.begin(), et_idx.end(),
-              [&et](IdxType i1, IdxType i2) { return et[i1] < et[i2]; });
-        CHECK_LT(et[et_idx[len - 1]], num_etypes)
-            << "etype values exceed the number of fanouts";
 
-        IdxType cur_et = et[et_idx[0]];
-        int64_t et_offset = 0;
-        int64_t et_len = 1;
-        for (int64_t j = 0; j < len; ++j) {
-          CHECK((j + 1 == len) || (et[et_idx[j]] <= et[et_idx[j + 1]]))
-              << "Edge type is not sorted. Please sort in advance or specify "
-                 "'rowwise_etype_sorted' as false.";
-          if ((j + 1 == len) || cur_et != et[et_idx[j + 1]]) {
-            // 1 end of the current etype
-            // 2 end of the row
-            // random pick for current etype
-            if ((num_picks[cur_et] == -1) ||
-                (et_len <= num_picks[cur_et] && !replace)) {
-              // fast path, select all
-              for (int64_t k = 0; k < et_len; ++k) {
-                const IdxType eid_offset = off + et_idx[et_offset + k];
-                const IdxType homogenized_eid =
-                    eid ? eid[eid_offset] : eid_offset;
-                auto it = std::upper_bound(
-                    eid2etype_offset.begin(), eid2etype_offset.end(),
-                    homogenized_eid);
-                const IdxType heterogenized_etype =
-                    it - eid2etype_offset.begin() - 1;
-                const IdxType heterogenized_eid =
-                    homogenized_eid - eid2etype_offset[heterogenized_etype];
+        IdxType cur_et;
+        int64_t et_offset;
+        int64_t et_end = 0;
+        int64_t et_len;
+        while (et_end < len) {
+          et_offset = et_end;
+          if (!et.empty()) {
+            cur_et = et[et_idx[et_offset]];
+          } else {
+            const IdxType eid_offset = off + et_idx[et_offset];
+            const IdxType homogenized_eid = eid ? eid[eid_offset] : eid_offset;
+            auto it = std::upper_bound(
+                eid2etype_offset.begin(), eid2etype_offset.end(),
+                homogenized_eid);
+            cur_et = it - eid2etype_offset.begin() - 1;
+          }
+          auto cur_it = et_idx.begin() + et_offset;
+          // The nested upper_bound is used to find the end of the current edge
+          // type. The outer upper_bound searches through the array of edge
+          // identifiers to find the first element whose edge type differs from
+          // the current edge type. The inner upper_bound function, on the other
+          // hand, searches through the edge type offset array to determine the
+          // edge type of the input edge ID.
+          auto next_it = std::upper_bound(
+              cur_it, et_idx.end(), cur_et,
+              [&](const IdxType value, const IdxType element) {
+                IdxType element_et;
+                if (!et.empty()) {
+                  element_et = et[element];
+                } else {
+                  const IdxType eid_offset = off + element;
+                  const IdxType homogenized_eid =
+                      eid ? eid[eid_offset] : eid_offset;
+                  auto it = std::upper_bound(
+                      eid2etype_offset.begin(), eid2etype_offset.end(),
+                      homogenized_eid);
+                  element_et = it - eid2etype_offset.begin() - 1;
+                }
+                return value < element_et;
+              });
+          et_len = next_it - cur_it;
+          et_end = et_offset + et_len;
 
-                if (!has_probs ||
-                    IsNullArray(prob_or_mask[heterogenized_etype])) {
-                  // No probability, select all
+          if ((num_picks[cur_et] == -1) ||
+              (et_len <= num_picks[cur_et] && !replace)) {
+            // fast path, select all
+            for (int64_t k = 0; k < et_len; ++k) {
+              const IdxType neighbor_offset = et_idx[et_offset + k];
+              const IdxType eid_offset = off + neighbor_offset;
+              const IdxType homogenized_eid =
+                  eid ? eid[eid_offset] : eid_offset;
+              if (!has_probs || IsNullArray(prob_or_mask[cur_et])) {
+                // No probability, select all
+                rows.push_back(rid);
+                cols.push_back(indices[eid_offset]);
+                idx.push_back(homogenized_eid);
+              } else {
+                // Select the entries with non-zero probability
+                const auto heterogenized_eid = et_eid[neighbor_offset];
+                const NDArray& p = prob_or_mask[cur_et];
+                const DType* pdata = p.Ptr<DType>();
+                if (pdata[heterogenized_eid] > 0) {
                   rows.push_back(rid);
                   cols.push_back(indices[eid_offset]);
                   idx.push_back(homogenized_eid);
-                } else {
-                  // Select the entries with non-zero probability
-                  const NDArray& p = prob_or_mask[heterogenized_etype];
-                  const DType* pdata = p.Ptr<DType>();
-                  if (pdata[heterogenized_eid] > 0) {
-                    rows.push_back(rid);
-                    cols.push_back(indices[eid_offset]);
-                    idx.push_back(homogenized_eid);
-                  }
-                }
-              }
-            } else {
-              IdArray picked_idx =
-                  Full(-1, num_picks[cur_et], sizeof(IdxType) * 8, ctx);
-              IdxType* picked_idata = picked_idx.Ptr<IdxType>();
-
-              // need call random pick
-              pick_fn(
-                  off, et_offset, cur_et, et_len, et_idx, et_eid, eid,
-                  picked_idata);
-              for (int64_t k = 0; k < num_picks[cur_et]; ++k) {
-                const IdxType picked = picked_idata[k];
-                if (picked == -1) continue;
-                rows.push_back(rid);
-                cols.push_back(indices[off + et_idx[et_offset + picked]]);
-                if (eid) {
-                  idx.push_back(eid[off + et_idx[et_offset + picked]]);
-                } else {
-                  idx.push_back(off + et_idx[et_offset + picked]);
                 }
               }
             }
-
-            if (j + 1 == len) break;
-            // next etype
-            cur_et = et[et_idx[j + 1]];
-            et_offset = j + 1;
-            et_len = 1;
           } else {
-            et_len++;
+            IdArray picked_idx =
+                Full(-1, num_picks[cur_et], sizeof(IdxType) * 8, ctx);
+            IdxType* picked_idata = picked_idx.Ptr<IdxType>();
+            // need call random pick
+            pick_fn(
+                off, et_offset, cur_et, et_len, et_idx, et_eid, eid,
+                picked_idata);
+            for (int64_t k = 0; k < num_picks[cur_et]; ++k) {
+              const IdxType picked = picked_idata[k];
+              if (picked == -1) continue;
+              rows.push_back(rid);
+              cols.push_back(indices[off + et_idx[et_offset + picked]]);
+              if (eid) {
+                idx.push_back(eid[off + et_idx[et_offset + picked]]);
+              } else {
+                idx.push_back(off + et_idx[et_offset + picked]);
+              }
+            }
           }
         }
 


### PR DESCRIPTION
## Description
Accelerating the row pick process by using binary search instead of linear search to find the boundary of an edge type.

## Checklist
Please feel free to remove inapplicable items for your PR.
- [ ] The PR title starts with [$CATEGORY] (such as [NN], [Model], [Doc], [Feature]])
- [ ] I've leverage the [tools](https://docs.google.com/document/d/1iHyj7zlmygKSk5gBPsqIqL5ASPzJSPREaNT_QdsiYA4/edit) to beautify the python and c++ code.
- [ ] The PR is complete and small, read the [Google eng practice (CL equals to PR)](https://google.github.io/eng-practices/review/developer/small-cls.html) to understand more about small PR. In DGL, we consider PRs with less than 200 lines of core code change are small (example, test and documentation could be exempted).
- [ ] All changes have test coverage
- [ ] Code is well-documented
- [ ] To the best of my knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change
- [ ] Related issue is referred in this PR
- [ ] If the PR is for a new model/paper, I've updated the example index [here](../examples/README.md).

## Changes
<!-- You could use following template
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)
-->
