### PR TITLE
[Model] Add Node explanation for Heterogenous PGExplainer Impl. 

### DIFF
--- a/python/dgl/nn/pytorch/explain/pgexplainer.py
+++ b/python/dgl/nn/pytorch/explain/pgexplainer.py
@@ -1046,18 +1046,8 @@ class HeteroPGExplainer(PGExplainer):
             ntype: batched_hetero_graph.nodes[ntype].data["feat"]
             for ntype in batched_hetero_graph.ntypes
         }
+
         # the model prediction with the updated edge mask
-
-        # print("____")
-        # for ntype in batched_hetero_graph.ntypes:
-        #     print(ntype, batched_hetero_graph.nodes(ntype))
-        # for ntype in batched_feats.keys():
-        #     print(ntype, batched_feats[ntype])
-        # for etype in batched_hetero_graph.canonical_etypes:
-        #     print(etype, batched_hetero_graph.edges(etype=etype))
-        # for etype in hetero_edge_mask.keys():
-        #     print(etype, hetero_edge_mask[etype])
-
         logits = self.model(
             batched_hetero_graph,
             batched_feats,

--- a/python/dgl/nn/pytorch/explain/pgexplainer.py
+++ b/python/dgl/nn/pytorch/explain/pgexplainer.py
@@ -230,7 +230,7 @@ class PGExplainer(nn.Module):
         """
         assert (
             self.graph_explanation
-        ), '"explain_graph" must be True in initializing the module.'
+        ), '"explain_graph" must be True when initializing the module.'
 
         self.model = self.model.to(graph.device)
         self.elayers = self.elayers.to(graph.device)
@@ -270,7 +270,7 @@ class PGExplainer(nn.Module):
         """
         assert (
             not self.graph_explanation
-        ), '"explain_graph" must be False in initializing the module.'
+        ), '"explain_graph" must be False when initializing the module.'
 
         self.model = self.model.to(graph.device)
         self.elayers = self.elayers.to(graph.device)
@@ -390,7 +390,7 @@ class PGExplainer(nn.Module):
         """
         assert (
             self.graph_explanation
-        ), '"explain_graph" must be True in initializing the module.'
+        ), '"explain_graph" must be True when initializing the module.'
 
         self.model = self.model.to(graph.device)
         self.elayers = self.elayers.to(graph.device)
@@ -525,10 +525,10 @@ class PGExplainer(nn.Module):
         """
         assert (
             not self.graph_explanation
-        ), '"explain_graph" must be False in initializing the module.'
+        ), '"explain_graph" must be False when initializing the module.'
         assert (
             self.num_hops is not None
-        ), '"num_hops" must be provided in initializing the module.'
+        ), '"num_hops" must be provided when initializing the module.'
 
         if isinstance(nodes, torch.Tensor):
             nodes = nodes.tolist()
@@ -814,6 +814,10 @@ class HeteroPGExplainer(PGExplainer):
         >>> feat = g.ndata.pop("h")
         >>> probs, edge_mask = explainer.explain_graph(g, feat)
         """
+        assert (
+            self.graph_explanation
+        ), '"explain_graph" must be True when initializing the module.'
+
         self.model = self.model.to(graph.device)
         self.elayers = self.elayers.to(graph.device)
 

--- a/python/dgl/nn/pytorch/explain/pgexplainer.py
+++ b/python/dgl/nn/pytorch/explain/pgexplainer.py
@@ -59,7 +59,7 @@ class PGExplainer(nn.Module):
 
         self.model = model
         self.graph_explanation = explain_graph
-        # node explanation requires additional self-embedding data
+        # Node explanation requires additional self-embedding data.
         self.num_features = num_features * (2 if self.graph_explanation else 3)
         self.num_hops = num_hops
 

--- a/python/dgl/nn/pytorch/explain/pgexplainer.py
+++ b/python/dgl/nn/pytorch/explain/pgexplainer.py
@@ -208,7 +208,7 @@ class PGExplainer(nn.Module):
         return gate_inputs
 
     def train_step(self, graph, feat, tmp, **kwargs):
-        r"""Compute the loss of the explanation network
+        r"""Compute the loss of the explanation network for graph classification
 
         Parameters
         ----------
@@ -245,7 +245,7 @@ class PGExplainer(nn.Module):
         return loss
 
     def train_step_node(self, nodes, graph, feat, tmp, **kwargs):
-        r"""Compute the loss of the explanation network
+        r"""Compute the loss of the explanation network for node classification
 
         Parameters
         ----------
@@ -427,9 +427,8 @@ class PGExplainer(nn.Module):
         self, nodes, graph, feat, tmp=1.0, training=False, **kwargs
     ):
         r"""Learn and return an edge mask that plays a crucial role to
