### PR TITLE
[Sparse] Sparse sample implementation

### DIFF
--- a/dgl_sparse/include/sparse/sparse_matrix.h
+++ b/dgl_sparse/include/sparse/sparse_matrix.h
@@ -196,11 +196,13 @@ class SparseMatrix : public torch::CustomClassHolder {
    * @param ids An optional tensor containing row or column IDs from which to
    * sample elements.
    * @param replace Indicates whether repeated sampling of the same element
-   * is allowed. When 'replace = true', repeated sampling is permitted; when
-   * 'replace = false', it is not allowed.
+   * is allowed. If True, repeated sampling is allowed; otherwise, it is not
+   * allowed.
    * @param bias An optional boolean flag indicating whether to enable biasing
-   * during sampling. When 'bias = true', the values of the sparse matrix will
-   * be used as bias weights.
+   * during sampling. If True, the values of the sparse matrix will be used as
+   * bias weights, meaning that elements with higher values will be more likely
+   * to be sampled. Otherwise, all elements will be sampled uniformly,
+   * regardless of their value.
    *
    * @return A new SparseMatrix with the same shape as the original matrix
    * containing the sampled elements.

--- a/dgl_sparse/include/sparse/sparse_matrix.h
+++ b/dgl_sparse/include/sparse/sparse_matrix.h
@@ -191,27 +191,26 @@ class SparseMatrix : public torch::CustomClassHolder {
    * with the specified sample count.
    *
    * @param dim Select rows (dim=0) or columns (dim=1) for sampling.
-   * @param n_pick The number of elements to randomly sample from each row or
+   * @param fanout The number of elements to randomly sample from each row or
    * column.
-   * @param replacement Indicates whether repeated sampling of the same element
-   * is allowed. When 'replacement = true', repeated sampling is permitted; when
-   * 'replacement = false', it is not allowed.
    * @param ids An optional tensor containing row or column IDs from which to
    * sample elements.
+   * @param replace Indicates whether repeated sampling of the same element
+   * is allowed. When 'replace = true', repeated sampling is permitted; when
+   * 'replace = false', it is not allowed.
    * @param bias An optional boolean flag indicating whether to enable biasing
    * during sampling. When 'bias = true', the values of the sparse matrix will
    * be used as bias weights.
    *
    * @return A new SparseMatrix with the same shape as the original matrix
    * containing the sampled elements.
-   * @note If 'replacement = false' and there are fewer elements than 'n_pick',
+   * @note If 'replace = false' and there are fewer elements than 'fanout',
    * all non-zero elements will be sampled.
    * @note If 'ids' is not provided, the function will sample from
    * all rows or columns.
    */
   c10::intrusive_ptr<SparseMatrix> Sample(
-      int64_t dim, int64_t n_pick, bool replacement, torch::Tensor ids,
-      bool bias);
+      int64_t dim, int64_t fanout, torch::Tensor ids, bool replace, bool bias);
 
   /**
    * @brief Create a SparseMatrix from a SparseMatrix using new values.

--- a/dgl_sparse/include/sparse/sparse_matrix.h
+++ b/dgl_sparse/include/sparse/sparse_matrix.h
@@ -183,6 +183,29 @@ class SparseMatrix : public torch::CustomClassHolder {
       int64_t dim, int64_t start, int64_t end);
 
   /**
+   * @brief Create a SparseMatrix by sampling elements based on provided
+   * dimension and number.
+   *
+   * This function allows you to create a new SparseMatrix by randomly sampling
+   * elements along a specified dimension (row-wise or column-wise) with the
+   * given number.
+   *
+   * @param dim Select rows (dim=0) or columns (dim=1) for sampling.
+   * @param n_pick The number of elements to randomly sample from each row or
+   * column.
+   * @param replacement Indicates whether repeated sampling of the same element
+   * is allowed. When 'replacement = true', repeated sampling is permitted; when
+   * 'replacement = false', it is not allowed.
+   *
+   * @return A new SparseMatrix with the same shape as the original matrix
+   * containing the sampled elements.
+   * @note If 'replacement = false' and there are fewer elements than 'n_pick',
+   * all non-zero elements will be sampled.
+   */
+  c10::intrusive_ptr<SparseMatrix> Sample(
+      int64_t dim, int64_t n_pick, bool replacement = false);
+
+  /**
    * @brief Create a SparseMatrix from a SparseMatrix using new values.
    * @param mat An existing sparse matrix
    * @param value New values of the sparse matrix

--- a/dgl_sparse/include/sparse/sparse_matrix.h
+++ b/dgl_sparse/include/sparse/sparse_matrix.h
@@ -186,9 +186,9 @@ class SparseMatrix : public torch::CustomClassHolder {
    * @brief Create a SparseMatrix by sampling elements based on the specified
    * dimension and sample count.
    *
-   * This function enables the creation of a new SparseMatrix by randomly
-   * sampling elements along a specified dimension (row-wise or column-wise)
-   * with the specified sample count.
+   * If `ids` is provided, this function samples elements from the specified
+   * set of row or column IDs, resulting in a sparse matrix containing only
+   * the sampled rows or columns.
    *
    * @param dim Select rows (dim=0) or columns (dim=1) for sampling.
    * @param fanout The number of elements to randomly sample from each row or
@@ -204,6 +204,7 @@ class SparseMatrix : public torch::CustomClassHolder {
    *
    * @return A new SparseMatrix with the same shape as the original matrix
    * containing the sampled elements.
+   *
    * @note If 'replace = false' and there are fewer elements than 'fanout',
    * all non-zero elements will be sampled.
    * @note If 'ids' is not provided, the function will sample from

--- a/dgl_sparse/include/sparse/sparse_matrix.h
+++ b/dgl_sparse/include/sparse/sparse_matrix.h
@@ -183,12 +183,12 @@ class SparseMatrix : public torch::CustomClassHolder {
       int64_t dim, int64_t start, int64_t end);
 
   /**
-   * @brief Create a SparseMatrix by sampling elements based on provided
-   * dimension and number.
+   * @brief Create a SparseMatrix by sampling elements based on the specified
+   * dimension and sample count.
    *
-   * This function allows you to create a new SparseMatrix by randomly sampling
-   * elements along a specified dimension (row-wise or column-wise) with the
-   * given number.
+   * This function enables the creation of a new SparseMatrix by randomly
+   * sampling elements along a specified dimension (row-wise or column-wise)
+   * with the specified sample count.
    *
    * @param dim Select rows (dim=0) or columns (dim=1) for sampling.
    * @param n_pick The number of elements to randomly sample from each row or
@@ -196,14 +196,22 @@ class SparseMatrix : public torch::CustomClassHolder {
    * @param replacement Indicates whether repeated sampling of the same element
    * is allowed. When 'replacement = true', repeated sampling is permitted; when
    * 'replacement = false', it is not allowed.
+   * @param ids An optional tensor containing row or column IDs from which to
+   * sample elements.
+   * @param bias An optional boolean flag indicating whether to enable biasing
+   * during sampling. When 'bias = true', the values of the sparse matrix will
+   * be used as bias weights.
    *
    * @return A new SparseMatrix with the same shape as the original matrix
    * containing the sampled elements.
    * @note If 'replacement = false' and there are fewer elements than 'n_pick',
    * all non-zero elements will be sampled.
+   * @note If 'ids' is not provided, the function will sample from
+   * all rows or columns.
    */
   c10::intrusive_ptr<SparseMatrix> Sample(
-      int64_t dim, int64_t n_pick, bool replacement = false);
+      int64_t dim, int64_t n_pick, bool replacement, torch::Tensor ids,
+      bool bias);
 
   /**
    * @brief Create a SparseMatrix from a SparseMatrix using new values.

--- a/dgl_sparse/src/python_binding.cc
+++ b/dgl_sparse/src/python_binding.cc
@@ -35,7 +35,8 @@ TORCH_LIBRARY(dgl_sparse, m) {
       .def("has_duplicate", &SparseMatrix::HasDuplicate)
       .def("is_diag", &SparseMatrix::HasDiag)
       .def("index_select", &SparseMatrix::IndexSelect)
-      .def("range_select", &SparseMatrix::RangeSelect);
+      .def("range_select", &SparseMatrix::RangeSelect)
+      .def("sample", &SparseMatrix::Sample);
   m.def("from_coo", &SparseMatrix::FromCOO)
       .def("from_csr", &SparseMatrix::FromCSR)
       .def("from_csc", &SparseMatrix::FromCSC)

--- a/dgl_sparse/src/sparse_matrix.cc
+++ b/dgl_sparse/src/sparse_matrix.cc
@@ -181,9 +181,8 @@ c10::intrusive_ptr<SparseMatrix> SparseMatrix::Sample(
 
   auto prob =
       bias ? TorchTensorToDGLArray(slice_value) : dgl::aten::NullArray();
-  std::vector<uint64_t> v(id_array.NumElements());
-  iota(v.begin(), v.end(), 0);
-  auto slice_id = NDArray::FromVector<uint64_t>(v);
+  auto slice_id =
+      dgl::aten::Range(0, id_array.NumElements(), 64, id_array->ctx);
   // Sampling all rows on sliced matrix.
   auto sample_coo =
       dgl::aten::CSRRowWiseSampling(slice_csr, slice_id, fanout, prob, replace);

--- a/dgl_sparse/src/sparse_matrix.cc
+++ b/dgl_sparse/src/sparse_matrix.cc
@@ -182,7 +182,7 @@ c10::intrusive_ptr<SparseMatrix> SparseMatrix::Sample(
   auto prob =
       bias ? TorchTensorToDGLArray(slice_value) : dgl::aten::NullArray();
   std::vector<uint64_t> v(id_array.NumElements());
-  for (int i = 0; i < id_array.NumElements(); i++) v[i] = i;
+  iota(v.begin(), v.end(), 0);
   auto slice_id = NDArray::FromVector<uint64_t>(v);
   // Sampling all rows on sliced matrix.
   auto sample_coo =

--- a/dgl_sparse/src/sparse_matrix.cc
+++ b/dgl_sparse/src/sparse_matrix.cc
@@ -168,22 +168,28 @@ c10::intrusive_ptr<SparseMatrix> SparseMatrix::RangeSelect(
 }
 
 c10::intrusive_ptr<SparseMatrix> SparseMatrix::Sample(
-    int64_t dim, int64_t n_pick, bool replacement = false) {
+    int64_t dim, int64_t n_pick, bool replacement, torch::Tensor ids,
+    bool bias) {
   bool rowwise = dim == 0;
   auto csr = rowwise ? this->CSRPtr() : this->CSCPtr();
-  auto row_num = rowwise ? csr->num_cols : csr->num_rows;
-  std::vector<uint64_t> vec;
-
-  for (uint64_t i = 0; i < row_num; i++) vec.push_back(i);
-  auto sample_csr = dgl::aten::CSRRowWiseSampling(
-      CSRToOldDGLCSR(csr), dim, FromVector, n_pick, dgl::aten::NullArray(),
+  if (ids.size(1) == 0) {
+    auto row_num = rowwise ? csr->num_cols : csr->num_rows;
+    std::vector<uint64_t> v(row_num);
+    iota(v.begin(), v.end(), row_num);
+    at::TensorOptions opts = at::TensorOptions().dtype(at::kInt);
+    ids = at::from_blob(v.data(), {row_num}, opts).clone();
+  }
+  auto sample_value = this->value().index_select(0, ids);
+  auto prob_or_mask =
+      bias ? TorchTensorToDGLArray(sample_value) : dgl::aten::NullArray();
+  auto sample_coo = dgl::aten::CSRRowWiseSampling(
+      CSRToOldDGLCSR(csr), TorchTensorToDGLArray(ids), n_pick, prob_or_mask,
       replacement);
-  auto sample_value =
-      this->value().index_select(0, DGLArrayToTorchTensor(slice_csr.data));
+  auto sample_csr = COOToCSR(sample_coo);
   // To prevent potential errors in future conversions to the COO format,
   // where this array might be used as an initialization array for
   // constructing COO representations, it is necessary to clear this array.
-  slice_csr.data = dgl::aten::NullArray();
+  sample_csr.data = dgl::aten::NullArray();
   auto ret = CSRFromOldDGLCSR(sample_csr);
   if (rowwise) {
     return SparseMatrix::FromCSRPointer(

--- a/python/dgl/sparse/sparse_matrix.py
+++ b/python/dgl/sparse/sparse_matrix.py
@@ -672,8 +672,10 @@ class SparseMatrix:
                      shape=(3, 2), nnz=3)
         """
         if ids is None:
-            num = self.shape[0] if dim == 0 else self.shape[1]
-            ids = torch.tensor(range(0, num))
+            dim_size = self.shape[0] if dim == 0 else self.shape[1]
+            ids = torch.range(
+                0, dim_size, dtype=torch.int64, device=self.device
+            )
         return SparseMatrix(
             self.c_sparse_matrix.sample(dim, fanout, ids, replace, bias)
         )

--- a/python/dgl/sparse/sparse_matrix.py
+++ b/python/dgl/sparse/sparse_matrix.py
@@ -613,7 +613,7 @@ class SparseMatrix:
             When `replace = True`, repeated sampling is permitted; when
             `replace = False`, it is not allowed.
             NOTE: If `replace = False` and there are fewer elements than
-            `n_pick`, all non-zero elements will be sampled.
+            `fanout`, all non-zero elements will be sampled.
         bias : bool, optional
             A boolean flag indicating whether to enable biasing during sampling.
             When `bias = True`, the values of the sparse matrix will be used as
@@ -671,7 +671,12 @@ class SparseMatrix:
                      values=tensor([0, 2, 3, 3]),
                      shape=(3, 2), nnz=3)
         """
-        raise NotImplementedError
+        if ids == None:
+            num = self.shape[0] if dim == 0 else self.shape[1]
+            ids = torch.tensor([id for id in range(num)])
+        return SparseMatrix(
+            self.c_sparse_matrix.sample(dim, fanout, ids, replace, bias)
+        )
 
 
 def spmatrix(

--- a/python/dgl/sparse/sparse_matrix.py
+++ b/python/dgl/sparse/sparse_matrix.py
@@ -587,7 +587,12 @@ class SparseMatrix:
         raise TypeError(f"{type(index).__name__} is unsupported input type.")
 
     def sample(
-        self, dim: int, n_pick: int, replacement: Optional[bool] = False
+        self,
+        dim: int,
+        n_pick: int,
+        ids: Optional[torch.Tensor] = None,
+        replacement: Optional[bool] = False,
+        bias: Optional[bool] = False,
     ):
         """Returns a sampled matrix on the given dimension and sample arguments.
 
@@ -598,12 +603,21 @@ class SparseMatrix:
             rowwise selection and `dim = 1` for columnwise selection.
         n_pick : int
             The number of elements to randomly sample on each row or column.
+        ids : torch.Tensor, optional
+            An optional tensor containing row or column IDs from which to
+            sample elements.
+            NOTE: If `ids` is not provided (i.e., `ids = None`), the function
+            will sample from all rows or columns.
         replacement : bool, optional
             Indicates whether repeated sampling of the same element is allowed.
             When `replacement = True`, repeated sampling is permitted; when
             `replacement = False`, it is not allowed.
             NOTE: If `replacement = False` and there are fewer elements than
             `n_pick`, all non-zero elements will be sampled.
+        bias : bool, optional
+            A boolean flag indicating whether to enable biasing during sampling.
+            When `bias = True`, the values of the sparse matrix will be used as
+            bias weights.
 
         The function does not support autograd.
 
@@ -623,35 +637,39 @@ class SparseMatrix:
 
         Case 1: Sample rows with the given number and disable repeated sampling.
 
-        >>> A.sample(0, 2)
-        SparseMatrix(indices=tensor([[0, 0, 1, 1, 2, 2],
-                                     [0, 2, 0, 1, 0, 2]]),
-                     values=tensor([0, 1, 2, 3, 4, 6]),
-                     shape=(3, 3), nnz=6)
+        >>> row_ids = torch.tensor([0, 2])
+        >>> A.sample(0, 2, row_ids)
+        SparseMatrix(indices=tensor([[0, 0, 1, 1],
+                                     [0, 2, 0, 2]]),
+                     values=tensor([0, 1, 4, 6]),
+                     shape=(2, 3), nnz=4)
 
         Case 2: Sample cols with the given number and disable repeated sampling.
 
-        >>> A.sample(1, 2)
-        SparseMatrix(indices=tensor([[0, 1, 1, 2, 0, 2],
-                                     [0, 0, 1, 1, 2, 2]]),
-                     values=tensor([0, 2, 3, 5, 1, 6]),
-                     shape=(3, 3), nnz=6)
+        >>> col_ids = torch.tensor([0, 2])
+        >>> A.sample(1, 2, col_ids)
+        SparseMatrix(indices=tensor([[0, 1, 0, 2],
+                                     [0, 0, 1, 1]]),
+                     values=tensor([0, 2, 1, 6]),
+                     shape=(3, 2), nnz=4)
 
         Case 3: Sample rows with the given number and enable repeated sampling.
 
-        >>> A.sample(0, 2, True)
-        SparseMatrix(indices=tensor([[0, 0, 1, 1, 2, 2],
-                                     [0, 2, 0, 0, 1, 2]]),
-                     values=tensor([0, 1, 2, 2, 5, 6]),
-                     shape=(3, 3), nnz=5)
+        >>> row_ids = torch.tensor([0, 1])
+        >>> A.sample(0, 2, row_ids, True)
+        SparseMatrix(indices=tensor([[0, 0, 1, 1],
+                                     [0, 2, 0, 0]]),
+                     values=tensor([0, 1, 2, 2]),
+                     shape=(2, 3), nnz=3)
 
         Case 4: Sample cols with the given number and enable repeated sampling.
 
-        >>> A.sample(1, 2, True)
-        SparseMatrix(indices=tensor([[0, 1, 1, 1, 2, 2],
-                                     [0, 0, 1, 1, 2, 2]]),
-                     values=tensor([0, 2, 3, 3, 6, 6]),
-                     shape=(3, 3), nnz=4)
+        >>> col_ids = torch.tensor([0, 1])
+        >>> A.sample(1, 2, col_ids, True)
+        SparseMatrix(indices=tensor([[0, 1, 1, 1],
+                                     [0, 0, 1, 1]]),
+                     values=tensor([0, 2, 3, 3]),
+                     shape=(3, 2), nnz=3)
         """
         raise NotImplementedError
 

--- a/python/dgl/sparse/sparse_matrix.py
+++ b/python/dgl/sparse/sparse_matrix.py
@@ -671,9 +671,9 @@ class SparseMatrix:
                      values=tensor([0, 2, 3, 3]),
                      shape=(3, 2), nnz=3)
         """
-        if ids == None:
+        if ids is None:
             num = self.shape[0] if dim == 0 else self.shape[1]
-            ids = torch.tensor([id for id in range(num)])
+            ids = torch.tensor(range(0, num))
         return SparseMatrix(
             self.c_sparse_matrix.sample(dim, fanout, ids, replace, bias)
         )

--- a/python/dgl/sparse/sparse_matrix.py
+++ b/python/dgl/sparse/sparse_matrix.py
@@ -589,9 +589,9 @@ class SparseMatrix:
     def sample(
         self,
         dim: int,
-        n_pick: int,
+        fanout: int,
         ids: Optional[torch.Tensor] = None,
-        replacement: Optional[bool] = False,
+        replace: Optional[bool] = False,
         bias: Optional[bool] = False,
     ):
         """Returns a sampled matrix on the given dimension and sample arguments.
@@ -601,18 +601,18 @@ class SparseMatrix:
         dim : int
             The dimension for sampling, should be 0 or 1. `dim = 0` for
             rowwise selection and `dim = 1` for columnwise selection.
-        n_pick : int
+        fanout : int
             The number of elements to randomly sample on each row or column.
         ids : torch.Tensor, optional
             An optional tensor containing row or column IDs from which to
             sample elements.
             NOTE: If `ids` is not provided (i.e., `ids = None`), the function
             will sample from all rows or columns.
-        replacement : bool, optional
+        replace : bool, optional
             Indicates whether repeated sampling of the same element is allowed.
-            When `replacement = True`, repeated sampling is permitted; when
-            `replacement = False`, it is not allowed.
-            NOTE: If `replacement = False` and there are fewer elements than
+            When `replace = True`, repeated sampling is permitted; when
+            `replace = False`, it is not allowed.
+            NOTE: If `replace = False` and there are fewer elements than
             `n_pick`, all non-zero elements will be sampled.
         bias : bool, optional
             A boolean flag indicating whether to enable biasing during sampling.

--- a/python/dgl/sparse/sparse_matrix.py
+++ b/python/dgl/sparse/sparse_matrix.py
@@ -589,7 +589,7 @@ class SparseMatrix:
     def sample(
         self, dim: int, n_pick: int, replacement: Optional[bool] = False
     ):
-        """Returns a sample matrix according to the given sample dim and number.
+        """Returns a sampled matrix on the given dimension and sample arguments.
 
         Parameters
         ----------
@@ -597,26 +597,27 @@ class SparseMatrix:
             The dimension for sampling, should be 0 or 1. `dim = 0` for
             rowwise selection and `dim = 1` for columnwise selection.
         n_pick : int
-            The number of nodes to randomly sample on each row or column.
+            The number of elements to randomly sample on each row or column.
         replacement : bool, optional
-            Whether to allow repeated sampling of the same neighbor.
-            `replacement = True` means allowing and `replacement = False`
-            means not.
-            NOTE: If `replacement = False` and there are fewer nodes
-            than n_pick, all nodes will be sampled.
+            Indicates whether repeated sampling of the same element is allowed.
+            When `replacement = True`, repeated sampling is permitted; when 
+            `replacement = False`, it is not allowed. 
+            NOTE: If `replacement = False` and there are fewer elements than 
+            `n_pick`, all non-zero elements will be sampled.
 
         The function does not support autograd.
 
         Returns
         -------
         SparseMatrix
-            A submatrix with the same shape as the original matrix
-            containing the sampled nodes.
+            A submatrix with the same shape as the original matrix, containing 
+            the randomly sampled non-zero elements.
 
         Examples
         --------
 
-        >>> indices = torch.tensor([0, 0, 1, 1, 2, 2, 2], [0, 2, 0, 1, 0, 1, 2]])
+        >>> indices = torch.tensor([[0, 0, 1, 1, 2, 2, 2],
+                                    [0, 2, 0, 1, 0, 1, 2]])
         >>> val = torch.tensor([0, 1, 2, 3, 4, 5, 6])
         >>> A = dglsp.spmatrix(indices, val)
 
@@ -634,7 +635,7 @@ class SparseMatrix:
         SparseMatrix(indices=tensor([[0, 1, 1, 2, 0, 2],
                                      [0, 0, 1, 1, 2, 2]]),
                      values=tensor([0, 2, 3, 5, 1, 6]),
-                     shape=(3, 3), nnz=4)
+                     shape=(3, 3), nnz=6)
 
         Case 3: Sample rows with the given number and enable repeated sampling.
 

--- a/python/dgl/sparse/sparse_matrix.py
+++ b/python/dgl/sparse/sparse_matrix.py
@@ -600,9 +600,9 @@ class SparseMatrix:
             The number of elements to randomly sample on each row or column.
         replacement : bool, optional
             Indicates whether repeated sampling of the same element is allowed.
-            When `replacement = True`, repeated sampling is permitted; when 
-            `replacement = False`, it is not allowed. 
-            NOTE: If `replacement = False` and there are fewer elements than 
+            When `replacement = True`, repeated sampling is permitted; when
+            `replacement = False`, it is not allowed.
+            NOTE: If `replacement = False` and there are fewer elements than
             `n_pick`, all non-zero elements will be sampled.
 
         The function does not support autograd.
@@ -610,7 +610,7 @@ class SparseMatrix:
         Returns
         -------
         SparseMatrix
-            A submatrix with the same shape as the original matrix, containing 
+            A submatrix with the same shape as the original matrix, containing
             the randomly sampled non-zero elements.
 
         Examples

--- a/python/dgl/sparse/sparse_matrix.py
+++ b/python/dgl/sparse/sparse_matrix.py
@@ -587,89 +587,70 @@ class SparseMatrix:
         raise TypeError(f"{type(index).__name__} is unsupported input type.")
 
     def sample(
-        self,
-        dim: int,
-        fanout: int,
-        ids: Optional[torch.Tensor] = None,
-        replace: Optional[bool] = False,
-        bias: Optional[bool] = False,
+        self, dim: int, n_pick: int, replacement: Optional[bool] = False
     ):
-        """Returns a sampled matrix on the given dimension and sample arguments.
+        """Returns a sample matrix according to the given sample dim and number.
 
         Parameters
         ----------
         dim : int
             The dimension for sampling, should be 0 or 1. `dim = 0` for
             rowwise selection and `dim = 1` for columnwise selection.
-        fanout : int
-            The number of elements to randomly sample on each row or column.
-        ids : torch.Tensor, optional
-            An optional tensor containing row or column IDs from which to
-            sample elements.
-            NOTE: If `ids` is not provided (i.e., `ids = None`), the function
-            will sample from all rows or columns.
-        replace : bool, optional
-            Indicates whether repeated sampling of the same element is allowed.
-            When `replace = True`, repeated sampling is permitted; when
-            `replace = False`, it is not allowed.
-            NOTE: If `replace = False` and there are fewer elements than
-            `fanout`, all non-zero elements will be sampled.
-        bias : bool, optional
-            A boolean flag indicating whether to enable biasing during sampling.
-            When `bias = True`, the values of the sparse matrix will be used as
-            bias weights.
+        n_pick : int
+            The number of nodes to randomly sample on each row or column.
+        replacement : bool, optional
+            Whether to allow repeated sampling of the same neighbor.
+            `replacement = True` means allowing and `replacement = False`
+            means not.
+            NOTE: If `replacement = False` and there are fewer nodes
+            than n_pick, all nodes will be sampled.
 
         The function does not support autograd.
 
         Returns
         -------
         SparseMatrix
-            A submatrix with the same shape as the original matrix, containing
-            the randomly sampled non-zero elements.
+            A submatrix with the same shape as the original matrix
+            containing the sampled nodes.
 
         Examples
         --------
 
-        >>> indices = torch.tensor([[0, 0, 1, 1, 2, 2, 2],
-                                    [0, 2, 0, 1, 0, 1, 2]])
+        >>> indices = torch.tensor([0, 0, 1, 1, 2, 2, 2], [0, 2, 0, 1, 0, 1, 2]])
         >>> val = torch.tensor([0, 1, 2, 3, 4, 5, 6])
         >>> A = dglsp.spmatrix(indices, val)
 
         Case 1: Sample rows with the given number and disable repeated sampling.
 
-        >>> row_ids = torch.tensor([0, 2])
-        >>> A.sample(0, 2, row_ids)
-        SparseMatrix(indices=tensor([[0, 0, 1, 1],
-                                     [0, 2, 0, 2]]),
-                     values=tensor([0, 1, 4, 6]),
-                     shape=(2, 3), nnz=4)
+        >>> A.sample(0, 2)
+        SparseMatrix(indices=tensor([[0, 0, 1, 1, 2, 2],
+                                     [0, 2, 0, 1, 0, 2]]),
+                     values=tensor([0, 1, 2, 3, 4, 6]),
+                     shape=(3, 3), nnz=6)
 
         Case 2: Sample cols with the given number and disable repeated sampling.
 
-        >>> col_ids = torch.tensor([0, 2])
-        >>> A.sample(1, 2, col_ids)
-        SparseMatrix(indices=tensor([[0, 1, 0, 2],
-                                     [0, 0, 1, 1]]),
-                     values=tensor([0, 2, 1, 6]),
-                     shape=(3, 2), nnz=4)
+        >>> A.sample(1, 2)
+        SparseMatrix(indices=tensor([[0, 1, 1, 2, 0, 2],
+                                     [0, 0, 1, 1, 2, 2]]),
+                     values=tensor([0, 2, 3, 5, 1, 6]),
+                     shape=(3, 3), nnz=4)
 
         Case 3: Sample rows with the given number and enable repeated sampling.
 
-        >>> row_ids = torch.tensor([0, 1])
-        >>> A.sample(0, 2, row_ids, True)
-        SparseMatrix(indices=tensor([[0, 0, 1, 1],
-                                     [0, 2, 0, 0]]),
-                     values=tensor([0, 1, 2, 2]),
-                     shape=(2, 3), nnz=3)
+        >>> A.sample(0, 2, True)
+        SparseMatrix(indices=tensor([[0, 0, 1, 1, 2, 2],
+                                     [0, 2, 0, 0, 1, 2]]),
+                     values=tensor([0, 1, 2, 2, 5, 6]),
+                     shape=(3, 3), nnz=5)
 
         Case 4: Sample cols with the given number and enable repeated sampling.
 
-        >>> col_ids = torch.tensor([0, 1])
-        >>> A.sample(1, 2, col_ids, True)
-        SparseMatrix(indices=tensor([[0, 1, 1, 1],
-                                     [0, 0, 1, 1]]),
-                     values=tensor([0, 2, 3, 3]),
-                     shape=(3, 2), nnz=3)
+        >>> A.sample(1, 2, True)
+        SparseMatrix(indices=tensor([[0, 1, 1, 1, 2, 2],
+                                     [0, 0, 1, 1, 2, 2]]),
+                     values=tensor([0, 2, 3, 3, 6, 6]),
+                     shape=(3, 3), nnz=4)
         """
         raise NotImplementedError
 

--- a/tests/python/pytorch/sparse/test_sparse_matrix.py
+++ b/tests/python/pytorch/sparse/test_sparse_matrix.py
@@ -504,6 +504,21 @@ def test_range_select(create_func, shape, dense_dim, select_dim, rang):
     assert torch.allclose(A_select_to_dense, dense_select)
 
 
+@pytest.mark.parametrize(
+    "create_func", [rand_diag, rand_csr, rand_csc, rand_coo]
+)
+@pytest.mark.parametrize("shape", [(5, 5)])
+@pytest.mark.parametrize("dense_dim", [None, 4])
+@pytest.mark.parametrize("sample_dim", [0, 1])
+@pytest.mark.parametrize("index", [None, (0, 1, 3)])
+@pytest.mark.parametrize("inplace", [0, 1])
+@pytest.mark.parametrize("bias", [0, 1])
+def test_sample(create_func, shape, dense_dim, sample_dim, index, inplace, bias):
+    ctx = F.ctx()
+    A = create_func(shape, 20, ctx, dense_dim)
+    A_sample = A.sample(sample_dim, index, inplace, bias)
+
+
 def test_print():
     ctx = F.ctx()
 
@@ -612,7 +627,8 @@ def test_torch_sparse_coo_conversion(row, col, nz_dim, shape):
         torch_sparse_shape += (nz_dim,)
         val_shape += (nz_dim,)
     val = torch.randn(val_shape).to(dev)
-    torch_sparse_coo = torch.sparse_coo_tensor(indices, val, torch_sparse_shape)
+    torch_sparse_coo = torch.sparse_coo_tensor(
+        indices, val, torch_sparse_shape)
     spmat = from_torch_sparse(torch_sparse_coo)
 
     def _assert_spmat_equal_to_torch_sparse_coo(spmat, torch_sparse_coo):

--- a/tests/python/pytorch/sparse/test_sparse_matrix.py
+++ b/tests/python/pytorch/sparse/test_sparse_matrix.py
@@ -516,8 +516,7 @@ def test_sample(create_func, sample_dim, index, replace, bias):
     shape = (5, 5)
     sample_num = 3
     A = create_func(shape, 10, ctx)
-    A_row, A_col, A_val = A.row, A.col, torch.abs(A.val)
-    A = from_coo(A_row, A_col, A_val, shape)
+    A = val_like(A, torch.abs(A.val))
 
     index = torch.tensor(index).to(ctx)
 

--- a/tests/python/pytorch/sparse/test_sparse_matrix.py
+++ b/tests/python/pytorch/sparse/test_sparse_matrix.py
@@ -507,13 +507,13 @@ def test_range_select(create_func, shape, dense_dim, select_dim, rang):
 @pytest.mark.parametrize(
     "create_func", [rand_diag, rand_csr, rand_csc, rand_coo]
 )
-@pytest.mark.parametrize("sample_dim", [0, 1])
 @pytest.mark.parametrize("index", [(0, 1, 2, 3, 4), (0, 1, 3), (1, 1, 2)])
 @pytest.mark.parametrize("replace", [False, True])
 @pytest.mark.parametrize("bias", [False, True])
-def test_sample(create_func, sample_dim, index, replace, bias):
+def test_sample_rowwise(create_func, index, replace, bias):
     ctx = F.ctx()
     shape = (5, 5)
+    sample_dim = 0
     sample_num = 3
     A = create_func(shape, 10, ctx)
     A = val_like(A, torch.abs(A.val))
@@ -524,40 +524,64 @@ def test_sample(create_func, sample_dim, index, replace, bias):
     A_dense = sparse_matrix_to_dense(A)
     A_sample_to_dense = sparse_matrix_to_dense(A_sample)
 
-    if sample_dim == 0:
-        ans_shape = (index.size(0), shape[1])
-        # Verify sample elements in origin rows
-        for i, row in enumerate(list(index)):
-            ans_ele = list(A_dense[row, :].nonzero().reshape(-1))
-            ret_ele = list(A_sample_to_dense[i, :].nonzero().reshape(-1))
-            for e in ret_ele:
-                assert e in ans_ele
-            if replace:
-                # The number of sample elements in one row should be equal to
-                # 'sample_num' if the row is not empty otherwise should be
-                # equal to 0.
-                assert list(A_sample.row).count(torch.tensor(i)) == (
-                    sample_num if len(ans_ele) != 0 else 0
-                )
-            else:
-                assert len(ret_ele) == min(sample_num, len(ans_ele))
-    else:
-        ans_shape = (shape[0], index.size(0))
-        # Verify sample elements in origin columns
-        for i, col in enumerate(list(index)):
-            ans_ele = list(A_dense[:, col].nonzero().reshape(-1))
-            ret_ele = list(A_sample_to_dense[:, i].nonzero().reshape(-1))
-            for e in ret_ele:
-                assert e in ans_ele
-            if replace:
-                # The number of sample elements in one column should be equal to
-                # 'sample_num' if the column is not empty otherwise should be
-                # equal to 0.
-                assert list(A_sample.col).count(torch.tensor(i)) == (
-                    sample_num if len(ans_ele) != 0 else 0
-                )
-            else:
-                assert len(ret_ele) == min(sample_num, len(ans_ele))
+    ans_shape = (index.size(0), shape[1])
+    # Verify sample elements in origin rows
+    for i, row in enumerate(list(index)):
+        ans_ele = list(A_dense[row, :].nonzero().reshape(-1))
+        ret_ele = list(A_sample_to_dense[i, :].nonzero().reshape(-1))
+        for e in ret_ele:
+            assert e in ans_ele
+        if replace:
+            # The number of sample elements in one row should be equal to
+            # 'sample_num' if the row is not empty otherwise should be
+            # equal to 0.
+            assert list(A_sample.row).count(torch.tensor(i)) == (
+                sample_num if len(ans_ele) != 0 else 0
+            )
+        else:
+            assert len(ret_ele) == min(sample_num, len(ans_ele))
+
+    assert A_sample.shape == ans_shape
+    if not replace:
+        assert not A_sample.has_duplicate()
+
+
+@pytest.mark.parametrize(
+    "create_func", [rand_diag, rand_csr, rand_csc, rand_coo]
+)
+@pytest.mark.parametrize("index", [(0, 1, 2, 3, 4), (0, 1, 3), (1, 1, 2)])
+@pytest.mark.parametrize("replace", [False, True])
+@pytest.mark.parametrize("bias", [False, True])
+def test_sample_columnwise(create_func, index, replace, bias):
+    ctx = F.ctx()
+    shape = (5, 5)
+    sample_dim = 1
+    sample_num = 3
+    A = create_func(shape, 10, ctx)
+    A = val_like(A, torch.abs(A.val))
+
+    index = torch.tensor(index).to(ctx)
+
+    A_sample = A.sample(sample_dim, sample_num, index, replace, bias)
+    A_dense = sparse_matrix_to_dense(A)
+    A_sample_to_dense = sparse_matrix_to_dense(A_sample)
+
+    ans_shape = (shape[0], index.size(0))
+    # Verify sample elements in origin columns
+    for i, col in enumerate(list(index)):
+        ans_ele = list(A_dense[:, col].nonzero().reshape(-1))
+        ret_ele = list(A_sample_to_dense[:, i].nonzero().reshape(-1))
+        for e in ret_ele:
+            assert e in ans_ele
+        if replace:
+            # The number of sample elements in one column should be equal to
+            # 'sample_num' if the column is not empty otherwise should be
+            # equal to 0.
+            assert list(A_sample.col).count(torch.tensor(i)) == (
+                sample_num if len(ans_ele) != 0 else 0
+            )
+        else:
+            assert len(ret_ele) == min(sample_num, len(ans_ele))
 
     assert A_sample.shape == ans_shape
     if not replace:

--- a/tests/python/pytorch/sparse/test_sparse_matrix.py
+++ b/tests/python/pytorch/sparse/test_sparse_matrix.py
@@ -525,14 +525,6 @@ def test_sample(create_func, sample_dim, index, replace, bias):
     A_dense = sparse_matrix_to_dense(A)
     A_sample_to_dense = sparse_matrix_to_dense(A_sample)
 
-    # Counting the edges in row and column, includes duplicate edges.
-    # row_cnt, col_cnt = {}, {}
-    # for i in range(len(list(A_sample.row))):
-    #     if (A_sample.row[i], A_sample.col[i]) not in dcnt:
-    #         dcnt[(A_sample.row[i], A_sample.col[i])] = 1
-    #     else:
-    #         dcnt[(A_sample.row[i], A_sample.col[i])] += 1
-
     if sample_dim == 0:
         ans_shape = (index.size(0), shape[1])
         # Verify sample elements in origin rows


### PR DESCRIPTION
## Description
The implementation of sparse 'sample' operator. The sparse 'sample' operator differs slightly from DGL's 'sample' API. In the sparse sample, it only returns the submatrix selected by the index, rather than the entire original matrix.

## Checklist
Please feel free to remove inapplicable items for your PR.
- [ ] The PR title starts with [$CATEGORY] (such as [NN], [Model], [Doc], [Feature]])
- [ ] I've leverage the [tools](https://docs.google.com/document/d/1iHyj7zlmygKSk5gBPsqIqL5ASPzJSPREaNT_QdsiYA4/edit) to beautify the python and c++ code.
- [ ] The PR is complete and small, read the [Google eng practice (CL equals to PR)](https://google.github.io/eng-practices/review/developer/small-cls.html) to understand more about small PR. In DGL, we consider PRs with less than 200 lines of core code change are small (example, test and documentation could be exempted).
- [ ] All changes have test coverage
- [ ] Code is well-documented
- [ ] To the best of my knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change
- [ ] Related issue is referred in this PR
- [ ] If the PR is for a new model/paper, I've updated the example index [here](../examples/README.md).

## Changes