### PR TITLE
[Model] Add Node explanations for SubgraphX Homogeneous Explainer

### DIFF
--- a/python/dgl/nn/pytorch/explain/subgraphx.py
+++ b/python/dgl/nn/pytorch/explain/subgraphx.py
@@ -443,7 +443,7 @@ class SubgraphX(nn.Module):
         sg_feat = feat[sg_nodes]
 
         eg_nodes = self.explain_graph(sg, sg_feat, target_class, **kwargs)
-        original_nodes = sg_nodes[eg_nodes]
+        original_nodes = sg_nodes[eg_nodes.long()]
         return original_nodes
 
 
@@ -988,7 +988,7 @@ class HeteroSubgraphX(nn.Module):
 
         eg_nodes = self.explain_graph(sg, sg_feat, target_class, **kwargs)
         original_nodes = {
-            ntype: sg_nodes[ntype][eg_node_ids]
+            ntype: sg_nodes[ntype][eg_node_ids.long()]
             for ntype, eg_node_ids in eg_nodes.items()
         }
         return original_nodes

--- a/python/dgl/nn/pytorch/explain/subgraphx.py
+++ b/python/dgl/nn/pytorch/explain/subgraphx.py
@@ -6,7 +6,7 @@ import numpy as np
 import torch
 import torch.nn as nn
 
-from .... import to_heterogeneous, to_homogeneous, khop_out_subgraph
+from .... import khop_out_subgraph, to_heterogeneous, to_homogeneous
 from ....base import NID
 from ....convert import to_networkx
 from ....subgraph import node_subgraph

--- a/python/dgl/nn/pytorch/explain/subgraphx.py
+++ b/python/dgl/nn/pytorch/explain/subgraphx.py
@@ -157,10 +157,8 @@ class SubgraphX(nn.Module):
             # TODO: per paper, "when computing the marginalized contributions,
             # the zero-padding strategy should exclude the target node v_i"
             if (
-                self.explanation_type is not None
-                and self.explanation_type == "node"
-                # and self.explanation_node_target in subgraph_nodes # TODO(detailed impl.)
-            ):
+                self.explanation_type == "node"
+            ):  # and self.explanation_node_target in subgraph_nodes # TODO(detailed impl.)
                 exclude_mask[self.node_explanation_target] = 1.0
 
             # Mask for set S_i and g_i
@@ -344,6 +342,7 @@ class SubgraphX(nn.Module):
         ), f"The number of nodes in the\
             graph {graph.num_nodes()} should be bigger than {self.node_min}."
 
+        self.explanation_type = "graph"
         self.graph = graph
         self.feat = feat
         self.target_class = target_class

--- a/tests/python/pytorch/nn/test_nn.py
+++ b/tests/python/pytorch/nn/test_nn.py
@@ -1797,12 +1797,13 @@ def test_heterosubgraphx(g, idtype, input_dim, n_classes):
     model = Model(input_dim, n_classes, g.canonical_etypes)
     model = model.to(ctx)
     explainer = nn.HeteroSubgraphX(
-        model, num_hops=1, shapley_steps=20, num_rollouts=5, coef=2.0
+        model, num_hops=2, shapley_steps=20, num_rollouts=5, coef=2.0
     )
     # Explain graph prediction
     explainer.explain_graph(g, feat, target_class=0)
     # Explain node prediction
-    explainer.explain_node(g.ntypes[0], 0, g, feat, target_class=0)
+    # * node_id 0 from g.ntypes[0] will not pass the node_min requirement.
+    explainer.explain_node(g.ntypes[0], 1, g, feat, target_class=0)
 
 
 @parametrize_idtype

--- a/tests/python/pytorch/nn/test_nn.py
+++ b/tests/python/pytorch/nn/test_nn.py
@@ -1739,7 +1739,10 @@ def test_subgraphx(g, idtype, n_classes):
     explainer = nn.SubgraphX(
         model, num_hops=1, shapley_steps=20, num_rollouts=5, coef=2.0
     )
+    # Explain graph prediction
     explainer.explain_graph(g, feat, target_class=0)
+    # Explain node prediction
+    explainer.explain_node(0, g, feat, target_class=0)
 
 
 @pytest.mark.parametrize("g", get_cases(["hetero"], exclude=["zero-degree"]))
@@ -1796,7 +1799,10 @@ def test_heterosubgraphx(g, idtype, input_dim, n_classes):
     explainer = nn.HeteroSubgraphX(
         model, num_hops=1, shapley_steps=20, num_rollouts=5, coef=2.0
     )
+    # Explain graph prediction
     explainer.explain_graph(g, feat, target_class=0)
+    # Explain node prediction
+    explainer.explain_node(g.ntypes[0], 0, g, feat, target_class=0)
 
 
 @parametrize_idtype

--- a/tests/python/pytorch/nn/test_nn.py
+++ b/tests/python/pytorch/nn/test_nn.py
@@ -1725,24 +1725,36 @@ def test_subgraphx(g, idtype, n_classes):
     feat = F.randn((g.num_nodes(), 5))
 
     class Model(th.nn.Module):
-        def __init__(self, in_dim, n_classes):
+        def __init__(self, in_dim, n_classes, graph=False):
             super().__init__()
+            self.graph = graph
             self.conv = nn.GraphConv(in_dim, n_classes)
             self.pool = nn.AvgPooling()
 
         def forward(self, g, h):
-            h = th.nn.functional.relu(self.conv(g, h))
+            h = self.conv(g, h)
+
+            if not self.graph:
+                return h
+
+            h = th.nn.functional.relu(h)
             return self.pool(g, h)
 
