### PR TITLE
[CMAKE] Move DGL cuda file declaration to the main CMakeLists.txt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -259,8 +259,22 @@ list(APPEND DGL_SRC ${DGL_RPC_SRC})
 
 # Configure cuda
 if(USE_CUDA)
-  dgl_config_cuda(DGL_CUDA_SRC)
+  file(GLOB_RECURSE DGL_CUDA_SRC
+    src/array/cuda/*.cc
+    src/array/cuda/*.cu
+    src/array/cuda/uvm/*.cc
+    src/array/cuda/uvm/*.cu
+    src/kernel/cuda/*.cc
+    src/kernel/cuda/*.cu
+    src/partition/cuda/*.cu
+    src/runtime/cuda/*.cc
+    src/runtime/cuda/*.cu
+    src/geometry/cuda/*.cu
+    src/graph/transform/cuda/*.cu
+    src/graph/sampling/randomwalks/*.cu
+  )
   list(APPEND DGL_SRC ${DGL_CUDA_SRC})
+  dgl_config_cuda(DGL_LINKER_LIBS)
   cuda_add_library(dgl SHARED ${DGL_SRC})
 else(USE_CUDA)
   add_library(dgl SHARED ${DGL_SRC})

--- a/cmake/modules/CUDA.cmake
+++ b/cmake/modules/CUDA.cmake
@@ -203,10 +203,10 @@ function(dgl_select_nvcc_arch_flags out_variable)
 endfunction()
 
 ################################################################################################
-# Config cuda compilation.
+# Config cuda compilation and append CUDA libraries to linker_libs
 # Usage:
-#   dgl_config_cuda(<dgl_cuda_src>)
-macro(dgl_config_cuda out_variable)
+#  dgl_config_cuda(linker_libs)
+macro(dgl_config_cuda linker_libs)
   if(NOT CUDA_FOUND)
     message(FATAL_ERROR "Cannot find CUDA.")
   endif()
@@ -215,21 +215,6 @@ macro(dgl_config_cuda out_variable)
 	include_directories(${CUDA_INCLUDE_DIRS})
 
   add_definitions(-DDGL_USE_CUDA)
-
-  file(GLOB_RECURSE DGL_CUDA_SRC
-    src/array/cuda/*.cc
-    src/array/cuda/*.cu
-    src/array/cuda/uvm/*.cc
-    src/array/cuda/uvm/*.cu
-    src/kernel/cuda/*.cc
-    src/kernel/cuda/*.cu
-    src/partition/cuda/*.cu
-    src/runtime/cuda/*.cc
-    src/runtime/cuda/*.cu
-    src/geometry/cuda/*.cu
-    src/graph/transform/cuda/*.cu
-    src/graph/sampling/randomwalks/*.cu
-  )
 
   # NVCC flags
   # Manually set everything
@@ -252,10 +237,8 @@ macro(dgl_config_cuda out_variable)
 
   message(STATUS "CUDA_NVCC_FLAGS: ${CUDA_NVCC_FLAGS}")
 
-  list(APPEND DGL_LINKER_LIBS
+  list(APPEND ${linker_libs} 
     ${CUDA_CUDART_LIBRARY}
     ${CUDA_CUBLAS_LIBRARIES}
     ${CUDA_cusparse_LIBRARY})
-
-  set(${out_variable} ${DGL_CUDA_SRC})
 endmacro()


### PR DESCRIPTION
## Description

Move DGL cuda file declaration to the main CMakeLists.txt. Later both graphbolt and dgl sparse can use `dgl_config_cuda` to configure CUDA compilation

## Checklist
Please feel free to remove inapplicable items for your PR.
- [ ] The PR title starts with [$CATEGORY] (such as [NN], [Model], [Doc], [Feature]])
- [ ] I've leverage the [tools](https://docs.google.com/document/d/1iHyj7zlmygKSk5gBPsqIqL5ASPzJSPREaNT_QdsiYA4/edit) to beautify the python and c++ code.
- [ ] The PR is complete and small, read the [Google eng practice (CL equals to PR)](https://google.github.io/eng-practices/review/developer/small-cls.html) to understand more about small PR. In DGL, we consider PRs with less than 200 lines of core code change are small (example, test and documentation could be exempted).
- [ ] All changes have test coverage
- [ ] Code is well-documented
- [ ] To the best of my knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change
- [ ] Related issue is referred in this PR
- [ ] If the PR is for a new model/paper, I've updated the example index [here](../examples/README.md).

## Changes
<!-- You could use following template
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)
-->
