### PR TITLE
[GraphBolt] add support to generate TVT in ItemSet or ItemSetDict format

### DIFF
--- a/python/dgl/graphbolt/dataset.py
+++ b/python/dgl/graphbolt/dataset.py
@@ -2,11 +2,8 @@
 
 from typing import List, Optional
 
-import numpy as np
-
 import pydantic
 import pydantic_yaml
-import torch
 
 from .feature_store import FeatureStore
 from .itemset import ItemSet, ItemSetDict

--- a/python/dgl/graphbolt/dataset.py
+++ b/python/dgl/graphbolt/dataset.py
@@ -35,16 +35,16 @@ class Dataset:
     generate a subgraph.
     """
 
-    def train_set(self) -> ItemSet or ItemSetDict:
-        """Return the training set."""
+    def train_sets(self) -> List[ItemSet] or List[ItemSetDict]:
+        """Return the training sets."""
         raise NotImplementedError
 
-    def validation_set(self) -> ItemSet or ItemSetDict:
-        """Return the validation set."""
+    def validation_sets(self) -> List[ItemSet] or List[ItemSetDict]:
+        """Return the validation sets."""
         raise NotImplementedError
 
-    def test_set(self) -> ItemSet or ItemSetDict:
-        """Return the test set."""
+    def test_sets(self) -> List[ItemSet] or List[ItemSetDict]:
+        """Return the test sets."""
         raise NotImplementedError
 
     def graph(self) -> object:
@@ -79,9 +79,9 @@ class OnDiskMetaData(pydantic_yaml.YamlModel):
     is a list of list of ``OnDiskTVTSet``.
     """
 
-    train_set: Optional[List[List[OnDiskTVTSet]]]
-    validation_set: Optional[List[List[OnDiskTVTSet]]]
-    test_set: Optional[List[List[OnDiskTVTSet]]]
+    train_sets: Optional[List[List[OnDiskTVTSet]]]
+    validation_sets: Optional[List[List[OnDiskTVTSet]]]
+    test_sets: Optional[List[List[OnDiskTVTSet]]]
 
 
 class OnDiskDataset(Dataset):
@@ -97,17 +97,17 @@ class OnDiskDataset(Dataset):
 
     .. code-block:: yaml
 
-        train_set:
+        train_sets:
           - - type_name: paper # could be null for homogeneous graph.
               format: numpy
               in_memory: true # If not specified, default to true.
               path: set/paper-train.npy
-        validation_set:
+        validation_sets:
           - - type_name: paper
               format: numpy
               in_memory: true
               path: set/paper-validation.npy
-        test_set:
+        test_sets:
           - - type_name: paper
               format: numpy
               in_memory: true
@@ -122,21 +122,21 @@ class OnDiskDataset(Dataset):
     def __init__(self, path: str) -> None:
         with open(path, "r") as f:
             self._meta = OnDiskMetaData.parse_raw(f.read(), proto="yaml")
-        self._train_set = self._init_tvt_sets(self._meta.train_set)
-        self._validation_set = self._init_tvt_sets(self._meta.validation_set)
-        self._test_set = self._init_tvt_sets(self._meta.test_set)
+        self._train_sets = self._init_tvt_sets(self._meta.train_sets)
+        self._validation_sets = self._init_tvt_sets(self._meta.validation_sets)
+        self._test_sets = self._init_tvt_sets(self._meta.test_sets)
 
-    def train_set(self) -> ItemSet or ItemSetDict:
+    def train_sets(self) -> List[ItemSet] or List[ItemSetDict]:
         """Return the training set."""
-        return self._train_set
+        return self._train_sets
 
-    def validation_set(self) -> ItemSet or ItemSetDict:
+    def validation_sets(self) -> List[ItemSet] or List[ItemSetDict]:
         """Return the validation set."""
-        return self._validation_set
+        return self._validation_sets
 
-    def test_set(self) -> ItemSet or ItemSetDict:
+    def test_sets(self) -> List[ItemSet] or List[ItemSetDict]:
         """Return the test set."""
