### PR TITLE
[Graphbolt] Enhance preprocessing: Ensure relative paths in YAML and convert to absolute paths before loading.

### DIFF
--- a/python/dgl/graphbolt/impl/ondisk_dataset.py
+++ b/python/dgl/graphbolt/impl/ondisk_dataset.py
@@ -76,9 +76,10 @@ def preprocess_ondisk_dataset(dataset_dir: str) -> str:
         )
 
     # 0. Check if the dataset is already preprocessed.
-    if os.path.exists(os.path.join(dataset_dir, "preprocessed/metadata.yaml")):
+    preprocess_metadata_path = os.path.join("preprocessed", "metadata.yaml")
+    if os.path.exists(os.path.join(dataset_dir, preprocess_metadata_path)):
         print("The dataset is already preprocessed.")
-        return os.path.join(dataset_dir, "preprocessed/metadata.yaml")
+        return os.path.join(dataset_dir, preprocess_metadata_path)
 
     print("Start to preprocess the on-disk dataset.")
     processed_dir_prefix = "preprocessed"
@@ -215,7 +216,7 @@ def preprocess_ondisk_dataset(dataset_dir: str) -> str:
                         )
 
     # 8. Save the output_config.
-    output_config_path = os.path.join(dataset_dir, "preprocessed/metadata.yaml")
+    output_config_path = os.path.join(dataset_dir, preprocess_metadata_path)
     with open(output_config_path, "w") as f:
         yaml.dump(output_config, f)
     print("Finish preprocessing the on-disk dataset.")

