### PR TITLE
[GraphBolt] use str etype in data block

### DIFF
--- a/python/dgl/graphbolt/data_block.py
+++ b/python/dgl/graphbolt/data_block.py
@@ -30,7 +30,7 @@ class DataBlock:
     no node types, 'node_type' should be None.
     """
 
-    edge_feature: Dict[Tuple[str, str], torch.Tensor] = None
+    edge_feature: List[Dict[Tuple[str, str], torch.Tensor]] = None
     """Edge features associated with the 'sampled_subgraphs'.
     The keys are tuples in the format '(edge_type, feature_name)', and the
     values represent the corresponding features. In the case of a homogeneous

--- a/python/dgl/graphbolt/data_block.py
+++ b/python/dgl/graphbolt/data_block.py
@@ -37,9 +37,7 @@ class DataBlock:
     graph where no edge types exist, 'edge_type' should be set to None.
     """
 
-    input_nodes: Union[
-        torch.Tensor, Dict[str, torch.Tensor]
-    ] = None
+    input_nodes: Union[torch.Tensor, Dict[str, torch.Tensor]] = None
     """A representation of input nodes in the outermost layer. Conatins all nodes
        in the 'sampled_subgraphs'.
     - If `input_nodes` is a tensor: It indicates the graph is homogeneous.

--- a/python/dgl/graphbolt/data_block.py
+++ b/python/dgl/graphbolt/data_block.py
@@ -30,16 +30,15 @@ class DataBlock:
     no node types, 'node_type' should be None.
     """
 
-    edge_feature: List[Dict[Tuple[str, str], torch.Tensor]] = None
+    edge_feature: Dict[Tuple[str, str], torch.Tensor] = None
     """Edge features associated with the 'sampled_subgraphs'.
     The keys are tuples in the format '(edge_type, feature_name)', and the
     values represent the corresponding features. In the case of a homogeneous
     graph where no edge types exist, 'edge_type' should be set to None.
-    Note 'edge_type' are of format 'str:str:str'.
     """
 
     input_nodes: Union[
-        torch.Tensor, Dict[Tuple[str, str, str], torch.Tensor]
+        torch.Tensor, Dict[str, torch.Tensor]
     ] = None
     """A representation of input nodes in the outermost layer. Conatins all nodes
        in the 'sampled_subgraphs'.

--- a/python/dgl/graphbolt/link_prediction_block.py
+++ b/python/dgl/graphbolt/link_prediction_block.py
@@ -36,9 +36,7 @@ class LinkPredictionBlock(DataBlock):
       should correspond to given 'node_pair'.
     """
 
-    negative_head: Union[
-        torch.Tensor, Dict[str, torch.Tensor]
-    ] = None
+    negative_head: Union[torch.Tensor, Dict[str, torch.Tensor]] = None
     """
     Representation of negative samples for the head nodes in the link
     prediction task.
@@ -48,9 +46,7 @@ class LinkPredictionBlock(DataBlock):
       given type.
     """
 
-    negative_tail: Union[
-        torch.Tensor, Dict[str, torch.Tensor]
-    ] = None
+    negative_tail: Union[torch.Tensor, Dict[str, torch.Tensor]] = None
     """
     Representation of negative samples for the tail nodes in the link
     prediction task.
@@ -69,17 +65,13 @@ class LinkPredictionBlock(DataBlock):
     all node ids inside are compacted.
     """
 
-    compacted_negative_head: Union[
-        torch.Tensor, Dict[str, torch.Tensor]
-    ] = None
+    compacted_negative_head: Union[torch.Tensor, Dict[str, torch.Tensor]] = None
     """
     Representation of compacted nodes corresponding to 'negative_head', where
     all node ids inside are compacted.
     """
 
-    compacted_negative_tail: Union[
-        torch.Tensor, Dict[str, torch.Tensor]
-    ] = None
+    compacted_negative_tail: Union[torch.Tensor, Dict[str, torch.Tensor]] = None
     """
     Representation of compacted nodes corresponding to 'negative_tail', where
     all node ids inside are compacted.

