### PR TITLE
[Feature] Dataloader gpu cache

### DIFF
--- a/python/dgl/dataloading/dataloader.py
+++ b/python/dgl/dataloading/dataloader.py
@@ -403,7 +403,7 @@ def _prefetch_update_feats(
                     )
                     values = F.astype(values, F.dtype(missing_values))
                     F.scatter_row_inplace(values, missing_index, missing_values)
-                    # reshape the flattened result to match the original shape.
+                    # Reshape the flattened result to match the original shape.
                     F.reshape(values, (values.shape[0],) + item_shape)
                     values.__cache_miss__ = missing_keys.shape[0] / ids.shape[0]
                     feats[tid, key] = values

--- a/python/dgl/dataloading/dataloader.py
+++ b/python/dgl/dataloading/dataloader.py
@@ -346,12 +346,12 @@ def _numel_of_shape(shape):
 def _init_gpu_cache(graph, gpu_caches):
     caches = {}, {}
     if gpu_caches is None:
-        gpu_caches = {}, {}
-    elif not isinstance(gpu_caches, tuple):
+        return caches
+    if not isinstance(gpu_caches, tuple):
         gpu_caches = gpu_caches, {}
     for i, frames in enumerate([graph._node_frames, graph._edge_frames]):
         for tid, frame in enumerate(frames):
-            type_ = graph.ntypes[tid]
+            type_ = [graph.ntypes, graph.canonical_etypes][i][tid]
             for key in frame.keys():
                 if key in gpu_caches[i] and gpu_caches[i][key] > 0:
                     column = frame._columns[key]

--- a/python/dgl/dataloading/dataloader.py
+++ b/python/dgl/dataloading/dataloader.py
@@ -845,6 +845,11 @@ class DataLoader(torch.utils.data.DataLoader):
         Whether to pin the feature tensors into pinned memory.
 
         Default: True if the graph is on CPU and :attr:`device` is CUDA.  False otherwise.
+    gpu_cache : dict or tuple(dict, dict), optional
+        Which node or (node and edge) features to cache using HugeCTR gpu_cache.
+        Is supported only on NVIDIA GPUs with compute capability 70 or above.
+        The dictionary holds the keys of features along with the corresponding
+        cache sizes.
     kwargs : dict
         Key-word arguments to be passed to the parent PyTorch
         :py:class:`torch.utils.data.DataLoader` class. Common arguments are:

--- a/python/dgl/storages/tensor.py
+++ b/python/dgl/storages/tensor.py
@@ -14,4 +14,4 @@ class BaseTensorStorage(FeatureStorage):
     def fetch(
         self, indices, device, pin_memory=False, **kwargs
     ):  # pylint: disable=unused-argument
-        return F.copy_to(F.gather_row(tensor, indices), device, **kwargs)
+        return F.copy_to(F.gather_row(self.storage, indices), device, **kwargs)


### PR DESCRIPTION
Branched off of #4341 to utilize gpu cache inside dataloader to cache feature copies. #4718 depends on this feature. Only the dataloader is modified in this PR. Should be merged after #4341.

@frozenbugs 