### PR TITLE
[GraphBolt] change TVT format of OnDiskDataset

### DIFF
--- a/python/dgl/graphbolt/impl/ondisk_dataset.py
+++ b/python/dgl/graphbolt/impl/ondisk_dataset.py
@@ -15,7 +15,7 @@ import dgl
 
 from ..dataset import Dataset
 from ..itemset import ItemSet, ItemSetDict
-from ..utils import read_data, save_data, tensor_to_tuple
+from ..utils import read_data, save_data
 
 from .csc_sampling_graph import (
     CSCSamplingGraph,
@@ -23,12 +23,7 @@ from .csc_sampling_graph import (
     load_csc_sampling_graph,
     save_csc_sampling_graph,
 )
-from .ondisk_metadata import (
-    OnDiskGraphTopology,
-    OnDiskMetaData,
-    OnDiskTVTSet,
-    OnDiskTVTSetData,
-)
+from .ondisk_metadata import OnDiskGraphTopology, OnDiskMetaData, OnDiskTVTSet
 from .torch_based_feature_store import (
     load_feature_stores,
     TorchBasedFeatureStore,

--- a/python/dgl/graphbolt/impl/ondisk_metadata.py
+++ b/python/dgl/graphbolt/impl/ondisk_metadata.py
@@ -8,6 +8,7 @@ import pydantic
 
 __all__ = [
     "OnDiskFeatureDataFormat",
+    "OnDiskTVTSetData",
     "OnDiskTVTSet",
     "OnDiskFeatureDataDomain",
     "OnDiskFeatureData",
@@ -24,13 +25,19 @@ class OnDiskFeatureDataFormat(str, Enum):
     NUMPY = "numpy"
 
 
+class OnDiskTVTSetData(pydantic.BaseModel):
+    """Train-Validation-Test set data."""
+
+    format: OnDiskFeatureDataFormat
+    in_memory: Optional[bool] = True
+    path: str
+
+
 class OnDiskTVTSet(pydantic.BaseModel):
     """Train-Validation-Test set."""
 
     type: Optional[str] = None
-    format: OnDiskFeatureDataFormat
-    in_memory: Optional[bool] = True
-    path: str
+    data: List[OnDiskTVTSetData]
 
 
 class OnDiskFeatureDataDomain(str, Enum):

--- a/python/dgl/graphbolt/utils/internal.py
+++ b/python/dgl/graphbolt/utils/internal.py
@@ -45,9 +45,3 @@ def save_data(data, path, fmt):
         np.save(path, data)
     elif fmt == "torch":
         torch.save(data, path)
-
-
-def tensor_to_tuple(data):
-    """Split a torch.Tensor in column-wise to a tuple."""
-    assert isinstance(data, torch.Tensor), "data must be a torch.Tensor"
-    return tuple(data.t())

--- a/tests/python/pytorch/graphbolt/test_ondisk_dataset.py
+++ b/tests/python/pytorch/graphbolt/test_ondisk_dataset.py
@@ -22,8 +22,9 @@ def test_OnDiskDataset_TVTSet_exceptions():
         yaml_content = """
         train_sets:
           - - type: paper
-              format: torch_invalid
-              path: set/paper-train.pt
+              data:
+                - format: torch_invalid
+                  path: set/paper-train.pt
         """
         yaml_file = os.path.join(test_dir, "test.yaml")
         with open(yaml_file, "w") as f:
@@ -35,11 +36,13 @@ def test_OnDiskDataset_TVTSet_exceptions():
         yaml_content = """
             train_sets:
               - - type: null
-                  format: numpy
-                  path: set/train.npy
+                  data:
+                    - format: numpy
+                      path: set/train.npy
                 - type: null
-                  format: numpy
-                  path: set/train.npy
+                  data:
+                    - format: numpy
+                      path: set/train.npy
         """
         with open(yaml_file, "w") as f:
             f.write(yaml_content)
@@ -54,22 +57,25 @@ def test_OnDiskDataset_TVTSet_ItemSet_id_label():
     """Test TVTSet which returns ItemSet with IDs and labels."""
     with tempfile.TemporaryDirectory() as test_dir:
         train_ids = np.arange(1000)
+        train_ids_path = os.path.join(test_dir, "train_ids.npy")
+        np.save(train_ids_path, train_ids)
         train_labels = np.random.randint(0, 10, size=1000)
-        train_data = np.vstack([train_ids, train_labels]).T
-        train_path = os.path.join(test_dir, "train.npy")
-        np.save(train_path, train_data)
+        train_labels_path = os.path.join(test_dir, "train_labels.npy")
+        np.save(train_labels_path, train_labels)
 
         validation_ids = np.arange(1000, 2000)
+        validation_ids_path = os.path.join(test_dir, "validation_ids.npy")
+        np.save(validation_ids_path, validation_ids)
         validation_labels = np.random.randint(0, 10, size=1000)
-        validation_data = np.vstack([validation_ids, validation_labels]).T
-        validation_path = os.path.join(test_dir, "validation.npy")
-        np.save(validation_path, validation_data)
+        validation_labels_path = os.path.join(test_dir, "validation_labels.npy")
+        np.save(validation_labels_path, validation_labels)
 
         test_ids = np.arange(2000, 3000)
+        test_ids_path = os.path.join(test_dir, "test_ids.npy")
+        np.save(test_ids_path, test_ids)
         test_labels = np.random.randint(0, 10, size=1000)
-        test_data = np.vstack([test_ids, test_labels]).T
-        test_path = os.path.join(test_dir, "test.npy")
-        np.save(test_path, test_data)
+        test_labels_path = os.path.join(test_dir, "test_labels.npy")
+        np.save(test_labels_path, test_labels)
 
         # Case 1:
         #   all TVT sets are specified.
@@ -78,26 +84,30 @@ def test_OnDiskDataset_TVTSet_ItemSet_id_label():
         yaml_content = f"""
             train_sets:
               - - type: null
-                  format: numpy
-                  in_memory: true
-                  path: {train_path}
-              - - type: null
-                  format: numpy
-                  path: {train_path}
+                  data:
+                    - format: numpy
+                      in_memory: true
+                      path: {train_ids_path}
+                    - format: numpy
+                      in_memory: true
+                      path: {train_labels_path}
             validation_sets:
-              - - format: numpy
-                  path: {validation_path}
-              - - type: null
-                  format: numpy
-                  path: {validation_path}
+              - - data:
+                    - format: numpy
+                      in_memory: true
+                      path: {validation_ids_path}
+                    - format: numpy
+                      in_memory: true
+                      path: {validation_labels_path}
             test_sets:
               - - type: null
-                  format: numpy
-                  in_memory: false
-                  path: {test_path}
-              - - type: null
-                  format: numpy
-                  path: {test_path}
+                  data:
+                    - format: numpy
+                      in_memory: false
+                      path: {test_ids_path}
+                    - format: numpy
+                      in_memory: false
+                      path: {test_labels_path}
         """
         yaml_file = os.path.join(test_dir, "test.yaml")
         with open(yaml_file, "w") as f:
@@ -107,7 +117,7 @@ def test_OnDiskDataset_TVTSet_ItemSet_id_label():
 
         # Verify train set.
         train_sets = dataset.train_sets
-        assert len(train_sets) == 2
+        assert len(train_sets) == 1
         for train_set in train_sets:
             assert len(train_set) == 1000
             assert isinstance(train_set, gb.ItemSet)
@@ -118,7 +128,7 @@ def test_OnDiskDataset_TVTSet_ItemSet_id_label():
 
         # Verify validation set.
         validation_sets = dataset.validation_sets
-        assert len(validation_sets) == 2
+        assert len(validation_sets) == 1
         for validation_set in validation_sets:
             assert len(validation_set) == 1000
             assert isinstance(validation_set, gb.ItemSet)
@@ -129,7 +139,7 @@ def test_OnDiskDataset_TVTSet_ItemSet_id_label():
 
         # Verify test set.
         test_sets = dataset.test_sets
-        assert len(test_sets) == 2
+        assert len(test_sets) == 1
         for test_set in test_sets:
             assert len(test_set) == 1000
             assert isinstance(test_set, gb.ItemSet)
@@ -143,8 +153,9 @@ def test_OnDiskDataset_TVTSet_ItemSet_id_label():
         yaml_content = f"""
             train_sets:
               - - type: null
-                  format: numpy
-                  path: {train_path}
+                  data:
+                    - format: numpy
+                      path: {train_ids_path}
         """
         yaml_file = os.path.join(test_dir, "test.yaml")
         with open(yaml_file, "w") as f:
@@ -160,47 +171,72 @@ def test_OnDiskDataset_TVTSet_ItemSet_id_label():
 def test_OnDiskDataset_TVTSet_ItemSet_node_pair_label():
     """Test TVTSet which returns ItemSet with IDs and labels."""
     with tempfile.TemporaryDirectory() as test_dir:
-        train_pairs = (np.arange(1000), np.arange(1000, 2000))
+        train_src = np.arange(1000)
+        train_src_path = os.path.join(test_dir, "train_src.npy")
+        np.save(train_src_path, train_src)
+        train_dst = np.arange(1000, 2000)
+        train_dst_path = os.path.join(test_dir, "train_dst.npy")
+        np.save(train_dst_path, train_dst)
         train_labels = np.random.randint(0, 10, size=1000)
-        train_data = np.vstack([train_pairs, train_labels]).T
-        train_path = os.path.join(test_dir, "train.npy")
-        np.save(train_path, train_data)
+        train_labels_path = os.path.join(test_dir, "train_labels.npy")
+        np.save(train_labels_path, train_labels)
 
-        validation_pairs = (np.arange(1000, 2000), np.arange(2000, 3000))
+        validation_src = np.arange(1000, 2000)
+        validation_src_path = os.path.join(test_dir, "validation_src.npy")
+        np.save(validation_src_path, validation_src)
+        validation_dst = np.arange(2000, 3000)
+        validation_dst_path = os.path.join(test_dir, "validation_dst.npy")
+        np.save(validation_dst_path, validation_dst)
         validation_labels = np.random.randint(0, 10, size=1000)
-        validation_data = np.vstack([validation_pairs, validation_labels]).T
-        validation_path = os.path.join(test_dir, "validation.npy")
-        np.save(validation_path, validation_data)
+        validation_labels_path = os.path.join(test_dir, "validation_labels.npy")
+        np.save(validation_labels_path, validation_labels)
 
-        test_pairs = (np.arange(2000, 3000), np.arange(3000, 4000))
+        test_src = np.arange(2000, 3000)
+        test_src_path = os.path.join(test_dir, "test_src.npy")
+        np.save(test_src_path, test_src)
+        test_dst = np.arange(3000, 4000)
+        test_dst_path = os.path.join(test_dir, "test_dst.npy")
+        np.save(test_dst_path, test_dst)
         test_labels = np.random.randint(0, 10, size=1000)
-        test_data = np.vstack([test_pairs, test_labels]).T
-        test_path = os.path.join(test_dir, "test.npy")
-        np.save(test_path, test_data)
+        test_labels_path = os.path.join(test_dir, "test_labels.npy")
+        np.save(test_labels_path, test_labels)
 
         yaml_content = f"""
             train_sets:
               - - type: null
-                  format: numpy
-                  in_memory: true
-                  path: {train_path}
-              - - type: null
-                  format: numpy
-                  path: {train_path}
+                  data:
+                    - format: numpy
+                      in_memory: true
+                      path: {train_src_path}
+                    - format: numpy
+                      in_memory: true
+                      path: {train_dst_path}
+                    - format: numpy
+                      in_memory: true
+                      path: {train_labels_path}
             validation_sets:
-              - - format: numpy
-                  path: {validation_path}
-              - - type: null
-                  format: numpy
-                  path: {validation_path}
+              - - data:
+                    - format: numpy
+                      in_memory: true
+                      path: {validation_src_path}
+                    - format: numpy
+                      in_memory: true
+                      path: {validation_dst_path}
+                    - format: numpy
+                      in_memory: true
+                      path: {validation_labels_path}
             test_sets:
               - - type: null
-                  format: numpy
-                  in_memory: false
-                  path: {test_path}
-              - - type: null
-                  format: numpy
-                  path: {test_path}
+                  data:
+                    - format: numpy
+                      in_memory: true
+                      path: {test_src_path}
+                    - format: numpy
+                      in_memory: false
+                      path: {test_dst_path}
+                    - format: numpy
+                      in_memory: true
+                      path: {test_labels_path}
         """
         yaml_file = os.path.join(test_dir, "test.yaml")
         with open(yaml_file, "w") as f:
@@ -210,38 +246,158 @@ def test_OnDiskDataset_TVTSet_ItemSet_node_pair_label():
 
         # Verify train set.
         train_sets = dataset.train_sets
-        assert len(train_sets) == 2
+        assert len(train_sets) == 1
         for train_set in train_sets:
             assert len(train_set) == 1000
             assert isinstance(train_set, gb.ItemSet)
             for i, (src, dst, label) in enumerate(train_set):
-                assert src == train_pairs[0][i]
-                assert dst == train_pairs[1][i]
+                assert src == train_src[i]
+                assert dst == train_dst[i]
                 assert label == train_labels[i]
         train_sets = None
 
         # Verify validation set.
         validation_sets = dataset.validation_sets
-        assert len(validation_sets) == 2
+        assert len(validation_sets) == 1
         for validation_set in validation_sets:
             assert len(validation_set) == 1000
             assert isinstance(validation_set, gb.ItemSet)
             for i, (src, dst, label) in enumerate(validation_set):
-                assert src == validation_pairs[0][i]
-                assert dst == validation_pairs[1][i]
+                assert src == validation_src[i]
+                assert dst == validation_dst[i]
                 assert label == validation_labels[i]
         validation_sets = None
 
         # Verify test set.
         test_sets = dataset.test_sets
-        assert len(test_sets) == 2
+        assert len(test_sets) == 1
         for test_set in test_sets:
             assert len(test_set) == 1000
             assert isinstance(test_set, gb.ItemSet)
             for i, (src, dst, label) in enumerate(test_set):
-                assert src == test_pairs[0][i]
-                assert dst == test_pairs[1][i]
+                assert src == test_src[i]
+                assert dst == test_dst[i]
                 assert label == test_labels[i]
+        test_sets = None
+        dataset = None
+
+
+def test_OnDiskDataset_TVTSet_ItemSet_node_pair_negs():
+    """Test TVTSet which returns ItemSet with node pairs and negative ones."""
+    with tempfile.TemporaryDirectory() as test_dir:
+        train_src = np.arange(1000)
+        train_src_path = os.path.join(test_dir, "train_src.npy")
+        np.save(train_src_path, train_src)
+        train_dst = np.arange(1000, 2000)
+        train_dst_path = os.path.join(test_dir, "train_dst.npy")
+        np.save(train_dst_path, train_dst)
+        train_neg_dst = np.random.choice(1000 * 10, size=1000 * 10).reshape(
+            1000, 10
+        )
+        train_neg_dst_path = os.path.join(test_dir, "train_neg_dst.npy")
+        np.save(train_neg_dst_path, train_neg_dst)
+
+        validation_src = np.arange(1000, 2000)
+        validation_src_path = os.path.join(test_dir, "validation_src.npy")
+        np.save(validation_src_path, validation_src)
+        validation_dst = np.arange(2000, 3000)
+        validation_dst_path = os.path.join(test_dir, "validation_dst.npy")
+        np.save(validation_dst_path, validation_dst)
+        validation_neg_dst = train_neg_dst + 1
+        validation_neg_dst_path = os.path.join(
+            test_dir, "validation_neg_dst.npy"
+        )
+        np.save(validation_neg_dst_path, validation_neg_dst)
+
+        test_src = np.arange(2000, 3000)
+        test_src_path = os.path.join(test_dir, "test_src.npy")
+        np.save(test_src_path, test_src)
+        test_dst = np.arange(3000, 4000)
+        test_dst_path = os.path.join(test_dir, "test_dst.npy")
+        np.save(test_dst_path, test_dst)
+        test_neg_dst = train_neg_dst + 2
+        test_neg_dst_path = os.path.join(test_dir, "test_neg_dst.npy")
+        np.save(test_neg_dst_path, test_neg_dst)
+
+        yaml_content = f"""
+            train_sets:
+              - - type: null
+                  data:
+                    - format: numpy
+                      in_memory: true
+                      path: {train_src_path}
+                    - format: numpy
+                      in_memory: true
+                      path: {train_dst_path}
+                    - format: numpy
+                      in_memory: true
+                      path: {train_neg_dst_path}
+            validation_sets:
+              - - data:
+                    - format: numpy
+                      in_memory: true
+                      path: {validation_src_path}
+                    - format: numpy
+                      in_memory: true
+                      path: {validation_dst_path}
+                    - format: numpy
+                      in_memory: true
+                      path: {validation_neg_dst_path}
+            test_sets:
+              - - type: null
+                  data:
+                    - format: numpy
+                      in_memory: true
+                      path: {test_src_path}
+                    - format: numpy
+                      in_memory: false
+                      path: {test_dst_path}
+                    - format: numpy
+                      in_memory: true
+                      path: {test_neg_dst_path}
+        """
+        yaml_file = os.path.join(test_dir, "test.yaml")
+        with open(yaml_file, "w") as f:
+            f.write(yaml_content)
+
+        dataset = gb.OnDiskDataset(yaml_file)
+
+        # Verify train set.
+        train_sets = dataset.train_sets
+        assert len(train_sets) == 1
+        for train_set in train_sets:
+            assert len(train_set) == 1000
+            assert isinstance(train_set, gb.ItemSet)
+            for i, (src, dst, negs) in enumerate(train_set):
+                assert src == train_src[i]
+                assert dst == train_dst[i]
+                assert torch.equal(negs, torch.from_numpy(train_neg_dst[i]))
+        train_sets = None
+
+        # Verify validation set.
+        validation_sets = dataset.validation_sets
+        assert len(validation_sets) == 1
+        for validation_set in validation_sets:
+            assert len(validation_set) == 1000
+            assert isinstance(validation_set, gb.ItemSet)
+            for i, (src, dst, negs) in enumerate(validation_set):
+                assert src == validation_src[i]
+                assert dst == validation_dst[i]
+                assert torch.equal(
+                    negs, torch.from_numpy(validation_neg_dst[i])
+                )
+        validation_sets = None
+
+        # Verify test set.
+        test_sets = dataset.test_sets
+        assert len(test_sets) == 1
+        for test_set in test_sets:
+            assert len(test_set) == 1000
+            assert isinstance(test_set, gb.ItemSet)
+            for i, (src, dst, negs) in enumerate(test_set):
+                assert src == test_src[i]
+                assert dst == test_dst[i]
+                assert torch.equal(negs, torch.from_numpy(test_neg_dst[i]))
         test_sets = None
         dataset = None
 
@@ -270,27 +426,33 @@ def test_OnDiskDataset_TVTSet_ItemSetDict_id_label():
         yaml_content = f"""
             train_sets:
               - - type: paper
-                  format: numpy
-                  in_memory: true
-                  path: {train_path}
+                  data:
+                    - format: numpy
+                      in_memory: true
+                      path: {train_path}
               - - type: author
-                  format: numpy
-                  path: {train_path}
+                  data:
+                    - format: numpy
+                      path: {train_path}
             validation_sets:
               - - type: paper
-                  format: numpy
-                  path: {validation_path}
+                  data:
+                    - format: numpy
+                      path: {validation_path}
               - - type: author
-                  format: numpy
-                  path: {validation_path}
+                  data:
+                    - format: numpy
+                      path: {validation_path}
             test_sets:
               - - type: paper
-                  format: numpy
-                  in_memory: false
-                  path: {test_path}
+                  data:
+                    - format: numpy
+                      in_memory: false
+                      path: {test_path}
               - - type: author
-                  format: numpy
-                  path: {test_path}
+                  data:
+                    - format: numpy
+                      path: {test_path}
         """
         yaml_file = os.path.join(test_dir, "test.yaml")
         with open(yaml_file, "w") as f:
@@ -372,27 +534,33 @@ def test_OnDiskDataset_TVTSet_ItemSetDict_node_pair_label():
         yaml_content = f"""
             train_sets:
               - - type: paper
-                  format: numpy
-                  in_memory: true
-                  path: {train_path}
+                  data:
+                    - format: numpy
+                      in_memory: true
+                      path: {train_path}
               - - type: author
-                  format: numpy
-                  path: {train_path}
+                  data:
+                    - format: numpy
+                      path: {train_path}
             validation_sets:
               - - type: paper
-                  format: numpy
-                  path: {validation_path}
+                  data:
+                    - format: numpy
+                      path: {validation_path}
               - - type: author
-                  format: numpy
-                  path: {validation_path}
+                  data:
+                    - format: numpy
+                      path: {validation_path}
             test_sets:
               - - type: paper
-                  format: numpy
-                  in_memory: false
-                  path: {test_path}
+                  data:
+                    - format: numpy
+                      in_memory: false
+                      path: {test_path}
               - - type: author
-                  format: numpy
-                  path: {test_path}
+                  data:
+                    - format: numpy
+                      path: {test_path}
         """
         yaml_file = os.path.join(test_dir, "test.yaml")
         with open(yaml_file, "w") as f:
@@ -829,17 +997,19 @@ def test_OnDiskDataset_preprocess_homogeneous():
                   path: data/node-feat.npy
             train_sets:
                 - - type_name: null
-                    # shape: (num_trains, 3), 3 for (src, dst, label).
-                    format: numpy
-                    path: set/train.npy
+                    data:
+                      - format: numpy
+                        path: set/train.npy
             validation_sets:
                 - - type_name: null
-                    format: numpy
-                    path: set/validation.npy
+                    data:
+                      - format: numpy
+                        path: set/validation.npy
             test_sets:
                 - - type_name: null
-                    format: numpy
-                    path: set/test.npy
+                    data:
+                      - format: numpy
+                        path: set/test.npy
         """
         yaml_file = os.path.join(test_dir, "test.yaml")
         with open(yaml_file, "w") as f:

--- a/tests/python/pytorch/graphbolt/test_ondisk_dataset.py
+++ b/tests/python/pytorch/graphbolt/test_ondisk_dataset.py
@@ -103,10 +103,10 @@ def test_OnDiskDataset_TVTSet_ItemSet_id_label():
               - - type: null
                   data:
                     - format: numpy
-                      in_memory: false
+                      in_memory: true
                       path: {test_ids_path}
                     - format: numpy
-                      in_memory: false
+                      in_memory: true
                       path: {test_labels_path}
         """
         yaml_file = os.path.join(test_dir, "test.yaml")
@@ -232,7 +232,7 @@ def test_OnDiskDataset_TVTSet_ItemSet_node_pair_label():
                       in_memory: true
                       path: {test_src_path}
                     - format: numpy
-                      in_memory: false
+                      in_memory: true
                       path: {test_dst_path}
                     - format: numpy
                       in_memory: true
@@ -350,7 +350,7 @@ def test_OnDiskDataset_TVTSet_ItemSet_node_pair_negs():
                       in_memory: true
                       path: {test_src_path}
                     - format: numpy
-                      in_memory: false
+                      in_memory: true
                       path: {test_dst_path}
                     - format: numpy
                       in_memory: true


### PR DESCRIPTION
## Description
<!-- Brief description. Refer to the related issues if existed.
It'll be great if relevant reviewers can be assigned as well.-->
New format:
```
train_sets:
  - type: paper
    data: # each file will be one element in tuple of ItemSet.
     - format: numpy
       path: set/paper-train-src.npy
     - format: numpy
       path: set/paper-train-dst.npy
     - format: numpy
       path: set/paper-train-label.npy
  - type: author
    data: # each file will be one element in tuple of ItemSet.
     - format: numpy
       path: set/author-train-src.npy
     - format: numpy
       path: set/author-train-dst.npy
     - format: numpy
       path: set/author-train-label.npy
validation_sets:
  - type: author
    data: # each file will be one element in tuple of ItemSet.
     - format: numpy
       path: set/author-val-src.npy
     - format: numpy
       path: set/author-val-dst.npy
     - format: numpy
       path: set/author-val-neg-src.npy
     - format: numpy
       path: set/author-val-neg-dst.npy
test_sets:
  - type: paper
    data: # each file will be one element in tuple of ItemSet.
     - format: numpy
       path: set/author-test-src.npy
     - format: numpy
       path: set/author-test-dst.npy
     - format: numpy
       path: set/author-test-neg-src.npy
     - format: numpy
       path: set/author-test-neg-dst.npy
```
## Checklist
Please feel free to remove inapplicable items for your PR.
- [ ] The PR title starts with [$CATEGORY] (such as [NN], [Model], [Doc], [Feature]])
- [ ] I've leverage the [tools](https://docs.google.com/document/d/1iHyj7zlmygKSk5gBPsqIqL5ASPzJSPREaNT_QdsiYA4/edit) to beautify the python and c++ code.
- [ ] The PR is complete and small, read the [Google eng practice (CL equals to PR)](https://google.github.io/eng-practices/review/developer/small-cls.html) to understand more about small PR. In DGL, we consider PRs with less than 200 lines of core code change are small (example, test and documentation could be exempted).
- [ ] All changes have test coverage
- [ ] Code is well-documented
- [ ] To the best of my knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change
- [ ] Related issue is referred in this PR
- [ ] If the PR is for a new model/paper, I've updated the example index [here](../examples/README.md).

## Changes
<!-- You could use following template
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)
-->
