### PR TITLE
[Bug] Avoid importing packaging directly

### DIFF
--- a/python/dgl/transforms/functional.py
+++ b/python/dgl/transforms/functional.py
@@ -22,7 +22,7 @@ from collections.abc import Iterable, Mapping
 import numpy as np
 import scipy.sparse as sparse
 import scipy.sparse.linalg
-from packaging.version import Version
+from ..utils import version
 
 try:
     import torch as th
@@ -3592,7 +3592,7 @@ def random_walk_pe(g, k, eweight_name=None):
         )
         A = A.multiply(W)
     # 1-step transition probability
-    if Version(scipy.__version__) < Version("1.11.0"):
+    if version.parse(scipy.__version__) < version.parse("1.11.0"):
         RW = np.array(A / (A.sum(1) + 1e-30))
     else:
         # Sparse matrix divided by a dense array returns a sparse matrix in

--- a/python/dgl/transforms/functional.py
+++ b/python/dgl/transforms/functional.py
@@ -22,6 +22,7 @@ from collections.abc import Iterable, Mapping
 import numpy as np
 import scipy.sparse as sparse
 import scipy.sparse.linalg
+
 from ..utils import version
 
 try:


### PR DESCRIPTION
## Description
Avoid importing `packaging` directly. Use `dgl.utils.version` instead, which handles the situation where `packaging` is not installed.

Resolves https://github.com/dmlc/dgl/issues/6258.

## Checklist
Please feel free to remove inapplicable items for your PR.
- [x] The PR title starts with [$CATEGORY] (such as [NN], [Model], [Doc], [Feature]])
- [x] I've leverage the [tools](https://docs.google.com/document/d/1iHyj7zlmygKSk5gBPsqIqL5ASPzJSPREaNT_QdsiYA4/edit) to beautify the python and c++ code.
- [x] The PR is complete and small, read the [Google eng practice (CL equals to PR)](https://google.github.io/eng-practices/review/developer/small-cls.html) to understand more about small PR. In DGL, we consider PRs with less than 200 lines of core code change are small (example, test and documentation could be exempted).
- [x] All changes have test coverage
- [x] Code is well-documented
- [x] To the best of my knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change
- [x] Related issue is referred in this PR
- [ ] If the PR is for a new model/paper, I've updated the example index [here](../examples/README.md).

