### PR TITLE
[Graphbolt]Add negative sampler udf

### DIFF
--- a/python/dgl/graphbolt/__init__.py
+++ b/python/dgl/graphbolt/__init__.py
@@ -15,6 +15,7 @@ from .impl import *
 from .dataloader import *
 from .subgraph_sampler import *
 from .sampled_subgraph import *
+from .negative_sampler import *
 from .utils import unique_and_compact_node_pairs
 
 

--- a/python/dgl/graphbolt/__init__.py
+++ b/python/dgl/graphbolt/__init__.py
@@ -15,6 +15,7 @@ from .impl import *
 from .dataloader import *
 from .subgraph_sampler import *
 from .sampled_subgraph import *
+from .link_data_format import *
 from .negative_sampler import *
 from .utils import unique_and_compact_node_pairs
 

--- a/python/dgl/graphbolt/impl/__init__.py
+++ b/python/dgl/graphbolt/impl/__init__.py
@@ -4,3 +4,4 @@ from .ondisk_metadata import *
 from .torch_based_feature_store import *
 from .csc_sampling_graph import *
 from .sampled_subgraph_impl import *
+from .uniform_negative_sampler import *

--- a/python/dgl/graphbolt/impl/uniform_negative_sampler.py
+++ b/python/dgl/graphbolt/impl/uniform_negative_sampler.py
@@ -3,18 +3,49 @@
 from ..negative_sampler import (
     ConditionedNegativeSampler,
     IndependentNegativeSampler,
+    NegativeSampler,
 )
 
 
