### PR TITLE
[Graphbolt] Use `for` to implement `ItemSet.__iter__`

### DIFF
--- a/python/dgl/graphbolt/itemset.py
+++ b/python/dgl/graphbolt/itemset.py
@@ -88,6 +88,13 @@ class ItemSet:
 
         if isinstance(self._items[0], Sized):
             items_len = len(self._items[0])
+            # Use for-loop to iterate over the items. Can avoid a long
+            # wait time when the items are torch tensors. Since torch
+            # tensors need to call self.unbind(0) to slice themselves.
+            # While for-loops are slower than zip, they prevent excessive
+            # wait times during the loading phase, and the impact on overall
+            # performance during the training/testing stage is minimal.
+            # For more details, see https://github.com/dmlc/dgl/pull/6293.
             for i in range(items_len):
                 yield tuple(item[i] for item in self._items)
         else:

--- a/python/dgl/graphbolt/itemset.py
+++ b/python/dgl/graphbolt/itemset.py
@@ -85,9 +85,10 @@ class ItemSet:
         if len(self._items) == 1:
             yield from self._items[0]
             return
-        zip_items = zip(*self._items)
-        for item in zip_items:
-            yield tuple(item)
+
+        items_len = self._items[0].shape[0]
+        for i in range(items_len):
+            yield tuple(item[i] for item in self._items)
 
     def __len__(self) -> int:
         if isinstance(self._items[0], Sized):

--- a/python/dgl/graphbolt/itemset.py
+++ b/python/dgl/graphbolt/itemset.py
@@ -86,9 +86,15 @@ class ItemSet:
             yield from self._items[0]
             return
 
-        items_len = self._items[0].shape[0]
-        for i in range(items_len):
-            yield tuple(item[i] for item in self._items)
+        if isinstance(self._items[0], Sized):
+            items_len = len(self._items[0])
+            for i in range(items_len):
+                yield tuple(item[i] for item in self._items)
+        else:
+            # If the items are not Sized, we use zip to iterate over them.
+            zip_items = zip(*self._items)
+            for item in zip_items:
+                yield tuple(item)
 
     def __len__(self) -> int:
         if isinstance(self._items[0], Sized):

--- a/tests/python/pytorch/graphbolt/test_itemset.py
+++ b/tests/python/pytorch/graphbolt/test_itemset.py
@@ -36,31 +36,7 @@ def test_ItemSet_length():
     ids = torch.arange(0, 5)
     item_set = gb.ItemSet(ids)
     assert len(item_set) == 5
-
-    # Tuple of iterables with valid length.
-    item_set = gb.ItemSet((torch.arange(0, 5), torch.arange(5, 10)))
-    assert len(item_set) == 5
-
-    class InvalidLength:
-        def __iter__(self):
-            return iter([0, 1, 2])
-
-    # Single iterable with invalid length.
-    item_set = gb.ItemSet(InvalidLength())
-    with pytest.raises(TypeError):
-        _ = len(item_set)
-
-    # Tuple of iterables with invalid length.
-    item_set = gb.ItemSet((InvalidLength(), InvalidLength()))
-    with pytest.raises(TypeError):
-        _ = len(item_set)
-
-
-def test_ItemSet_iteration():
-    # Single iterable with valid length.
-    ids = torch.arange(0, 5)
-    item_set = gb.ItemSet(ids)
-    assert len(item_set) == 5
+    # Test __iter__ method. Same as below.
     for i, item in enumerate(item_set):
         assert i == item.item()
 

--- a/tests/python/pytorch/graphbolt/test_itemset.py
+++ b/tests/python/pytorch/graphbolt/test_itemset.py
@@ -56,6 +56,41 @@ def test_ItemSet_length():
         _ = len(item_set)
 
 
+def test_ItemSet_iteration():
+    # Single iterable with valid length.
+    ids = torch.arange(0, 5)
+    item_set = gb.ItemSet(ids)
+    assert len(item_set) == 5
+    for i, item in enumerate(item_set):
+        assert i == item.item()
+
+    # Tuple of iterables with valid length.
+    item_set = gb.ItemSet((torch.arange(0, 5), torch.arange(5, 10)))
+    assert len(item_set) == 5
+    for i, (item1, item2) in enumerate(item_set):
+        assert i == item1.item()
+        assert i + 5 == item2.item()
+
+    class InvalidLength:
+        def __iter__(self):
+            return iter([0, 1, 2])
+
+    # Single iterable with invalid length.
+    item_set = gb.ItemSet(InvalidLength())
+    with pytest.raises(TypeError):
+        _ = len(item_set)
+    for i, item in enumerate(item_set):
+        assert i == item
+
+    # Tuple of iterables with invalid length.
+    item_set = gb.ItemSet((InvalidLength(), InvalidLength()))
+    with pytest.raises(TypeError):
+        _ = len(item_set)
+    for i, (item1, item2) in enumerate(item_set):
+        assert i == item1
+        assert i == item2
+
+
 def test_ItemSet_iteration_seed_nodes():
     # Node IDs.
     item_set = gb.ItemSet(torch.arange(0, 5), names="seed_nodes")


