### PR TITLE
Fixing some unittest warnings.

### DIFF
--- a/python/dgl/backend/pytorch/tensor.py
+++ b/python/dgl/backend/pytorch/tensor.py
@@ -509,6 +509,7 @@ def backward(x, head_gradient=None):
 
 
 def grad(x):
+    x.retain_grad()
     return x.grad
 
 

--- a/python/dgl/convert.py
+++ b/python/dgl/convert.py
@@ -1231,6 +1231,13 @@ def bipartite_from_scipy(
     return g.to(device)
 
 
+def _batcher(lst):
+    if F.is_tensor(lst[0]):
+        return F.cat([F.unsqueeze(x, 0) for x in lst], dim=0)
+
+    return F.tensor(np.array(lst)) if type(lst[0]) is np.ndarray else F.tensor(lst)
+
+
 def from_networkx(
     nx_graph,
     node_attrs=None,
@@ -1367,12 +1374,6 @@ def from_networkx(
 
     # handle features
     # copy attributes
-    def _batcher(lst):
-        if F.is_tensor(lst[0]):
-            return F.cat([F.unsqueeze(x, 0) for x in lst], dim=0)
-        else:
-            return F.tensor(lst)
-
     if node_attrs is not None:
         # mapping from feature name to a list of tensors to be concatenated
         attr_dict = defaultdict(list)
@@ -1592,12 +1593,6 @@ def bipartite_from_networkx(
 
     # handle features
     # copy attributes
-    def _batcher(lst):
-        if F.is_tensor(lst[0]):
-            return F.cat([F.unsqueeze(x, 0) for x in lst], dim=0)
-        else:
-            return F.tensor(lst)
-
     if u_attrs is not None:
         # mapping from feature name to a list of tensors to be concatenated
         src_attr_dict = defaultdict(list)

--- a/python/dgl/convert.py
+++ b/python/dgl/convert.py
@@ -1235,7 +1235,7 @@ def _batcher(lst):
     if F.is_tensor(lst[0]):
         return F.cat([F.unsqueeze(x, 0) for x in lst], dim=0)
 
-    if type(lst[0]) is np.ndarray:
+    if isinstance(lst[0], np.ndarray):
         return F.tensor(np.array(lst))
 
     return F.tensor(lst)

--- a/python/dgl/convert.py
+++ b/python/dgl/convert.py
@@ -1,4 +1,4 @@
-    """Module for converting graph from/to other object."""
+"""Module for converting graph from/to other object."""
 from collections import defaultdict
 from collections.abc import Mapping
 
@@ -1238,7 +1238,7 @@ def _batcher(lst):
     if type(lst[0]) is np.ndarray:
         return F.tensor(np.array(lst))
 
-     return F.tensor(lst)
+    return F.tensor(lst)
 
 
 def from_networkx(

--- a/python/dgl/convert.py
+++ b/python/dgl/convert.py
@@ -1,4 +1,4 @@
-"""Module for converting graph from/to other object."""
+    """Module for converting graph from/to other object."""
 from collections import defaultdict
 from collections.abc import Mapping
 

--- a/python/dgl/convert.py
+++ b/python/dgl/convert.py
@@ -1235,7 +1235,10 @@ def _batcher(lst):
     if F.is_tensor(lst[0]):
         return F.cat([F.unsqueeze(x, 0) for x in lst], dim=0)
 
-    return F.tensor(np.array(lst)) if type(lst[0]) is np.ndarray else F.tensor(lst)
+    if type(lst[0]) is np.ndarray:
+        return F.tensor(np.array(lst))
+
+     return F.tensor(lst)
 
 
 def from_networkx(

--- a/tests/python/common/test_propagate.py
+++ b/tests/python/common/test_propagate.py
@@ -89,7 +89,7 @@ def test_prop_nodes_topo(idtype):
     assert check_fail(dgl.prop_nodes_topo, g)  # has loop
 
     # tree
-    tree = dgl.DGLGraph()
+    tree = dgl.graph([])
     tree.add_nodes(5)
     tree.add_edges(1, 0)
     tree.add_edges(2, 0)

--- a/tests/python/common/test_subgraph.py
+++ b/tests/python/common/test_subgraph.py
@@ -13,7 +13,7 @@ D = 5
 
 
 def generate_graph(grad=False, add_data=True):
-    g = dgl.DGLGraph().to(F.ctx())
+    g = dgl.graph([]).to(F.ctx())
     g.add_nodes(10)
     # create a graph where 0 is the source and 9 is the sink
     for i in range(1, 9):
@@ -111,7 +111,7 @@ def test_subgraph_relabel_nodes(relabel_nodes):
 
 
 def _test_map_to_subgraph():
-    g = dgl.DGLGraph()
+    g = dgl.graph([])
     g.add_nodes(10)
     g.add_edges(F.arange(0, 9), F.arange(1, 10))
     h = g.subgraph([0, 1, 2, 5, 8])

--- a/tests/python/common/test_traversal.py
+++ b/tests/python/common/test_traversal.py
@@ -95,7 +95,7 @@ DFS_LABEL_NAMES = ["forward", "reverse", "nontree"]
 
 @parametrize_idtype
 def test_dfs_labeled_edges(idtype, example=False):
-    dgl_g = dgl.DGLGraph().astype(idtype)
+    dgl_g = dgl.graph([]).astype(idtype)
     dgl_g.add_nodes(6)
     dgl_g.add_edges([0, 1, 0, 3, 3], [1, 2, 2, 4, 5])
     dgl_edges, dgl_labels = dgl.dfs_labeled_edges_generator(


### PR DESCRIPTION
## Description
<!-- Brief description. Refer to the related issues if existed.
It'll be great if relevant reviewers can be assigned as well.-->
Removing the following warning that appears in tests implemented in `test_heterograph-update-all.py`, `test_heterograph.py`, ``test_propagate.py`, `test_subgraph.py` and `test_traversal.py`:
```
================================================================================================= warnings summary =================================================================================================
tests/python/common/test_heterograph-update-all.py::test_binary_op[idtype0]
tests/python/common/test_heterograph-update-all.py::test_binary_op[idtype1]
  /usr/local/lib/python3.10/dist-packages/dgl/backend/pytorch/tensor.py:509: UserWarning: The .grad attribute of a Tensor that is not a leaf Tensor is being accessed.
  Its .grad attribute won't be populated during autograd.backward(). If you indeed want the .grad field to be populated for a non-leaf Tensor, use .retain_grad()
  on the non-leaf Tensor. If you access the non-leaf Tensor by mistake, make sure you access the leaf Tensor instead.
  See github.com/pytorch/pytorch/pull/30531 for more informations. (Triggered internally at /opt/pytorch/pytorch/build/aten/src/ATen/core/TensorBody.h:487.)

tests/python/common/test_heterograph.py::test_create[idtype0]
  /usr/local/lib/python3.10/dist-packages/dgl/backend/pytorch/tensor.py:52: UserWarning: Creating a tensor from a list of numpy.ndarrays is extremely slow.
  Please consider converting the list to a single numpy.ndarray with numpy.array() before converting to a tensor.
  (Triggered internally at /opt/pytorch/pytorch/torch/csrc/utils/tensor_new.cpp:261.)
    return th.as_tensor(data, dtype=dtype)

tests/python/common/test_propagate.py: 2 warnings
tests/python/common/test_subgraph.py: 2 warnings
tests/python/common/test_traversal.py: 2 warnings
/usr/local/lib/python3.10/dist-packages/dgl/heterograph.py:92: DGLWarning: Recommend creating graphs by `dgl.graph(data)` instead of `dgl.DGLGraph(data)`
```

## Checklist
Please feel free to remove inapplicable items for your PR.
- [x] I've leverage the [tools](https://docs.google.com/document/d/1iHyj7zlmygKSk5gBPsqIqL5ASPzJSPREaNT_QdsiYA4/edit) to beautify the python and c++ code.
- [x] The PR is complete and small, read the [Google eng practice (CL equals to PR)](https://google.github.io/eng-practices/review/developer/small-cls.html) to understand more about small PR. In DGL, we consider PRs with less than 200 lines of core code change are small (example, test and documentation could be exempted).
- [x] All changes have test coverage
- [x] Code is well-documented
- [x] To the best of my knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

## Changes
<!-- You could use following template
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)
-->
