### PR TITLE
[BugFix] Updated some Cython code to adapt to Cython 3.0.0 version.

### DIFF
--- a/python/dgl/_ffi/_cython/ndarray.pxi
+++ b/python/dgl/_ffi/_cython/ndarray.pxi
@@ -1,14 +1,14 @@
 from ..runtime_ctypes import DGLArrayHandle as PyDGLArrayHandle
-from cpython cimport PyObject
-from cpython cimport PyCapsule_Destructor
+from cpython cimport PyObject PyCapsule_Destructor
 
 cdef const char* _c_str_dltensor = "dltensor"
 cdef const char* _c_str_used_dltensor = "used_dltensor"
 
 
-cdef void _c_dlpack_deleter(PyObject* ptr):
+#cdef void _c_dlpack_deleter(PyObject* ptr):
+cdef void _c_dlpack_deleter(object pycaps):
     cdef DLManagedTensor* dltensor
-    cdef object pycaps = <object> ptr
+    #cdef object pycaps = <object> ptr
     if pycapsule.PyCapsule_IsValid(pycaps, _c_str_dltensor):
         dltensor = <DLManagedTensor*>pycapsule.PyCapsule_GetPointer(pycaps, _c_str_dltensor)
         DGLDLManagedTensorCallDeleter(dltensor)
@@ -80,7 +80,8 @@ cdef class NDArrayBase:
         if self.c_is_view != 0:
             raise ValueError("to_dlpack do not work with memory views")
         CALL(DGLArrayToDLPack(self.chandle, &dltensor, alignment))
-        return pycapsule.PyCapsule_New(dltensor, _c_str_dltensor, <PyCapsule_Destructor>_c_dlpack_deleter)
+        # return pycapsule.PyCapsule_New(dltensor, _c_str_dltensor, <PyCapsule_Destructor>_c_dlpack_deleter)
+        return pycapsule.PyCapsule_New(dltensor, _c_str_dltensor, _c_dlpack_deleter)
 
 
 cdef c_make_array(void* chandle, is_view):

--- a/python/dgl/_ffi/_cython/ndarray.pxi
+++ b/python/dgl/_ffi/_cython/ndarray.pxi
@@ -5,7 +5,7 @@ cdef const char* _c_str_dltensor = "dltensor"
 cdef const char* _c_str_used_dltensor = "used_dltensor"
 
 
-cdef void _c_dlpack_deleter(object pycaps):
+cdef _c_dlpack_deleter(object pycaps):
     cdef DLManagedTensor* dltensor
     if pycapsule.PyCapsule_IsValid(pycaps, _c_str_dltensor):
         dltensor = <DLManagedTensor*>pycapsule.PyCapsule_GetPointer(pycaps, _c_str_dltensor)

--- a/python/dgl/_ffi/_cython/ndarray.pxi
+++ b/python/dgl/_ffi/_cython/ndarray.pxi
@@ -6,10 +6,8 @@ cdef const char* _c_str_dltensor = "dltensor"
 cdef const char* _c_str_used_dltensor = "used_dltensor"
 
 
-#cdef void _c_dlpack_deleter(PyObject* ptr):
 cdef void _c_dlpack_deleter(object pycaps):
     cdef DLManagedTensor* dltensor
-    #cdef object pycaps = <object> ptr
     if pycapsule.PyCapsule_IsValid(pycaps, _c_str_dltensor):
         dltensor = <DLManagedTensor*>pycapsule.PyCapsule_GetPointer(pycaps, _c_str_dltensor)
         DGLDLManagedTensorCallDeleter(dltensor)
@@ -82,7 +80,6 @@ cdef class NDArrayBase:
             raise ValueError("to_dlpack do not work with memory views")
         CALL(DGLArrayToDLPack(self.chandle, &dltensor, alignment))
         return pycapsule.PyCapsule_New(dltensor, _c_str_dltensor, <PyCapsule_Destructor>_c_dlpack_deleter)
-        # return pycapsule.PyCapsule_New(dltensor, _c_str_dltensor, _c_dlpack_deleter)
 
 
 cdef c_make_array(void* chandle, is_view):

--- a/python/dgl/_ffi/_cython/ndarray.pxi
+++ b/python/dgl/_ffi/_cython/ndarray.pxi
@@ -1,5 +1,6 @@
 from ..runtime_ctypes import DGLArrayHandle as PyDGLArrayHandle
-from cpython cimport PyObject PyCapsule_Destructor
+from cpython cimport PyObject
+from cpython cimport PyCapsule_Destructor
 
 cdef const char* _c_str_dltensor = "dltensor"
 cdef const char* _c_str_used_dltensor = "used_dltensor"

--- a/python/dgl/_ffi/_cython/ndarray.pxi
+++ b/python/dgl/_ffi/_cython/ndarray.pxi
@@ -1,11 +1,14 @@
 from ..runtime_ctypes import DGLArrayHandle as PyDGLArrayHandle
+from cpython cimport PyObject
+from cpython cimport PyCapsule_Destructor
 
 cdef const char* _c_str_dltensor = "dltensor"
 cdef const char* _c_str_used_dltensor = "used_dltensor"
 
 