### PR DESCRIPTION
## Description
<!-- Brief description. Refer to the related issues if existed.
It'll be great if relevant reviewers can be assigned as well.-->

The original implementation of `ItemSet.__iter__` uses `zip` to obtain an iterator for `self._items`. When `self._items` is a `tuple` of `torch.Tensor`, `zip(self._items)` ends up calling `torch.unbind(0)`, which pre-slices the tensor and need a lot of time.

Although using `zip` is more efficient, it results in **significant waiting time for the user**( $100\sim 200s$ for most case). We've opted for a straightforward `for` loop to yield each item. While this approach incurs some performance overhead, it offers a better user experience, especially during **debugging** or when the full dataset is not required for training.

The following are the performance reports for both approaches. The share of time taken by `zip` (1.6%) and `for` (3.2%) in the overall training phase is negligible, leading us to prefer the `for` loop solution.

---

Use `for` (3.2%)

```
Timer unit: 1e-06 s

Total time: 451.875 s
File: /opt/conda/envs/dgl-dev-cpu-2.0.1/lib/python3.8/site-packages/dgl-1.2-py3.8-linux-x86_64.egg/dgl/graphbolt/itemset.py
Function: __iter__ at line 71

Line #      Hits         Time  Per Hit   % Time  Line Contents
==============================================================
    71                                               @profile
    72                                               def __iter__(self) -> Iterator:
    73         1          4.2      4.2      0.0          if len(self._items) == 1:
    74                                                       yield from self._items[0]
    75                                                       return
    76  30387995   29396050.2      1.0      6.5          for i in range(self._items[0].shape[0]):
    77  30387995  422478663.2     13.9     93.5              yield tuple(item[i] for item in self._items)

Total time: 14155.1 s
File: examples/sampling/graphbolt/link_prediction.py
Function: train at line 269

Line #      Hits         Time  Per Hit   % Time  Line Contents
==============================================================
   269                                           @profile
   270                                           def train(args, graph, features, train_set, valid_set, model):
   271         1        410.0    410.0      0.0      optimizer = torch.optim.Adam(model.parameters(), lr=args.lr)
   272         1      11750.1  11750.1      0.0      dataloader = current_dataloader(args, graph, features, train_set)
   273                                           
   274         1       2360.1   2360.1      0.0      for epoch in tqdm.trange(args.epochs):
   275         1        233.5    233.5      0.0          model.train()
   276         1          1.1      1.1      0.0          total_loss = 0
   277     59352 4597463954.3  77461.0     32.5          for step, data in enumerate(dataloader):
   278                                                       # Unpack LinkPredictionBlock.
   279                                                       # data.label is computed during the NegativeSampler phase.
   280     59352    4265932.2     71.9      0.0              label = data.label.float()
   281     59352     590949.6     10.0      0.0              compacted_pairs = data.compacted_node_pair
   282     59352  985209480.1  16599.4      7.0              node_feature = data.node_features["feat"].float()
   283                                                       # Convert sampled subgraphs to DGL blocks.
   284     59352  220909921.6   3722.0      1.6              blocks = to_dgl_blocks(data.sampled_subgraphs)
   285                                           
   286                                                       # Get the embeddings of the input nodes.
   287     59352 3751107657.3  63201.0     26.5              y = model(blocks, node_feature)
   288     59352   45589097.7    768.1      0.3              logits = model.predictor(
   289     59352   19304054.0    325.2      0.1                  y[compacted_pairs[0]] * y[compacted_pairs[1]]
   290                                                       ).squeeze()
   291                                           
   292                                                       # Compute loss.
   293     59352   16987324.1    286.2      0.1              loss = F.binary_cross_entropy_with_logits(logits, label)
   294     59352   13902271.5    234.2      0.1              optimizer.zero_grad()
   295     59352 4237892346.0  71402.7     29.9              loss.backward()
   296     59352  261450120.3   4405.1      1.8              optimizer.step()
   297                                           
   298     59352     272772.7      4.6      0.0              total_loss += loss.item()
   299     58759     111176.9      1.9      0.0              if (step % 100 == 0) and (step != 0):
   300       593      26747.9     45.1      0.0                  print(
   301       593       9681.7     16.3      0.0                      f"Epoch {epoch:05d} | "
   302                                                               f"Step {step:05d} | "
   303                                                               f"Loss {(total_loss) / (step + 1):.4f}",
   304       593        704.3      1.2      0.0                      end="\n",
   305                                                           )
   306         1        605.1    605.1      0.0          exit(0)
   307                                           
   308                                               # Evaluate the model.
   309                                               print("Validation")
   310                                               valid_mrr = evaluate(args, graph, features, valid_set, model)
   311                                               print(f"Valid MRR {valid_mrr.item():.4f}")
```