--- a/python/dgl/graphbolt/link_prediction_block.py
+++ b/python/dgl/graphbolt/link_prediction_block.py
@@ -16,7 +16,7 @@ class LinkPredictionBlock(DataBlock):
 
     node_pair: Union[
         Tuple[torch.Tensor, torch.Tensor],
-        Dict[Tuple[str, str, str], Tuple[torch.Tensor, torch.Tensor]],
+        Dict[str, Tuple[torch.Tensor, torch.Tensor]],
     ] = None
     """
     Representation of seed node pairs utilized in link prediction tasks.
@@ -27,7 +27,7 @@ class LinkPredictionBlock(DataBlock):
       type.
     """
 
-    label: Union[torch.Tensor, Dict[Tuple[str, str, str], torch.Tensor]] = None
+    label: Union[torch.Tensor, Dict[str, torch.Tensor]] = None
     """
     Labels associated with the link prediction task.
     - If `label` is a tensor: It indicates a homogeneous graph. The value are
@@ -37,7 +37,7 @@ class LinkPredictionBlock(DataBlock):
     """
 
     negative_head: Union[
-        torch.Tensor, Dict[Tuple[str, str, str], torch.Tensor]
+        torch.Tensor, Dict[str, torch.Tensor]
     ] = None
     """
     Representation of negative samples for the head nodes in the link
@@ -49,7 +49,7 @@ class LinkPredictionBlock(DataBlock):
     """
 
     negative_tail: Union[
-        torch.Tensor, Dict[Tuple[str, str, str], torch.Tensor]
+        torch.Tensor, Dict[str, torch.Tensor]
     ] = None
     """
     Representation of negative samples for the tail nodes in the link
@@ -62,7 +62,7 @@ class LinkPredictionBlock(DataBlock):
 
     compacted_node_pair: Union[
         Tuple[torch.Tensor, torch.Tensor],
-        Dict[Tuple[str, str, str], Tuple[torch.Tensor, torch.Tensor]],
+        Dict[str, Tuple[torch.Tensor, torch.Tensor]],
     ] = None
     """
     Representation of compacted node pairs corresponding to 'node_pair', where
@@ -70,7 +70,7 @@ class LinkPredictionBlock(DataBlock):
     """
 
     compacted_negative_head: Union[
-        torch.Tensor, Dict[Tuple[str, str, str], torch.Tensor]
+        torch.Tensor, Dict[str, torch.Tensor]
     ] = None
     """
     Representation of compacted nodes corresponding to 'negative_head', where
@@ -78,7 +78,7 @@ class LinkPredictionBlock(DataBlock):
     """
 
     compacted_negative_tail: Union[
-        torch.Tensor, Dict[Tuple[str, str, str], torch.Tensor]
+        torch.Tensor, Dict[str, torch.Tensor]
     ] = None
     """
     Representation of compacted nodes corresponding to 'negative_tail', where


### PR DESCRIPTION
## Description
<!-- Brief description. Refer to the related issues if existed.
It'll be great if relevant reviewers can be assigned as well.-->

## Checklist
Please feel free to remove inapplicable items for your PR.
- [ ] The PR title starts with [$CATEGORY] (such as [NN], [Model], [Doc], [Feature]])
- [ ] I've leverage the [tools](https://docs.google.com/document/d/1iHyj7zlmygKSk5gBPsqIqL5ASPzJSPREaNT_QdsiYA4/edit) to beautify the python and c++ code.
- [ ] The PR is complete and small, read the [Google eng practice (CL equals to PR)](https://google.github.io/eng-practices/review/developer/small-cls.html) to understand more about small PR. In DGL, we consider PRs with less than 200 lines of core code change are small (example, test and documentation could be exempted).
- [ ] All changes have test coverage
- [ ] Code is well-documented
- [ ] To the best of my knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change
- [ ] Related issue is referred in this PR
- [ ] If the PR is for a new model/paper, I've updated the example index [here](../examples/README.md).

## Changes
<!-- You could use following template
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)
-->
