### PR TITLE
[GRAPHBOLT] Activation of some csc_sampling_graph tests for data located on the GPUs.

### DIFF
--- a/tests/python/pytorch/graphbolt/gb_test_utils.py
+++ b/tests/python/pytorch/graphbolt/gb_test_utils.py
@@ -50,7 +50,9 @@ def get_metadata(num_ntypes, num_etypes):
     return gb.GraphMetadata(ntypes, etypes)
 
 
-def random_hetero_graph(num_nodes, num_edges, num_ntypes, num_etypes, device="cpu"):
+def random_hetero_graph(
+        num_nodes, num_edges, num_ntypes, num_etypes, device="cpu"
+):
     csc_indptr, indices = random_homo_graph(num_nodes, num_edges, device=device)
     metadata = get_metadata(num_ntypes, num_etypes)
     # Randomly get node type split point.

--- a/tests/python/pytorch/graphbolt/gb_test_utils.py
+++ b/tests/python/pytorch/graphbolt/gb_test_utils.py
@@ -25,18 +25,15 @@ def rand_csc_graph(N, density):
 
     indptr = torch.LongTensor(adj.indptr)
     indices = torch.LongTensor(adj.indices)
-
-    graph = gb.from_csc(indptr, indices)
-
-    return graph
+    return gb.from_csc(indptr, indices)
 
 
-def random_homo_graph(num_nodes, num_edges):
-    csc_indptr = torch.randint(0, num_edges, (num_nodes + 1,))
+def random_homo_graph(num_nodes, num_edges, device="cpu"):
+    csc_indptr = torch.randint(0, num_edges, (num_nodes + 1,), device=device)
     csc_indptr = torch.sort(csc_indptr)[0]
     csc_indptr[0] = 0
     csc_indptr[-1] = num_edges
-    indices = torch.randint(0, num_nodes, (num_edges,))
+    indices = torch.randint(0, num_nodes, (num_edges,), device=device)
     return csc_indptr, indices
 
 
@@ -53,8 +50,8 @@ def get_metadata(num_ntypes, num_etypes):
     return gb.GraphMetadata(ntypes, etypes)
 
 
-def random_hetero_graph(num_nodes, num_edges, num_ntypes, num_etypes):
-    csc_indptr, indices = random_homo_graph(num_nodes, num_edges)
+def random_hetero_graph(num_nodes, num_edges, num_ntypes, num_etypes, device="cpu"):
+    csc_indptr, indices = random_homo_graph(num_nodes, num_edges, device=device)
     metadata = get_metadata(num_ntypes, num_etypes)
     # Randomly get node type split point.
     node_type_offset = torch.sort(

--- a/tests/python/pytorch/graphbolt/impl/test_csc_sampling_graph.py
+++ b/tests/python/pytorch/graphbolt/impl/test_csc_sampling_graph.py
@@ -90,7 +90,9 @@ def test_metadata_with_etype_exception(etypes):
     "num_nodes, num_edges", [(1, 1), (100, 1), (10, 50), (1000, 50000)]
 )
 def test_homo_graph(num_nodes, num_edges):
-    csc_indptr, indices = gbt.random_homo_graph(num_nodes, num_edges, device=F.ctx())
+    csc_indptr, indices = gbt.random_homo_graph(
+        num_nodes, num_edges, device=F.ctx()
+    )
     edge_attributes = {
         "A1": torch.randn(num_edges),
         "A2": torch.randn(num_edges),
@@ -120,11 +122,12 @@ def test_hetero_graph(num_nodes, num_edges, num_ntypes, num_etypes):
         node_type_offset,
         type_per_edge,
         metadata,
-    ) = gbt.random_hetero_graph(num_nodes,
-                                num_edges,
-                                num_ntypes,
-                                num_etypes,
-                                device=F.ctx(),
+    ) = gbt.random_hetero_graph(
+        num_nodes,
+        num_edges,
+        num_ntypes,
+        num_etypes,
+        device=F.ctx(),
     )
     edge_attributes = {
         "A1": torch.randn(num_edges),
@@ -174,7 +177,9 @@ def test_node_type_offset_wrong_legnth(node_type_offset):
     "num_nodes, num_edges", [(1, 1), (100, 1), (10, 50), (1000, 50000)]
 )
 def test_load_save_homo_graph(num_nodes, num_edges):
-    csc_indptr, indices = gbt.random_homo_graph(num_nodes, num_edges, device=F.ctx())
+    csc_indptr, indices = gbt.random_homo_graph(
+        num_nodes, num_edges, device=F.ctx()
+    )
     graph = gb.from_csc(csc_indptr, indices)
 
     with tempfile.TemporaryDirectory() as test_dir:
@@ -204,11 +209,9 @@ def test_load_save_hetero_graph(num_nodes, num_edges, num_ntypes, num_etypes):
         node_type_offset,
         type_per_edge,
         metadata,
-    ) = gbt.random_hetero_graph(num_nodes,
-                                num_edges,
-                                num_ntypes,
-                                num_etypes,
-                                device=F.ctx())
+    ) = gbt.random_hetero_graph(
+        num_nodes, num_edges, num_ntypes, num_etypes, device=F.ctx()
+    )
     graph = gb.from_csc(
         csc_indptr, indices, node_type_offset, type_per_edge, None, metadata
     )
@@ -779,7 +782,9 @@ def check_tensors_on_the_same_shared_memory(t1: torch.Tensor, t2: torch.Tensor):
 )
 @pytest.mark.parametrize("test_edge_attrs", [True, False])
 def test_homo_graph_on_shared_memory(num_nodes, num_edges, test_edge_attrs):
-    csc_indptr, indices = gbt.random_homo_graph(num_nodes, num_edges, device=F.ctx())
+    csc_indptr, indices = gbt.random_homo_graph(
+        num_nodes, num_edges, device=F.ctx()
+    )
     if test_edge_attrs:
         edge_attributes = {
             "A1": torch.randn(num_edges),
@@ -844,7 +849,9 @@ def test_hetero_graph_on_shared_memory(
         node_type_offset,
         type_per_edge,
         metadata,
-    ) = gbt.random_hetero_graph(num_nodes, num_edges, num_ntypes, num_etypes, device=F.ctx())
+    ) = gbt.random_hetero_graph(
+        num_nodes, num_edges, num_ntypes, num_etypes, device=F.ctx()
+    )
 
     if test_edge_attrs:
         edge_attributes = {


### PR DESCRIPTION
## Description
<!-- Brief description. Refer to the related issues if existed.
It'll be great if relevant reviewers can be assigned as well.-->
13 out of 27 tests from `tests/python/pytorch/graphbolt/impl/test_csc_sampling_graph.py` are activated for `F._default_context_str = "gpu"`

## Checklist
Please feel free to remove inapplicable items for your PR.
- [x] The PR title starts with [$CATEGORY] (such as [NN], [Model], [Doc], [Feature]])
- [x] The PR is complete and small, read the [Google eng practice (CL equals to PR)](https://google.github.io/eng-practices/review/developer/small-cls.html) to understand more about small PR. In DGL, we consider PRs with less than 200 lines of core code change are small (example, test and documentation could be exempted).
- [x] All changes have test coverage
- [x] Code is well-documented
- [x] To the best of my knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