-    model = Model(feat.shape[1], n_classes)
+    # Explain node prediction
+    model = Model(feat.shape[1], n_classes, graph=False)
     model = model.to(ctx)
     explainer = nn.SubgraphX(
         model, num_hops=1, shapley_steps=20, num_rollouts=5, coef=2.0
     )
-    # Explain graph prediction
-    explainer.explain_graph(g, feat, target_class=0)
-    # Explain node prediction
     explainer.explain_node(0, g, feat, target_class=0)
+
+    # Explain graph prediction
+    model = Model(feat.shape[1], n_classes, graph=True)
+    model = model.to(ctx)
+    explainer = nn.SubgraphX(
+        model, num_hops=1, shapley_steps=20, num_rollouts=5, coef=2.0
+    )
+    explainer.explain_graph(g, feat, target_class=0)
 
 
 @pytest.mark.parametrize("g", get_cases(["hetero"], exclude=["zero-degree"]))
@@ -1766,8 +1778,9 @@ def test_heterosubgraphx(g, idtype, input_dim, n_classes):
     }
 
     class Model(th.nn.Module):
-        def __init__(self, in_dim, n_classes, canonical_etypes):
+        def __init__(self, in_dim, n_classes, canonical_etypes, graph):
             super(Model, self).__init__()
+            self.graph = graph
             self.etype_weights = th.nn.ModuleDict(
                 {
                     "_".join(c_etype): th.nn.Linear(in_dim, n_classes)
@@ -1787,22 +1800,30 @@ def test_heterosubgraphx(g, idtype, input_dim, n_classes):
                         fn.mean("m", "h"),
                     )
                 graph.multi_update_all(c_etype_func_dict, "sum")
+
+                if not self.graph:
+                    return graph.ndata["h"]
+
                 hg = 0
                 for ntype in graph.ntypes:
-                    if graph.num_nodes(ntype):
-                        hg = hg + dgl.mean_nodes(graph, "h", ntype=ntype)
-
+                    hg = hg + dgl.mean_nodes(graph, "h", ntype=ntype)
                 return hg
 
-    model = Model(input_dim, n_classes, g.canonical_etypes)
+    # Explain node prediction
+    model = Model(input_dim, n_classes, g.canonical_etypes, graph=False)
     model = model.to(ctx)
     explainer = nn.HeteroSubgraphX(
         model, num_hops=2, shapley_steps=20, num_rollouts=5, coef=2.0
     )
-    # Explain graph prediction
-    explainer.explain_graph(g, feat, target_class=0)
-    # Explain node prediction
     explainer.explain_node(g.ntypes[0], 1, g, feat, target_class=0)
+
+    # Explain graph prediction
+    model = Model(input_dim, n_classes, g.canonical_etypes, graph=True)
+    model = model.to(ctx)
+    explainer = nn.HeteroSubgraphX(
+        model, num_hops=2, shapley_steps=20, num_rollouts=5, coef=2.0
+    )
+    explainer.explain_graph(g, feat, target_class=0)
 
 
 @parametrize_idtype

--- a/tests/python/pytorch/nn/test_nn.py
+++ b/tests/python/pytorch/nn/test_nn.py
@@ -1809,14 +1809,6 @@ def test_heterosubgraphx(g, idtype, input_dim, n_classes):
                     hg = hg + dgl.mean_nodes(graph, "h", ntype=ntype)
                 return hg
 
-    # Explain node prediction
-    model = Model(input_dim, n_classes, g.canonical_etypes, graph=False)
-    model = model.to(ctx)
-    explainer = nn.HeteroSubgraphX(
-        model, num_hops=2, shapley_steps=20, num_rollouts=5, coef=2.0
-    )
-    explainer.explain_node(g.ntypes[0], 1, g, feat, target_class=0)
-
     # Explain graph prediction
     model = Model(input_dim, n_classes, g.canonical_etypes, graph=True)
     model = model.to(ctx)

--- a/tests/python/pytorch/nn/test_nn.py
+++ b/tests/python/pytorch/nn/test_nn.py
@@ -1802,7 +1802,6 @@ def test_heterosubgraphx(g, idtype, input_dim, n_classes):
     # Explain graph prediction
     explainer.explain_graph(g, feat, target_class=0)
     # Explain node prediction
-    # * node_id 0 from g.ntypes[0] will not pass the node_min requirement.
     explainer.explain_node(g.ntypes[0], 1, g, feat, target_class=0)
 
 


### PR DESCRIPTION
## Description

Implemented Node explanations for SubgraphX Explainer (https://arxiv.org/pdf/2102.05152.pdf) for Homogeneous Graphs. (extending from https://github.com/dmlc/dgl/pull/5315)

## Checklist
Please feel free to remove inapplicable items for your PR.
- [x] The PR title starts with [$CATEGORY] (such as [NN], [Model], [Doc], [Feature]])
- [x] I've leverage the [tools](https://docs.google.com/document/d/1iHyj7zlmygKSk5gBPsqIqL5ASPzJSPREaNT_QdsiYA4/edit) to beautify the python and c++ code.
- [ ] The PR is complete and small, read the [Google eng practice (CL equals to PR)](https://google.github.io/eng-practices/review/developer/small-cls.html) to understand more about small PR. In DGL, we consider PRs with less than 200 lines of core code change are small (example, test and documentation could be exempted).
- [x] All changes have test coverage
- [x] Code is well-documented
- [x] To the best of my knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change
- [x] Related issue is referred in this PR

## Changes

- [ ] Added the `explain_node` method for homogeneous implementations of SubgraphX Explainer.

Inline documentation is added following the original style, and an example of using the method is included in the documentation.