### PR TITLE
[Bugfix] Allow pinning of empty tensor

### DIFF
--- a/python/dgl/backend/pytorch/tensor.py
+++ b/python/dgl/backend/pytorch/tensor.py
@@ -451,11 +451,13 @@ else:
 
 
 def zerocopy_to_dgl_ndarray_for_write(input):
-    assert input.is_contiguous(), (
-        "Cannot convert non-contiguous tensors "
-        "to dgl ndarray for write. Call .to_contiguous() first."
-    )
-    check_is_view(input)
+    if input.numel() > 0:
+        # only check non-empty tensors
+        assert input.is_contiguous(), (
+            "Cannot convert non-contiguous tensors "
+            "to dgl ndarray for write. Call .to_contiguous() first."
+        )
+        check_is_view(input)
     return zerocopy_to_dgl_ndarray(input)
 
 

--- a/tests/python/pytorch/utils/test_pin_memory.py
+++ b/tests/python/pytorch/utils/test_pin_memory.py
@@ -31,6 +31,10 @@ def test_pin_view():
     with pytest.raises(dgl.DGLError):
         dgl.utils.pin_memory_inplace(v)
 
+    # make sure an empty view does not generate an erro
+    u = t[10:10]
+    u = dgl.utils.pin_memory_inplace(u)
+
 
 @pytest.mark.skipif(
     F._default_context_str == "cpu", reason="Need gpu for this test."

--- a/tests/python/pytorch/utils/test_pin_memory.py
+++ b/tests/python/pytorch/utils/test_pin_memory.py
@@ -31,7 +31,7 @@ def test_pin_view():
     with pytest.raises(dgl.DGLError):
         dgl.utils.pin_memory_inplace(v)
 
-    # make sure an empty view does not generate an erro
+    # make sure an empty view does not generate an error
     u = t[10:10]
     u = dgl.utils.pin_memory_inplace(u)
 


### PR DESCRIPTION
## Description
Calling pin_memory_() on a DGLBlock can generate errors for cases in which there are empty views. This PR makes it so we only ensure non-empty Tensors are contiguous and not views, since it is no-op in these cases.

## Checklist
Please feel free to remove inapplicable items for your PR.
- [x] The PR title starts with [$CATEGORY] (such as [NN], [Model], [Doc], [Feature]])
- [x] I've leverage the [tools](https://docs.google.com/document/d/1iHyj7zlmygKSk5gBPsqIqL5ASPzJSPREaNT_QdsiYA4/edit) to beautify the python and c++ code.
- [x] The PR is complete and small, read the [Google eng practice (CL equals to PR)](https://google.github.io/eng-practices/review/developer/small-cls.html) to understand more about small PR. In DGL, we consider PRs with less than 200 lines of core code change are small (example, test and documentation could be exempted).
- [x] All changes have test coverage
- [x] Code is well-documented
- [x] To the best of my knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change


