### PR TITLE
Improving transform tests.

### DIFF
--- a/python/dgl/transforms/functional.py
+++ b/python/dgl/transforms/functional.py
@@ -3600,11 +3600,11 @@ def random_walk_pe(g, k, eweight_name=None):
         RW = (A / (A.sum(1) + 1e-30)).toarray()
 
     # Iterate for k steps
-    PE = [F.astype(F.tensor(RW.diagonal()), F.float32)]
+    PE = [F.astype(F.tensor(np.array(RW.diagonal())), F.float32)]
     RW_power = RW
     for _ in range(k - 1):
         RW_power = RW_power @ RW
-        PE.append(F.astype(F.tensor(RW_power.diagonal()), F.float32))
+        PE.append(F.astype(F.tensor(np.array(RW_power.diagonal())), F.float32))
     PE = F.stack(PE, dim=-1)
 
     return PE


### PR DESCRIPTION
## Description
<!-- Brief description. Refer to the related issues if existed.
It'll be great if relevant reviewers can be assigned as well.-->
Removing the following warning that appears in tests implemented in `tests/python/common/transforms/test_transform.py`:
```
================================================================================================= warnings summary =================================================================================================
tests/python/common/transforms/test_transform.py: 10 warnings
  /usr/local/lib/python3.10/dist-packages/dgl/heterograph.py:92: DGLWarning: Recommend creating graphs by `dgl.graph(data)` instead of `dgl.DGLGraph(data)`.
    dgl_warning(

tests/python/common/transforms/test_transform.py::test_reverse_shared_frames[idtype0]
tests/python/common/transforms/test_transform.py::test_reverse_shared_frames[idtype1]
  /usr/local/lib/python3.10/dist-packages/dgl/transforms/functional.py:1365: DGLWarning: share_ndata argument has been renamed to copy_ndata.
    dgl_warning("share_ndata argument has been renamed to copy_ndata.")

tests/python/common/transforms/test_transform.py::test_reverse_shared_frames[idtype0]
tests/python/common/transforms/test_transform.py::test_reverse_shared_frames[idtype1]
  /usr/local/lib/python3.10/dist-packages/dgl/transforms/functional.py:1368: DGLWarning: share_edata argument has been renamed to copy_edata.
    dgl_warning("share_edata argument has been renamed to copy_edata.")

tests/python/common/transforms/test_transform.py::test_simple_graph
  /usr/local/lib/python3.10/dist-packages/dgl/heterograph.py:120: DGLWarning: Keyword arguments ['readonly'] are deprecated in v0.5, and can be safely removed in all cases.
    dgl_warning(

tests/python/common/transforms/test_transform.py::test_simple_graph
  /usr/local/lib/python3.10/dist-packages/dgl/transforms/functional.py:1420: DGLWarning: dgl.to_simple_graph is renamed to dgl.to_simple in v0.5.
    dgl_warning("dgl.to_simple_graph is renamed to dgl.to_simple in v0.5.")

tests/python/common/transforms/test_transform.py::test_module_random_walk_pe[idtype0]
  /usr/local/lib/python3.10/dist-packages/dgl/backend/pytorch/tensor.py:52: UserWarning: The given NumPy array is not writable, and PyTorch does not support non-writable tensors. This means writing to this tensor will result in undefined behavior. You may want to copy the array to protect its data or make it writable before converting it to a tensor. This type of warning will be suppressed for the rest of this program. (Triggered internally at /opt/pytorch/pytorch/torch/csrc/utils/tensor_numpy.cpp:206.)
    return th.as_tensor(data, dtype=dtype)
```

## Checklist
Please feel free to remove inapplicable items for your PR.
- [x] I've leverage the [tools](https://docs.google.com/document/d/1iHyj7zlmygKSk5gBPsqIqL5ASPzJSPREaNT_QdsiYA4/edit) to beautify the python and c++ code.
- [x] The PR is complete and small, read the [Google eng practice (CL equals to PR)](https://google.github.io/eng-practices/review/developer/small-cls.html) to understand more about small PR. In DGL, we consider PRs with less than 200 lines of core code change are small (example, test and documentation could be exempted).
- [x] All changes have test coverage
- [x] Code is well-documented
- [x] To the best of my knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

## Changes
<!-- You could use following template
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)
-->
