### PR TITLE
Improving gpu_cache test.

### DIFF
--- a/tests/python/common/cuda/test_gpu_cache.py
+++ b/tests/python/common/cuda/test_gpu_cache.py
@@ -25,7 +25,7 @@ D = 5
 
 
 def generate_graph(idtype, grad=False, add_data=True):
-    g = dgl.DGLGraph().to(F.ctx(), dtype=idtype)
+    g = dgl.graph([]).to(F.ctx(), dtype=idtype)
     g.add_nodes(10)
     u, v = [], []
     # create a graph where 0 is the source and 9 is the sink


### PR DESCRIPTION
## Description
<!-- Brief description. Refer to the related issues if existed.
It'll be great if relevant reviewers can be assigned as well.-->
Elimination  of the following warning that appears in `test_gpu_cache` implemented in `cuda/test_gpu_cache.py`:
```
tests/python/common/cuda/test_gpu_cache.py::test_gpu_cache[idtype0]
tests/python/common/cuda/test_gpu_cache.py::test_gpu_cache[idtype1]
  /usr/local/lib/python3.10/dist-packages/dgl/heterograph.py:92: DGLWarning: Recommend creating graphs by `dgl.graph(data)` instead of `dgl.DGLGraph(data)`.
```

## Checklist
- [x] I've leverage the [tools](https://docs.google.com/document/d/1iHyj7zlmygKSk5gBPsqIqL5ASPzJSPREaNT_QdsiYA4/edit) to beautify the python and c++ code.
- [x] The PR is complete and small, read the [Google eng practice (CL equals to PR)](https://google.github.io/eng-practices/review/developer/small-cls.html) to understand more about small PR. In DGL, we consider PRs with less than 200 lines of core code change are small (example, test and documentation could be exempted).
- [x] All changes have test coverage
- [x] Code is well-documented
- [x] To the best of my knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

