### PR TITLE
[GraphBolt] wrap tvt with task structure

### DIFF
--- a/python/dgl/graphbolt/dataset.py
+++ b/python/dgl/graphbolt/dataset.py
@@ -1,15 +1,86 @@
 """GraphBolt Dataset."""
-
-from typing import List
+from enum import Enum
+from typing import List, Optional
 
 from .feature_store import FeatureStore
 from .itemset import ItemSet, ItemSetDict
 
-__all__ = ["Task", "Dataset"]
+__all__ = [
+    "GNNTaskTypes",
+    "TaskMetadata",
+    "ClassificationTaskMetadata",
+    "Task",
+    "Dataset",
+]
+
+
+class GNNTaskTypes(str, Enum):
+    """Enum of task names."""
+
+    NODE_CLASSIFICATION = "node_classification"
+    NODE_REGRESSION = "node_regression"
+    EDGE_CLASSIFICATION = "edge_classification"
+    EDGE_REGRESSION = "edge_regression"
+    LINK_PREDICTION = "link_prediction"
+    GRAPH_CLASSIFICATION = "graph_classification"
+
+
+class TaskMetadata:
+    """Task metadata."""
+
+    def __init__(self, task_type: str):
+        """Initialize a task metadata.
+
+        Parameters
+        ----------
+        task_type : GNNTaskTypes
+            Task type.
+        """
+        self._task_type = task_type
+
+    @property
+    def task_type(self) -> str:
+        """Return the task type."""
+        return self._task_type
+
+
+class ClassificationTaskMetadata(TaskMetadata):
+    """Classification task metadata."""
+
+    def __init__(
+        self,
+        task_type: GNNTaskTypes,
+        num_classes: Optional[int] = None,
+        num_labels: Optional[int] = None,
+    ):
+        """Initialize a classification task metadata.
+
+        Parameters
+        ----------
+        task_type : GNNTaskTypes
+            Task type.
+        num_classes : int
+            Number of classes.
+        num_labels : int
+            Number of labels.
+        """
+        super().__init__(task_type)
+        self._num_classes = num_classes
+        self._num_labels = num_labels
+
+    @property
+    def num_classes(self) -> int:
+        """Return the number of classes."""
+        return self._num_classes
+
+    @property
+    def num_labels(self) -> int:
+        """Return the number of labels."""
+        return self._num_labels
 
 
 class Task:
-    """A task.
+    """An task.
 
     Task consists of several meta information and the *Train-Validation-Test Set*.
 