-        return self._test_set
+        return self._test_sets
 
     def graph(self) -> object:
         """Return the graph."""

--- a/python/dgl/graphbolt/utils.py
+++ b/python/dgl/graphbolt/utils.py
@@ -1,0 +1,26 @@
+import numpy as np
+import torch
+
+
+def _read_torch_data(path):
+    return torch.load(path)
+
+
+def _read_numpy_data(path, in_memory=True):
+    if in_memory:
+        return torch.from_numpy(np.load(path))
+    return torch.as_tensor(np.load(path, mmap_mode="r+"))
+
+
+def read_data(path, format, in_memory=True):
+    if format == "torch":
+        return _read_torch_data(path)
+    elif format == "numpy":
+        return _read_numpy_data(path, in_memory=in_memory)
+    else:
+        raise RuntimeError("Unsupported format: {}".format(format))
+
+
+def tensor_to_tuple(data):
+    assert isinstance(data, torch.Tensor), "data must be a torch.Tensor"
+    return tuple(data.t())

--- a/python/dgl/graphbolt/utils.py
+++ b/python/dgl/graphbolt/utils.py
@@ -1,3 +1,5 @@
+"""Utility functions for GraphBolt."""
+
 import numpy as np
 import torch
 
@@ -12,15 +14,17 @@ def _read_numpy_data(path, in_memory=True):
     return torch.as_tensor(np.load(path, mmap_mode="r+"))
 
 
-def read_data(path, format, in_memory=True):
-    if format == "torch":
+def read_data(path, fmt, in_memory=True):
+    """Read data from disk."""
+    if fmt == "torch":
         return _read_torch_data(path)
-    elif format == "numpy":
+    elif fmt == "numpy":
         return _read_numpy_data(path, in_memory=in_memory)
     else:
-        raise RuntimeError("Unsupported format: {}".format(format))
+        raise RuntimeError(f"Unsupported format: {fmt}")
 
 
 def tensor_to_tuple(data):
+    """Split a torch.Tensor in column-wise to a tuple."""
     assert isinstance(data, torch.Tensor), "data must be a torch.Tensor"
     return tuple(data.t())

--- a/tests/python/pytorch/graphbolt/test_dataset.py
+++ b/tests/python/pytorch/graphbolt/test_dataset.py
@@ -1,6 +1,8 @@
 import os
 import tempfile
 
+import numpy as np
+
 import pydantic
 import pytest
 from dgl import graphbolt as gb
@@ -20,34 +22,326 @@ def test_Dataset():
         _ = dataset.feature()
 
 
-def test_OnDiskDataset_TVTSet():
-    """Test OnDiskDataset with TVTSet."""
+def test_OnDiskDataset_TVTSet_exceptions():
+    """Test excpetions thrown when parsing TVTSet."""
     with tempfile.TemporaryDirectory() as test_dir:
-        yaml_content = """
-        train_set:
-          - - type_name: paper
-              format: torch
-              path: set/paper-train.pt
-            - type_name: 'paper:cites:paper'
-              format: numpy
-              path: set/cites-train.pt
-        """
         yaml_file = os.path.join(test_dir, "test.yaml")
-        with open(yaml_file, "w") as f:
-            f.write(yaml_content)
-        _ = gb.OnDiskDataset(yaml_file)
 
-        # Invalid format.
+        # Case 1: ``format`` is invalid.
         yaml_content = """
         train_set:
           - - type_name: paper
               format: torch_invalid
               path: set/paper-train.pt
-            - type_name: 'paper:cites:paper'
-              format: numpy_invalid
-              path: set/cites-train.pt
         """
+        yaml_file = os.path.join(test_dir, "test.yaml")
         with open(yaml_file, "w") as f:
             f.write(yaml_content)
         with pytest.raises(pydantic.ValidationError):
             _ = gb.OnDiskDataset(yaml_file)