-cdef void _c_dlpack_deleter(object pycaps):
+cdef void _c_dlpack_deleter(PyObject* ptr):
     cdef DLManagedTensor* dltensor
+    cdef object pycaps = <object> ptr
     if pycapsule.PyCapsule_IsValid(pycaps, _c_str_dltensor):
         dltensor = <DLManagedTensor*>pycapsule.PyCapsule_GetPointer(pycaps, _c_str_dltensor)
         DGLDLManagedTensorCallDeleter(dltensor)
@@ -77,7 +80,7 @@ cdef class NDArrayBase:
         if self.c_is_view != 0:
             raise ValueError("to_dlpack do not work with memory views")
         CALL(DGLArrayToDLPack(self.chandle, &dltensor, alignment))
-        return pycapsule.PyCapsule_New(dltensor, _c_str_dltensor, _c_dlpack_deleter)
+        return pycapsule.PyCapsule_New(dltensor, _c_str_dltensor, <PyCapsule_Destructor>_c_dlpack_deleter)
 
 
 cdef c_make_array(void* chandle, is_view):

--- a/python/dgl/_ffi/_cython/ndarray.pxi
+++ b/python/dgl/_ffi/_cython/ndarray.pxi
@@ -81,8 +81,8 @@ cdef class NDArrayBase:
         if self.c_is_view != 0:
             raise ValueError("to_dlpack do not work with memory views")
         CALL(DGLArrayToDLPack(self.chandle, &dltensor, alignment))
-        # return pycapsule.PyCapsule_New(dltensor, _c_str_dltensor, <PyCapsule_Destructor>_c_dlpack_deleter)
-        return pycapsule.PyCapsule_New(dltensor, _c_str_dltensor, _c_dlpack_deleter)
+        return pycapsule.PyCapsule_New(dltensor, _c_str_dltensor, <PyCapsule_Destructor>_c_dlpack_deleter)
+        # return pycapsule.PyCapsule_New(dltensor, _c_str_dltensor, _c_dlpack_deleter)
 
 
 cdef c_make_array(void* chandle, is_view):

--- a/python/dgl/_ffi/_cython/ndarray.pxi
+++ b/python/dgl/_ffi/_cython/ndarray.pxi
@@ -1,5 +1,4 @@
 from ..runtime_ctypes import DGLArrayHandle as PyDGLArrayHandle
-from cpython cimport PyObject
 from cpython cimport PyCapsule_Destructor
 
 cdef const char* _c_str_dltensor = "dltensor"


### PR DESCRIPTION
## Description
<!-- Brief description. Refer to the related issues if existed.
It'll be great if relevant reviewers can be assigned as well.-->
Update some Cython Code in python/dgl/_ffi/_cython/ndarray.pxi to adapt the latest cython version.
The original version of code would raise error:
```
[1/1] Cythonizing dgl/_ffi/_cython/core.pyx

Error compiling Cython file:
------------------------------------------------------------
...
        """
        cdef DLManagedTensor* dltensor
        if self.c_is_view != 0:
            raise ValueError("to_dlpack do not work with memory views")
        CALL(DGLArrayToDLPack(self.chandle, &dltensor, alignment))
        return pycapsule.PyCapsule_New(dltensor, _c_str_dltensor, _c_dlpack_deleter)
                                                                  ^
------------------------------------------------------------

dgl/_ffi/_cython/./ndarray.pxi:80:66: Cannot assign type 'void (object) except *' to 'PyCapsule_Destructor'
Traceback (most recent call last):
  File "/home/ubuntu/dgl/python/setup.py", line 240, in <module>
    ext_modules=config_cython(),
  File "/home/ubuntu/dgl/python/setup.py", line 141, in config_cython
    return cythonize(
  File "/opt/conda/envs/dgl-dev-gpu-117/lib/python3.10/site-packages/Cython/Build/Dependencies.py", line 1134, in cythonize
    cythonize_one(*args)
  File "/opt/conda/envs/dgl-dev-gpu-117/lib/python3.10/site-packages/Cython/Build/Dependencies.py", line 1301, in cythonize_one
    raise CompileError(None, pyx_file)
Cython.Compiler.Errors.CompileError: dgl/_ffi/_cython/core.pyx
```

## Checklist
Please feel free to remove inapplicable items for your PR.
- [ ] The PR title starts with [$CATEGORY] (such as [NN], [Model], [Doc], [Feature]])
- [ ] I've leverage the [tools](https://docs.google.com/document/d/1iHyj7zlmygKSk5gBPsqIqL5ASPzJSPREaNT_QdsiYA4/edit) to beautify the python and c++ code.
- [ ] The PR is complete and small, read the [Google eng practice (CL equals to PR)](https://google.github.io/eng-practices/review/developer/small-cls.html) to understand more about small PR. In DGL, we consider PRs with less than 200 lines of core code change are small (example, test and documentation could be exempted).
- [ ] All changes have test coverage
- [ ] Code is well-documented
- [ ] To the best of my knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change
- [ ] Related issue is referred in this PR
- [ ] If the PR is for a new model/paper, I've updated the example index [here](../examples/README.md).

## Changes
<!-- You could use following template
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)
-->
