### PR TITLE
[Doc] Fix typo in link prediction with sampling example

### DIFF
--- a/examples/sampling/link_prediction.py
+++ b/examples/sampling/link_prediction.py
@@ -12,7 +12,7 @@ that account for pairs of nodes and their joint neighborhoods.
 
 Before reading this example, please familiar yourself with graphsage node
 classification by reading the example in the
-`examples/core/graphsage/link_prediction.py`
+`examples/core/graphsage/node_classification.py`
 
 If you want to train graphsage on a large graph in a distributed fashion, read
 the example in the `examples/distributed/graphsage/`.


### PR DESCRIPTION
## Description
Fix typo in description of official example for link prediction with sampling: file name of previous example should be `node_classification.py` instead of `link_prediction.py`.

## Checklist
Please feel free to remove inapplicable items for your PR.
- [x] The PR title starts with [$CATEGORY] (such as [NN], [Model], [Doc], [Feature]])