### PR TITLE
[Graphbolt] Adapt negative sampler input

### DIFF
--- a/python/dgl/graphbolt/negative_sampler.py
+++ b/python/dgl/graphbolt/negative_sampler.py
@@ -43,7 +43,7 @@ class NegativeSampler(Mapper):
 
         Parameters
         ----------
-        LinkPredictionBlock : LinkPredictionBlock
+        data : LinkPredictionBlock
             An instance of 'LinkPredictionBlock' class requires the 'node_pair'
             field. This function is responsible for generating negative edges
             corresponding to the positive edges defined by the 'node_pair'. In

--- a/python/dgl/graphbolt/negative_sampler.py
+++ b/python/dgl/graphbolt/negative_sampler.py
@@ -43,11 +43,12 @@ class NegativeSampler(Mapper):
 
         Parameters
         ----------
-        LinkPredictionBlock : Tuple[Tensor] or Dict[etype, Tuple[Tensor]]
-            An instance of 'LinkPredictionBlock', where 'node_pair' is required
-            while 'negative_head' and 'negative_tail' should be None. If either
-            of them has value, it inidcates there have already negative samples
-            , thus the function will do nothing.
+        LinkPredictionBlock : LinkPredictionBlock
+            An instance of 'LinkPredictionBlock' class requires the 'node_pair'
+            field. This function is responsible for generating negative edges
+            corresponding to the positive edges defined by the 'node_pair'. In
+            cases where negative edges already exist, this function will
+            overwrite them.
 
         Returns
         -------
@@ -55,15 +56,14 @@ class NegativeSampler(Mapper):
             An instance of 'LinkPredictionBlock' encompasses both positive and
             negative samples.
         """
-        if data.negative_head is None and data.negative_tail is None:
-            node_pairs = data.node_pair
-            if isinstance(node_pairs, Mapping):
-                for etype, pos_pairs in node_pairs.items():
-                    self._collate(
-                        data, self._sample_with_etype(pos_pairs, etype), etype
-                    )
-            else:
-                self._collate(data, self._sample_with_etype(node_pairs))
+        node_pairs = data.node_pair
+        if isinstance(node_pairs, Mapping):
+            for etype, pos_pairs in node_pairs.items():
+                self._collate(
+                    data, self._sample_with_etype(pos_pairs, etype), etype
+                )
+        else:
+            self._collate(data, self._sample_with_etype(node_pairs))
         return data
 
     def _sample_with_etype(self, node_pairs, etype=None):

--- a/python/dgl/graphbolt/negative_sampler.py
+++ b/python/dgl/graphbolt/negative_sampler.py
@@ -6,7 +6,6 @@ import torch
 from torchdata.datapipes.iter import Mapper
 
 from .data_format import LinkPredictionEdgeFormat
-from .link_prediction_block import LinkPredictionBlock
 
 
 class NegativeSampler(Mapper):

--- a/tests/python/pytorch/graphbolt/impl/test_negative_sampler.py
+++ b/tests/python/pytorch/graphbolt/impl/test_negative_sampler.py
@@ -2,6 +2,11 @@ import dgl.graphbolt as gb
 import gb_test_utils
 import pytest
 import torch
+from torchdata.datapipes.iter import Mapper
+
+
+def to_data_block(data):
+    return gb.LinkPredictionBlock(node_pair=data)
 
 
 @pytest.mark.parametrize("negative_ratio", [1, 5, 10, 20])
@@ -17,9 +22,10 @@ def test_NegativeSampler_Independent_Format(negative_ratio):
     )
     batch_size = 10
     minibatch_sampler = gb.MinibatchSampler(item_set, batch_size=batch_size)
+    data_block_converter = Mapper(minibatch_sampler, to_data_block)
     # Construct NegativeSampler.
     negative_sampler = gb.UniformNegativeSampler(
-        minibatch_sampler,
+        data_block_converter,
         negative_ratio,
         gb.LinkPredictionEdgeFormat.INDEPENDENT,
         graph,
@@ -49,9 +55,10 @@ def test_NegativeSampler_Conditioned_Format(negative_ratio):
     )
     batch_size = 10
     minibatch_sampler = gb.MinibatchSampler(item_set, batch_size=batch_size)
+    data_block_converter = Mapper(minibatch_sampler, to_data_block)
     # Construct NegativeSampler.
     negative_sampler = gb.UniformNegativeSampler(
-        minibatch_sampler,
+        data_block_converter,
         negative_ratio,
         gb.LinkPredictionEdgeFormat.CONDITIONED,
         graph,
@@ -84,9 +91,10 @@ def test_NegativeSampler_Head_Conditioned_Format(negative_ratio):
     )
     batch_size = 10
     minibatch_sampler = gb.MinibatchSampler(item_set, batch_size=batch_size)
+    data_block_converter = Mapper(minibatch_sampler, to_data_block)
     # Construct NegativeSampler.
     negative_sampler = gb.UniformNegativeSampler(
-        minibatch_sampler,
+        data_block_converter,
         negative_ratio,
         gb.LinkPredictionEdgeFormat.HEAD_CONDITIONED,
         graph,
@@ -117,9 +125,10 @@ def test_NegativeSampler_Tail_Conditioned_Format(negative_ratio):
     )
     batch_size = 10
     minibatch_sampler = gb.MinibatchSampler(item_set, batch_size=batch_size)
+    data_block_converter = Mapper(minibatch_sampler, to_data_block)
     # Construct NegativeSampler.
     negative_sampler = gb.UniformNegativeSampler(
-        minibatch_sampler,
+        data_block_converter,
         negative_ratio,
         gb.LinkPredictionEdgeFormat.TAIL_CONDITIONED,
         graph,


### PR DESCRIPTION
## Description
Change negative sampler input ot `LinkPredictionBlock`.

## Checklist
Please feel free to remove inapplicable items for your PR.
- [ ] The PR title starts with [$CATEGORY] (such as [NN], [Model], [Doc], [Feature]])
- [ ] I've leverage the [tools](https://docs.google.com/document/d/1iHyj7zlmygKSk5gBPsqIqL5ASPzJSPREaNT_QdsiYA4/edit) to beautify the python and c++ code.
- [ ] The PR is complete and small, read the [Google eng practice (CL equals to PR)](https://google.github.io/eng-practices/review/developer/small-cls.html) to understand more about small PR. In DGL, we consider PRs with less than 200 lines of core code change are small (example, test and documentation could be exempted).
- [ ] All changes have test coverage
- [ ] Code is well-documented
- [ ] To the best of my knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change
- [ ] Related issue is referred in this PR
- [ ] If the PR is for a new model/paper, I've updated the example index [here](../examples/README.md).

## Changes
<!-- You could use following template
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)
-->