-        explain the prediction made by the GNN for node :attr:`node_id`.
-        Also, return the prediction made with the edges chosen based on
-        the edge mask.
+        explain the prediction made by the GNN for provided set of node IDs.
+        Also, return the prediction made with the graph and edge mask.
 
         Parameters
         ----------
@@ -451,8 +450,8 @@ class PGExplainer(nn.Module):
         -------
         Tensor
             Classification probabilities given the masked graph. It is a tensor of
-            shape :math:`(B, L)`, where :math:`L` is the different types of label
-            in the dataset, and :math:`B` is the batch size.
+            shape :math:`(B, N)`, where :math:`L` is the different types of node
+            labels in the dataset, and :math:`N` is the number of nodes in the graph.
         Tensor
             Edge weights which is a tensor of shape :math:`(E)`, where :math:`E`
             is the number of edges in the graph. A higher weight suggests a larger
@@ -629,7 +628,7 @@ class HeteroPGExplainer(PGExplainer):
     """
 
     def train_step(self, graph, feat, tmp, **kwargs):
-        r"""Compute the loss of the explanation network
+        r"""Compute the loss of the explanation network for graph classification
 
         Parameters
         ----------
@@ -653,7 +652,7 @@ class HeteroPGExplainer(PGExplainer):
         return super().train_step(graph, feat, tmp=tmp, **kwargs)
 
     def train_step_node(self, nodes, graph, feat, tmp, **kwargs):
-        r"""Compute the loss of the explanation network
+        r"""Compute the loss of the explanation network for node classification
 
         Parameters
         ----------
@@ -857,9 +856,8 @@ class HeteroPGExplainer(PGExplainer):
         self, nodes, graph, feat, tmp=1.0, training=False, **kwargs
     ):
         r"""Learn and return an edge mask that plays a crucial role to
-        explain the prediction made by the GNN for node :attr:`node_id`.
-        Also, return the prediction made with the edges chosen based on
-        the edge mask.
+        explain the prediction made by the GNN for provided set of node IDs.
+        Also, return the prediction made with the batched graph and edge mask.
 
         Parameters
         ----------
@@ -881,19 +879,21 @@ class HeteroPGExplainer(PGExplainer):
 
         Returns
         -------
-        Tensor
-            Classification probabilities given the masked graph. It is a tensor of
-            shape :math:`(B, L)`, where :math:`L` is the different types of label
-            in the dataset, and :math:`B` is the batch size.
-        Tensor
-            Edge weights which is a tensor of shape :math:`(E)`, where :math:`E`
-            is the number of edges in the graph. A higher weight suggests a larger
-            contribution of the edge.
+        dict[str, Tensor]
+            A dict mapping node types (keys) to classification probabilities
+            for node labels (values). The values are tensors of shape :math:`(N_t, L)`,
+            where :math:`L` is the different types of node labels in the dataset,
+            and :math:`N_t` is the number of nodes in the graph for node type :math:`t`.
+        dict[str, Tensor]
+            A dict mapping edge types (keys) to edge tensors (values) of shape :math:`(E_t)`,
+            where :math:`E_t` is the number of edges in the graph for edge type :math:`t`.
+            A higher weight suggests a larger contribution of the edge.
         DGLGraph
             The batched set of subgraphs induced on the k-hop in-neighborhood
             of the input center nodes.
-        Tensor
-            The new IDs of the subgraph center nodes.
+        dict[str, Tensor]
+            A dict mapping node types (keys) to a tensor of node IDs (values) which
+            correspond to the subgraph center nodes.
 
         Examples
         --------