+
+        # Case 2: ``type_name`` is not specified while multiple TVT sets are specified.
+        yaml_content = """
+            train_set:
+              - - type_name: null
+                  format: numpy
+                  path: set/train.npy
+                - type_name: null
+                  format: numpy
+                  path: set/train.npy
+        """
+        with open(yaml_file, "w") as f:
+            f.write(yaml_content)
+        with pytest.raises(
+            AssertionError,
+            match=r"Only one TVT set is allowed if type_name is not specified.",
+        ):
+            _ = gb.OnDiskDataset(yaml_file)
+
+
+def test_OnDiskDataset_TVTSet_ItemSet_id_label():
+    """Test TVTSet which returns ItemSet with IDs and labels."""
+    with tempfile.TemporaryDirectory() as test_dir:
+        train_ids = np.arange(1000)
+        train_labels = np.random.randint(0, 10, size=1000)
+        train_data = np.vstack([train_ids, train_labels]).T
+        train_path = os.path.join(test_dir, "train.npy")
+        np.save(train_path, train_data)
+
+        validation_ids = np.arange(1000, 2000)
+        validation_labels = np.random.randint(0, 10, size=1000)
+        validation_data = np.vstack([validation_ids, validation_labels]).T
+        validation_path = os.path.join(test_dir, "validation.npy")
+        np.save(validation_path, validation_data)
+
+        test_ids = np.arange(2000, 3000)
+        test_labels = np.random.randint(0, 10, size=1000)
+        test_data = np.vstack([test_ids, test_labels]).T
+        test_path = os.path.join(test_dir, "test.npy")
+        np.save(test_path, test_data)
+
+        # Case 1:
+        #   all TVT sets are specified.
+        #   ``type_name`` is not specified or specified as ``null``.
+        #   ``in_memory`` could be ``true`` and ``false``.
+        yaml_content = f"""
+            train_set:
+              - - type_name: null
+                  format: numpy
+                  in_memory: true
+                  path: {train_path}
+              - - type_name: null
+                  format: numpy
+                  path: {train_path}
+            validation_set:
+              - - format: numpy
+                  path: {validation_path}
+              - - type_name: null
+                  format: numpy
+                  path: {validation_path}
+            test_set:
+              - - type_name: null
+                  format: numpy
+                  in_memory: false
+                  path: {test_path}
+              - - type_name: null
+                  format: numpy
+                  path: {test_path}
+        """
+        yaml_file = os.path.join(test_dir, "test.yaml")
+        with open(yaml_file, "w") as f:
+            f.write(yaml_content)
+
+        dataset = gb.OnDiskDataset(yaml_file)
+
+        # Verify train set.
+        train_sets = dataset.train_set()
+        assert len(train_sets) == 2
+        for train_set in train_sets:
+            assert len(train_set) == 1000
+            assert isinstance(train_set, gb.ItemSet)
+            for i, (id, label) in enumerate(train_set):
+                assert id == train_ids[i]
+                assert label == train_labels[i]
+
+        # Verify validation set.
+        validation_sets = dataset.validation_set()
+        assert len(validation_sets) == 2
+        for validation_set in validation_sets:
+            assert len(validation_set) == 1000
+            assert isinstance(validation_set, gb.ItemSet)
+            for i, (id, label) in enumerate(validation_set):
+                assert id == validation_ids[i]
+                assert label == validation_labels[i]
+
+        # Verify test set.
+        test_sets = dataset.test_set()
+        assert len(test_sets) == 2
+        for test_set in test_sets:
+            assert len(test_set) == 1000
+            assert isinstance(test_set, gb.ItemSet)
+            for i, (id, label) in enumerate(test_set):
+                assert id == test_ids[i]
+                assert label == test_labels[i]
+
+        # Case 2: Some TVT sets are None.
+        yaml_content = f"""
+            train_set:
+              - - type_name: null
+                  format: numpy
+                  path: {train_path}
+        """
+        yaml_file = os.path.join(test_dir, "test.yaml")
+        with open(yaml_file, "w") as f:
+            f.write(yaml_content)
+
+        dataset = gb.OnDiskDataset(yaml_file)
+        assert dataset.train_set() is not None
+        assert dataset.validation_set() is None
+        assert dataset.test_set() is None
+
+
+def test_OnDiskDataset_TVTSet_ItemSet_node_pair_label():
+    """Test TVTSet which returns ItemSet with IDs and labels."""
+    with tempfile.TemporaryDirectory() as test_dir:
+        train_pairs = (np.arange(1000), np.arange(1000, 2000))
+        train_labels = np.random.randint(0, 10, size=1000)
+        train_data = np.vstack([train_pairs, train_labels]).T
+        train_path = os.path.join(test_dir, "train.npy")
+        np.save(train_path, train_data)
+
+        validation_pairs = (np.arange(1000, 2000), np.arange(2000, 3000))
+        validation_labels = np.random.randint(0, 10, size=1000)
+        validation_data = np.vstack([validation_pairs, validation_labels]).T
+        validation_path = os.path.join(test_dir, "validation.npy")
+        np.save(validation_path, validation_data)
+
+        test_pairs = (np.arange(2000, 3000), np.arange(3000, 4000))
+        test_labels = np.random.randint(0, 10, size=1000)
+        test_data = np.vstack([test_pairs, test_labels]).T
+        test_path = os.path.join(test_dir, "test.npy")
+        np.save(test_path, test_data)
+
+        yaml_content = f"""
+            train_set:
+              - - type_name: null
+                  format: numpy
+                  in_memory: true
+                  path: {train_path}
+              - - type_name: null
+                  format: numpy
+                  path: {train_path}
+            validation_set:
+              - - format: numpy
+                  path: {validation_path}
+              - - type_name: null
+                  format: numpy
+                  path: {validation_path}
+            test_set:
+              - - type_name: null
+                  format: numpy
+                  in_memory: false
+                  path: {test_path}
+              - - type_name: null
+                  format: numpy
+                  path: {test_path}
+        """
+        yaml_file = os.path.join(test_dir, "test.yaml")
+        with open(yaml_file, "w") as f:
+            f.write(yaml_content)
+
+        dataset = gb.OnDiskDataset(yaml_file)
+
+        # Verify train set.
+        train_sets = dataset.train_set()
+        assert len(train_sets) == 2
+        for train_set in train_sets:
+            assert len(train_set) == 1000
+            assert isinstance(train_set, gb.ItemSet)
+            for i, (src, dst, label) in enumerate(train_set):
+                assert src == train_pairs[0][i]
+                assert dst == train_pairs[1][i]
+                assert label == train_labels[i]
+
+        # Verify validation set.
+        validation_sets = dataset.validation_set()
+        assert len(validation_sets) == 2
+        for validation_set in validation_sets:
+            assert len(validation_set) == 1000
+            assert isinstance(validation_set, gb.ItemSet)
+            for i, (src, dst, label) in enumerate(validation_set):
+                assert src == validation_pairs[0][i]
+                assert dst == validation_pairs[1][i]
+                assert label == validation_labels[i]
+
+        # Verify test set.
+        test_sets = dataset.test_set()
+        assert len(test_sets) == 2
+        for test_set in test_sets:
+            assert len(test_set) == 1000
+            assert isinstance(test_set, gb.ItemSet)
+            for i, (src, dst, label) in enumerate(test_set):
+                assert src == test_pairs[0][i]
+                assert dst == test_pairs[1][i]
+                assert label == test_labels[i]
+
+
+def test_OnDiskDataset_TVTSet_ItemSetDict_node_pair_label():
+    """Test TVTSet which returns ItemSet with IDs and labels."""
+    with tempfile.TemporaryDirectory() as test_dir:
+        train_pairs = (np.arange(1000), np.arange(1000, 2000))
+        train_labels = np.random.randint(0, 10, size=1000)
+        train_data = np.vstack([train_pairs, train_labels]).T
+        train_path = os.path.join(test_dir, "train.npy")
+        np.save(train_path, train_data)
+
+        validation_pairs = (np.arange(1000, 2000), np.arange(2000, 3000))
+        validation_labels = np.random.randint(0, 10, size=1000)
+        validation_data = np.vstack([validation_pairs, validation_labels]).T
+        validation_path = os.path.join(test_dir, "validation.npy")
+        np.save(validation_path, validation_data)
+
+        test_pairs = (np.arange(2000, 3000), np.arange(3000, 4000))
+        test_labels = np.random.randint(0, 10, size=1000)
+        test_data = np.vstack([test_pairs, test_labels]).T
+        test_path = os.path.join(test_dir, "test.npy")
+        np.save(test_path, test_data)
+
+        yaml_content = f"""
+            train_set:
+              - - type_name: paper
+                  format: numpy
+                  in_memory: true
+                  path: {train_path}
+              - - type_name: author
+                  format: numpy
+                  path: {train_path}
+            validation_set:
+              - - type_name: paper
+                  format: numpy
+                  path: {validation_path}
+              - - type_name: author
+                  format: numpy
+                  path: {validation_path}
+            test_set:
+              - - type_name: paper
+                  format: numpy
+                  in_memory: false
+                  path: {test_path}
+              - - type_name: author
+                  format: numpy
+                  path: {test_path}
+        """
+        yaml_file = os.path.join(test_dir, "test.yaml")
+        with open(yaml_file, "w") as f:
+            f.write(yaml_content)
+
+        dataset = gb.OnDiskDataset(yaml_file)
+
+        # Verify train set.
+        train_sets = dataset.train_set()
+        assert len(train_sets) == 2
+        for train_set in train_sets:
+            assert len(train_set) == 1000
+            assert isinstance(train_set, gb.ItemSetDict)
+            for i, item in enumerate(train_set):
+                assert isinstance(item, dict)
+                assert len(item) == 1
+                key = list(item.keys())[0]
+                assert key in ["paper", "author"]
+                src, dst, label = item[key]
+                assert src == train_pairs[0][i]
+                assert dst == train_pairs[1][i]
+                assert label == train_labels[i]
+
+        # Verify validation set.
+        validation_sets = dataset.validation_set()
+        assert len(validation_sets) == 2
+        for validation_set in validation_sets:
+            assert len(validation_set) == 1000
+            assert isinstance(train_set, gb.ItemSetDict)
+            for i, item in enumerate(validation_set):
+                assert isinstance(item, dict)
+                assert len(item) == 1
+                key = list(item.keys())[0]
+                assert key in ["paper", "author"]
+                src, dst, label = item[key]
+                assert src == validation_pairs[0][i]
+                assert dst == validation_pairs[1][i]
+                assert label == validation_labels[i]
+
+        # Verify test set.
+        test_sets = dataset.test_set()
+        assert len(test_sets) == 2
+        for test_set in test_sets:
+            assert len(test_set) == 1000
+            assert isinstance(train_set, gb.ItemSetDict)
+            for i, item in enumerate(test_set):
+                assert isinstance(item, dict)
+                assert len(item) == 1
+                key = list(item.keys())[0]
+                assert key in ["paper", "author"]
+                src, dst, label = item[key]
+                assert src == test_pairs[0][i]
+                assert dst == test_pairs[1][i]
+                assert label == test_labels[i]

