### PR TITLE
[GraphBolt] use type instead of type_name to be unified

### DIFF
--- a/python/dgl/graphbolt/impl/ondisk_dataset.py
+++ b/python/dgl/graphbolt/impl/ondisk_dataset.py
@@ -49,17 +49,17 @@ class OnDiskDataset(Dataset):
             in_memory: false
             path: edge_data/author-writes-paper-feat.npy
         train_sets:
-          - - type_name: paper # could be null for homogeneous graph.
+          - - type: paper # could be null for homogeneous graph.
               format: numpy
               in_memory: true # If not specified, default to true.
               path: set/paper-train.npy
         validation_sets:
-          - - type_name: paper
+          - - type: paper
               format: numpy
               in_memory: true
               path: set/paper-validation.npy
         test_sets:
-          - - type_name: paper
+          - - type: paper
               format: numpy
               in_memory: true
               path: set/paper-test.npy
@@ -139,10 +139,10 @@ class OnDiskDataset(Dataset):
         for tvt_set in tvt_sets:
             if (tvt_set is None) or (len(tvt_set) == 0):
                 ret.append(None)
-            if tvt_set[0].type_name is None:
+            if tvt_set[0].type is None:
                 assert (
                     len(tvt_set) == 1
-                ), "Only one TVT set is allowed if type_name is not specified."
+                ), "Only one TVT set is allowed if type is not specified."
                 data = read_data(
                     tvt_set[0].path, tvt_set[0].format, tvt_set[0].in_memory
                 )
@@ -150,7 +150,7 @@ class OnDiskDataset(Dataset):
             else:
                 data = {}
                 for tvt in tvt_set:
-                    data[tvt.type_name] = ItemSet(
+                    data[tvt.type] = ItemSet(
                         tensor_to_tuple(
                             read_data(tvt.path, tvt.format, tvt.in_memory)
                         )

--- a/python/dgl/graphbolt/impl/ondisk_metadata.py
+++ b/python/dgl/graphbolt/impl/ondisk_metadata.py
@@ -27,7 +27,7 @@ class OnDiskFeatureDataFormat(pydantic_yaml.YamlStrEnum):
 class OnDiskTVTSet(pydantic.BaseModel):
     """Train-Validation-Test set."""
 
-    type_name: Optional[str]
+    type: Optional[str]
     format: OnDiskFeatureDataFormat
     in_memory: Optional[bool] = True
     path: str

--- a/tests/python/pytorch/graphbolt/test_ondisk_dataset.py
+++ b/tests/python/pytorch/graphbolt/test_ondisk_dataset.py
@@ -19,7 +19,7 @@ def test_OnDiskDataset_TVTSet_exceptions():
         # Case 1: ``format`` is invalid.
         yaml_content = """
         train_sets:
-          - - type_name: paper
+          - - type: paper
               format: torch_invalid
               path: set/paper-train.pt
         """
@@ -29,13 +29,13 @@ def test_OnDiskDataset_TVTSet_exceptions():
         with pytest.raises(pydantic.ValidationError):
             _ = gb.OnDiskDataset(yaml_file)
 
-        # Case 2: ``type_name`` is not specified while multiple TVT sets are specified.
+        # Case 2: ``type`` is not specified while multiple TVT sets are specified.
         yaml_content = """
             train_sets:
-              - - type_name: null
+              - - type: null
                   format: numpy
                   path: set/train.npy
-                - type_name: null
+                - type: null
                   format: numpy
                   path: set/train.npy
         """
@@ -43,7 +43,7 @@ def test_OnDiskDataset_TVTSet_exceptions():
             f.write(yaml_content)
         with pytest.raises(
             AssertionError,
-            match=r"Only one TVT set is allowed if type_name is not specified.",
+            match=r"Only one TVT set is allowed if type is not specified.",
         ):
             _ = gb.OnDiskDataset(yaml_file)
 
@@ -71,29 +71,29 @@ def test_OnDiskDataset_TVTSet_ItemSet_id_label():
 
         # Case 1:
         #   all TVT sets are specified.
-        #   ``type_name`` is not specified or specified as ``null``.
+        #   ``type`` is not specified or specified as ``null``.
         #   ``in_memory`` could be ``true`` and ``false``.
         yaml_content = f"""
             train_sets:
-              - - type_name: null
+              - - type: null
                   format: numpy
                   in_memory: true
                   path: {train_path}
-              - - type_name: null
+              - - type: null
                   format: numpy
                   path: {train_path}
             validation_sets:
               - - format: numpy
                   path: {validation_path}
-              - - type_name: null
+              - - type: null
                   format: numpy
                   path: {validation_path}
             test_sets:
-              - - type_name: null
+              - - type: null
                   format: numpy
                   in_memory: false
                   path: {test_path}
-              - - type_name: null
+              - - type: null
                   format: numpy
                   path: {test_path}
         """
@@ -140,7 +140,7 @@ def test_OnDiskDataset_TVTSet_ItemSet_id_label():
         # Case 2: Some TVT sets are None.
         yaml_content = f"""
             train_sets:
-              - - type_name: null
+              - - type: null
                   format: numpy
                   path: {train_path}
         """
@@ -178,25 +178,25 @@ def test_OnDiskDataset_TVTSet_ItemSet_node_pair_label():
 
         yaml_content = f"""
             train_sets:
-              - - type_name: null
+              - - type: null
                   format: numpy
                   in_memory: true
                   path: {train_path}
-              - - type_name: null
+              - - type: null
                   format: numpy
                   path: {train_path}
             validation_sets:
               - - format: numpy
                   path: {validation_path}
-              - - type_name: null
+              - - type: null
                   format: numpy
                   path: {validation_path}
             test_sets:
-              - - type_name: null
+              - - type: null
                   format: numpy
                   in_memory: false
                   path: {test_path}
-              - - type_name: null
+              - - type: null
                   format: numpy
                   path: {test_path}
         """
@@ -267,26 +267,26 @@ def test_OnDiskDataset_TVTSet_ItemSetDict_id_label():
 
         yaml_content = f"""
             train_sets:
-              - - type_name: paper
+              - - type: paper
                   format: numpy
                   in_memory: true
                   path: {train_path}
-              - - type_name: author
+              - - type: author
                   format: numpy
                   path: {train_path}
             validation_sets:
-              - - type_name: paper
+              - - type: paper
                   format: numpy
                   path: {validation_path}
-              - - type_name: author
+              - - type: author
                   format: numpy
                   path: {validation_path}
             test_sets:
-              - - type_name: paper
+              - - type: paper
                   format: numpy
                   in_memory: false
                   path: {test_path}
-              - - type_name: author
+              - - type: author
                   format: numpy
                   path: {test_path}
         """
@@ -369,26 +369,26 @@ def test_OnDiskDataset_TVTSet_ItemSetDict_node_pair_label():
 
         yaml_content = f"""
             train_sets:
-              - - type_name: paper
+              - - type: paper
                   format: numpy
                   in_memory: true
                   path: {train_path}
-              - - type_name: author
+              - - type: author
                   format: numpy
                   path: {train_path}
             validation_sets:
-              - - type_name: paper
+              - - type: paper
                   format: numpy
                   path: {validation_path}
-              - - type_name: author
+              - - type: author
                   format: numpy
                   path: {validation_path}
             test_sets:
-              - - type_name: paper
+              - - type: paper
                   format: numpy
                   in_memory: false
                   path: {test_path}
-              - - type_name: author
+              - - type: author
                   format: numpy
                   path: {test_path}
         """


### PR DESCRIPTION
## Description
<!-- Brief description. Refer to the related issues if existed.
It'll be great if relevant reviewers can be assigned as well.-->
To be unified, let's use `type`(used in `feature_data`) instead of `type_name` in TVT.
## Checklist
Please feel free to remove inapplicable items for your PR.
- [ ] The PR title starts with [$CATEGORY] (such as [NN], [Model], [Doc], [Feature]])
- [ ] I've leverage the [tools](https://docs.google.com/document/d/1iHyj7zlmygKSk5gBPsqIqL5ASPzJSPREaNT_QdsiYA4/edit) to beautify the python and c++ code.
- [ ] The PR is complete and small, read the [Google eng practice (CL equals to PR)](https://google.github.io/eng-practices/review/developer/small-cls.html) to understand more about small PR. In DGL, we consider PRs with less than 200 lines of core code change are small (example, test and documentation could be exempted).
- [ ] All changes have test coverage
- [ ] Code is well-documented
- [ ] To the best of my knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change
- [ ] Related issue is referred in this PR
- [ ] If the PR is for a new model/paper, I've updated the example index [here](../examples/README.md).

## Changes
<!-- You could use following template
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)
-->