-class UniformIndependentNegativeSampler(IndependentNegativeSampler):
-    """Negative samplers randomly select negative destination nodes for each
+class UniformNegativeSampler(NegativeSampler):
+    """
+    Negative samplers randomly select negative destination nodes for each
     source node based on a uniform distribution. It's important to note that
     the term 'negative' refers to false negatives, indicating that the sampled
     pairs are not ensured to be absent in the graph.
     For each edge ``(u, v)``, it is supposed to generate `negative_ratio` pairs
     of negative edges ``(u, v')``, where ``v'`` is chosen uniformly from all
     the nodes in the graph.
+    """
 
+    def __init__(self, datapipe, negative_ratio, graph):
+        """
+        Initlization for a uniform negative sampler.
+
+        Parameters
+        ----------
+        datapipe : DataPipe
+            The datapipe.
+        negative_ratio : int
+            The proportion of negative samples to positive samples.
+        graph
+            The graph on which to perform negative sampling.
+        """
+        super().__init__(datapipe, negative_ratio)
+        self.graph = graph
+
+    def _generate_negative_pairs(self, node_pairs, etype=None):
+        return self.graph.sample_negative_edges_uniform(
+            etype,
+            node_pairs,
+            self.negative_ratio,
+        )
+
+
+class UniformIndependentNegativeSampler(
+    UniformNegativeSampler, IndependentNegativeSampler
+):
+    """
     Examples
     --------
     >>> from dgl import graphbolt as gb
@@ -31,27 +62,17 @@ class UniformIndependentNegativeSampler(IndependentNegativeSampler):
     >>> for data in neg_sampler:
         ...  print(data)
         ...
-    (tensor([0, 0, 0]), tensor([1, 2, 0]), tensor([1, 0, 0]))
-    (tensor([1, 1, 1]), tensor([2, 2, 1]), tensor([1, 0, 0]))
+    (tensor([0]), tensor([1]), tensor([[0, 0]]), tensor([[2, 1]]))
+    (tensor([1]), tensor([2]), tensor([[1, 1]]), tensor([[1, 2]]))
     """
 
-    def _generate_negative_pairs(self, node_pairs, etype=None):
-        return self.graph.sample_negative_edges_uniform(
-            etype,
-            node_pairs,
-            self.negative_ratio,
-        )
+    pass
 
 
-class UniformConditionedNegativeSampler(ConditionedNegativeSampler):
-    """Negative samplers randomly select negative destination nodes for each
-    source node based on a uniform distribution. It's important to note that
-    the term 'negative' refers to false negatives, indicating that the sampled
-    pairs are not ensured to be absent in the graph.
-    For each edge ``(u, v)``, it is supposed to generate `negative_ratio` pairs
-    of negative edges ``(u, v')``, where ``v'`` is chosen uniformly from all
-    the nodes in the graph.
-
+class UniformConditionedNegativeSampler(
+    UniformNegativeSampler, ConditionedNegativeSampler
+):
+    """
     Examples
     --------
     >>> from dgl import graphbolt as gb
@@ -72,9 +93,4 @@ class UniformConditionedNegativeSampler(ConditionedNegativeSampler):
     (tensor([1]), tensor([2]), tensor([[0, 1]]))
     """
 
-    def _generate_negative_pairs(self, node_pairs, etype=None):
-        return self.graph.sample_negative_edges_uniform(
-            etype,
-            node_pairs,
-            self.negative_ratio,
-        )
+    pass

--- a/python/dgl/graphbolt/impl/uniform_negative_sampler.py
+++ b/python/dgl/graphbolt/impl/uniform_negative_sampler.py
@@ -18,7 +18,12 @@ class UniformNegativeSampler(NegativeSampler):
     the nodes in the graph.
     """
 
-    def __init__(self, datapipe, negative_ratio, graph):
+    def __init__(
+        self,
+        datapipe,
+        negative_ratio,
+        graph,
+    ):
         """
         Initlization for a uniform negative sampler.
 
@@ -28,13 +33,13 @@ class UniformNegativeSampler(NegativeSampler):
             The datapipe.
         negative_ratio : int
             The proportion of negative samples to positive samples.
-        graph
+        graph : CSCSamplingGraph
             The graph on which to perform negative sampling.
         """
         super().__init__(datapipe, negative_ratio)
         self.graph = graph
 
-    def _generate_negative_pairs(self, node_pairs, etype=None):
+    def _sample_negative_pairs(self, node_pairs, etype=None):
         return self.graph.sample_negative_edges_uniform(
             etype,
             node_pairs,
@@ -66,8 +71,6 @@ class UniformIndependentNegativeSampler(
     (tensor([1, 1, 1]), tensor([2, 1, 2]), tensor([1, 0, 0]))
     """
 
-    pass
-
 
 class UniformConditionedNegativeSampler(
     UniformNegativeSampler, ConditionedNegativeSampler
@@ -92,5 +95,3 @@ class UniformConditionedNegativeSampler(
     (tensor([0]), tensor([1]), tensor([[0, 0]]), tensor([[2, 1]]))
     (tensor([1]), tensor([2]), tensor([[1, 1]]), tensor([[1, 2]]))
     """
-
-    pass

--- a/python/dgl/graphbolt/impl/uniform_negative_sampler.py
+++ b/python/dgl/graphbolt/impl/uniform_negative_sampler.py
@@ -1,0 +1,78 @@
+"""Uniform negative sampler for GraphBolt."""
+
+from ..negative_sampler import (ConditionedNegativeSampler,
+                                IndependentNegativeSampler)
+
+
+class UniformIndependentNegativeSampler(IndependentNegativeSampler):
+    """Negative samplers randomly select negative destination nodes for each
+    source node based on a uniform distribution. It's important to note that
+    the term 'negative' refers to false negatives, indicating that the sampled
+    pairs are not ensured to be absent in the graph.
+    For each edge ``(u, v)``, it is supposed to generate `negative_ratio` pairs
+    of negative edges ``(u, v')``, where ``v'`` is chosen uniformly from all
+    the nodes in the graph.
+
+    Examples
+    --------
+    >>> from dgl import graphbolt as gb
+    >>> indptr = torch.LongTensor([0, 2, 4, 5])
+    >>> indices = torch.LongTensor([1, 2, 0, 2, 0])
+    >>> graph = gb.from_csc(indptr, indices)
+    >>> node_pairs = (torch.tensor([0, 1]), torch.tensor([1, 2]))
+    >>> item_set = gb.ItemSet(node_pairs)
+    >>> minibatch_sampler = gb.MinibatchSampler(
+        ...item_set, batch_size=1,
+        ...)
+    >>> neg_sampler = gb.UniformIndependentNegativeSampler(
+        ...minibatch_sampler, graph, 2)
+    >>> for data in neg_sampler:
+        ...  print(data)
+        ...
+    (tensor([0, 0, 0]), tensor([1, 2, 0]), tensor([1, 0, 0]))
+    (tensor([1, 1, 1]), tensor([2, 2, 1]), tensor([1, 0, 0]))
+    """
+
+    def _generate_negative_pairs(self, node_pairs, etype=None):
+        return self.graph.sample_negative_edges_uniform(
+            etype,
+            node_pairs,
+            self.negative_ratio,
+        )
+
+
+class UniformConditionedNegativeSampler(ConditionedNegativeSampler):
+    """Negative samplers randomly select negative destination nodes for each
+    source node based on a uniform distribution. It's important to note that
+    the term 'negative' refers to false negatives, indicating that the sampled
+    pairs are not ensured to be absent in the graph.
+    For each edge ``(u, v)``, it is supposed to generate `negative_ratio` pairs
+    of negative edges ``(u, v')``, where ``v'`` is chosen uniformly from all
+    the nodes in the graph.
+
+    Examples
+    --------
+    >>> from dgl import graphbolt as gb
+    >>> indptr = torch.LongTensor([0, 2, 4, 5])
+    >>> indices = torch.LongTensor([1, 2, 0, 2, 0])
+    >>> graph = gb.from_csc(indptr, indices)
+    >>> node_pairs = (torch.tensor([0, 1]), torch.tensor([1, 2]))
+    >>> item_set = gb.ItemSet(node_pairs)
+    >>> minibatch_sampler = gb.MinibatchSampler(
+        ...item_set, batch_size=1,
+        ...)
+    >>> neg_sampler = gb.UniformConditionedNegativeSampler(
+        ...minibatch_sampler, graph, 2)
+    >>> for data in neg_sampler:
+        ...  print(data)
+        ...
+    (tensor([0]), tensor([1]), tensor([[1, 2]]))
+    (tensor([1]), tensor([2]), tensor([[0, 1]]))
+    """
+
+    def _generate_negative_pairs(self, node_pairs, etype=None):
+        return self.graph.sample_negative_edges_uniform(
+            etype,
+            node_pairs,
+            self.negative_ratio,
+        )

--- a/python/dgl/graphbolt/impl/uniform_negative_sampler.py
+++ b/python/dgl/graphbolt/impl/uniform_negative_sampler.py
@@ -58,12 +58,12 @@ class UniformIndependentNegativeSampler(
         ...item_set, batch_size=1,
         ...)
     >>> neg_sampler = gb.UniformIndependentNegativeSampler(
-        ...minibatch_sampler, graph, 2)
+        ...minibatch_sampler, 2, graph)
     >>> for data in neg_sampler:
         ...  print(data)
         ...
-    (tensor([0]), tensor([1]), tensor([[0, 0]]), tensor([[2, 1]]))
-    (tensor([1]), tensor([2]), tensor([[1, 1]]), tensor([[1, 2]]))
+    (tensor([0, 0, 0]), tensor([1, 1, 2]), tensor([1, 0, 0]))
+    (tensor([1, 1, 1]), tensor([2, 1, 2]), tensor([1, 0, 0]))
     """
 
     pass
@@ -85,12 +85,12 @@ class UniformConditionedNegativeSampler(
         ...item_set, batch_size=1,
         ...)
     >>> neg_sampler = gb.UniformConditionedNegativeSampler(
-        ...minibatch_sampler, graph, 2)
+        ...minibatch_sampler, 2, graph)
     >>> for data in neg_sampler:
         ...  print(data)
         ...
-    (tensor([0]), tensor([1]), tensor([[1, 2]]))
-    (tensor([1]), tensor([2]), tensor([[0, 1]]))
+    (tensor([0]), tensor([1]), tensor([[0, 0]]), tensor([[2, 1]]))
+    (tensor([1]), tensor([2]), tensor([[1, 1]]), tensor([[1, 2]]))
     """
 
     pass

--- a/python/dgl/graphbolt/impl/uniform_negative_sampler.py
+++ b/python/dgl/graphbolt/impl/uniform_negative_sampler.py
@@ -50,7 +50,7 @@ class UniformNegativeSampler(NegativeSampler):
         >>> indptr = torch.LongTensor([0, 2, 4, 5])
         >>> indices = torch.LongTensor([1, 2, 0, 2, 0])
         >>> graph = gb.from_csc(indptr, indices)
-        >>> link_data_format = gb.LinkDataFormat.CONDITIONED
+        >>> link_data_format = gb.LinkDataFormat.INDEPENDENT
         >>> node_pairs = (torch.tensor([0, 1]), torch.tensor([1, 2]))
         >>> item_set = gb.ItemSet(node_pairs)
         >>> minibatch_sampler = gb.MinibatchSampler(
@@ -68,7 +68,7 @@ class UniformNegativeSampler(NegativeSampler):
         >>> indptr = torch.LongTensor([0, 2, 4, 5])
         >>> indices = torch.LongTensor([1, 2, 0, 2, 0])
         >>> graph = gb.from_csc(indptr, indices)
-        >>> link_data_format = gb.LinkDataFormat.INDEPENDENT
+        >>> link_data_format = gb.LinkDataFormat.CONDITIONED
         >>> node_pairs = (torch.tensor([0, 1]), torch.tensor([1, 2]))
         >>> item_set = gb.ItemSet(node_pairs)
         >>> minibatch_sampler = gb.MinibatchSampler(

--- a/python/dgl/graphbolt/impl/uniform_negative_sampler.py
+++ b/python/dgl/graphbolt/impl/uniform_negative_sampler.py
@@ -1,7 +1,9 @@
 """Uniform negative sampler for GraphBolt."""
 
-from ..negative_sampler import (ConditionedNegativeSampler,
-                                IndependentNegativeSampler)
+from ..negative_sampler import (
+    ConditionedNegativeSampler,
+    IndependentNegativeSampler,
+)
 
 
 class UniformIndependentNegativeSampler(IndependentNegativeSampler):

--- a/python/dgl/graphbolt/impl/uniform_negative_sampler.py
+++ b/python/dgl/graphbolt/impl/uniform_negative_sampler.py
@@ -1,10 +1,6 @@
 """Uniform negative sampler for GraphBolt."""
 
-from ..negative_sampler import (
-    ConditionedNegativeSampler,
-    IndependentNegativeSampler,
-    NegativeSampler,
-)
+from ..negative_sampler import NegativeSampler
 
 
 class UniformNegativeSampler(NegativeSampler):
@@ -22,6 +18,7 @@ class UniformNegativeSampler(NegativeSampler):
         self,
         datapipe,
         negative_ratio,
+        link_data_format,
         graph,
     ):
         """
@@ -33,65 +30,64 @@ class UniformNegativeSampler(NegativeSampler):
             The datapipe.
         negative_ratio : int
             The proportion of negative samples to positive samples.
+        link_data_format : LinkDataFormat
+            Determines the format of the output data:
+                - Conditioned format: Outputs data as quadruples
+                `[u, v, [negative heads], [negative tails]]`. Here, 'u' and 'v'
+                are the source and destination nodes of positive edges,  while
+                'negative heads' and 'negative tails' refer to the source and
+                destination nodes of negative edges.
+                - Independent format: Outputs data as triples `[u, v, label]`.
+                In this case, 'u' and 'v' are the source and destination nodes
+                of an edge, and 'label' indicates whether the edge is negative
+                (0) or positive (1).
         graph : CSCSamplingGraph
             The graph on which to perform negative sampling.
+
+        Examples
+        --------
+        >>> from dgl import graphbolt as gb
+        >>> indptr = torch.LongTensor([0, 2, 4, 5])
+        >>> indices = torch.LongTensor([1, 2, 0, 2, 0])
+        >>> graph = gb.from_csc(indptr, indices)
+        >>> link_data_format = gb.LinkDataFormat.CONDITIONED
+        >>> node_pairs = (torch.tensor([0, 1]), torch.tensor([1, 2]))
+        >>> item_set = gb.ItemSet(node_pairs)
+        >>> minibatch_sampler = gb.MinibatchSampler(
+            ...item_set, batch_size=1,
+            ...)
+        >>> neg_sampler = gb.UniformNegativeSampler(
+            ...minibatch_sampler, 2, link_data_format, graph)
+        >>> for data in neg_sampler:
+            ...  print(data)
+            ...
+        (tensor([0, 0, 0]), tensor([1, 1, 2]), tensor([1, 0, 0]))
+        (tensor([1, 1, 1]), tensor([2, 1, 2]), tensor([1, 0, 0]))
+
+        >>> from dgl import graphbolt as gb
+        >>> indptr = torch.LongTensor([0, 2, 4, 5])
+        >>> indices = torch.LongTensor([1, 2, 0, 2, 0])
+        >>> graph = gb.from_csc(indptr, indices)
+        >>> link_data_format = gb.LinkDataFormat.INDEPENDENT
+        >>> node_pairs = (torch.tensor([0, 1]), torch.tensor([1, 2]))
+        >>> item_set = gb.ItemSet(node_pairs)
+        >>> minibatch_sampler = gb.MinibatchSampler(
+            ...item_set, batch_size=1,
+            ...)
+        >>> neg_sampler = gb.UniformNegativeSampler(
+            ...minibatch_sampler, 2, link_data_format, graph)
+        >>> for data in neg_sampler:
+            ...  print(data)
+            ...
+        (tensor([0]), tensor([1]), tensor([[0, 0]]), tensor([[2, 1]]))
+        (tensor([1]), tensor([2]), tensor([[1, 1]]), tensor([[1, 2]]))
         """
-        super().__init__(datapipe, negative_ratio)
+        super().__init__(datapipe, negative_ratio, link_data_format)
         self.graph = graph
 
-    def _sample_negative_pairs(self, node_pairs, etype=None):
+    def _sample_with_etype(self, node_pairs, etype=None):
         return self.graph.sample_negative_edges_uniform(
             etype,
             node_pairs,
             self.negative_ratio,
         )
-
-
-class UniformIndependentNegativeSampler(
-    UniformNegativeSampler, IndependentNegativeSampler
-):
-    """
-    Examples
-    --------
-    >>> from dgl import graphbolt as gb
-    >>> indptr = torch.LongTensor([0, 2, 4, 5])
-    >>> indices = torch.LongTensor([1, 2, 0, 2, 0])
-    >>> graph = gb.from_csc(indptr, indices)
-    >>> node_pairs = (torch.tensor([0, 1]), torch.tensor([1, 2]))
-    >>> item_set = gb.ItemSet(node_pairs)
-    >>> minibatch_sampler = gb.MinibatchSampler(
-        ...item_set, batch_size=1,
-        ...)
-    >>> neg_sampler = gb.UniformIndependentNegativeSampler(
-        ...minibatch_sampler, 2, graph)
-    >>> for data in neg_sampler:
-        ...  print(data)
-        ...
-    (tensor([0, 0, 0]), tensor([1, 1, 2]), tensor([1, 0, 0]))
-    (tensor([1, 1, 1]), tensor([2, 1, 2]), tensor([1, 0, 0]))
-    """
-
-
-class UniformConditionedNegativeSampler(
-    UniformNegativeSampler, ConditionedNegativeSampler
-):
-    """
-    Examples
-    --------
-    >>> from dgl import graphbolt as gb
-    >>> indptr = torch.LongTensor([0, 2, 4, 5])
-    >>> indices = torch.LongTensor([1, 2, 0, 2, 0])
-    >>> graph = gb.from_csc(indptr, indices)
-    >>> node_pairs = (torch.tensor([0, 1]), torch.tensor([1, 2]))
-    >>> item_set = gb.ItemSet(node_pairs)
-    >>> minibatch_sampler = gb.MinibatchSampler(
-        ...item_set, batch_size=1,
-        ...)
-    >>> neg_sampler = gb.UniformConditionedNegativeSampler(
-        ...minibatch_sampler, 2, graph)
-    >>> for data in neg_sampler:
-        ...  print(data)
-        ...
-    (tensor([0]), tensor([1]), tensor([[0, 0]]), tensor([[2, 1]]))
-    (tensor([1]), tensor([2]), tensor([[1, 1]]), tensor([[1, 2]]))
-    """

--- a/python/dgl/graphbolt/link_data_format.py
+++ b/python/dgl/graphbolt/link_data_format.py
@@ -1,0 +1,23 @@
+"""Linked data format."""
+
+from enum import Enum
+
+__all__ = ["LinkDataFormat"]
+
+
+class LinkDataFormat(Enum):
+    """
+    An Enum class representing the two data formats used in link prediction:
+
+    Attributes:
+    CONDITIONED: Represents the 'conditioned' format where data is
+    structured as quadruples `[u, v, [negative heads], [negative tails]]`
+    indicating the source and destination nodes of positive and negative edges.
+
+    INDEPENDENT: Represents the 'independent' format where data is structured
+    as triples `[u, v, label]` indicating the source and  destination nodes of
+    an edge, with a label (0 or 1) denoting it as negative or positive.
+    """
+
+    CONDITIONED = "conditioned"
+    INDEPENDENT = "independent"

--- a/python/dgl/graphbolt/negative_sampler.py
+++ b/python/dgl/graphbolt/negative_sampler.py
@@ -79,7 +79,7 @@ class NegativeSampler(Mapper):
         Tuple[Tensor]
             A mixed collection of positive and negative node pairs.
         """
-        raise NotImplementedError
+        pass
 
     def _sample_negative_pairs(self, node_pairs, etype=None):
         """Generate negative pairs for a given etype form positive pairs
@@ -99,7 +99,7 @@ class NegativeSampler(Mapper):
         Tuple[Tensor]
             A collection of negative node pairs.
         """
-        raise NotImplementedError
+        pass
 
 
 class IndependentNegativeSampler(NegativeSampler):

--- a/python/dgl/graphbolt/negative_sampler.py
+++ b/python/dgl/graphbolt/negative_sampler.py
@@ -79,7 +79,6 @@ class NegativeSampler(Mapper):
         Tuple[Tensor]
             A mixed collection of positive and negative node pairs.
         """
-        pass
 
     def _sample_negative_pairs(self, node_pairs, etype=None):
         """Generate negative pairs for a given etype form positive pairs
@@ -99,7 +98,6 @@ class NegativeSampler(Mapper):
         Tuple[Tensor]
             A collection of negative node pairs.
         """
-        pass
 
 
 class IndependentNegativeSampler(NegativeSampler):

--- a/python/dgl/graphbolt/negative_sampler.py
+++ b/python/dgl/graphbolt/negative_sampler.py
@@ -1,0 +1,127 @@
+"""Negative samplers."""
+
+import torch
+from _collections_abc import Mapping
+from torchdata.datapipes.iter import Mapper
+
+
+class NegativeSampler(Mapper):
+    """
+    A negative sampler used to generate negative samples and return
+    a mix of positive and negative samples.
+    """
+
+    def __init__(
+        self,
+        datapipe,
+        graph,
+        negative_ratio,
+    ):
+        """
+        Initlization for a negative sampler.
+
+        Parameters
+        ----------
+        graph
+            The graph on which to perform negative sampling.
+        negative_ratio : int
+            The proportion of negative samples to positive samples.
+        """
+        super().__init__(datapipe, self._sample)
+        self.graph = graph
+        assert (
+            negative_ratio > 0
+        ), "Negative_ratio should shoubld be positive Integer."
+        self.negative_ratio = negative_ratio
+
+    def _sample(self, node_pairs):
+        """
+        Generates a mix of positive and negative samples.
+
+        Parameters
+        ----------
+        node_pairs : Tuple[Tensor] or Dict[etype, Tuple[Tensor]]
+            A tuple of tensors or a dictionary that represents source-destination node pairs
+            of positive edges, where positive means the edge must exist in the graph.
+
+        Returns
+        -------
+        Tuple[Tensor] or Dict[etype, Tuple[Tensor]]
+            A collection of edges or a dictionary that maps etypes to edges, which includes
+            both positive and negative samples.
+        """
+        if isinstance(node_pairs, Mapping):
+            return {
+                etype: self._generate(pos_pairs, etype)
+                for etype, pos_pairs in node_pairs.items()
+            }
+        else:
+            return self._generate(node_pairs, None)
+
+    def _generate(self, node_pairs, etype=None):
+        """Generate a mix of positive and negative samples for a given etype.
+
+        Parameters
+        ----------
+        node_pairs : Tuple[Tensor]
+            A tuple of tensors or a dictionary that represents source-destination node pairs
+            of positive edges, where positive means the edge must exist in the graph.
+        etype : (str, str, str)
+            Canonical edge type.
+        Returns
+        -------
+        Tuple[Tensor]
+            A mixed collection of positive and negative node pairs.
+        """
+        raise NotImplementedError
+
+    def _generate_negative_pairs(self, node_pairs, etype=None):
+        """Generate negative pairs for a given etype form positive pairs.
+        Parameters
+        ----------
+        node_pairs : Tuple[Tensor]
+            A tuple of tensors or a dictionary that represents source-destination node pairs
+            of positive edges, where positive means the edge must exist in the graph.
+        etype : (str, str, str)
+            Canonical edge type.
+        Returns
+        -------
+        Tuple[Tensor]
+            A collection of negative node pairs.
+        """
+        raise NotImplementedError
+
+
+class IndependentNegativeSampler(NegativeSampler):
+    """
+    A kind of negative sampler. `Independent` denotes the data format, where
+    data is structured as triples `[u, v, label]`. Each triple represents an
+    edge between nodes 'u' and 'v', and the 'label' indicates whether the edge
+    is negative (0) or positive (1).
+    """
+
+    def _generate(self, node_pairs, etype=None):
+        neg_src, neg_dst = self._generate_negative_pairs(node_pairs, etype)
+        pos_src, pos_dst = node_pairs
+        pos_label = torch.ones_like(pos_src)
+        neg_label = torch.zeros_like(neg_src)
+        src = torch.cat([pos_src, neg_src])
+        dst = torch.cat([pos_dst, neg_dst])
+        label = torch.cat([pos_label, neg_label])
+        return (src, dst, label)
+
+
+class ConditionedNegativeSampler(NegativeSampler):
+    """
+    A kind of negative sampler. `Conditioned` denotes the data format, where
+    data is structured as  `[u, v, [neg_v]]`. Here, 'u' and 'v' represent the
+    source-destination positive node pairs, and 'u' combined with each node in
+    'neg_v' creates negative node pairs. The length of 'neg_v' is same as
+    'negative_ratio'.
+    """
+
+    def _generate(self, node_pairs, etype=None):
+        _, neg_dst = self._generate_negative_pairs(node_pairs, etype)
+        pos_src, pos_dst = node_pairs
+        neg_dst = neg_dst.view(-1, self.negative_ratio)
+        return (pos_src, pos_dst, neg_dst)

--- a/python/dgl/graphbolt/negative_sampler.py
+++ b/python/dgl/graphbolt/negative_sampler.py
@@ -50,13 +50,13 @@ class NegativeSampler(Mapper):
         """
         if isinstance(node_pairs, Mapping):
             return {
-                etype: self._generate(pos_pairs, etype)
+                etype: self._post_process(pos_pairs, etype)
                 for etype, pos_pairs in node_pairs.items()
             }
         else:
-            return self._generate(node_pairs, None)
+            return self._post_process(node_pairs, None)
 
-    def _generate(self, node_pairs, etype=None):
+    def _post_process(self, node_pairs, etype=None):
         """Generate a mix of positive and negative samples for a given etype.
 
         Parameters
@@ -74,7 +74,7 @@ class NegativeSampler(Mapper):
         """
         raise NotImplementedError
 
-    def _generate_negative_pairs(self, node_pairs, etype=None):
+    def _sample_negative_pairs(self, node_pairs, etype=None):
         """Generate negative pairs for a given etype form positive pairs.
         Parameters
         ----------
@@ -100,8 +100,8 @@ class IndependentNegativeSampler(NegativeSampler):
     is negative (0) or positive (1).
     """
 
-    def _generate(self, node_pairs, etype=None):
-        neg_src, neg_dst = self._generate_negative_pairs(node_pairs, etype)
+    def _post_process(self, node_pairs, etype=None):
+        neg_src, neg_dst = self._sample_negative_pairs(node_pairs, etype)
         pos_src, pos_dst = node_pairs
         pos_label = torch.ones_like(pos_src)
         neg_label = torch.zeros_like(neg_src)
@@ -120,8 +120,8 @@ class ConditionedNegativeSampler(NegativeSampler):
     and 'neg_v' is same as 'negative_ratio'.
     """
 
-    def _generate(self, node_pairs, etype=None):
-        neg_src, neg_dst = self._generate_negative_pairs(node_pairs, etype)
+    def _post_process(self, node_pairs, etype=None):
+        neg_src, neg_dst = self._sample_negative_pairs(node_pairs, etype)
         pos_src, pos_dst = node_pairs
         neg_src = neg_src.view(-1, self.negative_ratio)
         neg_dst = neg_dst.view(-1, self.negative_ratio)

--- a/python/dgl/graphbolt/negative_sampler.py
+++ b/python/dgl/graphbolt/negative_sampler.py
@@ -1,7 +1,8 @@
 """Negative samplers."""
 
-import torch
 from _collections_abc import Mapping
+
+import torch
 from torchdata.datapipes.iter import Mapper
 
 

--- a/python/dgl/graphbolt/negative_sampler.py
+++ b/python/dgl/graphbolt/negative_sampler.py
@@ -5,6 +5,8 @@ from _collections_abc import Mapping
 import torch
 from torchdata.datapipes.iter import Mapper
 
+from .link_data_format import LinkDataFormat
+
 
 class NegativeSampler(Mapper):
     """
@@ -16,6 +18,7 @@ class NegativeSampler(Mapper):
         self,
         datapipe,
         negative_ratio,
+        link_data_format,
     ):
         """
         Initlization for a negative sampler.
@@ -26,10 +29,22 @@ class NegativeSampler(Mapper):
             The datapipe.
         negative_ratio : int
             The proportion of negative samples to positive samples.
+        link_data_format : LinkDataFormat
+            Determines the format of the output data:
+                - Conditioned format: Outputs data as quadruples
+                `[u, v, [negative heads], [negative tails]]`. Here, 'u' and 'v'
+                are the source and destination nodes of positive edges,  while
+                'negative heads' and 'negative tails' refer to the source and
+                destination nodes of negative edges.
+                - Independent format: Outputs data as triples `[u, v, label]`.
+                In this case, 'u' and 'v' are the source and destination nodes
+                of an edge, and 'label' indicates whether the edge is negative
+                (0) or positive (1).
         """
         super().__init__(datapipe, self._sample)
         assert negative_ratio > 0, "Negative_ratio should be positive Integer."
         self.negative_ratio = negative_ratio
+        self.link_data_format = link_data_format
 
     def _sample(self, node_pairs):
         """
@@ -51,14 +66,33 @@ class NegativeSampler(Mapper):
         if isinstance(node_pairs, Mapping):
             return {
                 etype: self._collate(
-                    pos_pairs, self._sample_negative_pairs(pos_pairs, etype)
+                    pos_pairs, self._sample_with_etype(pos_pairs, etype)
                 )
                 for etype, pos_pairs in node_pairs.items()
             }
         else:
             return self._collate(
-                node_pairs, self._sample_negative_pairs(node_pairs, None)
+                node_pairs, self._sample_with_etype(node_pairs, None)
             )
+
+    def _sample_with_etype(self, node_pairs, etype=None):
+        """Generate negative pairs for a given etype form positive pairs
+        for a given etype.
+
+        Parameters
+        ----------
+        node_pairs : Tuple[Tensor]
+            A tuple of tensors or a dictionary represents source-destination
+            node pairs of positive edges, where positive means the edge must
+            exist in the graph.
+        etype : (str, str, str)
+            Canonical edge type.
+
+        Returns
+        -------
+        Tuple[Tensor]
+            A collection of negative node pairs.
+        """
 
     def _collate(self, pos_pairs, neg_pairs):
         """Collates positive and negative samples.
@@ -79,58 +113,20 @@ class NegativeSampler(Mapper):
         Tuple[Tensor]
             A mixed collection of positive and negative node pairs.
         """
-
-    def _sample_negative_pairs(self, node_pairs, etype=None):
-        """Generate negative pairs for a given etype form positive pairs
-        for a given etype.
-
-        Parameters
-        ----------
-        node_pairs : Tuple[Tensor]
-            A tuple of tensors or a dictionary represents source-destination
-            node pairs of positive edges, where positive means the edge must
-            exist in the graph.
-        etype : (str, str, str)
-            Canonical edge type.
-
-        Returns
-        -------
-        Tuple[Tensor]
-            A collection of negative node pairs.
-        """
-
-
-class IndependentNegativeSampler(NegativeSampler):
-    """
-    A kind of negative sampler. `Independent` denotes the data format, where
-    data is structured as triples `[u, v, label]`. Each triple represents an
-    edge between nodes 'u' and 'v', and the 'label' indicates whether the edge
-    is negative (0) or positive (1).
-    """
-
-    def _collate(self, pos_pairs, neg_pairs):
-        pos_src, pos_dst = pos_pairs
-        neg_src, neg_dst = neg_pairs
-        pos_label = torch.ones_like(pos_src)
-        neg_label = torch.zeros_like(neg_src)
-        src = torch.cat([pos_src, neg_src])
-        dst = torch.cat([pos_dst, neg_dst])
-        label = torch.cat([pos_label, neg_label])
-        return (src, dst, label)
-
-
-class ConditionedNegativeSampler(NegativeSampler):
-    """
-    A kind of negative sampler. `Conditioned` denotes the data format, where
-    data is structured as `[u, v, [neg_u], [neg_v]]`. Here, 'u' and 'v' denote
-    the source-destination positive node pairs, while 'neg_u' combined with
-    'neg_v' creates corresponding negative node pairs. The length of 'neg_u'
-    and 'neg_v' is same as 'negative_ratio'.
-    """
-
-    def _collate(self, pos_pairs, neg_pairs):
-        pos_src, pos_dst = pos_pairs
-        neg_src, neg_dst = neg_pairs
-        neg_src = neg_src.view(-1, self.negative_ratio)
-        neg_dst = neg_dst.view(-1, self.negative_ratio)
-        return (pos_src, pos_dst, neg_src, neg_dst)
+        if self.link_data_format == LinkDataFormat.INDEPENDENT:
+            pos_src, pos_dst = pos_pairs
+            neg_src, neg_dst = neg_pairs
+            pos_label = torch.ones_like(pos_src)
+            neg_label = torch.zeros_like(neg_src)
+            src = torch.cat([pos_src, neg_src])
+            dst = torch.cat([pos_dst, neg_dst])
+            label = torch.cat([pos_label, neg_label])
+            return (src, dst, label)
+        elif self.link_data_format == LinkDataFormat.CONDITIONED:
+            pos_src, pos_dst = pos_pairs
+            neg_src, neg_dst = neg_pairs
+            neg_src = neg_src.view(-1, self.negative_ratio)
+            neg_dst = neg_dst.view(-1, self.negative_ratio)
+            return (pos_src, pos_dst, neg_src, neg_dst)
+        else:
+            raise ValueError("Unsupported link data format.")

--- a/tests/python/pytorch/graphbolt/impl/test_negative_sampler.py
+++ b/tests/python/pytorch/graphbolt/impl/test_negative_sampler.py
@@ -1,0 +1,63 @@
+import dgl.graphbolt as gb
+import gb_test_utils
+import pytest
+import torch
+
+
+@pytest.mark.parametrize("negative_ratio", [1, 5, 10, 20])
+def test_NegativeSampler_Independent_Format(negative_ratio):
+    # Construct CSCSamplingGraph.
+    graph = gb_test_utils.rand_csc_graph(100, 0.05)
+    num_seeds = 30
+    item_set= gb.ItemSet((
+        torch.arange(0, num_seeds),
+        torch.arange(num_seeds, num_seeds * 2),
+    ))
+    batch_size = 10 
+    minibatch_sampler = gb.MinibatchSampler(item_set, batch_size=batch_size)
+    # Construct NegativeSampler.
+    negative_sampler = gb.UniformIndependentNegativeSampler(
+        minibatch_sampler,
+        negative_ratio,
+        graph,
+    )
+    # Perform Negative sampling.
+    for data in negative_sampler:
+        src, dst, label = data
+        # Assertation
+        assert len(src) == batch_size * (negative_ratio + 1)
+        assert len(dst) == batch_size * (negative_ratio + 1)
+        assert len(label) == batch_size * (negative_ratio + 1)
+        assert torch.all(torch.eq(label[:batch_size], 1))
+        assert torch.all(torch.eq(label[batch_size:], 0))
+
+
+@pytest.mark.parametrize("negative_ratio", [1, 5, 10, 20])
+def test_NegativeSampler_Conditioned_Format(negative_ratio):
+    # Construct CSCSamplingGraph.
+    graph = gb_test_utils.rand_csc_graph(100, 0.05)
+    num_seeds = 30
+    item_set= gb.ItemSet((
+        torch.arange(0, num_seeds),
+        torch.arange(num_seeds, num_seeds * 2),
+    ))
+    batch_size = 10 
+    minibatch_sampler = gb.MinibatchSampler(item_set, batch_size=batch_size)
+    # Construct NegativeSampler.
+    negative_sampler = gb.UniformConditionedNegativeSampler(
+        minibatch_sampler,
+        negative_ratio,
+        graph,
+    )
+    # Perform Negative sampling.
+    for data in negative_sampler:
+        pos_src, pos_dst, neg_src, neg_dst = data
+        # Assertation
+        assert len(pos_src) == batch_size
+        assert len(pos_dst) == batch_size
+        assert len(neg_src) == batch_size
+        assert len(neg_dst) == batch_size
+        assert neg_src.numel() == batch_size * negative_ratio
+        assert neg_dst.numel() == batch_size * negative_ratio
+        expected_src = pos_src.repeat(negative_ratio).view(-1, negative_ratio)
+        assert torch.equal(expected_src, neg_src)

--- a/tests/python/pytorch/graphbolt/impl/test_negative_sampler.py
+++ b/tests/python/pytorch/graphbolt/impl/test_negative_sampler.py
@@ -18,9 +18,10 @@ def test_NegativeSampler_Independent_Format(negative_ratio):
     batch_size = 10
     minibatch_sampler = gb.MinibatchSampler(item_set, batch_size=batch_size)
     # Construct NegativeSampler.
-    negative_sampler = gb.UniformIndependentNegativeSampler(
+    negative_sampler = gb.UniformNegativeSampler(
         minibatch_sampler,
         negative_ratio,
+        gb.LinkDataFormat.INDEPENDENT,
         graph,
     )
     # Perform Negative sampling.
@@ -48,9 +49,10 @@ def test_NegativeSampler_Conditioned_Format(negative_ratio):
     batch_size = 10
     minibatch_sampler = gb.MinibatchSampler(item_set, batch_size=batch_size)
     # Construct NegativeSampler.
-    negative_sampler = gb.UniformConditionedNegativeSampler(
+    negative_sampler = gb.UniformNegativeSampler(
         minibatch_sampler,
         negative_ratio,
+        gb.LinkDataFormat.CONDITIONED,
         graph,
     )
     # Perform Negative sampling.

--- a/tests/python/pytorch/graphbolt/impl/test_negative_sampler.py
+++ b/tests/python/pytorch/graphbolt/impl/test_negative_sampler.py
@@ -9,11 +9,13 @@ def test_NegativeSampler_Independent_Format(negative_ratio):
     # Construct CSCSamplingGraph.
     graph = gb_test_utils.rand_csc_graph(100, 0.05)
     num_seeds = 30
-    item_set= gb.ItemSet((
-        torch.arange(0, num_seeds),
-        torch.arange(num_seeds, num_seeds * 2),
-    ))
-    batch_size = 10 
+    item_set = gb.ItemSet(
+        (
+            torch.arange(0, num_seeds),
+            torch.arange(num_seeds, num_seeds * 2),
+        )
+    )
+    batch_size = 10
     minibatch_sampler = gb.MinibatchSampler(item_set, batch_size=batch_size)
     # Construct NegativeSampler.
     negative_sampler = gb.UniformIndependentNegativeSampler(
@@ -37,11 +39,13 @@ def test_NegativeSampler_Conditioned_Format(negative_ratio):
     # Construct CSCSamplingGraph.
     graph = gb_test_utils.rand_csc_graph(100, 0.05)
     num_seeds = 30
-    item_set= gb.ItemSet((
-        torch.arange(0, num_seeds),
-        torch.arange(num_seeds, num_seeds * 2),
-    ))
-    batch_size = 10 
+    item_set = gb.ItemSet(
+        (
+            torch.arange(0, num_seeds),
+            torch.arange(num_seeds, num_seeds * 2),
+        )
+    )
+    batch_size = 10
     minibatch_sampler = gb.MinibatchSampler(item_set, batch_size=batch_size)
     # Construct NegativeSampler.
     negative_sampler = gb.UniformConditionedNegativeSampler(


### PR DESCRIPTION
## Description
UDF of negative sampler in graphbolt.

## Checklist
Please feel free to remove inapplicable items for your PR.
- [ ] The PR title starts with [$CATEGORY] (such as [NN], [Model], [Doc], [Feature]])
- [ ] I've leverage the [tools](https://docs.google.com/document/d/1iHyj7zlmygKSk5gBPsqIqL5ASPzJSPREaNT_QdsiYA4/edit) to beautify the python and c++ code.
- [ ] The PR is complete and small, read the [Google eng practice (CL equals to PR)](https://google.github.io/eng-practices/review/developer/small-cls.html) to understand more about small PR. In DGL, we consider PRs with less than 200 lines of core code change are small (example, test and documentation could be exempted).
- [ ] All changes have test coverage
- [ ] Code is well-documented
- [ ] To the best of my knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change
- [ ] Related issue is referred in this PR
- [ ] If the PR is for a new model/paper, I've updated the example index [here](../examples/README.md).

## Changes
<!-- You could use following template
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)
-->