@@ -22,9 +93,7 @@ class Task:
 
     def __init__(
         self,
-        name: str,
-        num_classes: int,
-        num_labels: int,
+        metadata: TaskMetadata,
         train_set: ItemSet or ItemSetDict,
         validation_set: ItemSet or ItemSetDict,
         test_set: ItemSet or ItemSetDict,
@@ -33,12 +102,8 @@ class Task:
 
         Parameters
         ----------
-        name : str
-            Task name.
-        num_classes : int
-            Number of classes.
-        num_labels : int
-            Number of labels.
+        metadata : TaskMetadata
+            Metadata.
         train_set : ItemSet or ItemSetDict
             Training set.
         validation_set : ItemSet or ItemSetDict
@@ -46,27 +111,15 @@ class Task:
         test_set : ItemSet or ItemSetDict
             Test set.
         """
-        self._name = name
-        self._num_classes = num_classes
-        self._num_labels = num_labels
+        self._metadata = metadata
         self._train_set = train_set
         self._validation_set = validation_set
         self._test_set = test_set
 
     @property
-    def name(self) -> str:
-        """Return the task name."""
-        return self._name
-
-    @property
-    def num_classes(self) -> int:
-        """Return the number of classes."""
-        return self._num_classes
-
-    @property
-    def num_labels(self) -> int:
-        """Return the number of labels."""
-        return self._num_labels
+    def metadata(self) -> TaskMetadata:
+        """Return the task metadata."""
+        return self._metadata
 
     @property
     def train_set(self) -> ItemSet or ItemSetDict:

--- a/python/dgl/graphbolt/dataset.py
+++ b/python/dgl/graphbolt/dataset.py
@@ -1,88 +1,23 @@
 """GraphBolt Dataset."""
-from enum import Enum
-from typing import List, Optional
+from typing import Dict, List
 
 from .feature_store import FeatureStore
 from .itemset import ItemSet, ItemSetDict
 
 __all__ = [
-    "GNNTaskTypes",
-    "TaskMetadata",
-    "ClassificationTaskMetadata",
     "Task",
     "Dataset",
 ]
 
 
-class GNNTaskTypes(str, Enum):
-    """Enum of task names."""
-
-    NODE_CLASSIFICATION = "node_classification"
-    NODE_REGRESSION = "node_regression"
-    EDGE_CLASSIFICATION = "edge_classification"
-    EDGE_REGRESSION = "edge_regression"
-    LINK_PREDICTION = "link_prediction"
-    GRAPH_CLASSIFICATION = "graph_classification"
-
-
-class TaskMetadata:
-    """Task metadata."""
-
-    def __init__(self, task_type: str):
-        """Initialize a task metadata.
-
-        Parameters
-        ----------
-        task_type : GNNTaskTypes
-            Task type.
-        """
-        self._task_type = task_type
-
-    @property
-    def task_type(self) -> str:
-        """Return the task type."""
-        return self._task_type.value
-
-
-class ClassificationTaskMetadata(TaskMetadata):
-    """Classification task metadata."""
-
-    def __init__(
-        self,
-        task_type: GNNTaskTypes,
-        num_classes: Optional[int] = None,
-        num_labels: Optional[int] = None,
-    ):
-        """Initialize a classification task metadata.
-
-        Parameters
-        ----------
-        task_type : GNNTaskTypes
-            Task type.
-        num_classes : int
-            Number of classes.
-        num_labels : int
-            Number of labels.
-        """
-        super().__init__(task_type)
-        self._num_classes = num_classes
-        self._num_labels = num_labels
-
-    @property
-    def num_classes(self) -> int:
-        """Return the number of classes."""
-        return self._num_classes
-
-    @property
-    def num_labels(self) -> int:
-        """Return the number of labels."""
-        return self._num_labels
-
-
 class Task:
-    """An task.
+    """An abstract task.
 
-    Task consists of several meta information and the *Train-Validation-Test Set*.
+    Task consists of several meta information and *Train-Validation-Test Set*.
+
+    *meta information*:
+    The meta information of a task includes any kinds of data that are defined
+    by the user in YAML when instantiating the task.
 
     *Train-Validation-Test Set*:
     The training-validation-testing (TVT) set which is used to train the neural
@@ -91,50 +26,25 @@ class Task:
     neural network parameters.
     """
 
-    def __init__(
-        self,
-        metadata: TaskMetadata,
-        train_set: ItemSet or ItemSetDict,
-        validation_set: ItemSet or ItemSetDict,
-        test_set: ItemSet or ItemSetDict,
-    ):
-        """Initialize a task.
-
-        Parameters
-        ----------
-        metadata : TaskMetadata
-            Metadata.
-        train_set : ItemSet or ItemSetDict
-            Training set.
-        validation_set : ItemSet or ItemSetDict
-            Validation set.
-        test_set : ItemSet or ItemSetDict
-            Test set.
-        """
-        self._metadata = metadata
-        self._train_set = train_set
-        self._validation_set = validation_set
-        self._test_set = test_set
-
     @property
-    def metadata(self) -> TaskMetadata:
+    def metadata(self) -> Dict:
         """Return the task metadata."""
-        return self._metadata
+        raise NotImplementedError
 
     @property
     def train_set(self) -> ItemSet or ItemSetDict:
         """Return the training set."""
-        return self._train_set
+        raise NotImplementedError
 
     @property
     def validation_set(self) -> ItemSet or ItemSetDict:
         """Return the validation set."""
-        return self._validation_set
+        raise NotImplementedError
 
     @property
     def test_set(self) -> ItemSet or ItemSetDict:
         """Return the test set."""
-        return self._test_set
+        raise NotImplementedError
 
 
 class Dataset:

--- a/python/dgl/graphbolt/dataset.py
+++ b/python/dgl/graphbolt/dataset.py
@@ -1,9 +1,87 @@
 """GraphBolt Dataset."""
 
+from typing import List
+
 from .feature_store import FeatureStore
 from .itemset import ItemSet, ItemSetDict
 
-__all__ = ["Dataset"]
+__all__ = ["Task", "Dataset"]
+
+
+class Task:
+    """A task.
+
+    Task consists of several meta information and the *Train-Validation-Test Set*.
+
+    *Train-Validation-Test Set*:
+    The training-validation-testing (TVT) set which is used to train the neural
+    networks. We calculate the embeddings based on their respective features
+    and the graph structure, and then utilize the embeddings to optimize the
+    neural network parameters.
+    """
+
+    def __init__(
+        self,
+        name: str,
+        num_classes: int,
+        num_labels: int,
+        train_set: ItemSet or ItemSetDict,
+        validation_set: ItemSet or ItemSetDict,
+        test_set: ItemSet or ItemSetDict,
+    ):
+        """Initialize a task.
+
+        Parameters
+        ----------
+        name : str
+            Task name.
+        num_classes : int
+            Number of classes.
+        num_labels : int
+            Number of labels.
+        train_set : ItemSet or ItemSetDict
+            Training set.
+        validation_set : ItemSet or ItemSetDict
+            Validation set.
+        test_set : ItemSet or ItemSetDict
+            Test set.
+        """
+        self._name = name
+        self._num_classes = num_classes
+        self._num_labels = num_labels
+        self._train_set = train_set
+        self._validation_set = validation_set
+        self._test_set = test_set
+
+    @property
+    def name(self) -> str:
+        """Return the task name."""
+        return self._name
+
+    @property
+    def num_classes(self) -> int:
+        """Return the number of classes."""
+        return self._num_classes
+
+    @property
+    def num_labels(self) -> int:
+        """Return the number of labels."""
+        return self._num_labels
+
+    @property
+    def train_set(self) -> ItemSet or ItemSetDict:
+        """Return the training set."""
+        return self._train_set
+
+    @property
+    def validation_set(self) -> ItemSet or ItemSetDict:
+        """Return the validation set."""
+        return self._validation_set
+
+    @property
+    def test_set(self) -> ItemSet or ItemSetDict:
+        """Return the test set."""
+        return self._test_set
 
 
 class Dataset:
@@ -13,13 +91,11 @@ class Dataset:
     The data abstraction could be a native CPU memory block, a shared memory
     block, a file handle of an opened file on disk, a service that provides
     the API to access the data e.t.c. There are 3 primary components in the
-    dataset: *Train-Validation-Test Set*, *Feature Storage*, *Graph Topology*.
+    dataset: *Task*, *Feature Storage*, *Graph Topology*.
 
-    *Train-Validation-Test Set*:
-    The training-validation-testing (TVT) set which is used to train the neural
-    networks. We calculate the embeddings based on their respective features
-    and the graph structure, and then utilize the embeddings to optimize the
-    neural network parameters.
+    *Task*:
+    A task consists of several meta information and the
+    *Train-Validation-Test Set*. A dataset could have multiple tasks.
 
     *Feature Storage*:
     A key-value store which stores node/edge/graph features.
@@ -30,18 +106,8 @@ class Dataset:
     """
 
     @property
-    def train_set(self) -> ItemSet or ItemSetDict:
-        """Return the training set."""
-        raise NotImplementedError
-
-    @property
-    def validation_set(self) -> ItemSet or ItemSetDict:
-        """Return the validation set."""
-        raise NotImplementedError
-
-    @property
-    def test_set(self) -> ItemSet or ItemSetDict:
-        """Return the test set."""
+    def tasks(self) -> List[Task]:
+        """Return the tasks."""
         raise NotImplementedError
 
     @property
@@ -57,14 +123,4 @@ class Dataset:
     @property
     def dataset_name(self) -> str:
         """Return the dataset name."""
-        raise NotImplementedError
-
-    @property
-    def num_classes(self) -> int:
-        """Return the number of classes."""
-        raise NotImplementedError
-
-    @property
-    def num_labels(self) -> int:
-        """Return the number of labels."""
         raise NotImplementedError

--- a/python/dgl/graphbolt/dataset.py
+++ b/python/dgl/graphbolt/dataset.py
@@ -41,7 +41,7 @@ class TaskMetadata:
     @property
     def task_type(self) -> str:
         """Return the task type."""
-        return self._task_type
+        return self._task_type.value
 
 
 class ClassificationTaskMetadata(TaskMetadata):

--- a/python/dgl/graphbolt/impl/ondisk_dataset.py
+++ b/python/dgl/graphbolt/impl/ondisk_dataset.py
@@ -12,12 +12,7 @@ import yaml
 
 import dgl
 
-from ..dataset import (
-    ClassificationTaskMetadata,
-    Dataset,
-    Task,
-    TaskMetadata,
-)
+from ..dataset import ClassificationTaskMetadata, Dataset, Task, TaskMetadata
 from ..itemset import ItemSet, ItemSetDict
 from ..utils import read_data, save_data
 

--- a/python/dgl/graphbolt/impl/ondisk_dataset.py
+++ b/python/dgl/graphbolt/impl/ondisk_dataset.py
@@ -4,7 +4,7 @@ import os
 import shutil
 
 from copy import deepcopy
-from typing import List
+from typing import Dict, List, Tuple
 
 import pandas as pd
 import torch
@@ -12,7 +12,7 @@ import yaml
 
 import dgl
 
-from ..dataset import Dataset
+from ..dataset import Dataset, Task
 from ..itemset import ItemSet, ItemSetDict
 from ..utils import read_data, save_data
 
@@ -22,7 +22,12 @@ from .csc_sampling_graph import (
     load_csc_sampling_graph,
     save_csc_sampling_graph,
 )
-from .ondisk_metadata import OnDiskGraphTopology, OnDiskMetaData, OnDiskTVTSet
+from .ondisk_metadata import (
+    OnDiskGraphTopology,
+    OnDiskMetaData,
+    OnDiskTask,
+    OnDiskTVTSet,
+)
 from .torch_based_feature_store import TorchBasedFeatureStore
 
 __all__ = ["OnDiskDataset", "preprocess_ondisk_dataset"]
@@ -178,28 +183,32 @@ def preprocess_ondisk_dataset(dataset_dir: str) -> str:
                 feature["in_memory"],
             )
 
-    # 7. Save the train/val/test split according to the output_config.
-    for set_name in ["train_set", "validation_set", "test_set"]:
-        if set_name not in input_config:
-            continue
-        for input_set_per_type, output_set_per_type in zip(
-            input_config[set_name], output_config[set_name]
+    # 7. Save tasks and train/val/test split according to the output_config.
+    if input_config.get("task", None):
+        for input_task, output_task in zip(
+            input_config["task"], output_config["task"]
         ):
-            for input_data, output_data in zip(
-                input_set_per_type["data"], output_set_per_type["data"]
-            ):
-                # Always save the feature in numpy format.
-                output_data["format"] = "numpy"
-                output_data["path"] = os.path.join(
-                    processed_dir_prefix,
-                    input_data["path"].replace("pt", "npy"),
-                )
-                _copy_or_convert_data(
-                    os.path.join(dataset_dir, input_data["path"]),
-                    output_data["path"],
-                    input_data["format"],
-                    output_data["format"],
-                )
+            for set_name in ["train_set", "validation_set", "test_set"]:
+                if set_name not in input_task:
+                    continue
+                for input_set_per_type, output_set_per_type in zip(
+                    input_task[set_name], output_task[set_name]
+                ):
+                    for input_data, output_data in zip(
+                        input_set_per_type["data"], output_set_per_type["data"]
+                    ):
+                        # Always save the feature in numpy format.
+                        output_data["format"] = "numpy"
+                        output_data["path"] = os.path.join(
+                            processed_dir_prefix,
+                            input_data["path"].replace("pt", "npy"),
+                        )
+                        _copy_or_convert_data(
+                            os.path.join(dataset_dir, input_data["path"]),
+                            output_data["path"],
+                            input_data["format"],
+                            output_data["format"],
+                        )
 
     # 8. Save the output_config.
     output_config_path = os.path.join(dataset_dir, "preprocessed/metadata.yaml")
@@ -225,8 +234,6 @@ class OnDiskDataset(Dataset):
     .. code-block:: yaml
 
         dataset_name: graphbolt_test
-        num_classes: 10
-        num_labels: 10
         graph_topology:
           type: CSCSamplingGraph
           path: graph_topology/csc_sampling_graph.tar
@@ -243,27 +250,31 @@ class OnDiskDataset(Dataset):
             format: numpy
             in_memory: false
             path: edge_data/author-writes-paper-feat.npy
-        train_set:
-          - type: paper # could be null for homogeneous graph.
-            data: # multiple data sources could be specified.
-              - format: numpy
-                in_memory: true # If not specified, default to true.
-                path: set/paper-train-src.npy
-              - format: numpy
-                in_memory: false
-                path: set/paper-train-dst.npy
-        validation_set:
-          - type: paper
-            data:
-              - format: numpy
-                in_memory: true
-                path: set/paper-validation.npy
-        test_set:
-          - type: paper
-            data:
-              - format: numpy
-                in_memory: true
-                path: set/paper-test.npy
+        tasks:
+          - name: "link prediction"
+            num_classes: 10
+            num_labels: 10
+            train_set:
+              - type: paper # could be null for homogeneous graph.
+                data: # multiple data sources could be specified.
+                  - format: numpy
+                    in_memory: true # If not specified, default to true.
+                    path: set/paper-train-src.npy
+                  - format: numpy
+                    in_memory: false
+                    path: set/paper-train-dst.npy
+            validation_set:
+              - type: paper
+                data:
+                  - format: numpy
+                    in_memory: true
+                    path: set/paper-validation.npy
+            test_set:
+              - type: paper
+                data:
+                  - format: numpy
+                    in_memory: true
+                    path: set/paper-test.npy
 
     Parameters
     ----------
@@ -279,28 +290,14 @@ class OnDiskDataset(Dataset):
             yaml_data = yaml.load(f, Loader=yaml.loader.SafeLoader)
             self._meta = OnDiskMetaData(**yaml_data)
         self._dataset_name = self._meta.dataset_name
-        self._num_classes = self._meta.num_classes
-        self._num_labels = self._meta.num_labels
         self._graph = self._load_graph(self._meta.graph_topology)
         self._feature = TorchBasedFeatureStore(self._meta.feature_data)
-        self._train_set = self._init_tvt_set(self._meta.train_set)
-        self._validation_set = self._init_tvt_set(self._meta.validation_set)
-        self._test_set = self._init_tvt_set(self._meta.test_set)
+        self._tasks = self._init_tasks(self._meta.tasks)
 
     @property
-    def train_set(self) -> ItemSet or ItemSetDict:
-        """Return the training set."""
-        return self._train_set
-
-    @property
-    def validation_set(self) -> ItemSet or ItemSetDict:
-        """Return the validation set."""
-        return self._validation_set
-
-    @property
-    def test_set(self) -> ItemSet or ItemSetDict:
-        """Return the test set."""
-        return self._test_set
+    def tasks(self) -> List[Task]:
+        """Return the tasks."""
+        return self._tasks
 
     @property
     def graph(self) -> object:
@@ -317,15 +314,23 @@ class OnDiskDataset(Dataset):
         """Return the dataset name."""
         return self._dataset_name
 
-    @property
-    def num_classes(self) -> int:
-        """Return the number of classes."""
-        return self._num_classes
-
-    @property
-    def num_labels(self) -> int:
-        """Return the number of labels."""
-        return self._num_labels
+    def _init_tasks(self, tasks: List[OnDiskTask]) -> List[Task]:
+        """Initialize the tasks."""
+        ret = []
+        if tasks is None:
+            return ret
+        for task in tasks:
+            ret.append(
+                Task(
+                    task.name,
+                    task.num_classes,
+                    task.num_labels,
+                    self._init_tvt_set(task.train_set),
+                    self._init_tvt_set(task.validation_set),
+                    self._init_tvt_set(task.test_set),
+                )
+            )
+        return ret
 
     def _load_graph(
         self, graph_topology: OnDiskGraphTopology

--- a/python/dgl/graphbolt/impl/ondisk_dataset.py
+++ b/python/dgl/graphbolt/impl/ondisk_dataset.py
@@ -372,17 +372,15 @@ class OnDiskDataset(Dataset):
         if tasks is None:
             return ret
         for task in tasks:
-            ret.append(self._init_task(task))
+            ret.append(
+                OnDiskTask(
+                    task.extra_fields,
+                    self._init_tvt_set(task.train_set),
+                    self._init_tvt_set(task.validation_set),
+                    self._init_tvt_set(task.test_set),
+                )
+            )
         return ret
-
-    def _init_task(self, task: OnDiskTaskData) -> OnDiskTask:
-        """Initialize the task."""
-        return OnDiskTask(
-            task.extra_fields,
-            self._init_tvt_set(task.train_set),
-            self._init_tvt_set(task.validation_set),
-            self._init_tvt_set(task.test_set),
-        )
 
     def _load_graph(
         self, graph_topology: OnDiskGraphTopology

--- a/python/dgl/graphbolt/impl/ondisk_dataset.py
+++ b/python/dgl/graphbolt/impl/ondisk_dataset.py
@@ -4,7 +4,7 @@ import os
 import shutil
 
 from copy import deepcopy
-from typing import Dict, List, Tuple
+from typing import List
 
 import pandas as pd
 import torch

--- a/python/dgl/graphbolt/impl/ondisk_metadata.py
+++ b/python/dgl/graphbolt/impl/ondisk_metadata.py
@@ -80,6 +80,7 @@ class OnDiskTaskData(pydantic.BaseModel, extra="allow"):
     extra_fields: Optional[Dict[str, Any]] = {}
 
     @pydantic.model_validator(mode="before")
+    @classmethod
     def build_extra(cls, values: Dict[str, Any]) -> Dict[str, Any]:
         """Build extra fields."""
         for key in list(values.keys()):

--- a/python/dgl/graphbolt/impl/ondisk_metadata.py
+++ b/python/dgl/graphbolt/impl/ondisk_metadata.py
@@ -1,11 +1,9 @@
 """Ondisk metadata of GraphBolt."""
 
 from enum import Enum
-from typing import List, Optional
+from typing import Any, Dict, List, Optional
 
 import pydantic
-
-from ..dataset import GNNTaskTypes
 
 __all__ = [
     "OnDiskFeatureDataFormat",
@@ -16,7 +14,7 @@ __all__ = [
     "OnDiskMetaData",
     "OnDiskGraphTopologyType",
     "OnDiskGraphTopology",
-    "OnDiskTask",
+    "OnDiskTaskData",
 ]
 
 
@@ -73,15 +71,22 @@ class OnDiskGraphTopology(pydantic.BaseModel):
     path: str
 
 
-class OnDiskTask(pydantic.BaseModel):
+class OnDiskTaskData(pydantic.BaseModel, extra="allow"):
     """Task specification in YAML."""
 
-    task_type: GNNTaskTypes
-    num_classes: Optional[int] = None
-    num_labels: Optional[int] = None
     train_set: Optional[List[OnDiskTVTSet]] = []
     validation_set: Optional[List[OnDiskTVTSet]] = []
     test_set: Optional[List[OnDiskTVTSet]] = []
+    extra_fields: Optional[Dict[str, Any]] = {}
+
+    @pydantic.model_validator(mode="before")
+    def build_extra(cls, values: Dict[str, Any]) -> Dict[str, Any]:
+        """Build extra fields."""
+        for key in list(values.keys()):
+            if key not in cls.model_fields:
+                values["extra_fields"] = values.get("extra_fields", {})
+                values["extra_fields"][key] = values.pop(key)
+        return values
 
 
 class OnDiskMetaData(pydantic.BaseModel):
@@ -94,4 +99,4 @@ class OnDiskMetaData(pydantic.BaseModel):
     dataset_name: Optional[str] = None
     graph_topology: Optional[OnDiskGraphTopology] = None
     feature_data: Optional[List[OnDiskFeatureData]] = []
-    tasks: Optional[List[OnDiskTask]] = []
+    tasks: Optional[List[OnDiskTaskData]] = []

--- a/python/dgl/graphbolt/impl/ondisk_metadata.py
+++ b/python/dgl/graphbolt/impl/ondisk_metadata.py
@@ -5,6 +5,7 @@ from typing import List, Optional
 
 import pydantic
 
+from ..dataset import GNNTaskTypes
 
 __all__ = [
     "OnDiskFeatureDataFormat",
@@ -75,7 +76,7 @@ class OnDiskGraphTopology(pydantic.BaseModel):
 class OnDiskTask(pydantic.BaseModel):
     """Task specification in YAML."""
 
-    name: Optional[str] = None
+    task_type: GNNTaskTypes
     num_classes: Optional[int] = None
     num_labels: Optional[int] = None
     train_set: Optional[List[OnDiskTVTSet]] = []
@@ -91,8 +92,6 @@ class OnDiskMetaData(pydantic.BaseModel):
     """
 
     dataset_name: Optional[str] = None
-    num_classes: Optional[int] = None
-    num_labels: Optional[int] = None
     graph_topology: Optional[OnDiskGraphTopology] = None
     feature_data: Optional[List[OnDiskFeatureData]] = []
     tasks: Optional[List[OnDiskTask]] = []

--- a/python/dgl/graphbolt/impl/ondisk_metadata.py
+++ b/python/dgl/graphbolt/impl/ondisk_metadata.py
@@ -15,6 +15,7 @@ __all__ = [
     "OnDiskMetaData",
     "OnDiskGraphTopologyType",
     "OnDiskGraphTopology",
+    "OnDiskTask",
 ]
 
 
@@ -71,6 +72,17 @@ class OnDiskGraphTopology(pydantic.BaseModel):
     path: str
 
 
+class OnDiskTask(pydantic.BaseModel):
+    """Task specification in YAML."""
+
+    name: Optional[str] = None
+    num_classes: Optional[int] = None
+    num_labels: Optional[int] = None
+    train_set: Optional[List[OnDiskTVTSet]] = []
+    validation_set: Optional[List[OnDiskTVTSet]] = []
+    test_set: Optional[List[OnDiskTVTSet]] = []
+
+
 class OnDiskMetaData(pydantic.BaseModel):
     """Metadata specification in YAML.
 
@@ -83,6 +95,4 @@ class OnDiskMetaData(pydantic.BaseModel):
     num_labels: Optional[int] = None
     graph_topology: Optional[OnDiskGraphTopology] = None
     feature_data: Optional[List[OnDiskFeatureData]] = []
-    train_set: Optional[List[OnDiskTVTSet]] = []
-    validation_set: Optional[List[OnDiskTVTSet]] = []
-    test_set: Optional[List[OnDiskTVTSet]] = []
+    tasks: Optional[List[OnDiskTask]] = []

--- a/tests/python/pytorch/graphbolt/test_dataset.py
+++ b/tests/python/pytorch/graphbolt/test_dataset.py
@@ -5,18 +5,10 @@ from dgl import graphbolt as gb
 def test_Dataset():
     dataset = gb.Dataset()
     with pytest.raises(NotImplementedError):
-        _ = dataset.train_set
-    with pytest.raises(NotImplementedError):
-        _ = dataset.validation_set
-    with pytest.raises(NotImplementedError):
-        _ = dataset.test_set
+        _ = dataset.tasks
     with pytest.raises(NotImplementedError):
         _ = dataset.graph
     with pytest.raises(NotImplementedError):
         _ = dataset.feature
     with pytest.raises(NotImplementedError):
         _ = dataset.dataset_name
-    with pytest.raises(NotImplementedError):
-        _ = dataset.num_classes
-    with pytest.raises(NotImplementedError):
-        _ = dataset.num_labels

--- a/tests/python/pytorch/graphbolt/test_ondisk_dataset.py
+++ b/tests/python/pytorch/graphbolt/test_ondisk_dataset.py
@@ -14,62 +14,6 @@ import yaml
 from dgl import graphbolt as gb
 
 
-def test_OnDiskDataset_Tasks():
-    """Test tasks."""
-    with tempfile.TemporaryDirectory() as test_dir:
-        os.makedirs(os.path.join(test_dir, "preprocessed"), exist_ok=True)
-        yaml_file = os.path.join(test_dir, "preprocessed/metadata.yaml")
-
-        # Case 1: classification tasks.
-        for task_type in [
-            "node_classification",
-            "edge_classification",
-            "graph_classification",
-        ]:
-            yaml_content = f"""
-          tasks:
-            - task_type: {task_type}
-              num_classes: 2
-              num_labels: 3
-          """
-            yaml_file = os.path.join(test_dir, "preprocessed/metadata.yaml")
-            with open(yaml_file, "w") as f:
-                f.write(yaml_content)
-            dataset = gb.OnDiskDataset(test_dir)
-            assert dataset.tasks[0].metadata.task_type == task_type
-            assert dataset.tasks[0].metadata.num_classes == 2
-            assert dataset.tasks[0].metadata.num_labels == 3
-            dataset = None
-
-        # Case 2: regression/prediction tasks.
-        for task_type in [
-            "node_regression",
-            "edge_regression",
-            "link_prediction",
-        ]:
-            yaml_content = f"""
-          tasks:
-            - task_type: {task_type}
-          """
-            yaml_file = os.path.join(test_dir, "preprocessed/metadata.yaml")
-            with open(yaml_file, "w") as f:
-                f.write(yaml_content)
-            dataset = gb.OnDiskDataset(test_dir)
-            assert dataset.tasks[0].metadata.task_type == task_type
-            dataset = None
-
-        # Case 3: invalid task type.
-        yaml_content = """
-        tasks:
-          - task_type: invalid
-        """
-        yaml_file = os.path.join(test_dir, "preprocessed/metadata.yaml")
-        with open(yaml_file, "w") as f:
-            f.write(yaml_content)
-        with pytest.raises(pydantic.ValidationError):
-            _ = gb.OnDiskDataset(test_dir)
-
-
 def test_OnDiskDataset_TVTSet_exceptions():
     """Test excpetions thrown when parsing TVTSet."""
     with tempfile.TemporaryDirectory() as test_dir:
@@ -79,7 +23,7 @@ def test_OnDiskDataset_TVTSet_exceptions():
         # Case 1: ``format`` is invalid.
         yaml_content = """
         tasks:
-          - task_type: node_classification
+          - name: node_classification
             train_set:
               - type: paper
                 data:
@@ -96,7 +40,7 @@ def test_OnDiskDataset_TVTSet_exceptions():
         # specified.
         yaml_content = """
             tasks:
-              - task_type: node_classification
+              - name: node_classification
                 train_set:
                 - type: null
                   data:
@@ -146,9 +90,8 @@ def test_OnDiskDataset_TVTSet_ItemSet_id_label():
         #   ``in_memory`` could be ``true`` and ``false``.
         yaml_content = f"""
             tasks:
-              - task_type: node_classification
+              - name: node_classification
                 num_classes: 10
-                num_labels: 10
                 train_set:
                   - type: null
                     data:
@@ -185,9 +128,8 @@ def test_OnDiskDataset_TVTSet_ItemSet_id_label():
 
         # Verify tasks.
         assert len(dataset.tasks) == 1
-        assert dataset.tasks[0].metadata.task_type == "node_classification"
-        assert dataset.tasks[0].metadata.num_classes == 10
-        assert dataset.tasks[0].metadata.num_labels == 10
+        assert dataset.tasks[0].metadata["name"] == "node_classification"
+        assert dataset.tasks[0].metadata["num_classes"] == 10
 
         # Verify train set.
         train_set = dataset.tasks[0].train_set
@@ -220,7 +162,7 @@ def test_OnDiskDataset_TVTSet_ItemSet_id_label():
         # Case 2: Some TVT sets are None.
         yaml_content = f"""
             tasks:
-              - task_type: node_classification
+              - name: node_classification
                 train_set:
                   - type: null
                     data:
@@ -273,7 +215,7 @@ def test_OnDiskDataset_TVTSet_ItemSet_node_pair_label():
 
         yaml_content = f"""
             tasks:
-              - task_type: link_prediction
+              - name: link_prediction
                 train_set:
                   - type: null
                     data:
@@ -388,7 +330,7 @@ def test_OnDiskDataset_TVTSet_ItemSet_node_pair_negs():
 
         yaml_content = f"""
             tasks:
-              - task_type: link_prediction
+              - name: link_prediction
                 train_set:
                   - type: null
                     data:
@@ -487,7 +429,7 @@ def test_OnDiskDataset_TVTSet_ItemSetDict_id_label():
 
         yaml_content = f"""
             tasks:
-              - task_type: node_classification
+              - name: node_classification
                 train_set:
                   - type: paper
                     data:
@@ -592,7 +534,7 @@ def test_OnDiskDataset_TVTSet_ItemSetDict_node_pair_label():
 
         yaml_content = f"""
             tasks:
-              - task_type: edge_classification
+              - name: edge_classification
                 train_set:
                   - type: paper
                     data:
@@ -971,7 +913,6 @@ def test_OnDiskDataset_preprocess_homogeneous():
         num_nodes = 4000
         num_edges = 20000
         num_classes = 10
-        num_labels = 9
 
         # Generate random edges.
         nodes = np.repeat(np.arange(num_nodes), 5)
@@ -1038,9 +979,8 @@ def test_OnDiskDataset_preprocess_homogeneous():
                   in_memory: false
                   path: data/node-feat.npy
             tasks:
-              - task_type: node_classification
+              - name: node_classification
                 num_classes: {num_classes}
-                num_labels: {num_labels}
                 train_set:
                   - type_name: null
                     data:
@@ -1067,7 +1007,6 @@ def test_OnDiskDataset_preprocess_homogeneous():
 
         assert processed_dataset["dataset_name"] == dataset_name
         assert processed_dataset["tasks"][0]["num_classes"] == num_classes
-        assert processed_dataset["tasks"][0]["num_labels"] == num_labels
         assert "graph" not in processed_dataset
         assert "graph_topology" in processed_dataset
 
@@ -1092,7 +1031,6 @@ def test_OnDiskDataset_preprocess_path():
         # All metadata fields are specified.
         dataset_name = "graphbolt_test"
         num_classes = 10
-        num_labels = 9
 
         yaml_content = f"""
             dataset_name: {dataset_name}

--- a/tests/python/pytorch/graphbolt/test_ondisk_dataset.py
+++ b/tests/python/pytorch/graphbolt/test_ondisk_dataset.py
@@ -22,11 +22,12 @@ def test_OnDiskDataset_TVTSet_exceptions():
 
         # Case 1: ``format`` is invalid.
         yaml_content = """
-        train_set:
-          - type: paper
-            data:
-              - format: torch_invalid
-                path: set/paper-train.pt
+        tasks:
+          - train_set:
+              - type: paper
+                data:
+                  - format: torch_invalid
+                    path: set/paper-train.pt
         """
         yaml_file = os.path.join(test_dir, "preprocessed/metadata.yaml")
         with open(yaml_file, "w") as f:
@@ -37,15 +38,16 @@ def test_OnDiskDataset_TVTSet_exceptions():
         # Case 2: ``type`` is not specified while multiple TVT sets are
         # specified.
         yaml_content = """
-            train_set:
-              - type: null
-                data:
-                  - format: numpy
-                    path: set/train.npy
-              - type: null
-                data:
-                  - format: numpy
-                    path: set/train.npy
+            tasks:
+              - train_set:
+                - type: null
+                  data:
+                    - format: numpy
+                      path: set/train.npy
+                - type: null
+                  data:
+                    - format: numpy
+                      path: set/train.npy
         """
         with open(yaml_file, "w") as f:
             f.write(yaml_content)
@@ -85,32 +87,36 @@ def test_OnDiskDataset_TVTSet_ItemSet_id_label():
         #   ``type`` is not specified or specified as ``null``.
         #   ``in_memory`` could be ``true`` and ``false``.
         yaml_content = f"""
-            train_set:
-              - type: null
-                data:
-                  - format: numpy
-                    in_memory: true
-                    path: {train_ids_path}
-                  - format: numpy
-                    in_memory: true
-                    path: {train_labels_path}
-            validation_set:
-              - data:
-                  - format: numpy
-                    in_memory: true
-                    path: {validation_ids_path}
-                  - format: numpy
-                    in_memory: true
-                    path: {validation_labels_path}
-            test_set:
-              - type: null
-                data:
-                  - format: numpy
-                    in_memory: true
-                    path: {test_ids_path}
-                  - format: numpy
-                    in_memory: true
-                    path: {test_labels_path}
+            tasks:
+              - name: node_classification
+                num_classes: 10
+                num_labels: 10
+                train_set:
+                  - type: null
+                    data:
+                      - format: numpy
+                        in_memory: true
+                        path: {train_ids_path}
+                      - format: numpy
+                        in_memory: true
+                        path: {train_labels_path}
+                validation_set:
+                  - data:
+                      - format: numpy
+                        in_memory: true
+                        path: {validation_ids_path}
+                      - format: numpy
+                        in_memory: true
+                        path: {validation_labels_path}
+                test_set:
+                  - type: null
+                    data:
+                      - format: numpy
+                        in_memory: true
+                        path: {test_ids_path}
+                      - format: numpy
+                        in_memory: true
+                        path: {test_labels_path}
         """
         os.makedirs(os.path.join(test_dir, "preprocessed"), exist_ok=True)
         yaml_file = os.path.join(test_dir, "preprocessed/metadata.yaml")
@@ -119,8 +125,14 @@ def test_OnDiskDataset_TVTSet_ItemSet_id_label():
 
         dataset = gb.OnDiskDataset(test_dir)
 
+        # Verify tasks.
+        assert len(dataset.tasks) == 1
+        assert dataset.tasks[0].name == "node_classification"
+        assert dataset.tasks[0].num_classes == 10
+        assert dataset.tasks[0].num_labels == 10
+
         # Verify train set.
-        train_set = dataset.train_set
+        train_set = dataset.tasks[0].train_set
         assert len(train_set) == 1000
         assert isinstance(train_set, gb.ItemSet)
         for i, (id, label) in enumerate(train_set):
@@ -129,7 +141,7 @@ def test_OnDiskDataset_TVTSet_ItemSet_id_label():
         train_set = None
 
         # Verify validation set.
-        validation_set = dataset.validation_set
+        validation_set = dataset.tasks[0].validation_set
         assert len(validation_set) == 1000
         assert isinstance(validation_set, gb.ItemSet)
         for i, (id, label) in enumerate(validation_set):
@@ -138,7 +150,7 @@ def test_OnDiskDataset_TVTSet_ItemSet_id_label():
         validation_set = None
 
         # Verify test set.
-        test_set = dataset.test_set
+        test_set = dataset.tasks[0].test_set
         assert len(test_set) == 1000
         assert isinstance(test_set, gb.ItemSet)
         for i, (id, label) in enumerate(test_set):
@@ -149,20 +161,21 @@ def test_OnDiskDataset_TVTSet_ItemSet_id_label():
 
         # Case 2: Some TVT sets are None.
         yaml_content = f"""
-            train_set:
-              - type: null
-                data:
-                  - format: numpy
-                    path: {train_ids_path}
+            tasks:
+              - train_set:
+                  - type: null
+                    data:
+                      - format: numpy
+                        path: {train_ids_path}
         """
         yaml_file = os.path.join(test_dir, "preprocessed/metadata.yaml")
         with open(yaml_file, "w") as f:
             f.write(yaml_content)
 
         dataset = gb.OnDiskDataset(test_dir)
-        assert dataset.train_set is not None
-        assert dataset.validation_set is None
-        assert dataset.test_set is None
+        assert dataset.tasks[0].train_set is not None
+        assert dataset.tasks[0].validation_set is None
+        assert dataset.tasks[0].test_set is None
         dataset = None
 
 
@@ -200,41 +213,42 @@ def test_OnDiskDataset_TVTSet_ItemSet_node_pair_label():
         np.save(test_labels_path, test_labels)
 
         yaml_content = f"""
-            train_set:
-              - type: null
-                data:
-                  - format: numpy
-                    in_memory: true
-                    path: {train_src_path}
-                  - format: numpy
-                    in_memory: true
-                    path: {train_dst_path}
-                  - format: numpy
-                    in_memory: true
-                    path: {train_labels_path}
-            validation_set:
-              - data:
-                  - format: numpy
-                    in_memory: true
-                    path: {validation_src_path}
-                  - format: numpy
-                    in_memory: true
-                    path: {validation_dst_path}
-                  - format: numpy
-                    in_memory: true
-                    path: {validation_labels_path}
-            test_set:
-              - type: null
-                data:
-                  - format: numpy
-                    in_memory: true
-                    path: {test_src_path}
-                  - format: numpy
-                    in_memory: true
-                    path: {test_dst_path}
-                  - format: numpy
-                    in_memory: true
-                    path: {test_labels_path}
+            tasks:
+              - train_set:
+                  - type: null
+                    data:
+                      - format: numpy
+                        in_memory: true
+                        path: {train_src_path}
+                      - format: numpy
+                        in_memory: true
+                        path: {train_dst_path}
+                      - format: numpy
+                        in_memory: true
+                        path: {train_labels_path}
+                validation_set:
+                  - data:
+                      - format: numpy
+                        in_memory: true
+                        path: {validation_src_path}
+                      - format: numpy
+                        in_memory: true
+                        path: {validation_dst_path}
+                      - format: numpy
+                        in_memory: true
+                        path: {validation_labels_path}
+                test_set:
+                  - type: null
+                    data:
+                      - format: numpy
+                        in_memory: true
+                        path: {test_src_path}
+                      - format: numpy
+                        in_memory: true
+                        path: {test_dst_path}
+                      - format: numpy
+                        in_memory: true
+                        path: {test_labels_path}
         """
         os.makedirs(os.path.join(test_dir, "preprocessed"), exist_ok=True)
         yaml_file = os.path.join(test_dir, "preprocessed/metadata.yaml")
@@ -244,7 +258,7 @@ def test_OnDiskDataset_TVTSet_ItemSet_node_pair_label():
         dataset = gb.OnDiskDataset(test_dir)
 
         # Verify train set.
-        train_set = dataset.train_set
+        train_set = dataset.tasks[0].train_set
         assert len(train_set) == 1000
         assert isinstance(train_set, gb.ItemSet)
         for i, (src, dst, label) in enumerate(train_set):
@@ -254,7 +268,7 @@ def test_OnDiskDataset_TVTSet_ItemSet_node_pair_label():
         train_set = None
 
         # Verify validation set.
-        validation_set = dataset.validation_set
+        validation_set = dataset.tasks[0].validation_set
         assert len(validation_set) == 1000
         assert isinstance(validation_set, gb.ItemSet)
         for i, (src, dst, label) in enumerate(validation_set):
@@ -264,7 +278,7 @@ def test_OnDiskDataset_TVTSet_ItemSet_node_pair_label():
         validation_set = None
 
         # Verify test set.
-        test_set = dataset.test_set
+        test_set = dataset.tasks[0].test_set
         assert len(test_set) == 1000
         assert isinstance(test_set, gb.ItemSet)
         for i, (src, dst, label) in enumerate(test_set):
@@ -313,41 +327,42 @@ def test_OnDiskDataset_TVTSet_ItemSet_node_pair_negs():
         np.save(test_neg_dst_path, test_neg_dst)
 
         yaml_content = f"""
-            train_set:
-              - type: null
-                data:
-                  - format: numpy
-                    in_memory: true
-                    path: {train_src_path}
-                  - format: numpy
-                    in_memory: true
-                    path: {train_dst_path}
-                  - format: numpy
-                    in_memory: true
-                    path: {train_neg_dst_path}
-            validation_set:
-              - data:
-                  - format: numpy
-                    in_memory: true
-                    path: {validation_src_path}
-                  - format: numpy
-                    in_memory: true
-                    path: {validation_dst_path}
-                  - format: numpy
-                    in_memory: true
-                    path: {validation_neg_dst_path}
-            test_set:
-              - type: null
-                data:
-                  - format: numpy
-                    in_memory: true
-                    path: {test_src_path}
-                  - format: numpy
-                    in_memory: true
-                    path: {test_dst_path}
-                  - format: numpy
-                    in_memory: true
-                    path: {test_neg_dst_path}
+            tasks:
+              - train_set:
+                  - type: null
+                    data:
+                      - format: numpy
+                        in_memory: true
+                        path: {train_src_path}
+                      - format: numpy
+                        in_memory: true
+                        path: {train_dst_path}
+                      - format: numpy
+                        in_memory: true
+                        path: {train_neg_dst_path}
+                validation_set:
+                  - data:
+                      - format: numpy
+                        in_memory: true
+                        path: {validation_src_path}
+                      - format: numpy
+                        in_memory: true
+                        path: {validation_dst_path}
+                      - format: numpy
+                        in_memory: true
+                        path: {validation_neg_dst_path}
+                test_set:
+                  - type: null
+                    data:
+                      - format: numpy
+                        in_memory: true
+                        path: {test_src_path}
+                      - format: numpy
+                        in_memory: true
+                        path: {test_dst_path}
+                      - format: numpy
+                        in_memory: true
+                        path: {test_neg_dst_path}
         """
         os.makedirs(os.path.join(test_dir, "preprocessed"), exist_ok=True)
         yaml_file = os.path.join(test_dir, "preprocessed/metadata.yaml")
@@ -357,7 +372,7 @@ def test_OnDiskDataset_TVTSet_ItemSet_node_pair_negs():
         dataset = gb.OnDiskDataset(test_dir)
 
         # Verify train set.
-        train_set = dataset.train_set
+        train_set = dataset.tasks[0].train_set
         assert len(train_set) == 1000
         assert isinstance(train_set, gb.ItemSet)
         for i, (src, dst, negs) in enumerate(train_set):
@@ -367,7 +382,7 @@ def test_OnDiskDataset_TVTSet_ItemSet_node_pair_negs():
         train_set = None
 
         # Verify validation set.
-        validation_set = dataset.validation_set
+        validation_set = dataset.tasks[0].validation_set
         assert len(validation_set) == 1000
         assert isinstance(validation_set, gb.ItemSet)
         for i, (src, dst, negs) in enumerate(validation_set):
@@ -377,7 +392,7 @@ def test_OnDiskDataset_TVTSet_ItemSet_node_pair_negs():
         validation_set = None
 
         # Verify test set.
-        test_set = dataset.test_set
+        test_set = dataset.tasks[0].test_set
         assert len(test_set) == 1000
         assert isinstance(test_set, gb.ItemSet)
         for i, (src, dst, negs) in enumerate(test_set):
@@ -410,35 +425,36 @@ def test_OnDiskDataset_TVTSet_ItemSetDict_id_label():
         np.save(test_path, test_data)
 
         yaml_content = f"""
-            train_set:
-              - type: paper
-                data:
-                  - format: numpy
-                    in_memory: true
-                    path: {train_path}
-              - type: author
-                data:
-                  - format: numpy
-                    path: {train_path}
-            validation_set:
-              - type: paper
-                data:
-                  - format: numpy
-                    path: {validation_path}
-              - type: author
-                data:
-                  - format: numpy
-                    path: {validation_path}
-            test_set:
-              - type: paper
-                data:
-                  - format: numpy
-                    in_memory: false
-                    path: {test_path}
-              - type: author
-                data:
-                  - format: numpy
-                    path: {test_path}
+            tasks:
+              - train_set:
+                  - type: paper
+                    data:
+                      - format: numpy
+                        in_memory: true
+                        path: {train_path}
+                  - type: author
+                    data:
+                      - format: numpy
+                        path: {train_path}
+                validation_set:
+                  - type: paper
+                    data:
+                      - format: numpy
+                        path: {validation_path}
+                  - type: author
+                    data:
+                      - format: numpy
+                        path: {validation_path}
+                test_set:
+                  - type: paper
+                    data:
+                      - format: numpy
+                        in_memory: false
+                        path: {test_path}
+                  - type: author
+                    data:
+                      - format: numpy
+                        path: {test_path}
         """
         os.makedirs(os.path.join(test_dir, "preprocessed"), exist_ok=True)
         yaml_file = os.path.join(test_dir, "preprocessed/metadata.yaml")
@@ -448,7 +464,7 @@ def test_OnDiskDataset_TVTSet_ItemSetDict_id_label():
         dataset = gb.OnDiskDataset(test_dir)
 
         # Verify train set.
-        train_set = dataset.train_set
+        train_set = dataset.tasks[0].train_set
         assert len(train_set) == 2000
         assert isinstance(train_set, gb.ItemSetDict)
         for i, item in enumerate(train_set):
@@ -462,7 +478,7 @@ def test_OnDiskDataset_TVTSet_ItemSetDict_id_label():
         train_set = None
 
         # Verify validation set.
-        validation_set = dataset.validation_set
+        validation_set = dataset.tasks[0].validation_set
         assert len(validation_set) == 2000
         assert isinstance(validation_set, gb.ItemSetDict)
         for i, item in enumerate(validation_set):
@@ -476,7 +492,7 @@ def test_OnDiskDataset_TVTSet_ItemSetDict_id_label():
         validation_set = None
 
         # Verify test set.
-        test_set = dataset.test_set
+        test_set = dataset.tasks[0].test_set
         assert len(test_set) == 2000
         assert isinstance(test_set, gb.ItemSetDict)
         for i, item in enumerate(test_set):
@@ -513,35 +529,36 @@ def test_OnDiskDataset_TVTSet_ItemSetDict_node_pair_label():
         np.save(test_path, test_data)
 
         yaml_content = f"""
-            train_set:
-              - type: paper
-                data:
-                  - format: numpy
-                    in_memory: true
-                    path: {train_path}
-              - type: author
-                data:
-                  - format: numpy
-                    path: {train_path}
-            validation_set:
-              - type: paper
-                data:
-                  - format: numpy
-                    path: {validation_path}
-              - type: author
-                data:
-                  - format: numpy
-                    path: {validation_path}
-            test_set:
-              - type: paper
-                data:
-                  - format: numpy
-                    in_memory: false
-                    path: {test_path}
-              - type: author
-                data:
-                  - format: numpy
-                    path: {test_path}
+            tasks:
+              - train_set:
+                  - type: paper
+                    data:
+                      - format: numpy
+                        in_memory: true
+                        path: {train_path}
+                  - type: author
+                    data:
+                      - format: numpy
+                        path: {train_path}
+                validation_set:
+                  - type: paper
+                    data:
+                      - format: numpy
+                        path: {validation_path}
+                  - type: author
+                    data:
+                      - format: numpy
+                        path: {validation_path}
+                test_set:
+                  - type: paper
+                    data:
+                      - format: numpy
+                        in_memory: false
+                        path: {test_path}
+                  - type: author
+                    data:
+                      - format: numpy
+                        path: {test_path}
         """
         os.makedirs(os.path.join(test_dir, "preprocessed"), exist_ok=True)
         yaml_file = os.path.join(test_dir, "preprocessed/metadata.yaml")
@@ -551,7 +568,7 @@ def test_OnDiskDataset_TVTSet_ItemSetDict_node_pair_label():
         dataset = gb.OnDiskDataset(test_dir)
 
         # Verify train set.
-        train_set = dataset.train_set
+        train_set = dataset.tasks[0].train_set
         assert len(train_set) == 2000
         assert isinstance(train_set, gb.ItemSetDict)
         for i, item in enumerate(train_set):
@@ -566,7 +583,7 @@ def test_OnDiskDataset_TVTSet_ItemSetDict_node_pair_label():
         train_set = None
 
         # Verify validation set.
-        validation_set = dataset.validation_set
+        validation_set = dataset.tasks[0].validation_set
         assert len(validation_set) == 2000
         assert isinstance(validation_set, gb.ItemSetDict)
         for i, item in enumerate(validation_set):
@@ -581,7 +598,7 @@ def test_OnDiskDataset_TVTSet_ItemSetDict_node_pair_label():
         validation_set = None
 
         # Verify test set.
-        test_set = dataset.test_set
+        test_set = dataset.tasks[0].test_set
         assert len(test_set) == 2000
         assert isinstance(test_set, gb.ItemSetDict)
         for i, item in enumerate(test_set):
@@ -860,12 +877,8 @@ def test_OnDiskDataset_Metadata():
     with tempfile.TemporaryDirectory() as test_dir:
         # All metadata fields are specified.
         dataset_name = "graphbolt_test"
-        num_classes = 10
-        num_labels = 9
         yaml_content = f"""
             dataset_name: {dataset_name}
-            num_classes: {num_classes}
-            num_labels: {num_labels}
         """
         os.makedirs(os.path.join(test_dir, "preprocessed"), exist_ok=True)
         yaml_file = os.path.join(test_dir, "preprocessed/metadata.yaml")
@@ -874,8 +887,6 @@ def test_OnDiskDataset_Metadata():
 
         dataset = gb.OnDiskDataset(test_dir)
         assert dataset.dataset_name == dataset_name
-        assert dataset.num_classes == num_classes
-        assert dataset.num_labels == num_labels
 
         # Only dataset_name is specified.
         yaml_content = f"""
@@ -887,8 +898,6 @@ def test_OnDiskDataset_Metadata():
 
         dataset = gb.OnDiskDataset(test_dir)
         assert dataset.dataset_name == dataset_name
-        assert dataset.num_classes is None
-        assert dataset.num_labels is None
 
 
 def test_OnDiskDataset_preprocess_homogeneous():
@@ -945,8 +954,6 @@ def test_OnDiskDataset_preprocess_homogeneous():
 
         yaml_content = f"""
             dataset_name: {dataset_name}
-            num_classes: {num_classes}
-            num_labels: {num_labels}
             graph: # graph structure and required attributes.
                 nodes:
                     - num: {num_nodes}
@@ -967,21 +974,24 @@ def test_OnDiskDataset_preprocess_homogeneous():
                   format: numpy
                   in_memory: false
                   path: data/node-feat.npy
-            train_set:
-                - type_name: null
-                  data:
-                    - format: numpy
-                      path: set/train.npy
-            validation_set:
-                - type_name: null
-                  data:
-                    - format: numpy
-                      path: set/validation.npy
-            test_set:
-                - type_name: null
-                  data:
-                    - format: numpy
-                      path: set/test.npy
+            tasks:
+              - num_classes: {num_classes}
+                num_labels: {num_labels}
+                train_set:
+                  - type_name: null
+                    data:
+                      - format: numpy
+                        path: set/train.npy
+                validation_set:
+                  - type_name: null
+                    data:
+                      - format: numpy
+                        path: set/validation.npy
+                test_set:
+                  - type_name: null
+                    data:
+                      - format: numpy
+                        path: set/test.npy
         """
         yaml_file = os.path.join(test_dir, "metadata.yaml")
         with open(yaml_file, "w") as f:
@@ -992,8 +1002,8 @@ def test_OnDiskDataset_preprocess_homogeneous():
             processed_dataset = yaml.load(f, Loader=yaml.Loader)
 
         assert processed_dataset["dataset_name"] == dataset_name
-        assert processed_dataset["num_classes"] == num_classes
-        assert processed_dataset["num_labels"] == num_labels
+        assert processed_dataset["tasks"][0]["num_classes"] == num_classes
+        assert processed_dataset["tasks"][0]["num_labels"] == num_labels
         assert "graph" not in processed_dataset
         assert "graph_topology" in processed_dataset
 
@@ -1022,8 +1032,6 @@ def test_OnDiskDataset_preprocess_path():
 
         yaml_content = f"""
             dataset_name: {dataset_name}
-            num_classes: {num_classes}
-            num_labels: {num_labels}
         """
         yaml_file = os.path.join(test_dir, "metadata.yaml")
         with open(yaml_file, "w") as f:


### PR DESCRIPTION
## Description
<!-- Brief description. Refer to the related issues if existed.
It'll be great if relevant reviewers can be assigned as well.-->
`TVT` is wrapped into `Task` and data format is shown below:
```
tasks: # Multiple tasks are listed below.
  - name: "node_classification" # "node/link/graph prediction/classification"
    num_classes: 3
    train_set:
      - type: 'paper:cites:paper'
        data: # each file will be one element in tuple of ItemSet.
         - format: numpy
           path: set/cites-train-src.npy
         - format: numpy
           path: set/cites-train-dst.npy
         - format: numpy
           path: set/cites-train-label.npy
      - type: 'author:writes:paper'
        data: # each file will be one element in tuple of ItemSet.
         - format: numpy
           path: set/writes-train-src.npy
         - format: numpy
           path: set/writes-train-dst.npy
         - format: numpy
           path: set/writes-train-label.npy
    validation_set:
      - type: 'author:writes:paper'
        data: # each file will be one element in tuple of ItemSet.
         - format: numpy
           path: set/writes-val-src.npy
         - format: numpy
           path: set/writes-val-dst.npy
         - format: numpy
           path: set/writes-val-neg-src.npy
         - format: numpy
           path: set/writes-val-neg-dst.npy
    test_set:
      - type: 'author:writes:paper'
        data: # each file will be one element in tuple of ItemSet.
         - format: numpy
           path: set/writes-test-src.npy
         - format: numpy
           path: set/writes-test-dst.npy
         - format: numpy
           path: set/writes-test-neg-src.npy
         - format: numpy
           path: set/writes-test-neg-dst.npy
  - name: "node classification" # "node/link/graph prediction/classification"
    num_labels: 10
    train_set:
      - type: paper
        data: # each file will be one element in tuple of ItemSet.
         - format: numpy
           path: set/paper-train-ids.npy
           path: set/paper-train-labels.npy
    validation_set:
      - type: paper
        data: # each file will be one element in tuple of ItemSet.
         - format: numpy
           path: set/paper-val-ids.npy
         - format: numpy
           path: set/paper-val-labels.npy
    test_set:
      - type: paper
        data: # each file will be one element in tuple of ItemSet.
         - format: numpy
           path: set/paper-test-ids.npy
         - format: numpy
           path: set/paper-test-labels.npy
```
## Checklist
Please feel free to remove inapplicable items for your PR.
- [ ] The PR title starts with [$CATEGORY] (such as [NN], [Model], [Doc], [Feature]])
- [ ] I've leverage the [tools](https://docs.google.com/document/d/1iHyj7zlmygKSk5gBPsqIqL5ASPzJSPREaNT_QdsiYA4/edit) to beautify the python and c++ code.
- [ ] The PR is complete and small, read the [Google eng practice (CL equals to PR)](https://google.github.io/eng-practices/review/developer/small-cls.html) to understand more about small PR. In DGL, we consider PRs with less than 200 lines of core code change are small (example, test and documentation could be exempted).
- [ ] All changes have test coverage
- [ ] Code is well-documented
- [ ] To the best of my knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change
- [ ] Related issue is referred in this PR
- [ ] If the PR is for a new model/paper, I've updated the example index [here](../examples/README.md).

## Changes
<!-- You could use following template
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)
-->
