### PR TITLE
[GraphBolt] enable TVT sets to read DGLGraphs

### DIFF
--- a/python/dgl/graphbolt/impl/ondisk_metadata.py
+++ b/python/dgl/graphbolt/impl/ondisk_metadata.py
@@ -23,6 +23,7 @@ class OnDiskFeatureDataFormat(str, Enum):
 
     TORCH = "torch"
     NUMPY = "numpy"
+    DGLGRAPH = "DGLGraph"
 
 
 class OnDiskTVTSetData(pydantic.BaseModel):

--- a/python/dgl/graphbolt/utils/internal.py
+++ b/python/dgl/graphbolt/utils/internal.py
@@ -5,6 +5,8 @@ import os
 import numpy as np
 import torch
 
+from ...data.graph_serialize import load_graphs
+
 
 def _read_torch_data(path):
     return torch.load(path)
@@ -22,6 +24,8 @@ def read_data(path, fmt, in_memory=True):
         return _read_torch_data(path)
     elif fmt == "numpy":
         return _read_numpy_data(path, in_memory=in_memory)
+    elif fmt == "DGLGraph":
+        return load_graphs(path)[0]
     else:
         raise RuntimeError(f"Unsupported format: {fmt}")
 


### PR DESCRIPTION
## Description
<!-- Brief description. Refer to the related issues if existed.
It'll be great if relevant reviewers can be assigned as well.-->
Data after preprocess should be in below format:
```
dataset_name: graph_classification
graph_topology: null
feature_data:
  - domain: graph
    type: null
    name: feat
    format: numpy
    in_memory: false
    path: preprocessed/graph_data/feat.npy
  - domain: graph
    type: null
    name: label
    format: numpy
    in_memory: true
    path: preprocessed/graph_data/label.npy
tasks:
  - name: graph_classification
    num_classes: 10
    train_set:
      - type: null
        data: # length of g.bin and label.npy should be same.
          - format: DGLGraph
            path: preprocessed/set/graph-train-g.bin
          - format: numpy
            in_memory: true
            path: preprocessed/set/graph-train-label.npy
    validation_set:
      - data:
          - format: DGLGraph
            path: preprocessed/set/graph-val-g.bin
          - format: numpy
            path: preprocessed/set/graph-val-label.npy
    test_set:
      - data:
          - format: DGLGraph
            path: preprocessed/set/graph-test-g.bin
          - format: numpy
            path: preprocessed/set/graph-test-label.npy
```
## Checklist
Please feel free to remove inapplicable items for your PR.
- [ ] The PR title starts with [$CATEGORY] (such as [NN], [Model], [Doc], [Feature]])
- [ ] I've leverage the [tools](https://docs.google.com/document/d/1iHyj7zlmygKSk5gBPsqIqL5ASPzJSPREaNT_QdsiYA4/edit) to beautify the python and c++ code.
- [ ] The PR is complete and small, read the [Google eng practice (CL equals to PR)](https://google.github.io/eng-practices/review/developer/small-cls.html) to understand more about small PR. In DGL, we consider PRs with less than 200 lines of core code change are small (example, test and documentation could be exempted).
- [ ] All changes have test coverage
- [ ] Code is well-documented
- [ ] To the best of my knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change
- [ ] Related issue is referred in this PR
- [ ] If the PR is for a new model/paper, I've updated the example index [here](../examples/README.md).

## Changes
<!-- You could use following template
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)
-->
