### PR TITLE
Improving the GATv2 example.

### DIFF
--- a/examples/pytorch/model_zoo/citation_network/run.py
+++ b/examples/pytorch/model_zoo/citation_network/run.py
@@ -61,7 +61,7 @@ def main(args):
     val_mask = g.ndata["val_mask"]
     test_mask = g.ndata["test_mask"]
     in_feats = features.shape[1]
-    n_classes = data.num_labels
+    n_classes = data.num_classes
     n_edges = g.num_edges()
     print(
         """----Data statistics------'
@@ -108,7 +108,7 @@ def main(args):
     )
 
     # initialize graph
-    dur = []
+    mean = 0
     for epoch in range(200):
         model.train()
         if epoch >= 3:
@@ -122,19 +122,18 @@ def main(args):
         optimizer.step()
 
         if epoch >= 3:
-            dur.append(time.time() - t0)
-
-        acc = evaluate(model, features, labels, val_mask)
-        print(
-            "Epoch {:05d} | Time(s) {:.4f} | Loss {:.4f} | Accuracy {:.4f} | "
-            "ETputs(KTEPS) {:.2f}".format(
-                epoch,
-                np.mean(dur),
-                loss.item(),
-                acc,
-                n_edges / np.mean(dur) / 1000,
+            mean = (mean * (epoch - 3) + (time.time() - t0)) / (epoch - 2)
+            acc = evaluate(model, features, labels, val_mask)
+            print(
+                "Epoch {:05d} | Time(s) {:.4f} | Loss {:.4f} | Accuracy {:.4f} | "
+                "ETputs(KTEPS) {:.2f}".format(
+                    epoch,
+                    mean,
+                    loss.item(),
+                    acc,
+                    n_edges / mean / 1000,
+                )
             )
-        )
 
     print()
     acc = evaluate(model, features, labels, test_mask)

--- a/examples/pytorch/model_zoo/citation_network/run.py
+++ b/examples/pytorch/model_zoo/citation_network/run.py
@@ -61,7 +61,7 @@ def main(args):
     val_mask = g.ndata["val_mask"]
     test_mask = g.ndata["test_mask"]
     in_feats = features.shape[1]
-    n_classes = data.num_classes
+    n_classes = data.num_labels
     n_edges = g.num_edges()
     print(
         """----Data statistics------'
@@ -108,7 +108,7 @@ def main(args):
     )
 
     # initialize graph
-    mean = 0
+    dur = []
     for epoch in range(200):
         model.train()
         if epoch >= 3:
@@ -122,18 +122,19 @@ def main(args):
         optimizer.step()
 
         if epoch >= 3:
-            mean = (mean * (epoch - 3) + (time.time() - t0)) / (epoch - 2)
-            acc = evaluate(model, features, labels, val_mask)
-            print(
-                "Epoch {:05d} | Time(s) {:.4f} | Loss {:.4f} | Accuracy {:.4f} | "
-                "ETputs(KTEPS) {:.2f}".format(
-                    epoch,
-                    mean,
-                    loss.item(),
-                    acc,
-                    n_edges / mean / 1000,
-                )
+            dur.append(time.time() - t0)
+
+        acc = evaluate(model, features, labels, val_mask)
+        print(
+            "Epoch {:05d} | Time(s) {:.4f} | Loss {:.4f} | Accuracy {:.4f} | "
+            "ETputs(KTEPS) {:.2f}".format(
+                epoch,
+                np.mean(dur),
+                loss.item(),
+                acc,
+                n_edges / np.mean(dur) / 1000,
             )
+        )
 
     print()
     acc = evaluate(model, features, labels, test_mask)


### PR DESCRIPTION
## Description
<!-- Brief description. Refer to the related issues if existed.
It'll be great if relevant reviewers can be assigned as well.-->
In the current PR we eliminate the following warnings:
```
/usr/local/lib/python3.10/dist-packages/dgl/data/utils.py:354: UserWarning: Property dataset.num_labels will be deprecated, please use dataset.num_classes instead.

/usr/local/lib/python3.10/dist-packages/numpy/core/fromnumeric.py:3474: RuntimeWarning: Mean of empty slice.
  return _methods._mean(a, axis=axis, dtype=dtype,

/usr/local/lib/python3.10/dist-packages/numpy/core/_methods.py:189: RuntimeWarning: invalid value encountered in double_scalars
  ret = ret.dtype.type(ret / rcount)
```
and few nan outputs:
```
Epoch 00000 | Time(s) nan | Loss 1.9473 | TrainAcc 0.1143 | ValAcc 0.1900 | ETputs(KTEPS) nan
Epoch 00001 | Time(s) nan | Loss 1.9422 | TrainAcc 0.1643 | ValAcc 0.2840 | ETputs(KTEPS) nan
Epoch 00002 | Time(s) nan | Loss 1.9434 | TrainAcc 0.2000 | ValAcc 0.4260 | ETputs(KTEPS) nan
```
Current PR is quite similar to https://github.com/dmlc/dgl/pull/5999,

The average duration of the epoch calculations, which was previously done with np.mean(dur), is now done recursively.

## Checklist
Please feel free to remove inapplicable items for your PR.
- [X] I've leverage the [tools](https://docs.google.com/document/d/1iHyj7zlmygKSk5gBPsqIqL5ASPzJSPREaNT_QdsiYA4/edit) to beautify the python and c++ code.
- [x] The PR is complete and small, read the [Google eng practice (CL equals to PR)](https://google.github.io/eng-practices/review/developer/small-cls.html) to understand more about small PR. In DGL, we consider PRs with less than 200 lines of core code change are small (example, test and documentation could be exempted).
- [x] All changes have test coverage
- [x] Code is well-documented
- [x] To the best of my knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

## Changes
<!-- You could use following template
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)
-->
