### PR TITLE
[Misc] Disable LibXSMM SpMM Cmp for AVX2 platforms

### DIFF
--- a/src/array/cpu/spmm.h
+++ b/src/array/cpu/spmm.h
@@ -267,10 +267,10 @@ void SpMMCmpCsr(
 #if !defined(_WIN32)
 #ifdef USE_LIBXSMM
   int cpu_id = libxsmm_cpuid_x86();
-  const bool no_libxsmm =
-      bcast.use_bcast || std::is_same<DType, double>::value ||
-      (std::is_same<DType, BFloat16>::value && cpu_id < LIBXSMM_X86_AVX512) ||
-      !dgl::runtime::Config::Global()->IsLibxsmmAvailable();
+  const bool no_libxsmm = bcast.use_bcast ||
+                          std::is_same<DType, double>::value ||
+                          cpu_id < LIBXSMM_X86_AVX512 ||
+                          !dgl::runtime::Config::Global()->IsLibxsmmAvailable();
   if (!no_libxsmm) {
     SpMMCmpCsrLibxsmm<IdType, DType, Op, Cmp>(
         bcast, csr, ufeat, efeat, out, argu, arge);


### PR DESCRIPTION
## Description
<!-- Brief description. Refer to the related issues if existed.
It'll be great if relevant reviewers can be assigned as well.-->
Unfortunately SpMM Cmp was disabled for AVX2 and less platforms in [LIBXSMM](https://github.com/libxsmm/libxsmm/blob/main_stable/src/generator_mateltwise_sse_avx_avx512.c#L746)
Resolves https://github.com/dmlc/dgl/issues/5960
## Checklist
Please feel free to remove inapplicable items for your PR.
- [ ] The PR title starts with [$CATEGORY] (such as [NN], [Model], [Doc], [Feature]])
- [ ] I've leverage the [tools](https://docs.google.com/document/d/1iHyj7zlmygKSk5gBPsqIqL5ASPzJSPREaNT_QdsiYA4/edit) to beautify the python and c++ code.
- [ ] The PR is complete and small, read the [Google eng practice (CL equals to PR)](https://google.github.io/eng-practices/review/developer/small-cls.html) to understand more about small PR. In DGL, we consider PRs with less than 200 lines of core code change are small (example, test and documentation could be exempted).
- [ ] All changes have test coverage
- [ ] Code is well-documented
- [ ] To the best of my knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change
- [ ] Related issue is referred in this PR
- [ ] If the PR is for a new model/paper, I've updated the example index [here](../examples/README.md).

## Changes
<!-- You could use following template
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)
-->
