### PR TITLE
[Graphbolt] Delete the expensive check

### DIFF
--- a/graphbolt/src/csc_sampling_graph.cc
+++ b/graphbolt/src/csc_sampling_graph.cc
@@ -403,12 +403,6 @@ c10::intrusive_ptr<SampledSubgraph> CSCSamplingGraph::SampleNeighbors(
         probs_or_mask.value().dtype() == torch::kFloat16) {
       probs_or_mask = probs_or_mask.value().to(torch::kFloat32);
     }
-    TORCH_CHECK(
-        ((probs_or_mask.value().max() < INFINITY) &
-         (probs_or_mask.value().min() >= 0))
-            .item()
-            .to<bool>(),
-        "Invalid probs_or_mask (contains either `inf`, `nan` or element < 0).");
   }
 
   if (layer) {


### PR DESCRIPTION
## Description
Deleted an time-expensive check in NeighborSampling.
Solve #6257.

Only tested the affected branches:

Before:
Labor, False, True: 51.4157
Labor, True, True: 86.6231

After:
Labor, False, True: 33.5337
Labor, True, True: 66.5594

## Checklist
Please feel free to remove inapplicable items for your PR.
- [ ] The PR title starts with [$CATEGORY] (such as [NN], [Model], [Doc], [Feature]])
- [ ] I've leverage the [tools](https://docs.google.com/document/d/1iHyj7zlmygKSk5gBPsqIqL5ASPzJSPREaNT_QdsiYA4/edit) to beautify the python and c++ code.
- [ ] The PR is complete and small, read the [Google eng practice (CL equals to PR)](https://google.github.io/eng-practices/review/developer/small-cls.html) to understand more about small PR. In DGL, we consider PRs with less than 200 lines of core code change are small (example, test and documentation could be exempted).
- [ ] All changes have test coverage
- [ ] Code is well-documented
- [ ] To the best of my knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change
- [ ] Related issue is referred in this PR
- [ ] If the PR is for a new model/paper, I've updated the example index [here](../examples/README.md).

## Changes
- Deleted a check.