### PR TITLE
[GraphBolt] enable to invoke gb samplers in functional form

### DIFF
--- a/python/dgl/graphbolt/base.py
+++ b/python/dgl/graphbolt/base.py
@@ -1,5 +1,6 @@
 """Base types and utilities for Graph Bolt."""
 
+from torch.utils.data import functional_datapipe
 from torchdata.datapipes.iter import IterDataPipe
 
 from ..utils import recursive_apply
@@ -53,6 +54,7 @@ def _to(x, device):
     return x.to(device) if hasattr(x, "to") else x
 
 
+@functional_datapipe("copy_to")
 class CopyTo(IterDataPipe):
     """DataPipe that transfers each element yielded from the previous DataPipe
     to the given device.

--- a/python/dgl/graphbolt/feature_fetcher.py
+++ b/python/dgl/graphbolt/feature_fetcher.py
@@ -2,9 +2,12 @@
 
 from typing import Dict
 
+from torch.utils.data import functional_datapipe
+
 from torchdata.datapipes.iter import Mapper
 
 
+@functional_datapipe("fetch_feature")
 class FeatureFetcher(Mapper):
     """A feature fetcher used to fetch features for node/edge in graphbolt."""
 

--- a/python/dgl/graphbolt/impl/neighbor_sampler.py
+++ b/python/dgl/graphbolt/impl/neighbor_sampler.py
@@ -1,10 +1,13 @@
 """Neighbor subgraph samplers for GraphBolt."""
 
+from torch.utils.data import functional_datapipe
+
 from ..subgraph_sampler import SubgraphSampler
 from ..utils import unique_and_compact_node_pairs
 from .sampled_subgraph_impl import SampledSubgraphImpl
 
 
+@functional_datapipe("sample_neighbor")
 class NeighborSampler(SubgraphSampler):
     """
     Neighbor sampler is responsible for sampling a subgraph from given data. It
@@ -112,6 +115,7 @@ class NeighborSampler(SubgraphSampler):
         return seeds, subgraphs
 
 
+@functional_datapipe("sample_layer_neighbor")
 class LayerNeighborSampler(NeighborSampler):
     """
     Layer-Neighbor sampler is responsible for sampling a subgraph from given

--- a/python/dgl/graphbolt/impl/uniform_negative_sampler.py
+++ b/python/dgl/graphbolt/impl/uniform_negative_sampler.py
@@ -1,8 +1,11 @@
 """Uniform negative sampler for GraphBolt."""
 
+from torch.utils.data import functional_datapipe
+
 from ..negative_sampler import NegativeSampler
 
 
+@functional_datapipe("sample_uniform_negative")
 class UniformNegativeSampler(NegativeSampler):
     """
     Negative samplers randomly select negative destination nodes for each

--- a/python/dgl/graphbolt/item_sampler.py
+++ b/python/dgl/graphbolt/item_sampler.py
@@ -4,7 +4,7 @@ from collections.abc import Mapping
 from functools import partial
 from typing import Callable, Iterator, Optional
 
-from torch.utils.data import default_collate
+from torch.utils.data import default_collate, functional_datapipe
 from torchdata.datapipes.iter import IterableWrapper, IterDataPipe
 
 from ..base import dgl_warning
@@ -78,6 +78,7 @@ def minibatcher_default(batch, names):
     return minibatch
 
 
+@functional_datapipe("sample_item")
 class ItemSampler(IterDataPipe):
     """Item Sampler.
 

--- a/python/dgl/graphbolt/negative_sampler.py
+++ b/python/dgl/graphbolt/negative_sampler.py
@@ -3,11 +3,13 @@
 from _collections_abc import Mapping
 
 import torch
+from torch.utils.data import functional_datapipe
 from torchdata.datapipes.iter import Mapper
 
 from .data_format import LinkPredictionEdgeFormat
 
 
+@functional_datapipe("sample_negative")
 class NegativeSampler(Mapper):
     """
     A negative sampler used to generate negative samples and return

--- a/python/dgl/graphbolt/subgraph_sampler.py
+++ b/python/dgl/graphbolt/subgraph_sampler.py
@@ -3,12 +3,14 @@
 from collections import defaultdict
 from typing import Dict
 
+from torch.utils.data import functional_datapipe
 from torchdata.datapipes.iter import Mapper
 
 from .base import etype_str_to_tuple
 from .utils import unique_and_compact
 
 
+@functional_datapipe("sample_subgraph")
 class SubgraphSampler(Mapper):
     """A subgraph sampler used to sample a subgraph from a given set of nodes
     from a larger graph."""

--- a/tests/python/pytorch/graphbolt/impl/test_negative_sampler.py
+++ b/tests/python/pytorch/graphbolt/impl/test_negative_sampler.py
@@ -5,6 +5,75 @@ import torch
 from torchdata.datapipes.iter import Mapper
 
 
