### PR TITLE
[Bug] fix memory leak in cpp tests

### DIFF
--- a/src/runtime/workspace_pool.cc
+++ b/src/runtime/workspace_pool.cc
@@ -128,6 +128,8 @@ WorkspacePool::~WorkspacePool() {
    * Comment out the destruct of WorkspacePool, due to Segmentation fault with
    * MXNet Since this will be only called at the termination of process, not
    * manually wiping out should not cause problems.
+   * Note, this will cause memory leak without the following code, so, maybe
+   * we need to solve the problem.
    */
   // for (size_t i = 0; i < array_.size(); ++i) {
   //   if (array_[i] != nullptr) {

--- a/tests/cpp/message_queue_test.cc
+++ b/tests/cpp/message_queue_test.cc
@@ -89,9 +89,9 @@ TEST(MessageQueueTest, MultiThread) {
   MessageQueue queue(100000, kNumOfProducer);
   EXPECT_EQ(queue.EmptyAndNoMoreAdd(), false);
   EXPECT_EQ(queue.Empty(), true);
-  std::vector<std::thread*> thread_pool;
+  std::vector<std::thread> thread_pool(kNumOfProducer);
   for (int i = 0; i < kNumOfProducer; ++i) {
-    thread_pool.push_back(new std::thread(start_add, &queue, i));
+    thread_pool[i] = std::thread(start_add, &queue, i);
   }
   for (int i = 0; i < kNumOfProducer * kNumOfMessage; ++i) {
     Message msg;
@@ -99,7 +99,7 @@ TEST(MessageQueueTest, MultiThread) {
     EXPECT_EQ(string(msg.data, msg.size), string("apple"));
   }
   for (int i = 0; i < kNumOfProducer; ++i) {
-    thread_pool[i]->join();
+    thread_pool[i].join();
   }
   EXPECT_EQ(queue.EmptyAndNoMoreAdd(), true);
 }

--- a/tests/cpp/socket_communicator_test.cc
+++ b/tests/cpp/socket_communicator_test.cc
@@ -44,20 +44,20 @@ static void start_server(int id);
 
 TEST(SocketCommunicatorTest, SendAndRecv) {
   // start 10 client
-  std::vector<std::thread*> client_thread;
+  std::vector<std::thread> client_thread(kNumSender);
   for (int i = 0; i < kNumSender; ++i) {
-    client_thread.push_back(new std::thread(start_client));
+    client_thread[i] = std::thread(start_client);
   }
   // start 10 server
-  std::vector<std::thread*> server_thread;
+  std::vector<std::thread> server_thread(kNumReceiver);
   for (int i = 0; i < kNumReceiver; ++i) {
-    server_thread.push_back(new std::thread(start_server, i));
+    server_thread[i] = std::thread(start_server, i);
   }
   for (int i = 0; i < kNumSender; ++i) {
-    client_thread[i]->join();
+    client_thread[i].join();
   }
   for (int i = 0; i < kNumReceiver; ++i) {
-    server_thread[i]->join();
+    server_thread[i].join();
   }
 }
 


### PR DESCRIPTION
## Description
<!-- Brief description. Refer to the related issues if existed.
It'll be great if relevant reviewers can be assigned as well.-->
There are memory leaks in cpp tests, we can see them when building with ASAN, fix them.
Add the ASAN option in CMakeLists.txt.

## Checklist
Please feel free to remove inapplicable items for your PR.
- [x] The PR title starts with [$CATEGORY] (such as [NN], [Model], [Doc], [Feature]])
- [x] I've leverage the [tools](https://docs.google.com/document/d/1iHyj7zlmygKSk5gBPsqIqL5ASPzJSPREaNT_QdsiYA4/edit) to beautify the python and c++ code.
- [x] The PR is complete and small, read the [Google eng practice (CL equals to PR)](https://google.github.io/eng-practices/review/developer/small-cls.html) to understand more about small PR. In DGL, we consider PRs with less than 200 lines of core code change are small (example, test and documentation could be exempted).
- [x] All changes have test coverage
- [x] Code is well-documented
- [x] To the best of my knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

## Changes
<!-- You could use following template
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)
-->
