### PR TITLE
[Graphbolt] Add `cat` optimization for UniformPick

### DIFF
--- a/graphbolt/src/csc_sampling_graph.cc
+++ b/graphbolt/src/csc_sampling_graph.cc
@@ -141,50 +141,64 @@ c10::intrusive_ptr<SampledSubgraph> CSCSamplingGraph::SampleNeighborsImpl(
   // If true, perform sampling for each edge type of each node, otherwise just
   // sample once for each node with no regard of edge types.
   bool consider_etype = (fanouts.size() > 1);
-  std::vector<torch::Tensor> picked_neighbors_per_node(num_nodes);
+  const int64_t num_threads = torch::get_num_threads();
+  std::vector<torch::Tensor> picked_neighbors_per_thread(num_threads);
   torch::Tensor num_picked_neighbors_per_node =
       torch::zeros({num_nodes + 1}, indptr_.options());
 
+  // Calculate GrainSize for parallel_for.
+  int64_t grain_size = (num_nodes + num_threads - 1) / num_threads;
   AT_DISPATCH_INTEGRAL_TYPES(
       indptr_.scalar_type(), "parallel_for", ([&] {
-        torch::parallel_for(0, num_nodes, 32, [&](scalar_t b, scalar_t e) {
-          const scalar_t* indptr_data = indptr_.data_ptr<scalar_t>();
-          for (scalar_t i = b; i < e; ++i) {
-            const auto nid = nodes[i].item<int64_t>();
-            TORCH_CHECK(
-                nid >= 0 && nid < NumNodes(),
-                "The seed nodes' IDs should fall within the range of the "
-                "graph's node IDs.");
-            const auto offset = indptr_data[nid];
-            const auto num_neighbors = indptr_data[nid + 1] - offset;
+        torch::parallel_for(
+            0, num_nodes, grain_size, [&](scalar_t begin, scalar_t end) {
+              const auto indptr_options = indptr_.options();
+              const scalar_t* indptr_data = indptr_.data_ptr<scalar_t>();
+              // Get current thread id.
+              auto t_id = torch::get_thread_num();
+              int64_t cur_grain_size = end - begin;
+              std::vector<torch::Tensor> picked_neighbors_cur_thread(
+                  cur_grain_size);
 
-            if (num_neighbors == 0) {
-              // To avoid crashing during concatenation in the master thread,
-              // initializing with empty tensors.
-              picked_neighbors_per_node[i] =
-                  torch::tensor({}, indptr_.options());
-              continue;
-            }
+              for (scalar_t i = begin; i < end; ++i) {
+                const auto nid = nodes[i].item<int64_t>();
+                TORCH_CHECK(
+                    nid >= 0 && nid < NumNodes(),
+                    "The seed nodes' IDs should fall within the range of the "
+                    "graph's node IDs.");
+                const auto offset = indptr_data[nid];
+                const auto num_neighbors = indptr_data[nid + 1] - offset;
 
-            if (consider_etype) {
-              picked_neighbors_per_node[i] = PickByEtype(
-                  offset, num_neighbors, fanouts, replace, indptr_.options(),
-                  type_per_edge_.value(), probs_or_mask, args);
-            } else {
-              picked_neighbors_per_node[i] = Pick(
-                  offset, num_neighbors, fanouts[0], replace, indptr_.options(),
-                  probs_or_mask, args);
-            }
-            num_picked_neighbors_per_node[i + 1] =
-                picked_neighbors_per_node[i].size(0);
-          }
-        });  // End of the thread.
+                if (num_neighbors == 0) {
+                  // Initialization is performed here because all tensors will
+                  // be concatenated in the current thread, and having an
+                  // undefined tensor during concatenation can result in a
+                  // crash.
+                  picked_neighbors_cur_thread[i - begin] =
+                      torch::tensor({}, indptr_options);
+                  continue;
+                }
+
+                if (consider_etype) {
+                  picked_neighbors_cur_thread[i - begin] = PickByEtype(
+                      offset, num_neighbors, fanouts, replace, indptr_options,
+                      type_per_edge_.value(), probs_or_mask, args);
+                } else {
+                  picked_neighbors_cur_thread[i - begin] = Pick(
+                      offset, num_neighbors, fanouts[0], replace,
+                      indptr_options, probs_or_mask, args);
+                }
+                num_picked_neighbors_per_node[i + 1] =
+                    picked_neighbors_cur_thread[i - begin].size(0);
+              }
+              picked_neighbors_per_thread[t_id] =
+                  torch::cat(picked_neighbors_cur_thread);
+            });  // End of parallel_for.
       }));
-
   torch::Tensor subgraph_indptr =
       torch::cumsum(num_picked_neighbors_per_node, 0);
 
-  torch::Tensor picked_eids = torch::cat(picked_neighbors_per_node);
+  torch::Tensor picked_eids = torch::cat(picked_neighbors_per_thread);
   torch::Tensor subgraph_indices =
       torch::index_select(indices_, 0, picked_eids);
   torch::optional<torch::Tensor> subgraph_type_per_edge = torch::nullopt;

--- a/graphbolt/src/csc_sampling_graph.cc
+++ b/graphbolt/src/csc_sampling_graph.cc
@@ -155,7 +155,7 @@ c10::intrusive_ptr<SampledSubgraph> CSCSamplingGraph::SampleNeighborsImpl(
               const auto indptr_options = indptr_.options();
               const scalar_t* indptr_data = indptr_.data_ptr<scalar_t>();
               // Get current thread id.
-              auto t_id = torch::get_thread_num();
+              auto thread_id = torch::get_thread_num();
               int64_t local_grain_size = end - begin;
               std::vector<torch::Tensor> picked_neighbors_cur_thread(
                   local_grain_size);
@@ -189,7 +189,7 @@ c10::intrusive_ptr<SampledSubgraph> CSCSamplingGraph::SampleNeighborsImpl(
                 num_picked_neighbors_per_node[i + 1] =
                     picked_neighbors_cur_thread[i - begin].size(0);
               }
-              picked_neighbors_per_thread[t_id] =
+              picked_neighbors_per_thread[thread_id] =
                   torch::cat(picked_neighbors_cur_thread);
             });  // End of parallel_for.
       }));