--- a/python/dgl/nn/pytorch/explain/pgexplainer.py
+++ b/python/dgl/nn/pytorch/explain/pgexplainer.py
@@ -14,10 +14,11 @@ class PGExplainer(nn.Module):
     r"""PGExplainer from `Parameterized Explainer for Graph Neural Network
     <https://arxiv.org/pdf/2011.04573>`
 
-    PGExplainer adopts a deep neural network (explanation network) to parameterize the generation
-    process of explanations, which enables it to explain multiple instances
-    collectively. PGExplainer models the underlying structure as edge
-    distributions, from which the explanatory graph is sampled.
+    PGExplainer adopts a deep neural network (explanation network) to
+    parameterize the generation process of explanations, which enables it to
+    explain multiple instances collectively. PGExplainer models the underlying
+    structure as edge distributions, from which the explanatory graph is
+    sampled.
 
     Parameters
     ----------
@@ -250,8 +251,8 @@ class PGExplainer(nn.Module):
         Parameters
         ----------
         nodes : int, iterable[int], tensor
-            The nodes from the graph used to train the explanation network, which cannot
-            have any duplicate value.
+            The nodes from the graph used to train the explanation network,
+            which cannot have any duplicate value.
         graph : DGLGraph
             Input homogeneous graph.
         feat : Tensor
@@ -313,13 +314,13 @@ class PGExplainer(nn.Module):
         Returns
         -------
         Tensor
-            Classification probabilities given the masked graph. It is a tensor of
-            shape :math:`(B, L)`, where :math:`L` is the different types of label
-            in the dataset, and :math:`B` is the batch size.
+            Classification probabilities given the masked graph. It is a tensor
+            of shape :math:`(B, L)`, where :math:`L` is the different types of
+            label in the dataset, and :math:`B` is the batch size.
         Tensor
             Edge weights which is a tensor of shape :math:`(E)`, where :math:`E`
-            is the number of edges in the graph. A higher weight suggests a larger
-            contribution of the edge.
+            is the number of edges in the graph. A higher weight suggests a
+            larger contribution of the edge.
 
         Examples
         --------
@@ -449,13 +450,14 @@ class PGExplainer(nn.Module):
         Returns
         -------
         Tensor
-            Classification probabilities given the masked graph. It is a tensor of
-            shape :math:`(B, N)`, where :math:`L` is the different types of node
-            labels in the dataset, and :math:`N` is the number of nodes in the graph.
+            Classification probabilities given the masked graph. It is a tensor
+            of shape :math:`(B, N)`, where :math:`L` is the different types of
+            node labels in the dataset, and :math:`N` is the number of nodes in
+            the graph.
         Tensor
             Edge weights which is a tensor of shape :math:`(E)`, where :math:`E`
-            is the number of edges in the graph. A higher weight suggests a larger
-            contribution of the edge.
+            is the number of edges in the graph. A higher weight suggests a
+            larger contribution of the edge.
         DGLGraph
             The batched set of subgraphs induced on the k-hop in-neighborhood
             of the input center nodes.
@@ -602,10 +604,11 @@ class HeteroPGExplainer(PGExplainer):
     r"""PGExplainer from `Parameterized Explainer for Graph Neural Network
     <https://arxiv.org/pdf/2011.04573>`__, adapted for heterogeneous graphs
 
-    PGExplainer adopts a deep neural network (explanation network) to parameterize the generation
-    process of explanations, which enables it to explain multiple instances
-    collectively. PGExplainer models the underlying structure as edge
-    distributions, from which the explanatory graph is sampled.
+    PGExplainer adopts a deep neural network (explanation network) to
+    parameterize the generation process of explanations, which enables it to
+    explain multiple instances collectively. PGExplainer models the underlying
+    structure as edge distributions, from which the explanatory graph is
+    sampled.
 
     Parameters
     ----------
@@ -636,9 +639,9 @@ class HeteroPGExplainer(PGExplainer):
             Input batched heterogeneous graph.
         feat : dict[str, Tensor]
             A dict mapping node types (keys) to feature tensors (values).
-            The input features are of shape :math:`(N_t, D_t)`. :math:`N_t` is the
-            number of nodes for node type :math:`t`, and :math:`D_t` is the feature
-            size for node type :math:`t`
+            The input features are of shape :math:`(N_t, D_t)`. :math:`N_t` is
+            the number of nodes for node type :math:`t`, and :math:`D_t` is the
+            feature size for node type :math:`t`
         tmp : float
             The temperature parameter fed to the sampling procedure.
         kwargs : dict
