### PR TITLE
[Sparse] Add relabel API

### DIFF
--- a/python/dgl/sparse/sparse_matrix.py
+++ b/python/dgl/sparse/sparse_matrix.py
@@ -685,28 +685,33 @@ class SparseMatrix:
         dim: int,
         leading_indices: Optional[torch.Tensor] = None,
     ):
-        """Relabels indices of a dimension and remove rows or columns without non-zero
-        elements in the sparse matrix.
-    This function serves a dual purpose: it allows you to reorganize the indices
-    within a specific dimension (rows or columns) of the sparse matrix and, if
-    needed, place certain 'heading_indices' at the beginning of the relabeled dimension.
+        """Relabels indices of a dimension and remove rows or columns without
+        non-zero elements in the sparse matrix.
 
-    In the absence of 'heading_indices' (when it's set to `None`), the order of
-    relabeled indices remains the same as the original order, except that rows or
-    columns without non-zero elements are removed. When 'heading_indices' are provided,
-    they are positioned at the start of the relabeled dimension.
+        This function serves a dual purpose: it allows you to reorganize the
+        indices within a specific dimension (rows or columns) of the sparse
+        matrix and, if needed, place certain 'leading_indices' at the beginning
+        of the relabeled dimension.
 
-    This function mimics 'dgl.to_block', a method used to compress a sampled
-    subgraph by eliminating redundant nodes. The 'heading_indices' parameter
-    replicates the behavior of 'include_dst_in_src' in 'dgl.to_block.' Setting
-    'heading_indices' to column IDs when relabeling the row dimension, for example,
-    achieves the same effect as including destination nodes in source nodes.
+        In the absence of 'leading_indices' (when it's set to `None`), the order
+        of relabeled indices remains the same as the original order, except that
+        rows or columns without non-zero elements are removed. When
+        'leading_indices' are provided, they are positioned at the start of the
+        relabeled dimension.
+
+        This function mimics 'dgl.to_block', a method used to compress a sampled
+        subgraph by eliminating redundant nodes. The 'leading_indices' parameter
+        replicates the behavior of 'include_dst_in_src' in 'dgl.to_block.'
+        Setting 'leading_indices' to column IDs when relabeling the row
+        dimension, for example, achieves the same effect as including destination
+        nodes in source nodes.
+
         Parameters
         ----------
         dim : int
             The dimension to relabel. Should be 0 or 1. Use `dim = 0` for rowwise
             relabeling and `dim = 1` for columnwise relabeling.
-        heading_indices : torch.Tensor, optional
+        leading_indices : torch.Tensor, optional
             An optional tensor containing row or column ids that should be placed
             at the beginning of the relabeled dimension.
 
@@ -724,7 +729,7 @@ class SparseMatrix:
 
         Case 1: Relabel rows without indices.
 
-        >>> B, original_rows = A.relabel(dim=0, heading_indices=None)
+        >>> B, original_rows = A.relabel(dim=0, leading_indices=None)
         >>> print(B)
         SparseMatrix(indices=tensor([[0, 1], [1, 2]]),
                      shape=(2, 3), nnz=2)
@@ -733,7 +738,7 @@ class SparseMatrix:
 
         Case 2: Relabel rows with indices.
 
-        >>> B, original_rows = A.relabel(dim=0, heading_indices=[1, 2])
+        >>> B, original_rows = A.relabel(dim=0, leading_indices=[1, 2])
         >>> print(B)
         SparseMatrix(indices=tensor([[1, 2], [2, 1]]),
                      shape=(3, 3), nnz=2)

--- a/python/dgl/sparse/sparse_matrix.py
+++ b/python/dgl/sparse/sparse_matrix.py
@@ -701,7 +701,8 @@ class SparseMatrix:
 
         This function mimics 'dgl.to_block', a method used to compress a sampled
         subgraph by eliminating redundant nodes. The 'leading_indices' parameter
-        replicates the behavior of 'include_dst_in_src' in 'dgl.to_block.'
+        replicates the behavior of 'include_dst_in_src' in 'dgl.to_block',
+        adding destination node information for message passing.
         Setting 'leading_indices' to column IDs when relabeling the row
         dimension, for example, achieves the same effect as including destination
         nodes in source nodes.

--- a/python/dgl/sparse/sparse_matrix.py
+++ b/python/dgl/sparse/sparse_matrix.py
@@ -680,6 +680,55 @@ class SparseMatrix:
             self.c_sparse_matrix.sample(dim, fanout, ids, replace, bias)
         )
 
+    def relabel(
+        self,
+        dim: int,
+        heading_indices: Optional[torch.Tensor] = None,
+    ):
+        """Relabels ids of a dimension to remove rows or columns without non-zero
+        elements in the sparse matrix.
+
+        Parameters
+        ----------
+        dim : int
+            The dimension to relabel. Should be 0 or 1. Use `dim = 0` for rowwise
+            relabeling and `dim = 1` for columnwise relabeling.
+        heading_indices : torch.Tensor, optional
+            An optional tensor containing row or column ids that should be placed
+            at the beginning of the relabeled dimension. 
+
+        Returns
+        -------
+        Tuple[SparseMatrix, torch.Tensor]
+            A tuple containing the relabeled sparse matrix and the index mapping
+            of the relabeled dimension from the new index to the original index.
+
+        Examples
+        --------
+        >>> indices = torch.tensor([[0, 2],
+                                    [1, 2]])
+        >>> A = dglsp.spmatrix(indices)
+
+        Case 1: Relabel rows without indices.
+
+        >>> B, original_rows = A.relabel(dim=0, heading_indices=None)
+        >>> print(B)
+        SparseMatrix(indices=tensor([[0, 1], [1, 2]]),
+                     shape=(2, 3), nnz=2)
+        >>> print(original_rows)
+        torch.Tensor([0, 2])
+
+        Case 2: Relabel rows with indices.
+
+        >>> B, original_rows = A.relabel(dim=0, heading_indices=[1, 2])
+        >>> print(B)
+        SparseMatrix(indices=tensor([[1, 2], [2, 1]]),
+                     shape=(3, 3), nnz=2)
+        >>> print(original_rows)
+        torch.Tensor([1, 2, 0])
+        """
+        raise NotImplementedError
+
 
 def spmatrix(
     indices: torch.Tensor,

--- a/python/dgl/sparse/sparse_matrix.py
+++ b/python/dgl/sparse/sparse_matrix.py
@@ -695,7 +695,7 @@ class SparseMatrix:
             relabeling and `dim = 1` for columnwise relabeling.
         heading_indices : torch.Tensor, optional
             An optional tensor containing row or column ids that should be placed
-            at the beginning of the relabeled dimension. 
+            at the beginning of the relabeled dimension.
 
         Returns
         -------

--- a/python/dgl/sparse/sparse_matrix.py
+++ b/python/dgl/sparse/sparse_matrix.py
@@ -683,11 +683,24 @@ class SparseMatrix:
     def relabel(
         self,
         dim: int,
-        heading_indices: Optional[torch.Tensor] = None,
+        leading_indices: Optional[torch.Tensor] = None,
     ):
-        """Relabels ids of a dimension to remove rows or columns without non-zero
+        """Relabels indices of a dimension and remove rows or columns without non-zero
         elements in the sparse matrix.
+    This function serves a dual purpose: it allows you to reorganize the indices
+    within a specific dimension (rows or columns) of the sparse matrix and, if
+    needed, place certain 'heading_indices' at the beginning of the relabeled dimension.
 
+    In the absence of 'heading_indices' (when it's set to `None`), the order of
+    relabeled indices remains the same as the original order, except that rows or
+    columns without non-zero elements are removed. When 'heading_indices' are provided,
+    they are positioned at the start of the relabeled dimension.
+
+    This function mimics 'dgl.to_block', a method used to compress a sampled
+    subgraph by eliminating redundant nodes. The 'heading_indices' parameter
+    replicates the behavior of 'include_dst_in_src' in 'dgl.to_block.' Setting
+    'heading_indices' to column IDs when relabeling the row dimension, for example,
+    achieves the same effect as including destination nodes in source nodes.
         Parameters
         ----------
         dim : int


### PR DESCRIPTION
## Description
Add a relabel python API on sparse.

## Checklist
Please feel free to remove inapplicable items for your PR.
- [ ] The PR title starts with [$CATEGORY] (such as [NN], [Model], [Doc], [Feature]])
- [ ] I've leverage the [tools](https://docs.google.com/document/d/1iHyj7zlmygKSk5gBPsqIqL5ASPzJSPREaNT_QdsiYA4/edit) to beautify the python and c++ code.
- [ ] The PR is complete and small, read the [Google eng practice (CL equals to PR)](https://google.github.io/eng-practices/review/developer/small-cls.html) to understand more about small PR. In DGL, we consider PRs with less than 200 lines of core code change are small (example, test and documentation could be exempted).
- [ ] All changes have test coverage
- [ ] Code is well-documented
- [ ] To the best of my knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change
- [ ] Related issue is referred in this PR
- [ ] If the PR is for a new model/paper, I've updated the example index [here](../examples/README.md).

## Changes
