### PR TITLE
[GraphBolt] split node_pairs to tuple of (src, dst)

### DIFF
--- a/python/dgl/graphbolt/item_sampler.py
+++ b/python/dgl/graphbolt/item_sampler.py
@@ -110,10 +110,10 @@ class ItemSampler(IterDataPipe):
     >>> from dgl import graphbolt as gb
     >>> item_set = gb.ItemSet(torch.arange(0, 10), names="seed_nodes")
     >>> item_sampler = gb.ItemSampler(
-    ...     item_set, batch_size=4, shuffle=True, drop_last=False
+    ...     item_set, batch_size=4, shuffle=False, drop_last=False
     ... )
     >>> next(iter(item_sampler))
-    MiniBatch(seed_nodes=tensor([9, 0, 7, 2]), node_pairs=None, labels=None,
+    MiniBatch(seed_nodes=tensor([0, 1, 2, 3]), node_pairs=None, labels=None,
         negative_srcs=None, negative_dsts=None, sampled_subgraphs=None,
         input_nodes=None, node_features=None, edge_features=None,
         compacted_node_pairs=None, compacted_negative_srcs=None,
@@ -123,30 +123,28 @@ class ItemSampler(IterDataPipe):
     >>> item_set = gb.ItemSet(torch.arange(0, 20).reshape(-1, 2),
     ...     names="node_pairs")
     >>> item_sampler = gb.ItemSampler(
-    ...     item_set, batch_size=4, shuffle=True, drop_last=False
+    ...     item_set, batch_size=4, shuffle=False, drop_last=False
     ... )
     >>> next(iter(item_sampler))
-    MiniBatch(seed_nodes=None, node_pairs=tensor([[16, 17],
-        [ 4,  5],
-        [ 6,  7],
-        [10, 11]]), labels=None, negative_srcs=None, negative_dsts=None,
+    MiniBatch(seed_nodes=None,
+        node_pairs=(tensor([0, 2, 4, 6]), tensor([1, 3, 5, 7])),
+        labels=None, negative_srcs=None, negative_dsts=None,
         sampled_subgraphs=None, input_nodes=None, node_features=None,
         edge_features=None, compacted_node_pairs=None,
         compacted_negative_srcs=None, compacted_negative_dsts=None)
 
     3. Node pairs and labels.
     >>> item_set = gb.ItemSet(
-    ...     (torch.arange(0, 20).reshape(-1, 2), torch.arange(10, 15)),
+    ...     (torch.arange(0, 20).reshape(-1, 2), torch.arange(10, 20)),
     ...     names=("node_pairs", "labels")
     ... )
     >>> item_sampler = gb.ItemSampler(
-    ...     item_set, batch_size=4, shuffle=True, drop_last=False
+    ...     item_set, batch_size=4, shuffle=False, drop_last=False
     ... )
     >>> next(iter(item_sampler))
-    MiniBatch(seed_nodes=None, node_pairs=tensor([[8, 9],
-        [4, 5],
-        [0, 1],
-        [6, 7]]), labels=tensor([14, 12, 10, 13]), negative_srcs=None,
+    MiniBatch(seed_nodes=None,
+        node_pairs=(tensor([0, 2, 4, 6]), tensor([1, 3, 5, 7])),
+        labels=tensor([10, 11, 12, 13]), negative_srcs=None,
         negative_dsts=None, sampled_subgraphs=None, input_nodes=None,
         node_features=None, edge_features=None, compacted_node_pairs=None,
         compacted_negative_srcs=None, compacted_negative_dsts=None)
@@ -157,17 +155,16 @@ class ItemSampler(IterDataPipe):
     >>> item_set = gb.ItemSet((node_pairs, negative_dsts), names=("node_pairs",
     ...     "negative_dsts"))
     >>> item_sampler = gb.ItemSampler(
-    ...     item_set, batch_size=4, shuffle=True, drop_last=False
+    ...     item_set, batch_size=4, shuffle=False, drop_last=False
     ... )
     >>> next(iter(item_sampler))
-    MiniBatch(seed_nodes=None, node_pairs=tensor([[10, 11],
-        [ 6,  7],
-        [ 2,  3],
-        [ 8,  9]]), labels=None, negative_srcs=None,
-        negative_dsts=tensor([[20, 21],
-        [16, 17],
+    MiniBatch(seed_nodes=None,
+        node_pairs=(tensor([0, 2, 4, 6]), tensor([1, 3, 5, 7])),
+        labels=None, negative_srcs=None,
+        negative_dsts=tensor([[10, 11],
         [12, 13],
-        [18, 19]]), sampled_subgraphs=None, input_nodes=None,
+        [14, 15],
+        [16, 17]]), sampled_subgraphs=None, input_nodes=None,
         node_features=None, edge_features=None, compacted_node_pairs=None,
         compacted_negative_srcs=None, compacted_negative_dsts=None)
 
@@ -219,10 +216,10 @@ class ItemSampler(IterDataPipe):
     ... })
     >>> item_sampler = gb.ItemSampler(item_set, batch_size=4)
     >>> next(iter(item_sampler))
-    MiniBatch(seed_nodes=None, node_pairs={'user:like:item': tensor([[0, 1],
-        [2, 3],
-        [4, 5],
-        [6, 7]])}, labels=None, negative_srcs=None, negative_dsts=None,
+    MiniBatch(seed_nodes=None,
+        node_pairs={'user:like:item':
+            (tensor([0, 2, 4, 6]), tensor([1, 3, 5, 7]))},
+        labels=None, negative_srcs=None, negative_dsts=None,
         sampled_subgraphs=None, input_nodes=None, node_features=None,
         edge_features=None, compacted_node_pairs=None,
         compacted_negative_srcs=None, compacted_negative_dsts=None)
@@ -240,10 +237,10 @@ class ItemSampler(IterDataPipe):
     ... })
     >>> item_sampler = gb.ItemSampler(item_set, batch_size=4)
     >>> next(iter(item_sampler))
-    MiniBatch(seed_nodes=None, node_pairs={'user:like:item': tensor([[0, 1],
-        [2, 3],
-        [4, 5],
-        [6, 7]])}, labels={'user:like:item': tensor([0, 1, 2, 3])},
+    MiniBatch(seed_nodes=None,
+        node_pairs={'user:like:item':
+            (tensor([0, 2, 4, 6]), tensor([1, 3, 5, 7]))},
+        labels={'user:like:item': tensor([0, 1, 2, 3])},
         negative_srcs=None, negative_dsts=None, sampled_subgraphs=None,
         input_nodes=None, node_features=None, edge_features=None,
         compacted_node_pairs=None, compacted_negative_srcs=None,
@@ -262,10 +259,10 @@ class ItemSampler(IterDataPipe):
     ... })
     >>> item_sampler = gb.ItemSampler(item_set, batch_size=4)
     >>> next(iter(item_sampler))
-    MiniBatch(seed_nodes=None, node_pairs={'user:like:item': tensor([[0, 1],
-        [2, 3],
-        [4, 5],
-        [6, 7]])}, labels=None, negative_srcs=None,
+    MiniBatch(seed_nodes=None,
+        node_pairs={'user:like:item':
+            (tensor([0, 2, 4, 6]), tensor([1, 3, 5, 7]))},
+        labels=None, negative_srcs=None,
         negative_dsts={'user:like:item': tensor([[10, 11],
         [12, 13],
         [14, 15],

--- a/python/dgl/graphbolt/item_sampler.py
+++ b/python/dgl/graphbolt/item_sampler.py
@@ -67,6 +67,13 @@ def minibatcher_default(batch, names):
                 "`MiniBatch`. You probably need to provide a customized "
                 "`MiniBatcher`."
             )
+        if name == "node_pairs":
+            # `node_pairs` is passed as a tensor with shape (N, 2) and should
+            # be converted to a tuple of (src, dst).
+            if isinstance(item, Mapping):
+                item = {key: (item[key][:, 0], item[key][:, 1]) for key in item}
+            else:
+                item = (item[:, 0], item[:, 1])
         setattr(minibatch, name, item)
     return minibatch
 

--- a/python/dgl/graphbolt/item_sampler.py
+++ b/python/dgl/graphbolt/item_sampler.py
@@ -68,8 +68,8 @@ def minibatcher_default(batch, names):
                 "`MiniBatcher`."
             )
         if name == "node_pairs":
-            # `node_pairs` is passed as a tensor with shape (N, 2) and should
-            # be converted to a tuple of (src, dst).
+            # `node_pairs` is passed as a tensor in shape of `(N, 2)` and
+            # should be converted to a tuple of `(src, dst)`.
             if isinstance(item, Mapping):
                 item = {key: (item[key][:, 0], item[key][:, 1]) for key in item}
             else:

--- a/python/dgl/graphbolt/itemset.py
+++ b/python/dgl/graphbolt/itemset.py
@@ -15,8 +15,9 @@ class ItemSet:
     Parameters
     ----------
     items: Iterable or Tuple[Iterable]
-        The items to be iterated over. If it is a tuple, each item in the tuple
-        is an iterable of items.
+        The items to be iterated over. If it's multi-dimensional iterable such
+        as `torch.Tensor`, it will be iterated over the first dimension. If it
+        is a tuple, each item in the tuple is an iterable of items.
     names: str or Tuple[str], optional
         The names of the items. If it is a tuple, each name corresponds to an
         item in the tuple.

--- a/tests/python/pytorch/graphbolt/test_item_sampler.py
+++ b/tests/python/pytorch/graphbolt/test_item_sampler.py
@@ -184,8 +184,7 @@ def test_ItemSet_node_pairs(batch_size, shuffle, drop_last):
     for i, minibatch in enumerate(item_sampler):
         assert minibatch.node_pairs is not None
         assert minibatch.labels is None
-        src = minibatch.node_pairs[:, 0]
-        dst = minibatch.node_pairs[:, 1]
+        src, dst = minibatch.node_pairs
         is_last = (i + 1) * batch_size >= num_ids
         if not is_last or num_ids % batch_size == 0:
             expected_batch_size = batch_size
@@ -225,10 +224,10 @@ def test_ItemSet_node_pairs_labels(batch_size, shuffle, drop_last):
     for i, minibatch in enumerate(item_sampler):
         assert minibatch.node_pairs is not None
         assert minibatch.labels is not None
-        assert len(minibatch.node_pairs) == len(minibatch.labels)
-        src = minibatch.node_pairs[:, 0]
-        dst = minibatch.node_pairs[:, 1]
+        src, dst = minibatch.node_pairs
         label = minibatch.labels
+        assert len(src) == len(dst)
+        assert len(src) == len(label)
         is_last = (i + 1) * batch_size >= num_ids
         if not is_last or num_ids % batch_size == 0:
             expected_batch_size = batch_size
@@ -278,8 +277,7 @@ def test_ItemSet_node_pairs_negative_dsts(batch_size, shuffle, drop_last):
     for i, minibatch in enumerate(item_sampler):
         assert minibatch.node_pairs is not None
         assert minibatch.negative_dsts is not None
-        src = minibatch.node_pairs[:, 0]
-        dst = minibatch.node_pairs[:, 1]
+        src, dst = minibatch.node_pairs
         negs = minibatch.negative_dsts
         is_last = (i + 1) * batch_size >= num_ids
         if not is_last or num_ids % batch_size == 0:
@@ -452,8 +450,8 @@ def test_ItemSetDict_node_pairs(batch_size, shuffle, drop_last):
         src = []
         dst = []
         for _, node_pairs in minibatch.node_pairs.items():
-            src.append(node_pairs[:, 0])
-            dst.append(node_pairs[:, 1])
+            src.append(node_pairs[0])
+            dst.append(node_pairs[1])
         src = torch.cat(src)
         dst = torch.cat(dst)
         assert len(src) == expected_batch_size
@@ -510,8 +508,8 @@ def test_ItemSetDict_node_pairs_labels(batch_size, shuffle, drop_last):
         dst = []
         label = []
         for _, node_pairs in minibatch.node_pairs.items():
-            src.append(node_pairs[:, 0])
-            dst.append(node_pairs[:, 1])
+            src.append(node_pairs[0])
+            dst.append(node_pairs[1])
         for _, v_label in minibatch.labels.items():
             label.append(v_label)
         src = torch.cat(src)
@@ -582,8 +580,8 @@ def test_ItemSetDict_node_pairs_negative_dsts(batch_size, shuffle, drop_last):
         dst = []
         negs = []
         for _, node_pairs in minibatch.node_pairs.items():
-            src.append(node_pairs[:, 0])
-            dst.append(node_pairs[:, 1])
+            src.append(node_pairs[0])
+            dst.append(node_pairs[1])
         for _, v_negs in minibatch.negative_dsts.items():
             negs.append(v_negs)
         src = torch.cat(src)

--- a/tests/python/pytorch/graphbolt/test_item_sampler.py
+++ b/tests/python/pytorch/graphbolt/test_item_sampler.py
@@ -183,6 +183,7 @@ def test_ItemSet_node_pairs(batch_size, shuffle, drop_last):
     dst_ids = []
     for i, minibatch in enumerate(item_sampler):
         assert minibatch.node_pairs is not None
+        assert isinstance(minibatch.node_pairs, tuple)
         assert minibatch.labels is None
         src, dst = minibatch.node_pairs
         is_last = (i + 1) * batch_size >= num_ids
@@ -223,6 +224,7 @@ def test_ItemSet_node_pairs_labels(batch_size, shuffle, drop_last):
     labels = []
     for i, minibatch in enumerate(item_sampler):
         assert minibatch.node_pairs is not None
+        assert isinstance(minibatch.node_pairs, tuple)
         assert minibatch.labels is not None
         src, dst = minibatch.node_pairs
         label = minibatch.labels
@@ -276,6 +278,7 @@ def test_ItemSet_node_pairs_negative_dsts(batch_size, shuffle, drop_last):
     negs_ids = []
     for i, minibatch in enumerate(item_sampler):
         assert minibatch.node_pairs is not None
+        assert isinstance(minibatch.node_pairs, tuple)
         assert minibatch.negative_dsts is not None
         src, dst = minibatch.node_pairs
         negs = minibatch.negative_dsts
@@ -449,7 +452,8 @@ def test_ItemSetDict_node_pairs(batch_size, shuffle, drop_last):
                 assert False
         src = []
         dst = []
-        for _, node_pairs in minibatch.node_pairs.items():
+        for _, (node_pairs) in minibatch.node_pairs.items():
+            assert isinstance(node_pairs, tuple)
             src.append(node_pairs[0])
             dst.append(node_pairs[1])
         src = torch.cat(src)
@@ -508,6 +512,7 @@ def test_ItemSetDict_node_pairs_labels(batch_size, shuffle, drop_last):
         dst = []
         label = []
         for _, node_pairs in minibatch.node_pairs.items():
+            assert isinstance(node_pairs, tuple)
             src.append(node_pairs[0])
             dst.append(node_pairs[1])
         for _, v_label in minibatch.labels.items():
@@ -580,6 +585,7 @@ def test_ItemSetDict_node_pairs_negative_dsts(batch_size, shuffle, drop_last):
         dst = []
         negs = []
         for _, node_pairs in minibatch.node_pairs.items():
+            assert isinstance(node_pairs, tuple)
             src.append(node_pairs[0])
             dst.append(node_pairs[1])
         for _, v_negs in minibatch.negative_dsts.items():


### PR DESCRIPTION
## Description
<!-- Brief description. Refer to the related issues if existed.
It'll be great if relevant reviewers can be assigned as well.-->
For now, we assume `node_pairs` are saved/loaded as a tensor with shape of `(N, 2)` while it's assumed to be tuple of `(src , dst)` in `MiniBatch.node_pairs` and following modules. This PR aims to remove such discrepancy.

Another solution is to loaded from ondisk via `seed_srcs` and `seed_dsts` separately and pass them to instantiate `MiniBatch.node_pairs` to compose the tuple of `(src, dst)`. [Existing test cases for `NegativeSampler` are using this format.]

So the question is what kind of data format we're assuming for `node_pairs`: a `(N, 2)` tensor or 2 separate tensor of `(N, 1)`.

One more alternative:
```
node_pairs = (torch.arange(0, 5), torch.arange(5, 10))
labels = torch.arange(0, 5)
np.save()
np.load()
item_set = gb.ItemSet((node_pairs, labels), names=("node_pairs", "labels"))
for node_pairs, label in item_set:
    ....
```
But iterate on `node_pairs` in `ItemSet` needs to be handled specifically as it's a tuple of tensors.
## Checklist
Please feel free to remove inapplicable items for your PR.
- [ ] The PR title starts with [$CATEGORY] (such as [NN], [Model], [Doc], [Feature]])
- [ ] I've leverage the [tools](https://docs.google.com/document/d/1iHyj7zlmygKSk5gBPsqIqL5ASPzJSPREaNT_QdsiYA4/edit) to beautify the python and c++ code.
- [ ] The PR is complete and small, read the [Google eng practice (CL equals to PR)](https://google.github.io/eng-practices/review/developer/small-cls.html) to understand more about small PR. In DGL, we consider PRs with less than 200 lines of core code change are small (example, test and documentation could be exempted).
- [ ] All changes have test coverage
- [ ] Code is well-documented
- [ ] To the best of my knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change
- [ ] Related issue is referred in this PR
- [ ] If the PR is for a new model/paper, I've updated the example index [here](../examples/README.md).

## Changes
<!-- You could use following template
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)
-->