--- a/tests/python/pytorch/graphbolt/test_dataset.py
+++ b/tests/python/pytorch/graphbolt/test_dataset.py
@@ -11,11 +11,11 @@ from dgl import graphbolt as gb
 def test_Dataset():
     dataset = gb.Dataset()
     with pytest.raises(NotImplementedError):
-        _ = dataset.train_set()
+        _ = dataset.train_sets()
     with pytest.raises(NotImplementedError):
-        _ = dataset.validation_set()
+        _ = dataset.validation_sets()
     with pytest.raises(NotImplementedError):
-        _ = dataset.test_set()
+        _ = dataset.test_sets()
     with pytest.raises(NotImplementedError):
         _ = dataset.graph()
     with pytest.raises(NotImplementedError):
@@ -29,7 +29,7 @@ def test_OnDiskDataset_TVTSet_exceptions():
 
         # Case 1: ``format`` is invalid.
         yaml_content = """
-        train_set:
+        train_sets:
           - - type_name: paper
               format: torch_invalid
               path: set/paper-train.pt
@@ -42,7 +42,7 @@ def test_OnDiskDataset_TVTSet_exceptions():
 
         # Case 2: ``type_name`` is not specified while multiple TVT sets are specified.
         yaml_content = """
-            train_set:
+            train_sets:
               - - type_name: null
                   format: numpy
                   path: set/train.npy
