### PR TITLE
[Bugfix] Update dgl function `random_walk_pe` to be compatible with latest scipy 

### DIFF
--- a/python/dgl/transforms/functional.py
+++ b/python/dgl/transforms/functional.py
@@ -3590,11 +3590,11 @@ def random_walk_pe(g, k, eweight_name=None):
         )
         A = A.multiply(W)
     # 1-step transition probability
-    if scipy.__version__ < '1.11.0':
+    if scipy.__version__ < "1.11.0":
         RW = np.array(A / (A.sum(1) + 1e-30))
     else:
         # sparse matrix divided by a dense array returns a sparse matrix in scipy since 1.11.0
-        RW = (A / (A.sum(1) + 1e-30)).toarray()  
+        RW = (A / (A.sum(1) + 1e-30)).toarray()
 
     # Iterate for k steps
     PE = [F.astype(F.tensor(RW.diagonal()), F.float32)]

--- a/python/dgl/transforms/functional.py
+++ b/python/dgl/transforms/functional.py
@@ -3594,7 +3594,8 @@ def random_walk_pe(g, k, eweight_name=None):
     if Version(scipy.__version__) < Version("1.11.0"):
         RW = np.array(A / (A.sum(1) + 1e-30))
     else:
-        # sparse matrix divided by a dense array returns a sparse matrix in scipy since 1.11.0
+        # Sparse matrix divided by a dense array returns a sparse matrix in
+        # scipy since 1.11.0.
         RW = (A / (A.sum(1) + 1e-30)).toarray()
 
     # Iterate for k steps

--- a/python/dgl/transforms/functional.py
+++ b/python/dgl/transforms/functional.py
@@ -22,6 +22,7 @@ from collections.abc import Iterable, Mapping
 import numpy as np
 import scipy.sparse as sparse
 import scipy.sparse.linalg
+from packaging.version import Version
 
 try:
     import torch as th
@@ -3590,7 +3591,7 @@ def random_walk_pe(g, k, eweight_name=None):
         )
         A = A.multiply(W)
     # 1-step transition probability
-    if scipy.__version__ < "1.11.0":
+    if Version(scipy.__version__) < Version("1.11.0"):
         RW = np.array(A / (A.sum(1) + 1e-30))
     else:
         # sparse matrix divided by a dense array returns a sparse matrix in scipy since 1.11.0

--- a/python/dgl/transforms/functional.py
+++ b/python/dgl/transforms/functional.py
@@ -3589,7 +3589,12 @@ def random_walk_pe(g, k, eweight_name=None):
             shape=(N, N),
         )
         A = A.multiply(W)
-    RW = np.array(A / (A.sum(1) + 1e-30))  # 1-step transition probability
+    # 1-step transition probability
+    if scipy.__version__ < '1.11.0':
+        RW = np.array(A / (A.sum(1) + 1e-30))
+    else:
+        # sparse matrix divided by a dense array returns a sparse matrix in scipy since 1.11.0
+        RW = (A / (A.sum(1) + 1e-30)).toarray()  
 
     # Iterate for k steps
     PE = [F.astype(F.tensor(RW.diagonal()), F.float32)]


### PR DESCRIPTION
## Description
This is to fix https://github.com/dmlc/dgl/issues/5943.

Due to this PR: https://github.com/scipy/scipy/pull/18508, scipy changes the output of divide (sparse, dense) from dense to sparse format. As a result, it would break the function `random_walk_pe`, as follows:https://github.com/dmlc/dgl/blob/4b585ba068b67f10a25eada64532c09da6561d10/python/dgl/transforms/functional.py#L3592

Reference: 
Release note of scipy 1.11.0: https://github.com/scipy/scipy/releases/tag/v1.11.0
## Checklist
Please feel free to remove inapplicable items for your PR.
- [x] The PR title starts with [$CATEGORY] (such as [NN], [Model], [Doc], [Feature]])
- [x] I've leverage the [tools](https://docs.google.com/document/d/1iHyj7zlmygKSk5gBPsqIqL5ASPzJSPREaNT_QdsiYA4/edit) to beautify the python and c++ code.
- [x] The PR is complete and small, read the [Google eng practice (CL equals to PR)](https://google.github.io/eng-practices/review/developer/small-cls.html) to understand more about small PR. In DGL, we consider PRs with less than 200 lines of core code change are small (example, test and documentation could be exempted).
- [x] All changes have test coverage
- [x] Code is well-documented
- [ ] To the best of my knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change
- [ ] Related issue is referred in this PR
- [ ] If the PR is for a new model/paper, I've updated the example index [here](../examples/README.md).

## Changes
If scipy < 1.11.0, uses `np.array` to change the output to dense ndarray.
Otherwise, uses `.toarray()` to change the output to dense ndarray.