--- a/graphbolt/src/csc_sampling_graph.cc
+++ b/graphbolt/src/csc_sampling_graph.cc
@@ -147,6 +147,7 @@ c10::intrusive_ptr<SampledSubgraph> CSCSamplingGraph::SampleNeighborsImpl(
       torch::zeros({num_nodes + 1}, indptr_.options());
 
   // Calculate GrainSize for parallel_for.
+  // Set the default grain size to 64.
   const int64_t grain_size = 64;
   AT_DISPATCH_INTEGRAL_TYPES(
       indptr_.scalar_type(), "parallel_for", ([&] {

--- a/graphbolt/src/csc_sampling_graph.cc
+++ b/graphbolt/src/csc_sampling_graph.cc
@@ -147,7 +147,7 @@ c10::intrusive_ptr<SampledSubgraph> CSCSamplingGraph::SampleNeighborsImpl(
       torch::zeros({num_nodes + 1}, indptr_.options());
 
   // Calculate GrainSize for parallel_for.
-  int64_t grain_size = (num_nodes + num_threads - 1) / num_threads;
+  const int64_t grain_size = 64;
   AT_DISPATCH_INTEGRAL_TYPES(
       indptr_.scalar_type(), "parallel_for", ([&] {
         torch::parallel_for(


### PR DESCRIPTION
## Description
<!-- Brief description. Refer to the related issues if existed.
It'll be great if relevant reviewers can be assigned as well.-->
We've optimized the `SampleNeighborsImpl` function in `csc_sampling_graph.cc`. This PR primarily resolves this [Issue#5817 Optimize CSC neighbor sampler performance.](https://github.com/dmlc/dgl/issues/5817)

The original algorithm, when conducting multithreaded Neighbor Sampling, would place all sampled results into a general vector of Tensor. We want to optimize this part.

### Problem Analysis

Let's consider a scenario where we have $n$ `Tensors`(same size) and $m$ `threads`, and we need to concatenate all `Tensors` into one large `Tensor`. We consider two different strategies:

- Strategy **A**: Each `thread` uses `torch::cat` to combine up to $\frac{n}{m}$ `Tensors` into a `big Tensor`, then `torch::cat` is used again to combine the $m$ `big Tensors` into the `result`.
- Strategy **B**: Each `thread` only returns a `std::vector<Tensor>`, and in the main program, the results from each thread are combined into a `std::vector<Tensor> all_tensors`. Finally, `torch::cat` is used to combine the `all_tensors` with $n$ elements into the `result`. (currently strategy)

A necessary condition for Strategy **A** to outperform Strategy **B** is:

- **[Assumption 1]**: The performance of `torch::cat` when merging **fewer large-Tensors** is superior to that of merging **many small-Tensors**. We conducted a simple test to verify this: (where `small` represents a group of small tensors and `big` represents a group of large tensors)

| `small_num` | `small_size` | `big_num` | `big_size` | `device` |  `small`  |   `big`   |     `gap`     |
| :---------: | :----------: | :-------: | :--------: | :------: | :-------: | :-------: | :-----------: |
|   $10000$   |    $2000$    |   $20$    | $1000000$  |  `CPU`   | $1.1438s$ | $0.3369s$ |  $3.4\times$  |
|   $10000$   |    $2000$    |   $200$   |  $100000$  |  `CPU`   | $1.1321s$ | $0.3941s$ |  $2.9\times$  |
|   $10000$   |    $2000$    |   $20$    | $1000000$  |  `GPU`   | $0.1146s$ | $0.0020s$ | $57.3\times$  |
|   $10000$   |    $2000$    |   $200$   |  $100000$  |  `GPU`   | $0.1133s$ | $0.0037s$ | $30.62\times$ |

We found **[Assumption 1]** to be true, so we proceeded with the next optimization step.

Based on our performance tests, we observed that **if the results obtained by each thread are first stored within the thread and `cat` is performed once within the thread to obtain a smaller Tensor, and finally `cat` is performed externally on the Tensors obtained from all threads, the efficiency will be higher.** In other words, Strategy A is superior. The detailed performance test experiment is as follows: 

### Time Performance Test

![exp_cat](https://github.com/dmlc/dgl/assets/103916249/87e63bb6-b4d8-47f8-8ad7-722e323c634d)

![exp_cat_time_table](https://github.com/dmlc/dgl/assets/103916249/39486799-5846-4ab3-b271-a53240dc6808)

We found that except in very few cases, this optimization could bring about a performance improvement of around $2$ times. **For red cells in Graph3**, when the data is too large, it is possible that multiple `cat` operations within a thread may lead to performance degradation.

### Memory Usage Test

We performed memory tests using `Massif` in `Valgrind`, and for the sake of test accuracy, the entire test was conducted in a C++ environment, looping each test 5 times. (Massif is a tool in Valgrind, **used to measure the amount of heap memory used by an application**)

![exp_cat_memo](https://github.com/dmlc/dgl/assets/103916249/eb48e52b-6f88-4f1d-8e30-c5e34f377c9c)

![exp_cat_memo_table](https://github.com/dmlc/dgl/assets/103916249/fa878cb7-170c-4468-bb6e-731e4516aca9)

We only performed memory tests on two commonly used graphs. **For Graph1**, there was also an improvement in terms of memory. **For Graph2**, since there were only $10$ sampled nodes, our strategy did not significantly impact it. 

Therefore, this optimization is effective.