@@ -85,7 +85,7 @@ def test_OnDiskDataset_TVTSet_ItemSet_id_label():
         #   ``type_name`` is not specified or specified as ``null``.
         #   ``in_memory`` could be ``true`` and ``false``.
         yaml_content = f"""
-            train_set:
+            train_sets:
               - - type_name: null
                   format: numpy
                   in_memory: true
@@ -93,13 +93,13 @@ def test_OnDiskDataset_TVTSet_ItemSet_id_label():
               - - type_name: null
                   format: numpy
                   path: {train_path}
-            validation_set:
+            validation_sets:
               - - format: numpy
                   path: {validation_path}
               - - type_name: null
                   format: numpy
                   path: {validation_path}
-            test_set:
+            test_sets:
               - - type_name: null
                   format: numpy
                   in_memory: false
@@ -115,7 +115,7 @@ def test_OnDiskDataset_TVTSet_ItemSet_id_label():
         dataset = gb.OnDiskDataset(yaml_file)
 
         # Verify train set.
-        train_sets = dataset.train_set()
+        train_sets = dataset.train_sets()
         assert len(train_sets) == 2
         for train_set in train_sets:
             assert len(train_set) == 1000
@@ -125,7 +125,7 @@ def test_OnDiskDataset_TVTSet_ItemSet_id_label():
                 assert label == train_labels[i]
 
         # Verify validation set.
-        validation_sets = dataset.validation_set()
+        validation_sets = dataset.validation_sets()
         assert len(validation_sets) == 2
         for validation_set in validation_sets:
             assert len(validation_set) == 1000
@@ -135,7 +135,7 @@ def test_OnDiskDataset_TVTSet_ItemSet_id_label():
                 assert label == validation_labels[i]
 
         # Verify test set.
-        test_sets = dataset.test_set()
+        test_sets = dataset.test_sets()
         assert len(test_sets) == 2
         for test_set in test_sets:
             assert len(test_set) == 1000
@@ -146,7 +146,7 @@ def test_OnDiskDataset_TVTSet_ItemSet_id_label():
 
         # Case 2: Some TVT sets are None.
         yaml_content = f"""
