### PR TITLE
Testing a data frame with unnamed columns.

### DIFF
--- a/docs/source/guide/data-loadcsv.rst
+++ b/docs/source/guide/data-loadcsv.rst
@@ -461,7 +461,7 @@ To parse the string type labels, one can define a ``DataParser`` class as follow
             parsed = {}
             for header in df:
                 if 'Unnamed' in header:  # Handle Unnamed column
-                    print("Unamed column is found. Ignored...")
+                    print("Unnamed column is found. Ignored...")
                     continue
                 dt = df[header].to_numpy().squeeze()
                 if header == 'label':

--- a/python/dgl/data/csv_dataset_base.py
+++ b/python/dgl/data/csv_dataset_base.py
@@ -376,7 +376,7 @@ class DefaultDataParser:
         data = {}
         for header in df:
             if "Unnamed" in header:
-                dgl_warning("Unamed column is found. Ignored...")
+                dgl_warning("Unnamed column is found. Ignored...")
                 continue
             dt = df[header].to_numpy().squeeze()
             if len(dt) > 0 and isinstance(dt[0], str):

--- a/tests/python/common/data/test_data.py
+++ b/tests/python/common/data/test_data.py
@@ -737,17 +737,19 @@ def _test_construct_graphs_multiple():
     assert expect_except
 
 
-def _get_data_table(data_frame):
+def _get_data_table(data_frame, save_index=False):
     from dgl.data.csv_dataset_base import DefaultDataParser
 
     with tempfile.TemporaryDirectory() as test_dir:
         csv_path = os.path.join(test_dir, "nodes.csv")
 
-        data_frame.to_csv(csv_path, index=False)
+        data_frame.to_csv(csv_path, index=save_index)
         dp = DefaultDataParser()
         df = pd.read_csv(csv_path)
 
-    # Intercepting the warning: "Unamed column is found. Ignored...".
+    # Warning suppression : "Untitled column found. Ignored...",
+    # which appears when a CSV file is saved with an index:
+    #    data_frame.to_csv(csv_path, index=True).
     with warnings.catch_warnings():
         warnings.simplefilter("ignore", category=UserWarning)
         return dp(df)
@@ -785,7 +787,7 @@ def _test_DefaultDataParser():
 
     # csv has index column which is ignored as it's unnamed
     df = pd.DataFrame({"label": [1, 2, 3]})
-    dt = _get_data_table(df)
+    dt = _get_data_table(df, True)
     assert len(dt) == 1
 
 


### PR DESCRIPTION
## Description
<!-- Brief description. Refer to the related issues if existed.
It'll be great if relevant reviewers can be assigned as well.-->
In the test `_test_DefaultDataParser`, when `data_frame` is saved to CSV file with parameter `index=True`: 
```
          data_frame.to_csv(csv_path, index=True)
```
a column named "Unnamed 0:" is created. There was a test for reading such CSV files but it was accidentally deactivated by [PR#6144](https://github.com/dmlc/dgl/pull/6144), where we started using
```
          data_frame.to_csv(csv_path, index=False)
```
for all subtests.

In the current PR, we are restoring testing of reading CSV files with unnamed columns and fixing a few typos.

## Checklist
Please feel free to remove inapplicable items for your PR.
- [x] I've leverage the [tools](https://docs.google.com/document/d/1iHyj7zlmygKSk5gBPsqIqL5ASPzJSPREaNT_QdsiYA4/edit) to beautify the python and c++ code.
- [x] The PR is complete and small, read the [Google eng practice (CL equals to PR)](https://google.github.io/eng-practices/review/developer/small-cls.html) to understand more about small PR. In DGL, we consider PRs with less than 200 lines of core code change are small (example, test and documentation could be exempted).
- [x] All changes have test coverage
- [x] Code is well-documented
- [x] To the best of my knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change
