### PR TITLE
[Graphbolt] Update the sampler algorithm documentation for fanout = -1.

### DIFF
--- a/graphbolt/src/csc_sampling_graph.cc
+++ b/graphbolt/src/csc_sampling_graph.cc
@@ -458,10 +458,10 @@ inline torch::Tensor UniformPick(
  * @param num_neighbors The number of neighbors to pick.
  * @param fanout The number of edges to be sampled for each node. It should be
  * >= 0 or -1.
- *  - When the value is -1, all neighbors (with non-zero probability, if
- * weighted) will be sampled once regardless of replacement. It is equivalent to
- * selecting all neighbors with non-zero probability when the fanout is >= the
- * number of neighbors (and replacement is set to false).
+ *  - When the value is -1, all neighbors with non-zero probability will be
+ * sampled once regardless of replacement. It is equivalent to selecting all
+ * neighbors with non-zero probability when the fanout is >= the number of
+ * neighbors (and replacement is set to false).
  *  - When the value is a non-negative integer, it serves as a minimum
  * threshold for selecting neighbors.
  * @param replace Boolean indicating whether the sample is performed with or

--- a/graphbolt/src/csc_sampling_graph.cc
+++ b/graphbolt/src/csc_sampling_graph.cc
@@ -329,10 +329,9 @@ c10::intrusive_ptr<CSCSamplingGraph> CSCSamplingGraph::LoadFromSharedMemory(
  * @param num_neighbors The number of neighbors to pick.
  * @param fanout The number of edges to be sampled for each node. It should be
  * >= 0 or -1.
- *  - When the value is -1, all neighbors (with non-zero probability, if
- * weighted) will be sampled once regardless of replacement. It is equivalent to
- * selecting all neighbors with non-zero probability when the fanout is >= the
- * number of neighbors (and replacement is set to false).
+ *  - When the value is -1, all neighbors will be sampled once regardless of
+ * replacement. It is equivalent to selecting all neighbors when the fanout is
+ * >= the number of neighbors (and replacement is set to false).
  *  - When the value is a non-negative integer, it serves as a minimum
  * threshold for selecting neighbors.
  * @param replace Boolean indicating whether the sample is performed with or

--- a/graphbolt/src/csc_sampling_graph.cc
+++ b/graphbolt/src/csc_sampling_graph.cc
@@ -329,10 +329,10 @@ c10::intrusive_ptr<CSCSamplingGraph> CSCSamplingGraph::LoadFromSharedMemory(
  * @param num_neighbors The number of neighbors to pick.
  * @param fanout The number of edges to be sampled for each node. It should be
  * >= 0 or -1.
- *  - When the value is -1, all neighbors with non-zero probability will be
- * sampled once regardless of replacement. It is equivalent to selecting all
- * neighbors with non-zero probability when the fanout is >= the number of
- * neighbors (and replacement is set to false).
+ *  - When the value is -1, all neighbors (with non-zero probability, if
+ * weighted) will be sampled once regardless of replacement. It is equivalent to
+ * selecting all neighbors with non-zero probability when the fanout is >= the
+ * number of neighbors (and replacement is set to false).
  *  - When the value is a non-negative integer, it serves as a minimum
  * threshold for selecting neighbors.
  * @param replace Boolean indicating whether the sample is performed with or
@@ -459,10 +459,10 @@ inline torch::Tensor UniformPick(
  * @param num_neighbors The number of neighbors to pick.
  * @param fanout The number of edges to be sampled for each node. It should be
  * >= 0 or -1.
- *  - When the value is -1, all neighbors with non-zero probability will be
- * sampled once regardless of replacement. It is equivalent to selecting all
- * neighbors with non-zero probability when the fanout is >= the number of
- * neighbors (and replacement is set to false).
+ *  - When the value is -1, all neighbors (with non-zero probability, if
+ * weighted) will be sampled once regardless of replacement. It is equivalent to
+ * selecting all neighbors with non-zero probability when the fanout is >= the
+ * number of neighbors (and replacement is set to false).
  *  - When the value is a non-negative integer, it serves as a minimum
  * threshold for selecting neighbors.
  * @param replace Boolean indicating whether the sample is performed with or
@@ -594,10 +594,10 @@ inline void safe_divide(T& a, U b) {
  * @param num_neighbors The number of neighbors to pick.
  * @param fanout The number of edges to be sampled for each node. It should be
  * >= 0 or -1.
- *  - When the value is -1, all neighbors with non-zero probability will be
- * sampled once regardless of replacement. It is equivalent to selecting all
- * neighbors with non-zero probability when the fanout is >= the number of
- * neighbors (and replacement is set to false).
+ *  - When the value is -1, all neighbors (with non-zero probability, if
+ * weighted) will be sampled once regardless of replacement. It is equivalent to
+ * selecting all neighbors with non-zero probability when the fanout is >= the
+ * number of neighbors (and replacement is set to false).
  *  - When the value is a non-negative integer, it serves as a minimum
  * threshold for selecting neighbors.
  * @param options Tensor options specifying the desired data type of the result.

--- a/python/dgl/graphbolt/impl/csc_sampling_graph.py
+++ b/python/dgl/graphbolt/impl/csc_sampling_graph.py
@@ -395,8 +395,7 @@ class CSCSamplingGraph:
                 types, and each fanout value corresponds to a specific edge
                 type of the nodes.
             The value of each fanout should be >= 0 or = -1.
-              - When the value is -1, all neighbors will be chosen for
-                sampling. It is equivalent to selecting all neighbors when
+              - When the value is -1, all neighbors with non-zero probability will be sampled once regardless of replacement. It is equivalent to selecting all neighbors when
                 the fanout is >= the number of neighbors (and replace is set to
                 false).
               - When the value is a non-negative integer, it serves as a

--- a/python/dgl/graphbolt/impl/csc_sampling_graph.py
+++ b/python/dgl/graphbolt/impl/csc_sampling_graph.py
@@ -395,9 +395,10 @@ class CSCSamplingGraph:
                 types, and each fanout value corresponds to a specific edge
                 type of the nodes.
             The value of each fanout should be >= 0 or = -1.
-              - When the value is -1, all neighbors with non-zero probability will be sampled once regardless of replacement. It is equivalent to selecting all neighbors when
-                the fanout is >= the number of neighbors (and replace is set to
-                false).
+              - When the value is -1, all neighbors with non-zero probability
+                will be sampled once regardless of replacement. It is
+                equivalent to selecting all neighbors when the fanout is >=
+                the number of neighbors (and replace is set to false).
               - When the value is a non-negative integer, it serves as a
                 minimum threshold for selecting neighbors.
         replace: bool

--- a/python/dgl/graphbolt/impl/csc_sampling_graph.py
+++ b/python/dgl/graphbolt/impl/csc_sampling_graph.py
@@ -283,10 +283,11 @@ class CSCSamplingGraph:
                 types, and each fanout value corresponds to a specific edge
                 type of the nodes.
             The value of each fanout should be >= 0 or = -1.
-              - When the value is -1, all neighbors will be chosen for
-                sampling. It is equivalent to selecting all neighbors when
-                the fanout is >= the number of neighbors (and replace is set to
-                false).
+              - When the value is -1, all neighbors (with non-zero probability,
+                if weighted) will be sampled once regardless of replacement. It
+                is equivalent to selecting all neighbors with non-zero
+                probability when the fanout is >= the number of neighbors (and
+                replace is set to false).
               - When the value is a non-negative integer, it serves as a
                 minimum threshold for selecting neighbors.
         replace: bool
@@ -395,10 +396,11 @@ class CSCSamplingGraph:
                 types, and each fanout value corresponds to a specific edge
                 type of the nodes.
             The value of each fanout should be >= 0 or = -1.
-              - When the value is -1, all neighbors with non-zero probability
-                will be sampled once regardless of replacement. It is
-                equivalent to selecting all neighbors when the fanout is >=
-                the number of neighbors (and replace is set to false).
+              - When the value is -1, all neighbors (with non-zero probability,
+                if weighted) will be sampled once regardless of replacement. It
+                is equivalent to selecting all neighbors with non-zero
+                probability when the fanout is >= the number of neighbors (and
+                replace is set to false).
               - When the value is a non-negative integer, it serves as a
                 minimum threshold for selecting neighbors.
         replace: bool
@@ -455,10 +457,11 @@ class CSCSamplingGraph:
                 types, and each fanout value corresponds to a specific edge
                 type of the nodes.
             The value of each fanout should be >= 0 or = -1.
-              - When the value is -1, all neighbors will be chosen for
-                sampling. It is equivalent to selecting all neighbors when
-                the fanout is >= the number of neighbors (and replace is set to
-                false).
+              - When the value is -1, all neighbors (with non-zero probability,
+                if weighted) will be sampled once regardless of replacement. It
+                is equivalent to selecting all neighbors with non-zero
+                probability when the fanout is >= the number of neighbors (and
+                replace is set to false).
               - When the value is a non-negative integer, it serves as a
                 minimum threshold for selecting neighbors.
         replace: bool


### PR DESCRIPTION
## Description
Change the Labor sampling algorithm to match the behavior of Neighbor algorithm.
I simply changed the calculation of the actual picked number at the beginning of Labor process. However, since soon the picked number will be calculated in advance, this calculation will become useless and will be deleted.
Trying to solve https://github.com/dmlc/dgl/pull/6101/files/5e0de154b1d896e5c26be164b3480b9b81232c6c#r1285651084.

## Checklist
Please feel free to remove inapplicable items for your PR.
- [ ] The PR title starts with [$CATEGORY] (such as [NN], [Model], [Doc], [Feature]])
- [ ] I've leverage the [tools](https://docs.google.com/document/d/1iHyj7zlmygKSk5gBPsqIqL5ASPzJSPREaNT_QdsiYA4/edit) to beautify the python and c++ code.
- [ ] The PR is complete and small, read the [Google eng practice (CL equals to PR)](https://google.github.io/eng-practices/review/developer/small-cls.html) to understand more about small PR. In DGL, we consider PRs with less than 200 lines of core code change are small (example, test and documentation could be exempted).
- [ ] All changes have test coverage
- [ ] Code is well-documented
- [ ] To the best of my knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change
- [ ] Related issue is referred in this PR
- [ ] If the PR is for a new model/paper, I've updated the example index [here](../examples/README.md).

## Changes
- Modified Labor.
- Modified comments.