+def test_NegativeSampler_invoke():
+    # Instantiate graph and required datapipes.
+    num_seeds = 30
+    item_set = gb.ItemSet(
+        torch.arange(0, 2 * num_seeds).reshape(-1, 2), names="node_pairs"
+    )
+    batch_size = 10
+    item_sampler = gb.ItemSampler(item_set, batch_size=batch_size)
+    negative_ratio = 2
+
+    # Invoke NegativeSampler via class constructor.
+    negative_sampler = gb.NegativeSampler(
+        item_sampler,
+        negative_ratio,
+        gb.LinkPredictionEdgeFormat.INDEPENDENT,
+    )
+    with pytest.raises(NotImplementedError):
+        next(iter(negative_sampler))
+
+    # Invoke NegativeSampler via functional form.
+    negative_sampler = item_sampler.sample_negative(
+        negative_ratio,
+        gb.LinkPredictionEdgeFormat.INDEPENDENT,
+    )
+    with pytest.raises(NotImplementedError):
+        next(iter(negative_sampler))
+
+
+def test_UniformNegativeSampler_invoke():
+    # Instantiate graph and required datapipes.
+    graph = gb_test_utils.rand_csc_graph(100, 0.05)
+    num_seeds = 30
+    item_set = gb.ItemSet(
+        torch.arange(0, 2 * num_seeds).reshape(-1, 2), names="node_pairs"
+    )
+    batch_size = 10
+    item_sampler = gb.ItemSampler(item_set, batch_size=batch_size)
+    negative_ratio = 2
+
+    # Verify iteration over UniformNegativeSampler.
+    def _verify(negative_sampler):
+        for data in negative_sampler:
+            src, dst = data.node_pairs
+            labels = data.labels
+            # Assertation
+            assert len(src) == batch_size * (negative_ratio + 1)
+            assert len(dst) == batch_size * (negative_ratio + 1)
+            assert len(labels) == batch_size * (negative_ratio + 1)
+            assert torch.all(torch.eq(labels[:batch_size], 1))
+            assert torch.all(torch.eq(labels[batch_size:], 0))
+
+    # Invoke UniformNegativeSampler via class constructor.
+    negative_sampler = gb.UniformNegativeSampler(
+        item_sampler,
+        negative_ratio,
+        gb.LinkPredictionEdgeFormat.INDEPENDENT,
+        graph,
+    )
+    _verify(negative_sampler)
+
+    # Invoke UniformNegativeSampler via functional form.
+    negative_sampler = item_sampler.sample_uniform_negative(
+        negative_ratio,
+        gb.LinkPredictionEdgeFormat.INDEPENDENT,
+        graph,
+    )
+    _verify(negative_sampler)
+
+
 @pytest.mark.parametrize("negative_ratio", [1, 5, 10, 20])
 def test_NegativeSampler_Independent_Format(negative_ratio):
     # Construct CSCSamplingGraph.

--- a/tests/python/pytorch/graphbolt/test_base.py
+++ b/tests/python/pytorch/graphbolt/test_base.py
@@ -11,8 +11,14 @@ import torch
 @unittest.skipIf(F._default_context_str == "cpu", "CopyTo needs GPU to test")
 def test_CopyTo():
     dp = gb.ItemSampler(gb.ItemSet(torch.randn(20)), 4)
-    dp = gb.CopyTo(dp, "cuda")
 
+    # Invoke CopyTo via class constructor.
+    dp = gb.CopyTo(dp, "cuda")
+    for data in dp:
+        assert data.device.type == "cuda"
+
+    # Invoke CopyTo via functional form.
+    dp = dp.copy_to("cuda")
     for data in dp:
         assert data.device.type == "cuda"
 


### PR DESCRIPTION
## Description
<!-- Brief description. Refer to the related issues if existed.
It'll be great if relevant reviewers can be assigned as well.-->

## Checklist
Please feel free to remove inapplicable items for your PR.
- [ ] The PR title starts with [$CATEGORY] (such as [NN], [Model], [Doc], [Feature]])
- [ ] I've leverage the [tools](https://docs.google.com/document/d/1iHyj7zlmygKSk5gBPsqIqL5ASPzJSPREaNT_QdsiYA4/edit) to beautify the python and c++ code.
- [ ] The PR is complete and small, read the [Google eng practice (CL equals to PR)](https://google.github.io/eng-practices/review/developer/small-cls.html) to understand more about small PR. In DGL, we consider PRs with less than 200 lines of core code change are small (example, test and documentation could be exempted).
- [ ] All changes have test coverage
- [ ] Code is well-documented
- [ ] To the best of my knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change
- [ ] Related issue is referred in this PR
- [ ] If the PR is for a new model/paper, I've updated the example index [here](../examples/README.md).

## Changes
<!-- You could use following template
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)
-->