--- a/python/dgl/graphbolt/impl/ondisk_dataset.py
+++ b/python/dgl/graphbolt/impl/ondisk_dataset.py
@@ -60,6 +60,10 @@ def preprocess_ondisk_dataset(dataset_dir: str) -> str:
     output_config_path : str
         The path to the output config file.
     """
+    # Convert the dataset_dir to absolute path if it is not.
+    if not os.path.isabs(dataset_dir):
+        dataset_dir = os.path.abspath(dataset_dir)
+
     # Check if the dataset path is valid.
     if not os.path.exists(dataset_dir):
         raise RuntimeError(f"Invalid dataset path: {dataset_dir}")

--- a/python/dgl/graphbolt/impl/ondisk_dataset.py
+++ b/python/dgl/graphbolt/impl/ondisk_dataset.py
@@ -76,7 +76,6 @@ def preprocess_ondisk_dataset(dataset_dir: str) -> str:
         return os.path.join(dataset_dir, "preprocessed/metadata.yaml")
 
     print("Start to preprocess the on-disk dataset.")
-    # processed_dir_prefix = os.path.join(dataset_dir, "preprocessed")
     processed_dir_prefix = "preprocessed"
 
     # Check if the metadata.yaml exists.

--- a/tests/python/pytorch/graphbolt/test_ondisk_dataset.py
+++ b/tests/python/pytorch/graphbolt/test_ondisk_dataset.py
@@ -1,6 +1,7 @@
 import os
 import re
 import tempfile
+import unittest
 
 import gb_test_utils as gbt
 
@@ -1064,7 +1065,8 @@ def test_OnDiskDataset_preprocess_path():
             _ = gb.OnDiskDataset(fake_dir)
 
 
-def test_OnDiskDataset_preprocess_yaml_content():
+@unittest.skipIf(os.name == "nt", "Skip on Windows")
+def test_OnDiskDataset_preprocess_yaml_content_unix():
     """Test if the preprocessed metadata.yaml is correct."""
     with tempfile.TemporaryDirectory() as test_dir:
         # All metadata fields are specified.
@@ -1163,43 +1165,209 @@ def test_OnDiskDataset_preprocess_yaml_content():
         preprocessed_metadata_path = gb.preprocess_ondisk_dataset(test_dir)
         with open(preprocessed_metadata_path, "r") as f:
             yaml_data = yaml.safe_load(f)
-        assert yaml_data["dataset_name"] == dataset_name
 
-        assert "graph_topology" in yaml_data
-        assert yaml_data["graph_topology"]["path"] == os.path.join(
-            "preprocessed", "csc_sampling_graph.tar"
-        )
-        assert yaml_data["graph_topology"]["type"] == "CSCSamplingGraph"
+        target_yaml_content = f"""
+            dataset_name: {dataset_name}
+            graph_topology:
+              type: CSCSamplingGraph
+              path: preprocessed/csc_sampling_graph.tar
+            feature_data:
+              - domain: node
+                type: null
+                name: feat
+                format: numpy
+                in_memory: false
+                path: preprocessed/data/node-feat.npy
+            tasks:
+              - name: node_classification
+                num_classes: {num_classes}
+                train_set:
+                  - type_name: null
+                    data:
+                      - format: numpy
+                        path: preprocessed/set/train.npy
+                validation_set:
+                  - type_name: null
+                    data:
+                      - format: numpy
+                        path: preprocessed/set/validation.npy
+                test_set:
+                  - type_name: null
+                    data:
+                      - format: numpy
+                        path: preprocessed/set/test.npy
+        """
+        target_yaml_data = yaml.safe_load(target_yaml_content)
+        # Check yaml content.
+        assert (
+            yaml_data == target_yaml_data
+        ), "The preprocessed metadata.yaml is not correct."
+
+        # Check file existence.
         assert os.path.exists(
-            os.path.join(test_dir, "preprocessed/csc_sampling_graph.tar")
-        )
-
-        assert "feature_data" in yaml_data
-        assert yaml_data["feature_data"][0]["domain"] == "node"
-        assert yaml_data["feature_data"][0]["type"] is None
-        assert yaml_data["feature_data"][0]["name"] == "feat"
-        assert yaml_data["feature_data"][0]["format"] == "numpy"
-        assert yaml_data["feature_data"][0]["path"] == os.path.join(
-            "preprocessed", "data/node-feat.npy"
+            os.path.join(test_dir, yaml_data["graph_topology"]["path"])
         )
         assert os.path.exists(
-            os.path.join(test_dir, "preprocessed/data/node-feat.npy")
+            os.path.join(test_dir, yaml_data["feature_data"][0]["path"])
         )
-
-        assert "tasks" in yaml_data
-        assert yaml_data["tasks"][0]["name"] == "node_classification"
-        assert yaml_data["tasks"][0]["num_classes"] == num_classes
         for set_name in ["train_set", "validation_set", "test_set"]:
-            file_name = set_name.split("_")[0]
-            assert set_name in yaml_data["tasks"][0]
-            assert yaml_data["tasks"][0][set_name][0]["type_name"] is None
-            assert (
-                yaml_data["tasks"][0][set_name][0]["data"][0]["format"]
-                == "numpy"
-            )
-            assert yaml_data["tasks"][0][set_name][0]["data"][0][
-                "path"
-            ] == os.path.join("preprocessed", f"set/{file_name}.npy")
             assert os.path.exists(
-                os.path.join(test_dir, f"preprocessed/set/{file_name}.npy")
+                os.path.join(
+                    test_dir,
+                    yaml_data["tasks"][0][set_name][0]["data"][0]["path"],
+                )
+            )
+
+
+@unittest.skipIf(os.name != "nt", "Skip on Unix")
+def test_OnDiskDataset_preprocess_yaml_content_windows():
+    """Test if the preprocessed metadata.yaml is correct."""
+    with tempfile.TemporaryDirectory() as test_dir:
+        # All metadata fields are specified.
+        dataset_name = "graphbolt_test"
+        num_nodes = 4000
+        num_edges = 20000
+        num_classes = 10
+
+        # Generate random edges.
+        nodes = np.repeat(np.arange(num_nodes), 5)
+        neighbors = np.random.randint(0, num_nodes, size=(num_edges))
+        edges = np.stack([nodes, neighbors], axis=1)
+        # Wrtie into edges/edge.csv
+        os.makedirs(os.path.join(test_dir, "edges\\"), exist_ok=True)
+        edges = pd.DataFrame(edges, columns=["src", "dst"])
+        edges.to_csv(
+            os.path.join(test_dir, "edges\\edge.csv"),
+            index=False,
+            header=False,
+        )
+
+        # Generate random graph edge-feats.
+        edge_feats = np.random.rand(num_edges, 5)
+        os.makedirs(os.path.join(test_dir, "data\\"), exist_ok=True)
+        np.save(os.path.join(test_dir, "data\\edge-feat.npy"), edge_feats)
+
+        # Generate random node-feats.
+        node_feats = np.random.rand(num_nodes, 10)
+        np.save(os.path.join(test_dir, "data\\node-feat.npy"), node_feats)
+
+        # Generate train/test/valid set.
+        os.makedirs(os.path.join(test_dir, "set\\"), exist_ok=True)
+        train_pairs = (np.arange(1000), np.arange(1000, 2000))
+        train_labels = np.random.randint(0, 10, size=1000)
+        train_data = np.vstack([train_pairs, train_labels]).T
+        train_path = os.path.join(test_dir, "set\\train.npy")
+        np.save(train_path, train_data)
+
+        validation_pairs = (np.arange(1000, 2000), np.arange(2000, 3000))
+        validation_labels = np.random.randint(0, 10, size=1000)
+        validation_data = np.vstack([validation_pairs, validation_labels]).T
+        validation_path = os.path.join(test_dir, "set\\validation.npy")
+        np.save(validation_path, validation_data)
+
+        test_pairs = (np.arange(2000, 3000), np.arange(3000, 4000))
+        test_labels = np.random.randint(0, 10, size=1000)
+        test_data = np.vstack([test_pairs, test_labels]).T
+        test_path = os.path.join(test_dir, "set\\test.npy")
+        np.save(test_path, test_data)
+
+        yaml_content = f"""
+            dataset_name: {dataset_name}
+            graph: # graph structure and required attributes.
+                nodes:
+                    - num: {num_nodes}
+                edges:
+                    - format: csv
+                      path: edges\\edge.csv
+                feature_data:
+                    - domain: edge
+                      type: null
+                      name: feat
+                      format: numpy
+                      in_memory: true
+                      path: data\\edge-feat.npy
+            feature_data:
+                - domain: node
+                  type: null
+                  name: feat
+                  format: numpy
+                  in_memory: false
+                  path: data\\node-feat.npy
+            tasks:
+              - name: node_classification
+                num_classes: {num_classes}
+                train_set:
+                  - type_name: null
+                    data:
+                      - format: numpy
+                        path: set\\train.npy
+                validation_set:
+                  - type_name: null
+                    data:
+                      - format: numpy
+                        path: set\\validation.npy
+                test_set:
+                  - type_name: null
+                    data:
+                      - format: numpy
+                        path: set\\test.npy
+        """
+        yaml_file = os.path.join(test_dir, "metadata.yaml")
+        with open(yaml_file, "w") as f:
+            f.write(yaml_content)
+
+        preprocessed_metadata_path = gb.preprocess_ondisk_dataset(test_dir)
+        with open(preprocessed_metadata_path, "r") as f:
+            yaml_data = yaml.safe_load(f)
+
+        target_yaml_content = f"""
+            dataset_name: {dataset_name}
+            graph_topology:
+              type: CSCSamplingGraph
+              path: preprocessed\\csc_sampling_graph.tar
+            feature_data:
+              - domain: node
+                type: null
+                name: feat
+                format: numpy
+                in_memory: false
+                path: preprocessed\\data\\node-feat.npy
+            tasks:
+              - name: node_classification
+                num_classes: {num_classes}
+                train_set:
+                  - type_name: null
+                    data:
+                      - format: numpy
+                        path: preprocessed\\set\\train.npy
+                validation_set:
+                  - type_name: null
+                    data:
+                      - format: numpy
+                        path: preprocessed\\set\\validation.npy
+                test_set:
+                  - type_name: null
+                    data:
+                      - format: numpy
+                        path: preprocessed\\set\\test.npy
+        """
+        target_yaml_data = yaml.safe_load(target_yaml_content)
+        # Check yaml content.
+        assert (
+            yaml_data == target_yaml_data
+        ), "The preprocessed metadata.yaml is not correct."
+
+        # Check file existence.
+        assert os.path.exists(
+            os.path.join(test_dir, yaml_data["graph_topology"]["path"])
+        )
+        assert os.path.exists(
+            os.path.join(test_dir, yaml_data["feature_data"][0]["path"])
+        )
+        for set_name in ["train_set", "validation_set", "test_set"]:
+            assert os.path.exists(
+                os.path.join(
+                    test_dir,
+                    yaml_data["tasks"][0][set_name][0]["data"][0]["path"],
+                )
             )

--- a/tests/python/pytorch/graphbolt/test_ondisk_dataset.py
+++ b/tests/python/pytorch/graphbolt/test_ondisk_dataset.py
@@ -1166,9 +1166,8 @@ def test_OnDiskDataset_preprocess_yaml_content():
         assert yaml_data["dataset_name"] == dataset_name
 
         assert "graph_topology" in yaml_data
-        assert (
-            yaml_data["graph_topology"]["path"]
-            == "preprocessed/csc_sampling_graph.tar"
+        assert yaml_data["graph_topology"]["path"] == os.path.join(
+            "preprocessed", "csc_sampling_graph.tar"
         )
         assert yaml_data["graph_topology"]["type"] == "CSCSamplingGraph"
         assert os.path.exists(
@@ -1180,9 +1179,8 @@ def test_OnDiskDataset_preprocess_yaml_content():
         assert yaml_data["feature_data"][0]["type"] is None
         assert yaml_data["feature_data"][0]["name"] == "feat"
         assert yaml_data["feature_data"][0]["format"] == "numpy"
-        assert (
-            yaml_data["feature_data"][0]["path"]
-            == "preprocessed/data/node-feat.npy"
+        assert yaml_data["feature_data"][0]["path"] == os.path.join(
+            "preprocessed", "data", "node-feat.npy"
         )
         assert os.path.exists(
             os.path.join(test_dir, "preprocessed/data/node-feat.npy")
@@ -1199,10 +1197,9 @@ def test_OnDiskDataset_preprocess_yaml_content():
                 yaml_data["tasks"][0][set_name][0]["data"][0]["format"]
                 == "numpy"
             )
-            assert (
-                yaml_data["tasks"][0][set_name][0]["data"][0]["path"]
-                == f"preprocessed/set/{file_name}.npy"
-            )
+            assert yaml_data["tasks"][0][set_name][0]["data"][0][
+                "path"
+            ] == os.path.join("preprocessed", "set", f"{file_name}.npy")
             assert os.path.exists(
                 os.path.join(test_dir, f"preprocessed/set/{file_name}.npy")
             )

--- a/tests/python/pytorch/graphbolt/test_ondisk_dataset.py
+++ b/tests/python/pytorch/graphbolt/test_ondisk_dataset.py
@@ -1180,7 +1180,7 @@ def test_OnDiskDataset_preprocess_yaml_content():
         assert yaml_data["feature_data"][0]["name"] == "feat"
         assert yaml_data["feature_data"][0]["format"] == "numpy"
         assert yaml_data["feature_data"][0]["path"] == os.path.join(
-            "preprocessed", "data", "node-feat.npy"
+            "preprocessed", "data/node-feat.npy"
         )
         assert os.path.exists(
             os.path.join(test_dir, "preprocessed/data/node-feat.npy")
@@ -1199,7 +1199,7 @@ def test_OnDiskDataset_preprocess_yaml_content():
             )
             assert yaml_data["tasks"][0][set_name][0]["data"][0][
                 "path"
-            ] == os.path.join("preprocessed", "set", f"{file_name}.npy")
+            ] == os.path.join("preprocessed", "set/{file_name}.npy")
             assert os.path.exists(
                 os.path.join(test_dir, f"preprocessed/set/{file_name}.npy")
             )

--- a/tests/python/pytorch/graphbolt/test_ondisk_dataset.py
+++ b/tests/python/pytorch/graphbolt/test_ondisk_dataset.py
@@ -1199,7 +1199,7 @@ def test_OnDiskDataset_preprocess_yaml_content():
             )
             assert yaml_data["tasks"][0][set_name][0]["data"][0][
                 "path"
-            ] == os.path.join("preprocessed", "set/{file_name}.npy")
+            ] == os.path.join("preprocessed", f"set/{file_name}.npy")
             assert os.path.exists(
                 os.path.join(test_dir, f"preprocessed/set/{file_name}.npy")
             )


### PR DESCRIPTION
## Description
<!-- Brief description. Refer to the related issues if existed.
It'll be great if relevant reviewers can be assigned as well.-->

This PR primarily addresses the issue: [[Graphbolt] Update OndiskDataset loading logic](https://github.com/dmlc/dgl/issues/6022).

In the previous PR: [[Graphbolt] Update preprocess to Accept Dataset Path Instead of YAML File Path](https://github.com/dmlc/dgl/pull/6091). We've observed that moving the `dataset` directory invalidates the prior preprocessing due to absolute path issues.

To address this, we now ensure that after preprocessing, all paths within the YAML file are relative. To ensure data accessibility from any location, we've introduced a `_convert_yaml_path_to_absolute_path` function, which temporarily converts paths in the YAML to absolute paths before loading.


## Checklist
Please feel free to remove inapplicable items for your PR.
- [ ] The PR title starts with [$CATEGORY] (such as [NN], [Model], [Doc], [Feature]])
- [ ] I've leverage the [tools](https://docs.google.com/document/d/1iHyj7zlmygKSk5gBPsqIqL5ASPzJSPREaNT_QdsiYA4/edit) to beautify the python and c++ code.
- [ ] The PR is complete and small, read the [Google eng practice (CL equals to PR)](https://google.github.io/eng-practices/review/developer/small-cls.html) to understand more about small PR. In DGL, we consider PRs with less than 200 lines of core code change are small (example, test and documentation could be exempted).
- [ ] All changes have test coverage
- [ ] Code is well-documented
- [ ] To the best of my knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change
- [ ] Related issue is referred in this PR
- [ ] If the PR is for a new model/paper, I've updated the example index [here](../examples/README.md).

## Changes
<!-- You could use following template
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)
-->