@@ -662,9 +665,9 @@ class HeteroPGExplainer(PGExplainer):
             Input heterogeneous graph.
         feat : dict[str, Tensor]
             A dict mapping node types (keys) to feature tensors (values).
-            The input features are of shape :math:`(N_t, D_t)`. :math:`N_t` is the
-            number of nodes for node type :math:`t`, and :math:`D_t` is the feature
-            size for node type :math:`t`
+            The input features are of shape :math:`(N_t, D_t)`. :math:`N_t` is
+            the number of nodes for node type :math:`t`, and :math:`D_t` is the
+            feature size for node type :math:`t`
         temperature : float
             The temperature parameter fed to the sampling procedure.
         kwargs : dict
@@ -712,9 +715,9 @@ class HeteroPGExplainer(PGExplainer):
             A heterogeneous graph.
         feat : dict[str, Tensor]
             A dict mapping node types (keys) to feature tensors (values).
-            The input features are of shape :math:`(N_t, D_t)`. :math:`N_t` is the
-            number of nodes for node type :math:`t`, and :math:`D_t` is the feature
-            size for node type :math:`t`
+            The input features are of shape :math:`(N_t, D_t)`. :math:`N_t` is
+            the number of nodes for node type :math:`t`, and :math:`D_t` is the
+            feature size for node type :math:`t`
         tmp : float
             The temperature parameter fed to the sampling procedure.
         training : bool
@@ -725,13 +728,14 @@ class HeteroPGExplainer(PGExplainer):
         Returns
         -------
         Tensor
-            Classification probabilities given the masked graph. It is a tensor of
-            shape :math:`(B, L)`, where :math:`L` is the different types of label
-            in the dataset, and :math:`B` is the batch size.
+            Classification probabilities given the masked graph. It is a tensor
+            of shape :math:`(B, L)`, where :math:`L` is the different types of
+            label in the dataset, and :math:`B` is the batch size.
         dict[str, Tensor]
-            A dict mapping edge types (keys) to edge tensors (values) of shape :math:`(E_t)`,
-            where :math:`E_t` is the number of edges in the graph for edge type :math:`t`.
-            A higher weight suggests a larger contribution of the edge.
+            A dict mapping edge types (keys) to edge tensors (values) of shape
+            :math:`(E_t)`, where :math:`E_t` is the number of edges in the graph
+            for edge type :math:`t`.  A higher weight suggests a larger
+            contribution of the edge.
 
         Examples
         --------
@@ -867,9 +871,9 @@ class HeteroPGExplainer(PGExplainer):
             A heterogeneous graph.
         feat : dict[str, Tensor]
             A dict mapping node types (keys) to feature tensors (values).
-            The input features are of shape :math:`(N_t, D_t)`. :math:`N_t` is the
-            number of nodes for node type :math:`t`, and :math:`D_t` is the feature
-            size for node type :math:`t`
+            The input features are of shape :math:`(N_t, D_t)`. :math:`N_t` is
+            the number of nodes for node type :math:`t`, and :math:`D_t` is the
+            feature size for node type :math:`t`
         temperature : float
             The temperature parameter fed to the sampling procedure.
         training : bool
@@ -881,19 +885,21 @@ class HeteroPGExplainer(PGExplainer):
         -------
         dict[str, Tensor]
             A dict mapping node types (keys) to classification probabilities
-            for node labels (values). The values are tensors of shape :math:`(N_t, L)`,
-            where :math:`L` is the different types of node labels in the dataset,
-            and :math:`N_t` is the number of nodes in the graph for node type :math:`t`.
+            for node labels (values). The values are tensors of shape
+            :math:`(N_t, L)`, where :math:`L` is the different types of node
+            labels in the dataset, and :math:`N_t` is the number of nodes in
+            the graph for node type :math:`t`.
         dict[str, Tensor]