Use `zip` (1.6%)

```
Timer unit: 1e-06 s

Total time: 217.044 s
File: /opt/conda/envs/dgl-dev-cpu-2.0.1/lib/python3.8/site-packages/dgl-1.2-py3.8-linux-x86_64.egg/dgl/graphbolt/itemset.py
Function: __iter__ at line 71

Line #      Hits         Time  Per Hit   % Time  Line Contents
==============================================================
    71                                               @profile
    72                                               def __iter__(self) -> Iterator:
    73         1          3.2      3.2      0.0          if len(self._items) == 1:
    74                                                       yield from self._items[0]
    75                                                       return
    76                                                   # import pdb; pdb.set_trace()
    77         1          4.7      4.7      0.0          import time
    78         1          4.0      4.0      0.0          start_time = time.time()
    79         1  158595467.3 158595467.3     73.1          zip_items = zip(*self._items)
    80         1          6.9      6.9      0.0          end_time = time.time()
    81         1         50.9     50.9      0.0          print("zip time: ", end_time - start_time)
    82  30387995   32752006.3      1.1     15.1          for item in zip_items:
    83  30387995   25696566.8      0.8     11.8              yield tuple(item)

Total time: 13443.1 s
File: examples/sampling/graphbolt/link_prediction.py
Function: train at line 269

Line #      Hits         Time  Per Hit   % Time  Line Contents
==============================================================
   269                                           @profile
   270                                           def train(args, graph, features, train_set, valid_set, model):
   271         1        383.0    383.0      0.0      optimizer = torch.optim.Adam(model.parameters(), lr=args.lr)
   272         1      11271.2  11271.2      0.0      dataloader = current_dataloader(args, graph, features, train_set)
   273                                           
   274         1       2100.7   2100.7      0.0      for epoch in tqdm.trange(args.epochs):
   275         1        200.5    200.5      0.0          model.train()
   276         1          0.9      0.9      0.0          total_loss = 0
   277     59352 4247013882.1  71556.4     31.6          for step, data in enumerate(dataloader):
   278                                                       # Unpack LinkPredictionBlock.
   279                                                       # data.label is computed during the NegativeSampler phase.
   280     59352    3972679.3     66.9      0.0              label = data.label.float()
   281     59352     839883.1     14.2      0.0              compacted_pairs = data.compacted_node_pair
   282     59352  738777825.6  12447.4      5.5              node_feature = data.node_features["feat"].float()
   283                                                       # Convert sampled subgraphs to DGL blocks.
   284     59352  220355750.1   3712.7      1.6              blocks = to_dgl_blocks(data.sampled_subgraphs)
   285                                           
   286                                                       # Get the embeddings of the input nodes.
   287     59352 3685995245.3  62104.0     27.4              y = model(blocks, node_feature)
   288     59352   48091508.5    810.3      0.4              logits = model.predictor(
   289     59352   19002914.7    320.2      0.1                  y[compacted_pairs[0]] * y[compacted_pairs[1]]
   290                                                       ).squeeze()
   291                                           
   292                                                       # Compute loss.
   293     59352   36132296.8    608.8      0.3              loss = F.binary_cross_entropy_with_logits(logits, label)
   294     59352   19115522.2    322.1      0.1              optimizer.zero_grad()
   295     59352 4171205075.9  70279.1     31.0              loss.backward()
   296     59352  252121429.3   4247.9      1.9              optimizer.step()
   297                                           
   298     59352     271083.6      4.6      0.0              total_loss += loss.item()
   299     58759     116147.3      2.0      0.0              if (step % 100 == 0) and (step != 0):
   300       593      26764.4     45.1      0.0                  print(
   301       593       9181.8     15.5      0.0                      f"Epoch {epoch:05d} | "
   302                                                               f"Step {step:05d} | "
   303                                                               f"Loss {(total_loss) / (step + 1):.4f}",
   304       593        754.8      1.3      0.0                      end="\n",
   305                                                           )
   306         1        632.6    632.6      0.0          exit(0)
```


## Checklist
Please feel free to remove inapplicable items for your PR.
- [x] The PR title starts with [$CATEGORY] (such as [NN], [Model], [Doc], [Feature]])
- [x] I've leverage the [tools](https://docs.google.com/document/d/1iHyj7zlmygKSk5gBPsqIqL5ASPzJSPREaNT_QdsiYA4/edit) to beautify the python and c++ code.
- [x] The PR is complete and small, read the [Google eng practice (CL equals to PR)](https://google.github.io/eng-practices/review/developer/small-cls.html) to understand more about small PR. In DGL, we consider PRs with less than 200 lines of core code change are small (example, test and documentation could be exempted).
- [ ] All changes have test coverage
- [ ] Code is well-documented
- [ ] To the best of my knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change
- [ ] Related issue is referred in this PR
- [ ] If the PR is for a new model/paper, I've updated the example index [here](../examples/README.md).

## Changes
<!-- You could use following template
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)
-->
