### PR TITLE
[BugFix] add input/output shape check in GatedGraphConv

### DIFF
--- a/python/dgl/nn/pytorch/conv/gatedgraphconv.py
+++ b/python/dgl/nn/pytorch/conv/gatedgraphconv.py
@@ -60,6 +60,7 @@ class GatedGraphConv(nn.Module):
 
     def __init__(self, in_feats, out_feats, n_steps, n_etypes, bias=True):
         super(GatedGraphConv, self).__init__()
+        assert in_feats <= out_feats, "out_feats must be not less than in_feats"
         self._in_feats = in_feats
         self._out_feats = out_feats
         self._n_steps = n_steps


### PR DESCRIPTION
## Description
<!-- Brief description. Refer to the related issues if existed.
It'll be great if relevant reviewers can be assigned as well.-->
In the GatedGraphConv, the out_feats (output dimension) must be not less than in_feats (input dimension), so add assert in  GatedGraphConv __init__ function.

related issue: https://github.com/dmlc/dgl/issues/6042

``` python
>>> from dgl.nn import GatedGraphConv
>>> conv = GatedGraphConv(10, 10, 2, 3) # No problem
>>> conv = GatedGraphConv(10, 5, 2, 3)# raise assert
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "dgl/python/dgl/nn/pytorch/conv/gatedgraphconv.py", line 63, in __init__
    assert in_feats <= out_feats, "out_feats must be not less than in_feats"
AssertionError: out_feats must be not less than in_feats
```


## Checklist
Please feel free to remove inapplicable items for your PR.
- [x] The PR title starts with [$CATEGORY] (such as [NN], [Model], [Doc], [Feature]])
- [x] I've leverage the [tools](https://docs.google.com/document/d/1iHyj7zlmygKSk5gBPsqIqL5ASPzJSPREaNT_QdsiYA4/edit) to beautify the python and c++ code.
- [x] The PR is complete and small, read the [Google eng practice (CL equals to PR)](https://google.github.io/eng-practices/review/developer/small-cls.html) to understand more about small PR. In DGL, we consider PRs with less than 200 lines of core code change are small (example, test and documentation could be exempted).
- [x] To the best of my knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change
- [x] Related issue is referred in this PR

## Changes
<!-- You could use following template
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)
-->
