### PR TITLE
[GraphBolt] Pylintrc changes

### DIFF
--- a/tests/lint/pylintrc
+++ b/tests/lint/pylintrc
@@ -213,7 +213,9 @@ function-naming-style=snake_case
 # op - operators
 # ty - type
 # A, B, C, W - for tensor operators like matmul
-good-names=f,i,j,k,u,v,e,n,m,w,x,y,z,s,d,t,r,g,G,hg,sg,fn,ex,Run,_,us,vs,gs,es,op,ty,A,B,C,W,a,b,N,D1,D2,R
+# dp - DataPipes (see https://pytorch.org/data/main/torchdata.datapipes.iter.html)
+# it - iterators
+good-names=f,i,j,k,u,v,e,n,m,w,x,y,z,s,d,t,r,g,G,hg,sg,fn,ex,Run,_,us,vs,gs,es,op,ty,A,B,C,W,a,b,N,D1,D2,R,dp,it
 
 # Include a hint for the correct naming format with invalid-name.
 include-naming-hint=no


### PR DESCRIPTION
Add `dp` and `it` as good names since they are commonly used in PyTorch DataPipe codes.