### PR TITLE
[Build] Fix bf16/fp16 building issues for CUDA 12.2

### DIFF
--- a/src/array/cuda/bf16.cuh
+++ b/src/array/cuda/bf16.cuh
@@ -46,6 +46,8 @@ min(__nv_bfloat16 a, __nv_bfloat16 b) {
 // Arithmetic BF16 operations for architecture >= 8.0 are already defined in
 // cuda_bf16.h
 #if defined(__CUDA_ARCH__) && (__CUDA_ARCH__ < 800)
+// CUDA 12.2 adds "emulated" support for older architectures.
+#if defined(CUDART_VERSION) && (CUDART_VERSION < 12020)
 __device__ __forceinline__ __nv_bfloat16
 operator+(const __nv_bfloat16& lh, const __nv_bfloat16& rh) {
   return __nv_bfloat16(float(lh) + float(rh));  // NOLINT
@@ -138,6 +140,7 @@ __device__ __forceinline__ bool operator<=(
     const __nv_bfloat16& lh, const __nv_bfloat16& rh) {
   return float(lh) <= float(rh);  // NOLINT
 }
+#endif  // defined(CUDART_VERSION) && (CUDART_VERSION < 12020)
 #endif  // defined(__CUDA_ARCH__) && (__CUDA_ARCH__ < 800)
 #endif  // __CUDACC__
 

--- a/src/array/cuda/fp16.cuh
+++ b/src/array/cuda/fp16.cuh
@@ -45,6 +45,8 @@ static __device__ __forceinline__ half min(half a, half b) {
 // Arithmetic FP16 operations for architecture >= 5.3 are already defined in
 // cuda_fp16.h
 #if defined(__CUDA_ARCH__) && (__CUDA_ARCH__ < 530)
+// CUDA 12.2 adds "emulated" support for older architectures.
+#if defined(CUDART_VERSION) && (CUDART_VERSION < 12020)
 __device__ __forceinline__ __half
 operator+(const __half& lh, const __half& rh) {
   return __half(float(lh) + float(rh));  // NOLINT
@@ -125,7 +127,8 @@ __device__ __forceinline__ bool operator>=(const __half& lh, const __half& rh) {
 __device__ __forceinline__ bool operator<=(const __half& lh, const __half& rh) {
   return float(lh) <= float(rh);  // NOLINT
 }
-#endif  // __CUDA_ARCH__ < 530
+#endif  // defined(CUDART_VERSION) && (CUDART_VERSION < 12020)
+#endif  // defined(__CUDA_ARCH__) && (__CUDA_ARCH__ < 530)
 #endif  // __CUDACC__
 
 #endif  // DGL_ARRAY_CUDA_FP16_CUH_


### PR DESCRIPTION
## Description

CUDA 12.2 adds "emulated" support for FP16/BF16 operators on older devices ([reference](https://docs.nvidia.com/cuda/cuda-toolkit-release-notes/index.html#cuda-math-release-12-2)), which causes conflicts with the overloads we have in DGL.

## Checklist
Please feel free to remove inapplicable items for your PR.
- [ ] The PR title starts with [$CATEGORY] (such as [NN], [Model], [Doc], [Feature]])
- [ ] I've leverage the [tools](https://docs.google.com/document/d/1iHyj7zlmygKSk5gBPsqIqL5ASPzJSPREaNT_QdsiYA4/edit) to beautify the python and c++ code.
- [ ] The PR is complete and small, read the [Google eng practice (CL equals to PR)](https://google.github.io/eng-practices/review/developer/small-cls.html) to understand more about small PR. In DGL, we consider PRs with less than 200 lines of core code change are small (example, test and documentation could be exempted).
- [ ] All changes have test coverage
- [ ] Code is well-documented
- [ ] To the best of my knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change
- [ ] Related issue is referred in this PR
- [ ] If the PR is for a new model/paper, I've updated the example index [here](../examples/README.md).

## Changes
<!-- You could use following template
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)
-->
