### PR TITLE
[Graphbolt]Support unequal src and dst length in compact

### DIFF
--- a/python/dgl/graphbolt/utils/sample_utils.py
+++ b/python/dgl/graphbolt/utils/sample_utils.py
@@ -30,6 +30,12 @@ def unique_and_compact_node_pairs(
         - If `node_pairs` is a dictionary: The keys should be edge type and
         the values should be corresponding node pairs. And IDs inside are
         heterogeneous ids.
+        Note: These two tensors may have different shapes in some cases. For
+        instance, when the data format is 'HEAD_CONDITIONED', the 'src' tensor
+        is longer as it contains both positive and negative nodes, whereas
+        the 'dst' tensor only contains positive nodes. Similarly, for
+        'TAIL_CONDITIONED' data, the 'dst' tensor is longer.
+
     unique_dst_nodes: torch.Tensor or Dict[str, torch.Tensor]
         Unique nodes of all destination nodes in the node pairs.
         - If `unique_dst_nodes` is a tensor: It means the graph is homogeneous.
@@ -103,13 +109,14 @@ def unique_and_compact_node_pairs(
     compacted_node_pairs = {}
     # Map back with the same order.
     for etype, pair in node_pairs.items():
-        num_elem = pair[0].size(0)
+        num_src_elem = pair[0].size(0)
+        num_dst_elem = pair[1].size(0)
         src_type, _, dst_type = etype
-        src = compacted_src[src_type][:num_elem]
-        dst = compacted_dst[dst_type][:num_elem]
+        src = compacted_src[src_type][:num_src_elem]
+        dst = compacted_dst[dst_type][:num_dst_elem]
         compacted_node_pairs[etype] = (src, dst)
-        compacted_src[src_type] = compacted_src[src_type][num_elem:]
-        compacted_dst[dst_type] = compacted_dst[dst_type][num_elem:]
+        compacted_src[src_type] = compacted_src[src_type][num_src_elem:]
+        compacted_dst[dst_type] = compacted_dst[dst_type][num_dst_elem:]
 
     # Return singleton for a homogeneous graph.
     if is_homogeneous:

--- a/tests/python/pytorch/graphbolt/test_graphbolt_utils.py
+++ b/tests/python/pytorch/graphbolt/test_graphbolt_utils.py
@@ -69,3 +69,68 @@ def test_incomplete_unique_dst_nodes_():
     unique_dst_nodes = torch.arange(150, 200)
     with pytest.raises(IndexError):
         gb.unique_and_compact_node_pairs(node_pairs, unique_dst_nodes)
+
+
+@pytest.mark.parametrize("longer_src", [True, False])
+def test_unequal_src_dst_num_homo(longer_src):
+    num = 200
+    N = torch.randint(0, 50, (num,))
+    expected_unique_N = torch.unique(N)
+
+    num_src = num // 3 * 2 if longer_src // 3 else num // 3
+
+    node_pairs = (N[:num_src], N[num_src:])
+    unique_nodes, compacted_node_pairs = gb.unique_and_compact_node_pairs(
+        node_pairs
+    )
+    assert torch.equal(torch.sort(unique_nodes)[0], expected_unique_N)
+
+    u, v = compacted_node_pairs
+    u, v = unique_nodes[u], unique_nodes[v]
+    expected_u, expected_v = node_pairs
+    unique_v = torch.unique(expected_v)
+    assert torch.equal(u, expected_u)
+    assert torch.equal(v, expected_v)
+    assert torch.equal(unique_nodes[: unique_v.size(0)], unique_v)
+
+
+def test_unequal_src_dst_num_hetero():
+    N1 = torch.randint(0, 50, (30,))
+    N2 = torch.randint(0, 50, (20,))
+    N3 = torch.randint(0, 50, (10,))
+    unique_N1 = torch.unique(N1)
+    unique_N2 = torch.unique(N2)
+    unique_N3 = torch.unique(N3)
+    expected_unique_nodes = {
+        "n1": unique_N1,
+        "n2": unique_N2,
+        "n3": unique_N3,
+    }
+    node_pairs = {
+        ("n1", "e1", "n2"): (
+            N1[:20],
+            N2[:15],
+        ),
+        ("n1", "e2", "n3"): (
+            N1[15:30],
+            N3,
+        ),
+        ("n2", "e3", "n3"): (
+            N2[10:],
+            N3,
+        ),
+    }
+
+    unique_nodes, compacted_node_pairs = gb.unique_and_compact_node_pairs(
+        node_pairs
+    )
+    for ntype, nodes in unique_nodes.items():
+        expected_nodes = expected_unique_nodes[ntype]
+        assert torch.equal(torch.sort(nodes)[0], expected_nodes)
+    for etype, pair in compacted_node_pairs.items():
+        u, v = pair
+        u_type, _, v_type = etype
+        u, v = unique_nodes[u_type][u], unique_nodes[v_type][v]
+        expected_u, expected_v = node_pairs[etype]
+        assert torch.equal(u, expected_u)
+        assert torch.equal(v, expected_v)


### PR DESCRIPTION
## Description
Support unequal src and dst length in compact, this is for cases where data contains only negative heads or tails.

## Checklist
Please feel free to remove inapplicable items for your PR.
- [ ] The PR title starts with [$CATEGORY] (such as [NN], [Model], [Doc], [Feature]])
- [ ] I've leverage the [tools](https://docs.google.com/document/d/1iHyj7zlmygKSk5gBPsqIqL5ASPzJSPREaNT_QdsiYA4/edit) to beautify the python and c++ code.
- [ ] The PR is complete and small, read the [Google eng practice (CL equals to PR)](https://google.github.io/eng-practices/review/developer/small-cls.html) to understand more about small PR. In DGL, we consider PRs with less than 200 lines of core code change are small (example, test and documentation could be exempted).
- [ ] All changes have test coverage
- [ ] Code is well-documented
- [ ] To the best of my knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change
- [ ] Related issue is referred in this PR
- [ ] If the PR is for a new model/paper, I've updated the example index [here](../examples/README.md).

## Changes
<!-- You could use following template
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)
-->