-            A dict mapping edge types (keys) to edge tensors (values) of shape :math:`(E_t)`,
-            where :math:`E_t` is the number of edges in the graph for edge type :math:`t`.
-            A higher weight suggests a larger contribution of the edge.
+            A dict mapping edge types (keys) to edge tensors (values) of shape
+            :math:`(E_t)`, where :math:`E_t` is the number of edges in the graph
+            for edge type :math:`t`.  A higher weight suggests a larger
+            contribution of the edge.
         DGLGraph
             The batched set of subgraphs induced on the k-hop in-neighborhood
             of the input center nodes.
         dict[str, Tensor]
-            A dict mapping node types (keys) to a tensor of node IDs (values) which
-            correspond to the subgraph center nodes.
+            A dict mapping node types (keys) to a tensor of node IDs (values)
+            which correspond to the subgraph center nodes.
 
         Examples
         --------

--- a/python/dgl/nn/pytorch/explain/pgexplainer.py
+++ b/python/dgl/nn/pytorch/explain/pgexplainer.py
@@ -985,6 +985,9 @@ class HeteroPGExplainer(PGExplainer):
         batched_homo_graph = []
         batched_hetero_graph = []
         for target_ntype, target_nids in nodes.items():
+            if isinstance(target_nids, torch.Tensor):
+                target_nids = target_nids.tolist()
+
             for target_nid in target_nids:
                 sg, inverse_indices = khop_in_subgraph(
                     graph, {target_ntype: target_nid}, self.num_hops

--- a/python/dgl/nn/pytorch/explain/pgexplainer.py
+++ b/python/dgl/nn/pytorch/explain/pgexplainer.py
@@ -651,12 +651,12 @@ class HeteroPGExplainer(PGExplainer):
         """
         return super().train_step(graph, feat, tmp=tmp, **kwargs)
 
-    def train_step_node(self, nodes, graph, feat, tmp, **kwargs):
+    def train_step_node(self, nodes, graph, feat, temperature, **kwargs):
         r"""Compute the loss of the explanation network for node classification
 
         Parameters
         ----------
-        nodes : dict[str, interable[int]]
+        nodes : dict[str, Iterable[int]]
             A dict mapping node types (keys) to an iterable set of node ids (values).
         graph : DGLGraph
             Input heterogeneous graph.
@@ -665,7 +665,7 @@ class HeteroPGExplainer(PGExplainer):
             The input features are of shape :math:`(N_t, D_t)`. :math:`N_t` is the
             number of nodes for node type :math:`t`, and :math:`D_t` is the feature
             size for node type :math:`t`
-        tmp : float
+        temperature : float
             The temperature parameter fed to the sampling procedure.
         kwargs : dict
             Additional arguments passed to the GNN model.
@@ -677,7 +677,7 @@ class HeteroPGExplainer(PGExplainer):
         """
         assert (
             not self.graph_explanation
-        ), '"explain_graph" must be False in initializing the module.'
+        ), '"explain_graph" must be False when initializing the module.'
 
         self.model = self.model.to(graph.device)
         self.elayers = self.elayers.to(graph.device)
@@ -853,7 +853,7 @@ class HeteroPGExplainer(PGExplainer):
         return (probs, hetero_edge_mask)
 
     def explain_node(
-        self, nodes, graph, feat, tmp=1.0, training=False, **kwargs
+        self, nodes, graph, feat, temperature=1.0, training=False, **kwargs
     ):
         r"""Learn and return an edge mask that plays a crucial role to
         explain the prediction made by the GNN for provided set of node IDs.
@@ -861,7 +861,7 @@ class HeteroPGExplainer(PGExplainer):
 
         Parameters
         ----------
-        nodes : dict[str, interable[int]]
+        nodes : dict[str, Iterable[int]]
             A dict mapping node types (keys) to an iterable set of node ids (values).
         graph : DGLGraph
             A heterogeneous graph.
@@ -870,7 +870,7 @@ class HeteroPGExplainer(PGExplainer):
             The input features are of shape :math:`(N_t, D_t)`. :math:`N_t` is the
             number of nodes for node type :math:`t`, and :math:`D_t` is the feature
             size for node type :math:`t`
-        tmp : float
+        temperature : float
             The temperature parameter fed to the sampling procedure.
         training : bool
             Training the explanation network.
@@ -973,10 +973,10 @@ class HeteroPGExplainer(PGExplainer):
         """
         assert (
             not self.graph_explanation
-        ), '"explain_graph" must be False in initializing the module.'
+        ), '"explain_graph" must be False when initializing the module.'
         assert (
             self.num_hops is not None
-        ), '"num_hops" must be provided in initializing the module.'
+        ), '"num_hops" must be provided when initializing the module.'
 
         self.model = self.model.to(graph.device)
         self.elayers = self.elayers.to(graph.device)
@@ -1040,7 +1040,7 @@ class HeteroPGExplainer(PGExplainer):
 
         self.set_masks(batched_homo_graph, edge_mask)
 
-        # convert the edge mask back into heterogeneous format
+        # Convert the edge mask back into heterogeneous format.
         hetero_edge_mask = self._edge_mask_to_heterogeneous(
             edge_mask=edge_mask,
             homograph=batched_homo_graph,
@@ -1052,7 +1052,7 @@ class HeteroPGExplainer(PGExplainer):
             for ntype in batched_hetero_graph.ntypes
         }
 
-        # the model prediction with the updated edge mask
+        # The model prediction with the updated edge mask.
         logits = self.model(
             batched_hetero_graph,
             batched_feats,

--- a/python/dgl/nn/pytorch/explain/pgexplainer.py
+++ b/python/dgl/nn/pytorch/explain/pgexplainer.py
@@ -637,6 +637,7 @@ class HeteroPGExplainer(PGExplainer):
     """
 
     def train_step(self, graph, feat, temperature, **kwargs):
+        # pylint: disable=useless-super-delegation
         r"""Compute the loss of the explanation network for graph classification
 
         Parameters

--- a/python/dgl/nn/pytorch/explain/pgexplainer.py
+++ b/python/dgl/nn/pytorch/explain/pgexplainer.py
@@ -544,7 +544,7 @@ class PGExplainer(nn.Module):
             )
             sg.ndata["feat"] = feat[sg.ndata[NID].long()]
             sg.ndata["train"] = torch.tensor(
-                [nid in inverse_indices for nid in sg.nodes()]
+                [nid in inverse_indices for nid in sg.nodes()], device=sg.device
             )
 
             embed = self.model(sg, sg.ndata["feat"], embed=True, **kwargs)
@@ -999,7 +999,9 @@ class HeteroPGExplainer(PGExplainer):
                     ]
 
                     sg.nodes[sg_ntype].data["feat"] = sg_feat
-                    sg.nodes[sg_ntype].data["train"] = torch.tensor(train_mask)
+                    sg.nodes[sg_ntype].data["train"] = torch.tensor(
+                        train_mask, device=sg.device
+                    )
 
                 embed = self.model(sg, sg.ndata["feat"], embed=True, **kwargs)
                 for ntype in embed.keys():

--- a/tests/python/pytorch/nn/test_nn.py
+++ b/tests/python/pytorch/nn/test_nn.py
@@ -1863,16 +1863,10 @@ def test_pgexplainer(g, idtype, n_classes):
     explainer.train_step_node(th.tensor(0), g, g.ndata["attr"], 5.0)
     explainer.train_step_node(th.tensor([0, 1]), g, g.ndata["attr"], 5.0)
 
-    probs, edge_weight, bg, inverse_indices = explainer.explain_node(0, g, feat)
-    probs, edge_weight, bg, inverse_indices = explainer.explain_node(
-        [0, 1], g, feat
-    )
-    probs, edge_weight, bg, inverse_indices = explainer.explain_node(
-        th.tensor(0), g, feat
-    )
-    probs, edge_weight, bg, inverse_indices = explainer.explain_node(
-        th.tensor([0, 1]), g, feat
-    )
+    probs, edge_weight = explainer.explain_node(0, g, feat)
+    probs, edge_weight = explainer.explain_node([0, 1], g, feat)
+    probs, edge_weight = explainer.explain_node(th.tensor(0), g, feat)
+    probs, edge_weight = explainer.explain_node(th.tensor([0, 1]), g, feat)
 
 
 @pytest.mark.parametrize("g", get_cases(["hetero"]))
@@ -1944,15 +1938,13 @@ def test_heteropgexplainer(g, idtype, input_dim, n_classes):
     )
     model = model.to(ctx)
     explainer = nn.HeteroPGExplainer(
-        model, n_classes, num_hops=1, explain_graph=False
+        model, embed_dim, num_hops=1, explain_graph=False
     )
     explainer.train_step_node({g.ntypes[0]: [0]}, g, feat, 5.0)
     explainer.train_step_node({g.ntypes[0]: th.tensor([0, 1])}, g, feat, 5.0)
 
-    probs, edge_weight, bg, inverse_indices = explainer.explain_node(
-        {g.ntypes[0]: [0]}, g, feat
-    )
-    probs, edge_weight, bg, inverse_indices = explainer.explain_node(
+    probs, edge_weight = explainer.explain_node({g.ntypes[0]: [0]}, g, feat)
+    probs, edge_weight = explainer.explain_node(
         {g.ntypes[0]: th.tensor([0, 1])}, g, feat
     )
 

--- a/tests/python/pytorch/nn/test_nn.py
+++ b/tests/python/pytorch/nn/test_nn.py
@@ -1863,10 +1863,16 @@ def test_pgexplainer(g, idtype, n_classes):
     explainer.train_step_node(th.tensor(0), g, g.ndata["attr"], 5.0)
     explainer.train_step_node(th.tensor([0, 1]), g, g.ndata["attr"], 5.0)
 
-    probs, edge_weight = explainer.explain_node(0, g, feat)
-    probs, edge_weight = explainer.explain_node([0, 1], g, feat)
-    probs, edge_weight = explainer.explain_node(th.tensor(0), g, feat)
-    probs, edge_weight = explainer.explain_node(th.tensor([0, 1]), g, feat)
+    probs, edge_weight, bg, inverse_indices = explainer.explain_node(0, g, feat)
+    probs, edge_weight, bg, inverse_indices = explainer.explain_node(
+        [0, 1], g, feat
+    )
+    probs, edge_weight, bg, inverse_indices = explainer.explain_node(
+        th.tensor(0), g, feat
+    )
+    probs, edge_weight, bg, inverse_indices = explainer.explain_node(
+        th.tensor([0, 1]), g, feat
+    )
 
 
 @pytest.mark.parametrize("g", get_cases(["hetero"]))
@@ -1943,8 +1949,10 @@ def test_heteropgexplainer(g, idtype, input_dim, n_classes):
     explainer.train_step_node({g.ntypes[0]: [0]}, g, feat, 5.0)
     explainer.train_step_node({g.ntypes[0]: th.tensor([0, 1])}, g, feat, 5.0)
 
-    probs, edge_weight = explainer.explain_node({g.ntypes[0]: [0]}, g, feat)
-    probs, edge_weight = explainer.explain_node(
+    probs, edge_weight, bg, inverse_indices = explainer.explain_node(
+        {g.ntypes[0]: [0]}, g, feat
+    )
+    probs, edge_weight, bg, inverse_indices = explainer.explain_node(
         {g.ntypes[0]: th.tensor([0, 1])}, g, feat
     )
 


### PR DESCRIPTION
## Description

Implemented Node explanations for PGExplainer (https://arxiv.org/pdf/2011.04573.pdf) for Heterogenous Graphs. (extending https://github.com/dmlc/dgl/pull/5739)

## Checklist
Please feel free to remove inapplicable items for your PR.
- [x] The PR title starts with [$CATEGORY] (such as [NN], [Model], [Doc], [Feature]])
- [x] I've leverage the [tools](https://docs.google.com/document/d/1iHyj7zlmygKSk5gBPsqIqL5ASPzJSPREaNT_QdsiYA4/edit) to beautify the python and c++ code.
- [x] The PR is complete and small, read the [Google eng practice (CL equals to PR)](https://google.github.io/eng-practices/review/developer/small-cls.html) to understand more about small PR. In DGL, we consider PRs with less than 200 lines of core code change are small (example, test and documentation could be exempted). (*majority of new lines are documentation*)
- [x] All changes have test coverage
- [x] Code is well-documented
- [x] To the best of my knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

## Changes

* Added the `explain_node` method for heterogeneous implementation of PGExplainer.
* cleaned up `explain_node` internals for homogeneous implementation 

An example of using the method is included in the documentation.

Tests run for [MUTAG visualization scripts](https://gist.github.com/ndbaker1/68b956f9232acc948116e90d3aad14af#file-hetero_pgexplainer_node-py) utilizing `explain_node`.
