### PR TITLE
[Feature] Adding kappa feature for labor (Cooperative Minibatching)

### DIFF
--- a/include/dgl/aten/coo.h
+++ b/include/dgl/aten/coo.h
@@ -463,6 +463,7 @@ COOMatrix COOReorder(
  * @param prob Probability array for nonuniform sampling
  * @param importance_sampling Whether to enable importance sampling
  * @param random_seed The random seed for the sampler
+ * @param seed2_contribution The contribution of the second random seed, [0, 1)
  * @param NIDs global nids if sampling from a subgraph
  * @return A pair of COOMatrix storing the picked row and col indices and edge
  *         weights if importance_sampling != 0 or prob argument was passed.
@@ -472,7 +473,8 @@ COOMatrix COOReorder(
 std::pair<COOMatrix, FloatArray> COOLaborSampling(
     COOMatrix mat, IdArray rows, int64_t num_samples,
     FloatArray prob = NullArray(), int importance_sampling = 0,
-    IdArray random_seed = NullArray(), IdArray NIDs = NullArray());
+    IdArray random_seed = NullArray(), float seed2_contribution = 0,
+    IdArray NIDs = NullArray());
 
 /**
  * @brief Randomly select a fixed number of non-zero entries along each given

--- a/include/dgl/aten/csr.h
+++ b/include/dgl/aten/csr.h
@@ -518,6 +518,7 @@ CSRMatrix CSRRemove(CSRMatrix csr, IdArray entries);
  * @param prob Probability array for nonuniform sampling
  * @param importance_sampling Whether to enable importance sampling
  * @param random_seed The random seed for the sampler
+ * @param seed2_contribution The contribution of the second random seed, [0, 1)
  * @param NIDs global nids if sampling from a subgraph
  * @return A pair of COOMatrix storing the picked row and col indices and edge
  *         weights if importance_sampling != 0 or prob argument was passed. Its
@@ -527,7 +528,8 @@ CSRMatrix CSRRemove(CSRMatrix csr, IdArray entries);
 std::pair<COOMatrix, FloatArray> CSRLaborSampling(
     CSRMatrix mat, IdArray rows, int64_t num_samples,
     FloatArray prob = NullArray(), int importance_sampling = 0,
-    IdArray random_seed = NullArray(), IdArray NIDs = NullArray());
+    IdArray random_seed = NullArray(), float seed2_contribution = 0,
+    IdArray NIDs = NullArray());
 
 /*!
  * @brief Randomly select a fixed number of non-zero entries along each given

--- a/python/dgl/dataloading/labor_sampler.py
+++ b/python/dgl/dataloading/labor_sampler.py
@@ -165,7 +165,9 @@ class LaborSampler(BlockSampler):
         self.cnt = F.zeros(2, F.int64, F.cpu())
         self.cnt[0] = -1
         self.cnt[1] = batch_dependency
-        self.random_seed = F.zeros(2 if self.cnt[1] > 1 else 1, F.int64, F.cpu())
+        self.random_seed = F.zeros(
+            2 if self.cnt[1] > 1 else 1, F.int64, F.cpu()
+        )
         self.set_seed(None if batch_dependency > 0 else choice(1e18, 1).item())
 
     def set_seed(self, random_seed=None):
@@ -198,7 +200,7 @@ class LaborSampler(BlockSampler):
             self.cnt[0] += 1
             if self.cnt[1] > 0 and self.cnt[0] % self.cnt[1] == 0:
                 if self.cnt[0] <= 0 or self.cnt[1] <= 1:
-                    if not hasattr(self, 'rng'):
+                    if not hasattr(self, "rng"):
                         self.rng = default_rng(choice(1e18, 1).item())
                     self.random_seed[0] = self.rng.integers(1e18)
                     if self.cnt[1] > 1:

--- a/python/dgl/dataloading/labor_sampler.py
+++ b/python/dgl/dataloading/labor_sampler.py
@@ -17,6 +17,8 @@
 #
 
 """Data loading components for labor sampling"""
+from numpy.random import default_rng
+
 from .. import backend as F
 from ..base import EID, NID
 from ..random import choice
@@ -67,6 +69,10 @@ class LaborSampler(BlockSampler):
         Specifies whether different layers should use same random variates.
         Results into a reduction in the number of vertices sampled, but may
         degrade the quality slightly.
+    batch_dependency : int, default ``1``
+        Specifies whether different minibatches should use similar random
+        variates. Results in a higher temporal access locality of sampled
+        vertices, but may degrade the quality slightly.
     prefetch_node_feats : list[str] or dict[ntype, list[str]], optional
         The source node data to prefetch for the first MFG, corresponding to the
         input node features necessary for the first GNN layer.
@@ -139,6 +145,7 @@ class LaborSampler(BlockSampler):
         prob=None,
         importance_sampling=0,
         layer_dependency=False,
+        batch_dependency=1,
         prefetch_node_feats=None,
         prefetch_labels=None,
         prefetch_edge_feats=None,
@@ -155,7 +162,11 @@ class LaborSampler(BlockSampler):
         self.prob = prob
         self.importance_sampling = importance_sampling
         self.layer_dependency = layer_dependency
-        self.set_seed()
+        self.cnt = F.zeros(2, F.int64, F.cpu())
+        self.cnt[0] = -1
+        self.cnt[1] = batch_dependency
+        self.random_seed = F.zeros(2 if self.cnt[1] > 1 else 1, F.int64, F.cpu())
+        self.set_seed(None if batch_dependency > 0 else choice(1e18, 1).item())
 
     def set_seed(self, random_seed=None):
         """Updates the underlying seed for the sampler
@@ -184,9 +195,23 @@ class LaborSampler(BlockSampler):
             The random seed to be used for next sampling call.
         """
         if random_seed is None:
-            self.random_seed = choice(1e18, 1)
+            self.cnt[0] += 1
+            if self.cnt[1] > 0 and self.cnt[0] % self.cnt[1] == 0:
+                if self.cnt[0] <= 0 or self.cnt[1] <= 1:
+                    if not hasattr(self, 'rng'):
+                        self.rng = default_rng(choice(1e18, 1).item())
+                    self.random_seed[0] = self.rng.integers(1e18)
+                    if self.cnt[1] > 1:
+                        self.random_seed[1] = self.rng.integers(1e18)
+                else:
+                    self.random_seed[0] = self.random_seed[1]
+                    self.random_seed[1] = self.rng.integers(1e18)
         else:
-            self.random_seed = F.tensor(random_seed, F.int64)
+            self.rng = default_rng(random_seed)
+            self.random_seed[0] = self.rng.integers(1e18)
+            if self.cnt[1] > 1:
+                self.random_seed[1] = self.rng.integers(1e18)
+            self.cnt[0] = 0
 
     def sample_blocks(self, g, seed_nodes, exclude_eids=None):
         output_nodes = seed_nodes
@@ -195,6 +220,10 @@ class LaborSampler(BlockSampler):
             random_seed_i = F.zerocopy_to_dgl_ndarray(
                 self.random_seed + (i if not self.layer_dependency else 0)
             )
+            if self.cnt[1] <= 1:
+                seed2_contr = 0
+            else:
+                seed2_contr = ((self.cnt[0] % self.cnt[1]) / self.cnt[1]).item()
             frontier, importances = g.sample_labors(
                 seed_nodes,
                 fanout,
@@ -202,6 +231,7 @@ class LaborSampler(BlockSampler):
                 prob=self.prob,
                 importance_sampling=self.importance_sampling,
                 random_seed=random_seed_i,
+                seed2_contribution=seed2_contr,
                 output_device=self.output_device,
                 exclude_edges=exclude_eids,
             )

--- a/python/dgl/sampling/labor.py
+++ b/python/dgl/sampling/labor.py
@@ -21,7 +21,7 @@
 
 from .. import backend as F, ndarray as nd, utils
 from .._ffi.function import _init_api
-from ..base import DGLError, NID
+from ..base import DGLError
 from ..heterograph import DGLGraph
 from ..random import choice
 from .utils import EidExcluder

--- a/python/dgl/sampling/labor.py
+++ b/python/dgl/sampling/labor.py
@@ -21,7 +21,7 @@
 
 from .. import backend as F, ndarray as nd, utils
 from .._ffi.function import _init_api
-from ..base import DGLError
+from ..base import DGLError, NID
 from ..heterograph import DGLGraph
 from ..random import choice
 from .utils import EidExcluder
@@ -37,6 +37,7 @@ def sample_labors(
     prob=None,
     importance_sampling=0,
     random_seed=None,
+    seed2_contribution=0,
     copy_ndata=True,
     copy_edata=True,
     exclude_edges=None,
@@ -109,6 +110,10 @@ def sample_labors(
         If this function is called without a ``random_seed``, we get the random seed by getting a
         random number from DGL. Use this argument with identical random_seed if multiple calls to
         this function are used to sample as part of a single batch.
+    seed2_contribution : float, optional
+        A float value between [0, 1) that determines the contribution
+        of the second random seed to generate the random variates for the
+        LABOR sampling algorithm.
     copy_ndata: bool, optional
         If True, the node features of the new graph are copied from
         the original graph. If False, the new graph will not have any
@@ -206,6 +211,7 @@ def sample_labors(
             prob=prob,
             importance_sampling=importance_sampling,
             random_seed=random_seed,
+            seed2_contribution=seed2_contribution,
             copy_ndata=copy_ndata,
             copy_edata=copy_edata,
             exclude_edges=exclude_edges,
@@ -219,6 +225,7 @@ def sample_labors(
             prob=prob,
             importance_sampling=importance_sampling,
             random_seed=random_seed,
+            seed2_contribution=seed2_contribution,
             copy_ndata=copy_ndata,
             copy_edata=copy_edata,
         )
@@ -242,6 +249,7 @@ def _sample_labors(
     prob=None,
     importance_sampling=0,
     random_seed=None,
+    seed2_contribution=0,
     copy_ndata=True,
     copy_edata=True,
     exclude_edges=None,
@@ -329,6 +337,7 @@ def _sample_labors(
         excluded_edges_all_t,
         importance_sampling,
         random_seed,
+        seed2_contribution,
         nids_all_types,
     )
     subgidx = ret_val[0]

--- a/src/array/array.cc
+++ b/src/array/array.cc
@@ -556,14 +556,16 @@ CSRMatrix CSRRemove(CSRMatrix csr, IdArray entries) {
 
 std::pair<COOMatrix, FloatArray> CSRLaborSampling(
     CSRMatrix mat, IdArray rows, int64_t num_samples, FloatArray prob,
-    int importance_sampling, IdArray random_seed, IdArray NIDs) {
+    int importance_sampling, IdArray random_seed, float seed2_contribution,
+    IdArray NIDs) {
   std::pair<COOMatrix, FloatArray> ret;
   ATEN_CSR_SWITCH_CUDA_UVA(mat, rows, XPU, IdType, "CSRLaborSampling", {
     const auto dtype =
         IsNullArray(prob) ? DGLDataTypeTraits<float>::dtype : prob->dtype;
     ATEN_FLOAT_TYPE_SWITCH(dtype, FloatType, "probability", {
       ret = impl::CSRLaborSampling<XPU, IdType, FloatType>(
-          mat, rows, num_samples, prob, importance_sampling, random_seed, NIDs);
+          mat, rows, num_samples, prob, importance_sampling, random_seed,
+          seed2_contribution, NIDs);
     });
   });
   return ret;
@@ -829,14 +831,16 @@ COOMatrix COORemove(COOMatrix coo, IdArray entries) {
 
 std::pair<COOMatrix, FloatArray> COOLaborSampling(
     COOMatrix mat, IdArray rows, int64_t num_samples, FloatArray prob,
-    int importance_sampling, IdArray random_seed, IdArray NIDs) {
+    int importance_sampling, IdArray random_seed, float seed2_contribution,
+    IdArray NIDs) {
   std::pair<COOMatrix, FloatArray> ret;
   ATEN_COO_SWITCH(mat, XPU, IdType, "COOLaborSampling", {
     const auto dtype =
         IsNullArray(prob) ? DGLDataTypeTraits<float>::dtype : prob->dtype;
     ATEN_FLOAT_TYPE_SWITCH(dtype, FloatType, "probability", {
       ret = impl::COOLaborSampling<XPU, IdType, FloatType>(
-          mat, rows, num_samples, prob, importance_sampling, random_seed, NIDs);
+          mat, rows, num_samples, prob, importance_sampling, random_seed,
+          seed2_contribution, NIDs);
     });
   });
   return ret;

--- a/src/array/array_op.h
+++ b/src/array/array_op.h
@@ -168,12 +168,8 @@ CSRMatrix CSRRemove(CSRMatrix csr, IdArray entries);
 
 template <DGLDeviceType XPU, typename IdType, typename FloatType>
 std::pair<COOMatrix, FloatArray> CSRLaborSampling(
-    CSRMatrix mat,
-    IdArray rows,
-    int64_t num_samples,
-    FloatArray prob,
-    int importance_sampling,
-    IdArray random_seed,
+    CSRMatrix mat, IdArray rows, int64_t num_samples, FloatArray prob,
+    int importance_sampling, IdArray random_seed, float seed2_contribution,
     IdArray NIDs);
 
 // FloatType is the type of probability data.
@@ -285,12 +281,8 @@ COOMatrix COORemove(COOMatrix coo, IdArray entries);
 
 template <DGLDeviceType XPU, typename IdType, typename FloatType>
 std::pair<COOMatrix, FloatArray> COOLaborSampling(
-    COOMatrix mat,
-    IdArray rows,
-    int64_t num_samples,
-    FloatArray prob,
-    int importance_sampling,
-    IdArray random_seed,
+    COOMatrix mat, IdArray rows, int64_t num_samples, FloatArray prob,
+    int importance_sampling, IdArray random_seed, float seed2_contribution,
     IdArray NIDs);
 
 // FloatType is the type of probability data.

--- a/src/array/cpu/labor_sampling.cc
+++ b/src/array/cpu/labor_sampling.cc
@@ -29,46 +29,50 @@ namespace impl {
 template <DGLDeviceType XPU, typename IdxType, typename FloatType>
 std::pair<COOMatrix, FloatArray> CSRLaborSampling(
     CSRMatrix mat, IdArray rows, int64_t num_samples, FloatArray prob,
-    int importance_sampling, IdArray random_seed, IdArray NIDs) {
+    int importance_sampling, IdArray random_seed, float seed2_contribution,
+    IdArray NIDs) {
   return CSRLaborPick<IdxType, FloatType>(
-      mat, rows, num_samples, prob, importance_sampling, random_seed, NIDs);
+      mat, rows, num_samples, prob, importance_sampling, random_seed,
+      seed2_contribution, NIDs);
 }
 
 template std::pair<COOMatrix, FloatArray>
 CSRLaborSampling<kDGLCPU, int32_t, float>(
-    CSRMatrix, IdArray, int64_t, FloatArray, int, IdArray, IdArray);
+    CSRMatrix, IdArray, int64_t, FloatArray, int, IdArray, float, IdArray);
 template std::pair<COOMatrix, FloatArray>
 CSRLaborSampling<kDGLCPU, int64_t, float>(
-    CSRMatrix, IdArray, int64_t, FloatArray, int, IdArray, IdArray);
+    CSRMatrix, IdArray, int64_t, FloatArray, int, IdArray, float, IdArray);
 template std::pair<COOMatrix, FloatArray>
 CSRLaborSampling<kDGLCPU, int32_t, double>(
-    CSRMatrix, IdArray, int64_t, FloatArray, int, IdArray, IdArray);
+    CSRMatrix, IdArray, int64_t, FloatArray, int, IdArray, float, IdArray);
 template std::pair<COOMatrix, FloatArray>
 CSRLaborSampling<kDGLCPU, int64_t, double>(
-    CSRMatrix, IdArray, int64_t, FloatArray, int, IdArray, IdArray);
+    CSRMatrix, IdArray, int64_t, FloatArray, int, IdArray, float, IdArray);
 
 /////////////////////////////// COO ///////////////////////////////
 
 template <DGLDeviceType XPU, typename IdxType, typename FloatType>
 std::pair<COOMatrix, FloatArray> COOLaborSampling(
     COOMatrix mat, IdArray rows, int64_t num_samples, FloatArray prob,
-    int importance_sampling, IdArray random_seed, IdArray NIDs) {
+    int importance_sampling, IdArray random_seed, float seed2_contribution,
+    IdArray NIDs) {
   return COOLaborPick<IdxType, FloatType>(
-      mat, rows, num_samples, prob, importance_sampling, random_seed, NIDs);
+      mat, rows, num_samples, prob, importance_sampling, random_seed,
+      seed2_contribution, NIDs);
 }
 
 template std::pair<COOMatrix, FloatArray>
 COOLaborSampling<kDGLCPU, int32_t, float>(
-    COOMatrix, IdArray, int64_t, FloatArray, int, IdArray, IdArray);
+    COOMatrix, IdArray, int64_t, FloatArray, int, IdArray, float, IdArray);
 template std::pair<COOMatrix, FloatArray>
 COOLaborSampling<kDGLCPU, int64_t, float>(
-    COOMatrix, IdArray, int64_t, FloatArray, int, IdArray, IdArray);
+    COOMatrix, IdArray, int64_t, FloatArray, int, IdArray, float, IdArray);
 template std::pair<COOMatrix, FloatArray>
 COOLaborSampling<kDGLCPU, int32_t, double>(
-    COOMatrix, IdArray, int64_t, FloatArray, int, IdArray, IdArray);
+    COOMatrix, IdArray, int64_t, FloatArray, int, IdArray, float, IdArray);
 template std::pair<COOMatrix, FloatArray>
 COOLaborSampling<kDGLCPU, int64_t, double>(
-    COOMatrix, IdArray, int64_t, FloatArray, int, IdArray, IdArray);
+    COOMatrix, IdArray, int64_t, FloatArray, int, IdArray, float, IdArray);
 
 }  // namespace impl
 }  // namespace aten

--- a/src/random/continuous_seed.h
+++ b/src/random/continuous_seed.h
@@ -60,13 +60,13 @@ class continuous_seed {
 
 #ifdef __CUDA_ARCH__
   __device__ inline float uniform(const uint64_t t) const {
-    const uint64_t MAGIC_CONSTANT = 999961;  // Could be any random number.
+    const uint64_t kCurandSeed = 999961;  // Could be any random number.
     curandStatePhilox4_32_10_t rng;
-    curand_init(MAGIC_CONSTANT, s[0], t, &rng);
+    curand_init(kCurandSeed, s[0], t, &rng);
     float rnd;
     if (s[0] != s[1]) {
       rnd = c[0] * curand_normal(&rng);
-      curand_init(MAGIC_CONSTANT, s[1], t, &rng);
+      curand_init(kCurandSeed, s[1], t, &rng);
       rnd += c[1] * curand_normal(&rng);
       rnd = normcdff(rnd);
     } else {

--- a/src/random/continuous_seed.h
+++ b/src/random/continuous_seed.h
@@ -1,0 +1,94 @@
+/*!
+ *   Copyright (c) 2023, GT-TDAlab (Muhammed Fatih Balin & Umit V. Catalyurek)
+ *   All rights reserved.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ *
+ * @file dgl/continuous_seed.h
+ * @brief CPU and CUDA implementation for continuous random seeds
+ */
+#ifndef DGL_CONTINUOUS_SEED_H_
+#define DGL_CONTINUOUS_SEED_H_
+
+#include <dgl/array.h>
+
+#include <cmath>
+
+#ifdef __NVCC__
+#include <curand_kernel.h>
+#else
+#include <pcg_random.hpp>
+#include <random>
+#endif  // __CUDA_ARCH__
+
+namespace dgl {
+namespace random {
+
+class continuous_seed {
+  uint64_t s[2];
+  float c[2];
+
+ public:
+  continuous_seed(const uint64_t seed) {
+    s[0] = s[1] = seed;
+    c[0] = c[1] = 0;
+  }
+
+  continuous_seed(IdArray seed_arr, float r) {
+    auto seed = seed_arr.Ptr<int64_t>();
+    s[0] = seed[0];
+    s[1] = seed[seed_arr->shape[0] - 1];
+    const auto pi = std::acos(-1.0);
+    c[0] = std::cos(pi * r / 2);
+    c[1] = std::sin(pi * r / 2);
+  }
+
+#ifdef __CUDA_ARCH__
+  __device__ inline float uniform(const uint64_t t) const {
+    curandStatePhilox4_32_10_t rng;
+    // 123123 is just a number with no significance.
+    curand_init(123123, s[0], t, &rng);
+    float rnd;
+    if (s[0] != s[1]) {
+      rnd = c[0] * curand_normal(&rng);
+      curand_init(123123, s[1], t, &rng);
+      rnd += c[1] * curand_normal(&rng);
+      rnd = normcdff(rnd);
+    } else
+      rnd = curand_uniform(&rng);
+    return rnd;
+  }
+#else
+  inline float uniform(const uint64_t t) const {
+    pcg32 ng0(s[0], t);
+    float rnd;
+    if (s[0] != s[1]) {
+      std::normal_distribution<float> norm;
+      rnd = c[0] * norm(ng0);
+      pcg32 ng1(s[1], t);
+      norm.reset();
+      rnd += c[1] * norm(ng1);
+      rnd = std::erfc(-rnd * (float)M_SQRT1_2) / 2.0f;
+    } else {
+      std::uniform_real_distribution<float> uni;
+      rnd = uni(ng0);
+    }
+    return rnd;
+  }
+#endif  // __CUDA_ARCH__
+};
+
+}  // namespace random
+}  // namespace dgl
+
+#endif  // DGL_CONTINUOUS_SEED_H_

--- a/src/random/continuous_seed.h
+++ b/src/random/continuous_seed.h
@@ -60,13 +60,13 @@ class continuous_seed {
 
 #ifdef __CUDA_ARCH__
   __device__ inline float uniform(const uint64_t t) const {
+    const uint64_t MAGIC_CONSTANT = 999961;  // Could be any random number.
     curandStatePhilox4_32_10_t rng;
-    // 123123 is just a number with no significance.
-    curand_init(123123, s[0], t, &rng);
+    curand_init(MAGIC_CONSTANT, s[0], t, &rng);
     float rnd;
     if (s[0] != s[1]) {
       rnd = c[0] * curand_normal(&rng);
-      curand_init(123123, s[1], t, &rng);
+      curand_init(MAGIC_CONSTANT, s[1], t, &rng);
       rnd += c[1] * curand_normal(&rng);
       rnd = normcdff(rnd);
     } else {

--- a/src/random/continuous_seed.h
+++ b/src/random/continuous_seed.h
@@ -17,8 +17,8 @@
  * @file dgl/continuous_seed.h
  * @brief CPU and CUDA implementation for continuous random seeds
  */
-#ifndef DGL_CONTINUOUS_SEED_H_
-#define DGL_CONTINUOUS_SEED_H_
+#ifndef DGL_RANDOM_CONTINUOUS_SEED_H_
+#define DGL_RANDOM_CONTINUOUS_SEED_H_
 
 #include <dgl/array.h>
 
@@ -27,8 +27,9 @@
 #ifdef __NVCC__
 #include <curand_kernel.h>
 #else
-#include <pcg_random.hpp>
 #include <random>
+
+#include "pcg_random.hpp"
 #endif  // __CUDA_ARCH__
 
 namespace dgl {
@@ -39,7 +40,7 @@ class continuous_seed {
   float c[2];
 
  public:
-  continuous_seed(const uint64_t seed) {
+  /* implicit */ continuous_seed(const int64_t seed) {  // NOLINT
     s[0] = s[1] = seed;
     c[0] = c[1] = 0;
   }
@@ -64,8 +65,9 @@ class continuous_seed {
       curand_init(123123, s[1], t, &rng);
       rnd += c[1] * curand_normal(&rng);
       rnd = normcdff(rnd);
-    } else
+    } else {
       rnd = curand_uniform(&rng);
+    }
     return rnd;
   }
 #else
@@ -78,7 +80,7 @@ class continuous_seed {
       pcg32 ng1(s[1], t);
       norm.reset();
       rnd += c[1] * norm(ng1);
-      rnd = std::erfc(-rnd * (float)M_SQRT1_2) / 2.0f;
+      rnd = std::erfc(-rnd * static_cast<float>(M_SQRT1_2)) / 2.0f;
     } else {
       std::uniform_real_distribution<float> uni;
       rnd = uni(ng0);
@@ -91,4 +93,4 @@ class continuous_seed {
 }  // namespace random
 }  // namespace dgl
 
-#endif  // DGL_CONTINUOUS_SEED_H_
+#endif  // DGL_RANDOM_CONTINUOUS_SEED_H_

--- a/src/random/continuous_seed.h
+++ b/src/random/continuous_seed.h
@@ -22,6 +22,7 @@
 
 #include <dgl/array.h>
 
+#define _USE_MATH_DEFINES
 #include <cmath>
 
 #ifdef __NVCC__

--- a/src/random/continuous_seed.h
+++ b/src/random/continuous_seed.h
@@ -22,7 +22,6 @@
 
 #include <dgl/array.h>
 
-#define _USE_MATH_DEFINES
 #include <cmath>
 
 #ifdef __NVCC__
@@ -32,6 +31,10 @@
 
 #include "pcg_random.hpp"
 #endif  // __CUDA_ARCH__
+
+#ifndef M_SQRT1_2
+#define M_SQRT1_2 0.707106781186547524401
+#endif  // M_SQRT1_2
 
 namespace dgl {
 namespace random {


### PR DESCRIPTION
## Description
Adding dependency between sampled minibatches increases temporal locality of graph and feature accesses. This can be utilized with the GPU cache PR #4341. #4718 also depends on this PR.

![image](https://github.com/dmlc/dgl/assets/16190101/f30bcab1-a092-45d3-ad42-ac02e3405650)
![image](https://github.com/dmlc/dgl/assets/16190101/69f97410-8275-4217-8e40-8edf0252cb14)



## Checklist
Please feel free to remove inapplicable items for your PR.
- [x] The PR title starts with [$CATEGORY] (such as [NN], [Model], [Doc], [Feature]])
- [x] I've leverage the [tools](https://docs.google.com/document/d/1iHyj7zlmygKSk5gBPsqIqL5ASPzJSPREaNT_QdsiYA4/edit) to beautify the python and c++ code.
- [x] The PR is complete and small, read the [Google eng practice (CL equals to PR)](https://google.github.io/eng-practices/review/developer/small-cls.html) to understand more about small PR. In DGL, we consider PRs with less than 200 lines of core code change are small (example, test and documentation could be exempted).
- [ ] All changes have test coverage
- [x] Code is well-documented
- [x] To the best of my knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change
