### PR TITLE
Eliminating warning generated by test_hgt.

### DIFF
--- a/tests/python/pytorch/nn/test_nn.py
+++ b/tests/python/pytorch/nn/test_nn.py
@@ -2086,9 +2086,16 @@ def test_hgt(idtype, in_size, num_heads):
     train_idx = th.randperm(100, dtype=idtype)[:10]
     sampler = dgl.dataloading.NeighborSampler([-1])
     train_loader = dgl.dataloading.DataLoader(
-        g, train_idx.to(dev), sampler, batch_size=8, device=dev, shuffle=True
+        g,
+        train_idx.to(dev),
+        sampler,
+        batch_size=8,
+        num_workers=1,
+        device=dev,
+        shuffle=True
     )
-    (input_nodes, output_nodes, block) = next(iter(train_loader))
+    with train_loader.enable_cpu_affinity():
+        (input_nodes, output_nodes, block) = next(iter(train_loader))
     block = block[0]
     x = x[input_nodes.to(th.long)]
     ntype = ntype[input_nodes.to(th.long)]


### PR DESCRIPTION
## Description
<!-- Brief description. Refer to the related issues if existed.
It'll be great if relevant reviewers can be assigned as well.-->
Elimination  of the following warning that appears in `test_hgt` implemented in `nn/testnn.py`
```
tests/python/pytorch/nn/test_nn.py::test_hgt[1-4-idtype0]
tests/python/pytorch/nn/test_nn.py::test_hgt[1-4-idtype1]
  /usr/local/lib/python3.10/dist-packages/dgl/dataloading/dataloader.py:1149: DGLWarning: Dataloader CPU affinity opt is not enabled, consider switching it on (see enable_cpu_affinity() or CPU best practices for DGL [https://docs.dgl.ai/tutorials/cpu/cpu_best_practises.html])
```

## Checklist
Please feel free to remove inapplicable items for your PR.
- [x] I've leverage the [tools](https://docs.google.com/document/d/1iHyj7zlmygKSk5gBPsqIqL5ASPzJSPREaNT_QdsiYA4/edit) to beautify the python and c++ code.
- [x] The PR is complete and small, read the [Google eng practice (CL equals to PR)](https://google.github.io/eng-practices/review/developer/small-cls.html) to understand more about small PR. In DGL, we consider PRs with less than 200 lines of core code change are small (example, test and documentation could be exempted).
- [x] All changes have test coverage
- [x] Code is well-documented
- [x] To the best of my knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