-            train_set:
+            train_sets:
               - - type_name: null
                   format: numpy
                   path: {train_path}
@@ -156,9 +156,9 @@ def test_OnDiskDataset_TVTSet_ItemSet_id_label():
             f.write(yaml_content)
 
         dataset = gb.OnDiskDataset(yaml_file)
-        assert dataset.train_set() is not None
-        assert dataset.validation_set() is None
-        assert dataset.test_set() is None
+        assert dataset.train_sets() is not None
+        assert dataset.validation_sets() is None
+        assert dataset.test_sets() is None
 
 
 def test_OnDiskDataset_TVTSet_ItemSet_node_pair_label():
@@ -183,7 +183,7 @@ def test_OnDiskDataset_TVTSet_ItemSet_node_pair_label():
         np.save(test_path, test_data)
 
         yaml_content = f"""
-            train_set:
+            train_sets:
               - - type_name: null
                   format: numpy
                   in_memory: true
@@ -191,13 +191,13 @@ def test_OnDiskDataset_TVTSet_ItemSet_node_pair_label():
               - - type_name: null
                   format: numpy
                   path: {train_path}
-            validation_set:
+            validation_sets:
               - - format: numpy
                   path: {validation_path}
               - - type_name: null
                   format: numpy
                   path: {validation_path}
-            test_set:
+            test_sets:
               - - type_name: null
                   format: numpy
                   in_memory: false
@@ -213,7 +213,7 @@ def test_OnDiskDataset_TVTSet_ItemSet_node_pair_label():
         dataset = gb.OnDiskDataset(yaml_file)
 
         # Verify train set.
-        train_sets = dataset.train_set()
+        train_sets = dataset.train_sets()
         assert len(train_sets) == 2
         for train_set in train_sets:
             assert len(train_set) == 1000
@@ -224,7 +224,7 @@ def test_OnDiskDataset_TVTSet_ItemSet_node_pair_label():
                 assert label == train_labels[i]
 
         # Verify validation set.
-        validation_sets = dataset.validation_set()
+        validation_sets = dataset.validation_sets()
         assert len(validation_sets) == 2
         for validation_set in validation_sets:
             assert len(validation_set) == 1000
@@ -235,7 +235,7 @@ def test_OnDiskDataset_TVTSet_ItemSet_node_pair_label():
                 assert label == validation_labels[i]
 
         # Verify test set.
-        test_sets = dataset.test_set()
+        test_sets = dataset.test_sets()
         assert len(test_sets) == 2
         for test_set in test_sets:
             assert len(test_set) == 1000
@@ -268,7 +268,7 @@ def test_OnDiskDataset_TVTSet_ItemSetDict_node_pair_label():
         np.save(test_path, test_data)
 
         yaml_content = f"""
