### PR TITLE
[Sparse] Add sparse sample python API

### DIFF
--- a/python/dgl/sparse/sparse_matrix.py
+++ b/python/dgl/sparse/sparse_matrix.py
@@ -586,6 +586,74 @@ class SparseMatrix:
             )
         raise TypeError(f"{type(index).__name__} is unsupported input type.")
 
+    def sample(
+        self, dim: int, n_pick: int, replacement: Optional[bool] = False
+    ):
+        """Returns a sample matrix according to the given sample dim and number.
+
+        Parameters
+        ----------
+        dim : int
+            The dimension for sampling, should be 0 or 1. `dim = 0` for
+            rowwise selection and `dim = 1` for columnwise selection.
+        n_pick : int
+            The number of nodes to randomly sample on each row or column.
+        replacement : bool, optional
+            Whether to allow repeated sampling of the same neighbor.
+            `replacement = True` means allowing and `replacement = False`
+            means not.
+            NOTE: If `replacement = False` and there are fewer nodes
+            than n_pick, all nodes will be sampled.
+
+        The function does not support autograd.
+
+        Returns
+        -------
+        SparseMatrix
+            A submatrix with the same shape as the original matrix
+            containing the sampled nodes.
+
+        Examples
+        --------
+
+        >>> indices = torch.tensor([0, 0, 1, 1, 2, 2, 2], [0, 2, 0, 1, 0, 1, 2]])
+        >>> val = torch.tensor([0, 1, 2, 3, 4, 5, 6])
+        >>> A = dglsp.spmatrix(indices, val)
+
+        Case 1: Sample rows with the given number and disable repeated sampling.
+
+        >>> A.sample(0, 2)
+        SparseMatrix(indices=tensor([[0, 0, 1, 1, 2, 2],
+                                     [0, 2, 0, 1, 0, 2]]),
+                     values=tensor([0, 1, 2, 3, 4, 6]),
+                     shape=(3, 3), nnz=6)
+
+        Case 2: Sample cols with the given number and disable repeated sampling.
+
+        >>> A.sample(1, 2)
+        SparseMatrix(indices=tensor([[0, 1, 1, 2, 0, 2],
+                                     [0, 0, 1, 1, 2, 2]]),
+                     values=tensor([0, 2, 3, 5, 1, 6]),
+                     shape=(3, 3), nnz=4)
+
+        Case 3: Sample rows with the given number and enable repeated sampling.
+
+        >>> A.sample(0, 2, True)
+        SparseMatrix(indices=tensor([[0, 0, 1, 1, 2, 2],
+                                     [0, 2, 0, 0, 1, 2]]),
+                     values=tensor([0, 1, 2, 2, 5, 6]),
+                     shape=(3, 3), nnz=5)
+
+        Case 4: Sample cols with the given number and enable repeated sampling.
+
+        >>> A.sample(1, 2, True)
+        SparseMatrix(indices=tensor([[0, 1, 1, 1, 2, 2],
+                                     [0, 0, 1, 1, 2, 2]]),
+                     values=tensor([0, 2, 3, 3, 6, 6]),
+                     shape=(3, 3), nnz=4)
+        """
+        raise NotImplementedError
+
 
 def spmatrix(
     indices: torch.Tensor,

--- a/python/dgl/sparse/sparse_matrix.py
+++ b/python/dgl/sparse/sparse_matrix.py
@@ -613,7 +613,7 @@ class SparseMatrix:
             When `replace = True`, repeated sampling is permitted; when
             `replace = False`, it is not allowed.
             NOTE: If `replace = False` and there are fewer elements than
-            `n_pick`, all non-zero elements will be sampled.
+            `fanout`, all non-zero elements will be sampled.
         bias : bool, optional
             A boolean flag indicating whether to enable biasing during sampling.
             When `bias = True`, the values of the sparse matrix will be used as

--- a/python/dgl/sparse/sparse_matrix.py
+++ b/python/dgl/sparse/sparse_matrix.py
@@ -587,7 +587,12 @@ class SparseMatrix:
         raise TypeError(f"{type(index).__name__} is unsupported input type.")
 
     def sample(
-        self, dim: int, n_pick: int, replacement: Optional[bool] = False
+        self,
+        dim: int,
+        n_pick: int,
+        ids: Optional[torch.Tensor] = None,
+        replacement: Optional[bool] = False,
+        bias: Optional[bool] = False,
     ):
         """Returns a sampled matrix on the given dimension and sample arguments.
 
@@ -598,12 +603,21 @@ class SparseMatrix:
             rowwise selection and `dim = 1` for columnwise selection.
         n_pick : int
             The number of elements to randomly sample on each row or column.
+        ids : torch.Tensor, optional
+            An optional tensor containing row or column IDs from which to
+            sample elements.
+            NOTE: If `ids` is not provided (i.e., `ids = None`), the function
+            will sample from all rows or columns.
         replacement : bool, optional
             Indicates whether repeated sampling of the same element is allowed.
             When `replacement = True`, repeated sampling is permitted; when
             `replacement = False`, it is not allowed.
             NOTE: If `replacement = False` and there are fewer elements than
             `n_pick`, all non-zero elements will be sampled.
+        bias : bool, optional
+            A boolean flag indicating whether to enable biasing during sampling.
+            When `bias = True`, the values of the sparse matrix will be used as
+            bias weights.
 
         The function does not support autograd.
 
@@ -623,35 +637,39 @@ class SparseMatrix:
 
         Case 1: Sample rows with the given number and disable repeated sampling.
 
-        >>> A.sample(0, 2)
-        SparseMatrix(indices=tensor([[0, 0, 1, 1, 2, 2],
-                                     [0, 2, 0, 1, 0, 2]]),
-                     values=tensor([0, 1, 2, 3, 4, 6]),
-                     shape=(3, 3), nnz=6)
+        >>> row_ids = torch.tensor([0, 2])
+        >>> A.sample(0, 2, row_ids)
+        SparseMatrix(indices=tensor([[0, 0, 1, 1],
+                                     [0, 2, 0, 2]]),
+                     values=tensor([0, 1, 4, 6]),
+                     shape=(2, 3), nnz=4)
 
         Case 2: Sample cols with the given number and disable repeated sampling.
 
-        >>> A.sample(1, 2)
-        SparseMatrix(indices=tensor([[0, 1, 1, 2, 0, 2],
-                                     [0, 0, 1, 1, 2, 2]]),
-                     values=tensor([0, 2, 3, 5, 1, 6]),
-                     shape=(3, 3), nnz=6)
+        >>> col_ids = torch.tensor([0, 2])
+        >>> A.sample(1, 2, col_ids)
+        SparseMatrix(indices=tensor([[0, 1, 0, 2],
+                                     [0, 0, 1, 1]]),
+                     values=tensor([0, 2, 1, 6]),
+                     shape=(3, 2), nnz=4)
 
         Case 3: Sample rows with the given number and enable repeated sampling.
 
-        >>> A.sample(0, 2, True)
-        SparseMatrix(indices=tensor([[0, 0, 1, 1, 2, 2],
-                                     [0, 2, 0, 0, 1, 2]]),
-                     values=tensor([0, 1, 2, 2, 5, 6]),
-                     shape=(3, 3), nnz=5)
+        >>> row_ids = torch.tensor([0, 1])
+        >>> A.sample(0, 2, row_ids, True)
+        SparseMatrix(indices=tensor([[0, 0, 1, 1],
+                                     [0, 2, 0, 0]]),
+                     values=tensor([0, 1, 2, 2]),
+                     shape=(2, 3), nnz=3)
 
         Case 4: Sample cols with the given number and enable repeated sampling.
 
-        >>> A.sample(1, 2, True)
-        SparseMatrix(indices=tensor([[0, 1, 1, 1, 2, 2],
-                                     [0, 0, 1, 1, 2, 2]]),
-                     values=tensor([0, 2, 3, 3, 6, 6]),
-                     shape=(3, 3), nnz=4)
+        >>> col_ids = torch.tensor([0, 1])
+        >>> A.sample(1, 2, col_ids, True)
+        SparseMatrix(indices=tensor([[0, 1, 1, 1],
+                                     [0, 0, 1, 1]]),
+                     values=tensor([0, 2, 3, 3]),
+                     shape=(3, 2), nnz=3)
         """
         raise NotImplementedError
 

--- a/python/dgl/sparse/sparse_matrix.py
+++ b/python/dgl/sparse/sparse_matrix.py
@@ -589,9 +589,9 @@ class SparseMatrix:
     def sample(
         self,
         dim: int,
-        n_pick: int,
+        fanout: int,
         ids: Optional[torch.Tensor] = None,
-        replacement: Optional[bool] = False,
+        replace: Optional[bool] = False,
         bias: Optional[bool] = False,
     ):
         """Returns a sampled matrix on the given dimension and sample arguments.
@@ -601,18 +601,18 @@ class SparseMatrix:
         dim : int
             The dimension for sampling, should be 0 or 1. `dim = 0` for
             rowwise selection and `dim = 1` for columnwise selection.
-        n_pick : int
+        fanout : int
             The number of elements to randomly sample on each row or column.
         ids : torch.Tensor, optional
             An optional tensor containing row or column IDs from which to
             sample elements.
             NOTE: If `ids` is not provided (i.e., `ids = None`), the function
             will sample from all rows or columns.
-        replacement : bool, optional
+        replace : bool, optional
             Indicates whether repeated sampling of the same element is allowed.
-            When `replacement = True`, repeated sampling is permitted; when
-            `replacement = False`, it is not allowed.
-            NOTE: If `replacement = False` and there are fewer elements than
+            When `replace = True`, repeated sampling is permitted; when
+            `replace = False`, it is not allowed.
+            NOTE: If `replace = False` and there are fewer elements than
             `n_pick`, all non-zero elements will be sampled.
         bias : bool, optional
             A boolean flag indicating whether to enable biasing during sampling.

--- a/python/dgl/sparse/sparse_matrix.py
+++ b/python/dgl/sparse/sparse_matrix.py
@@ -589,7 +589,7 @@ class SparseMatrix:
     def sample(
         self, dim: int, n_pick: int, replacement: Optional[bool] = False
     ):
-        """Returns a sample matrix according to the given sample dim and number.
+        """Returns a sampled matrix on the given dimension and sample arguments.
 
         Parameters
         ----------
@@ -597,26 +597,27 @@ class SparseMatrix:
             The dimension for sampling, should be 0 or 1. `dim = 0` for
             rowwise selection and `dim = 1` for columnwise selection.
         n_pick : int
-            The number of nodes to randomly sample on each row or column.
+            The number of elements to randomly sample on each row or column.
         replacement : bool, optional
-            Whether to allow repeated sampling of the same neighbor.
-            `replacement = True` means allowing and `replacement = False`
-            means not.
-            NOTE: If `replacement = False` and there are fewer nodes
-            than n_pick, all nodes will be sampled.
+            Indicates whether repeated sampling of the same element is allowed.
+            When `replacement = True`, repeated sampling is permitted; when 
+            `replacement = False`, it is not allowed. 
+            NOTE: If `replacement = False` and there are fewer elements than 
+            `n_pick`, all non-zero elements will be sampled.
 
         The function does not support autograd.
 
         Returns
         -------
         SparseMatrix
-            A submatrix with the same shape as the original matrix
-            containing the sampled nodes.
+            A submatrix with the same shape as the original matrix, containing 
+            the randomly sampled non-zero elements.
 
         Examples
         --------
 
-        >>> indices = torch.tensor([0, 0, 1, 1, 2, 2, 2], [0, 2, 0, 1, 0, 1, 2]])
+        >>> indices = torch.tensor([[0, 0, 1, 1, 2, 2, 2],
+                                    [0, 2, 0, 1, 0, 1, 2]])
         >>> val = torch.tensor([0, 1, 2, 3, 4, 5, 6])
         >>> A = dglsp.spmatrix(indices, val)
 
@@ -634,7 +635,7 @@ class SparseMatrix:
         SparseMatrix(indices=tensor([[0, 1, 1, 2, 0, 2],
                                      [0, 0, 1, 1, 2, 2]]),
                      values=tensor([0, 2, 3, 5, 1, 6]),
-                     shape=(3, 3), nnz=4)
+                     shape=(3, 3), nnz=6)
 
         Case 3: Sample rows with the given number and enable repeated sampling.
 

--- a/python/dgl/sparse/sparse_matrix.py
+++ b/python/dgl/sparse/sparse_matrix.py
@@ -600,9 +600,9 @@ class SparseMatrix:
             The number of elements to randomly sample on each row or column.
         replacement : bool, optional
             Indicates whether repeated sampling of the same element is allowed.
-            When `replacement = True`, repeated sampling is permitted; when 
-            `replacement = False`, it is not allowed. 
-            NOTE: If `replacement = False` and there are fewer elements than 
+            When `replacement = True`, repeated sampling is permitted; when
+            `replacement = False`, it is not allowed.
+            NOTE: If `replacement = False` and there are fewer elements than
             `n_pick`, all non-zero elements will be sampled.
 
         The function does not support autograd.
@@ -610,7 +610,7 @@ class SparseMatrix:
         Returns
         -------
         SparseMatrix
-            A submatrix with the same shape as the original matrix, containing 
+            A submatrix with the same shape as the original matrix, containing
             the randomly sampled non-zero elements.
 
         Examples


### PR DESCRIPTION
## Description
Define sparse sample operator API.

## Checklist
Please feel free to remove inapplicable items for your PR.
- [ ] The PR title starts with [$CATEGORY] (such as [NN], [Model], [Doc], [Feature]])
- [ ] I've leverage the [tools](https://docs.google.com/document/d/1iHyj7zlmygKSk5gBPsqIqL5ASPzJSPREaNT_QdsiYA4/edit) to beautify the python and c++ code.
- [ ] The PR is complete and small, read the [Google eng practice (CL equals to PR)](https://google.github.io/eng-practices/review/developer/small-cls.html) to understand more about small PR. In DGL, we consider PRs with less than 200 lines of core code change are small (example, test and documentation could be exempted).
- [ ] All changes have test coverage
- [ ] Code is well-documented
- [ ] To the best of my knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change
- [ ] Related issue is referred in this PR
- [ ] If the PR is for a new model/paper, I've updated the example index [here](../examples/README.md).

## Changes