-            train_set:
+            train_sets:
               - - type_name: paper
                   format: numpy
                   in_memory: true
@@ -276,14 +276,14 @@ def test_OnDiskDataset_TVTSet_ItemSetDict_node_pair_label():
               - - type_name: author
                   format: numpy
                   path: {train_path}
-            validation_set:
+            validation_sets:
               - - type_name: paper
                   format: numpy
                   path: {validation_path}
               - - type_name: author
                   format: numpy
                   path: {validation_path}
-            test_set:
+            test_sets:
               - - type_name: paper
                   format: numpy
                   in_memory: false
@@ -299,7 +299,7 @@ def test_OnDiskDataset_TVTSet_ItemSetDict_node_pair_label():
         dataset = gb.OnDiskDataset(yaml_file)
 
         # Verify train set.
-        train_sets = dataset.train_set()
+        train_sets = dataset.train_sets()
         assert len(train_sets) == 2
         for train_set in train_sets:
             assert len(train_set) == 1000
@@ -315,7 +315,7 @@ def test_OnDiskDataset_TVTSet_ItemSetDict_node_pair_label():
                 assert label == train_labels[i]
 
         # Verify validation set.
-        validation_sets = dataset.validation_set()
+        validation_sets = dataset.validation_sets()
         assert len(validation_sets) == 2
         for validation_set in validation_sets:
             assert len(validation_set) == 1000
@@ -331,7 +331,7 @@ def test_OnDiskDataset_TVTSet_ItemSetDict_node_pair_label():
                 assert label == validation_labels[i]
 
         # Verify test set.
-        test_sets = dataset.test_set()
+        test_sets = dataset.test_sets()
         assert len(test_sets) == 2
         for test_set in test_sets:
             assert len(test_set) == 1000


### PR DESCRIPTION
## Description
<!-- Brief description. Refer to the related issues if existed.
It'll be great if relevant reviewers can be assigned as well.-->
add support for TVT sets of homograph/hetergraph + node/edge + classification/prediction.
## Checklist
Please feel free to remove inapplicable items for your PR.
- [ ] The PR title starts with [$CATEGORY] (such as [NN], [Model], [Doc], [Feature]])
- [ ] I've leverage the [tools](https://docs.google.com/document/d/1iHyj7zlmygKSk5gBPsqIqL5ASPzJSPREaNT_QdsiYA4/edit) to beautify the python and c++ code.
- [ ] The PR is complete and small, read the [Google eng practice (CL equals to PR)](https://google.github.io/eng-practices/review/developer/small-cls.html) to understand more about small PR. In DGL, we consider PRs with less than 200 lines of core code change are small (example, test and documentation could be exempted).
- [ ] All changes have test coverage
- [ ] Code is well-documented
- [ ] To the best of my knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change
- [ ] Related issue is referred in this PR
- [ ] If the PR is for a new model/paper, I've updated the example index [here](../examples/README.md).

## Changes
<!-- You could use following template
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)
-->
