### PR TITLE
[Graphbolt] Add MiniBatchTransformer to support exclude edges.

### DIFF
--- a/python/dgl/graphbolt/__init__.py
+++ b/python/dgl/graphbolt/__init__.py
@@ -14,6 +14,7 @@ from .feature_store import *
 from .impl import *
 from .itemset import *
 from .item_sampler import *
+from .minibatch_transformer import *
 from .negative_sampler import *
 from .sampled_subgraph import *
 from .subgraph_sampler import *

--- a/python/dgl/graphbolt/base.py
+++ b/python/dgl/graphbolt/base.py
@@ -1,9 +1,11 @@
 """Base types and utilities for Graph Bolt."""
 
 from torch.utils.data import functional_datapipe
-from torchdata.datapipes.iter import IterDataPipe
+from torchdata.datapipes.iter import IterDataPipe, Mapper
 
 from ..utils import recursive_apply
+
+from .minibatch import MiniBatch
 
 __all__ = [
     "CANONICAL_ETYPE_DELIMITER",
@@ -83,3 +85,34 @@ class CopyTo(IterDataPipe):
         for data in self.datapipe:
             data = recursive_apply(data, _to, self.device)
             yield data
+
+
+@functional_datapipe("transform")
+class MiniBatchTransformer(Mapper):
+    """A mini-batch transformer used to manipulate mini-batch"""
+
+    def __init__(
+        self,
+        datapipe,
+        transformer,
+    ):
+        """
+        Initlization for a subgraph transformer.
+        Parameters
+        ----------
+        datapipe : DataPipe
+            The datapipe.
+        fn:
+            The function applied to each minibatch which is responsible for
+            converting subgraph structures, potentially utilizing other fields
+            within the minibatch as arguments.
+        """
+        super().__init__(datapipe, self._transformer)
+        self.transformer = transformer
+
+    def _transformer(self, minibatch):
+        minibatch = transformer(minibatch)
+        assert isinstance(
+            minibatch, MiniBatch
+        ), "The transformer output should be a instance of MiniBatch"
+        return minibatch

--- a/python/dgl/graphbolt/base.py
+++ b/python/dgl/graphbolt/base.py
@@ -102,10 +102,9 @@ class MiniBatchTransformer(Mapper):
         ----------
         datapipe : DataPipe
             The datapipe.
-        fn:
+        transformer:
             The function applied to each minibatch which is responsible for
-            converting subgraph structures, potentially utilizing other fields
-            within the minibatch as arguments.
+            transforming the minibatch.
         """
         super().__init__(datapipe, self._transformer)
         self.transformer = transformer

--- a/python/dgl/graphbolt/base.py
+++ b/python/dgl/graphbolt/base.py
@@ -5,8 +5,6 @@ from torchdata.datapipes.iter import IterDataPipe
 
 from ..utils import recursive_apply
 
-from .minibatch import MiniBatch
-
 __all__ = [
     "CANONICAL_ETYPE_DELIMITER",
     "etype_str_to_tuple",

--- a/python/dgl/graphbolt/base.py
+++ b/python/dgl/graphbolt/base.py
@@ -1,7 +1,7 @@
 """Base types and utilities for Graph Bolt."""
 
 from torch.utils.data import functional_datapipe
-from torchdata.datapipes.iter import IterDataPipe, Mapper
+from torchdata.datapipes.iter import IterDataPipe
 
 from ..utils import recursive_apply
 
@@ -85,33 +85,3 @@ class CopyTo(IterDataPipe):
         for data in self.datapipe:
             data = recursive_apply(data, _to, self.device)
             yield data
-
-
-@functional_datapipe("transform")
-class MiniBatchTransformer(Mapper):
-    """A mini-batch transformer used to manipulate mini-batch"""
-
-    def __init__(
-        self,
-        datapipe,
-        transformer,
-    ):
-        """
-        Initlization for a subgraph transformer.
-        Parameters
-        ----------
-        datapipe : DataPipe
-            The datapipe.
-        transformer:
-            The function applied to each minibatch which is responsible for
-            transforming the minibatch.
-        """
-        super().__init__(datapipe, self._transformer)
-        self.transformer = transformer
-
-    def _transformer(self, minibatch):
-        minibatch = transformer(minibatch)
-        assert isinstance(
-            minibatch, MiniBatch
-        ), "The transformer output should be a instance of MiniBatch"
-        return minibatch

--- a/python/dgl/graphbolt/feature_fetcher.py
+++ b/python/dgl/graphbolt/feature_fetcher.py
@@ -4,11 +4,11 @@ from typing import Dict
 
 from torch.utils.data import functional_datapipe
 
-from torchdata.datapipes.iter import Mapper
+from .base import MiniBatchTransformer
 
 
 @functional_datapipe("fetch_feature")
-class FeatureFetcher(Mapper):
+class FeatureFetcher(MiniBatchTransformer):
     """A feature fetcher used to fetch features for node/edge in graphbolt."""
 
     def __init__(

--- a/python/dgl/graphbolt/feature_fetcher.py
+++ b/python/dgl/graphbolt/feature_fetcher.py
@@ -4,7 +4,7 @@ from typing import Dict
 
 from torch.utils.data import functional_datapipe
 
-from .base import MiniBatchTransformer
+from .minibatch_transformer import MiniBatchTransformer
 
 
 @functional_datapipe("fetch_feature")

--- a/python/dgl/graphbolt/impl/neighbor_sampler.py
+++ b/python/dgl/graphbolt/impl/neighbor_sampler.py
@@ -56,7 +56,6 @@ class NeighborSampler(SubgraphSampler):
         Examples
         -------
         >>> import dgl.graphbolt as gb
-        >>> from torchdata.datapipes.iter import Mapper
         >>> from dgl import graphbolt as gb
         >>> indptr = torch.LongTensor([0, 2, 4, 5, 6, 7 ,8])
         >>> indices = torch.LongTensor([1, 2, 0, 3, 5, 4, 3, 5])
@@ -165,7 +164,6 @@ class LayerNeighborSampler(NeighborSampler):
         Examples
         -------
         >>> import dgl.graphbolt as gb
-        >>> from torchdata.datapipes.iter import Mapper
         >>> from dgl import graphbolt as gb
         >>> indptr = torch.LongTensor([0, 2, 4, 5, 6, 7 ,8])
         >>> indices = torch.LongTensor([1, 2, 0, 3, 5, 4, 3, 5])

--- a/python/dgl/graphbolt/minibatch.py
+++ b/python/dgl/graphbolt/minibatch.py
@@ -9,6 +9,7 @@ import dgl
 
 from .base import etype_str_to_tuple
 from .sampled_subgraph import SampledSubgraph
+from .utils import add_reverse_edges
 
 __all__ = ["MiniBatch"]
 
@@ -225,3 +226,41 @@ class MiniBatch:
                     block.edata[dgl.EID] = subgraph.reverse_edge_ids
 
         return blocks
+
+
+def exclude_edges(
+    minibatch: MiniBatch,
+    edges: Union[
+        Dict[str, Tuple[torch.Tensor, torch.Tensor]],
+        Tuple[torch.Tensor, torch.Tensor],
+    ],
+):
+    """
+    Exclude edges from the sampled subgraphs in the minibatch.
+
+    Parameters
+    ----------
+    minibatch : MiniBatch
+        The minibatch.
+    edges : Dict[str, Tuple[torch.Tensor, torch.Tensor]] or Tuple[torch.Tensor, torch.Tensor]
+        The edges to be excluded.
+    """
+    minibatch.sampled_subgraphs = [
+        subgraph.exclude_edges(edges)
+        for subgraph in minibatch.sampled_subgraphs
+    ]
+    return minibatch
+
+
+def exclude_seed_edges(minibatch: MiniBatch):
+    """Exclude seed edges from the sampled subgraphs in the minibatch."""
+    return exclude_edges(minibatch, minibatch.node_pairs)
+
+
+def exclude_seed_edges_and_reverse(minibatch: MiniBatch):
+    """
+    Exclude seed edges and their reverse edges from the sampled subgraphs in
+    the minibatch.
+    """
+    edges_to_exclude = add_reverse_edges(minibatch.node_pairs)
+    return exclude_edges(minibatch, edges_to_exclude)

--- a/python/dgl/graphbolt/minibatch.py
+++ b/python/dgl/graphbolt/minibatch.py
@@ -264,7 +264,7 @@ def exclude_seed_edges_and_reverse(
     Exclude seed edges and their reverse edges from the sampled subgraphs in
     the minibatch.
 
-        Parameters
+    Parameters
     ----------
     minibatch : MiniBatch
         The minibatch.

--- a/python/dgl/graphbolt/minibatch.py
+++ b/python/dgl/graphbolt/minibatch.py
@@ -257,10 +257,19 @@ def exclude_seed_edges(minibatch: MiniBatch):
     return exclude_edges(minibatch, minibatch.node_pairs)
 
 
-def exclude_seed_edges_and_reverse(minibatch: MiniBatch):
+def exclude_seed_edges_and_reverse(
+    minibatch: MiniBatch, reverse_etypes: Dict[str, str] = None
+):
     """
     Exclude seed edges and their reverse edges from the sampled subgraphs in
     the minibatch.
+
+        Parameters
+    ----------
+    minibatch : MiniBatch
+        The minibatch.
+    reverse_etypes : Dict[str, str] = None
+        The mapping from the original edge types to their reverse edge types.
     """
-    edges_to_exclude = add_reverse_edges(minibatch.node_pairs)
+    edges_to_exclude = add_reverse_edges(minibatch.node_pairs, reverse_etypes)
     return exclude_edges(minibatch, edges_to_exclude)

--- a/python/dgl/graphbolt/minibatch_transformer.py
+++ b/python/dgl/graphbolt/minibatch_transformer.py
@@ -1,0 +1,36 @@
+"""Mini-batch transformer"""
+
+from torch.utils.data import functional_datapipe
+
+from torchdata.datapipes.iter import Mapper
+
+from .minibatch import MiniBatch
+
+@functional_datapipe("transform")
+class MiniBatchTransformer(Mapper):
+    """A mini-batch transformer used to manipulate mini-batch"""
+
+    def __init__(
+        self,
+        datapipe,
+        transformer,
+    ):
+        """
+        Initlization for a subgraph transformer.
+        Parameters
+        ----------
+        datapipe : DataPipe
+            The datapipe.
+        transformer:
+            The function applied to each minibatch which is responsible for
+            transforming the minibatch.
+        """
+        super().__init__(datapipe, self._transformer)
+        self.transformer = transformer
+
+    def _transformer(self, minibatch):
+        minibatch = transformer(minibatch)
+        assert isinstance(
+            minibatch, MiniBatch
+        ), "The transformer output should be a instance of MiniBatch"
+        return minibatch

--- a/python/dgl/graphbolt/minibatch_transformer.py
+++ b/python/dgl/graphbolt/minibatch_transformer.py
@@ -29,7 +29,7 @@ class MiniBatchTransformer(Mapper):
         self.transformer = transformer
 
     def _transformer(self, minibatch):
-        minibatch = transformer(minibatch)
+        minibatch = self.transformer(minibatch)
         assert isinstance(
             minibatch, MiniBatch
         ), "The transformer output should be a instance of MiniBatch"

--- a/python/dgl/graphbolt/minibatch_transformer.py
+++ b/python/dgl/graphbolt/minibatch_transformer.py
@@ -6,6 +6,7 @@ from torchdata.datapipes.iter import Mapper
 
 from .minibatch import MiniBatch
 
+
 @functional_datapipe("transform")
 class MiniBatchTransformer(Mapper):
     """A mini-batch transformer used to manipulate mini-batch"""

--- a/python/dgl/graphbolt/negative_sampler.py
+++ b/python/dgl/graphbolt/negative_sampler.py
@@ -3,11 +3,12 @@
 from _collections_abc import Mapping
 
 from torch.utils.data import functional_datapipe
-from torchdata.datapipes.iter import Mapper
+
+from .base import MiniBatchTransformer
 
 
 @functional_datapipe("sample_negative")
-class NegativeSampler(Mapper):
+class NegativeSampler(MiniBatchTransformer):
     """
     A negative sampler used to generate negative samples and return
     a mix of positive and negative samples.

--- a/python/dgl/graphbolt/negative_sampler.py
+++ b/python/dgl/graphbolt/negative_sampler.py
@@ -4,7 +4,7 @@ from _collections_abc import Mapping
 
 from torch.utils.data import functional_datapipe
 
-from .base import MiniBatchTransformer
+from .minibatch_transformer import MiniBatchTransformer
 
 
 @functional_datapipe("sample_negative")

--- a/python/dgl/graphbolt/subgraph_sampler.py
+++ b/python/dgl/graphbolt/subgraph_sampler.py
@@ -4,14 +4,13 @@ from collections import defaultdict
 from typing import Dict
 
 from torch.utils.data import functional_datapipe
-from torchdata.datapipes.iter import Mapper
 
-from .base import etype_str_to_tuple
+from .base import etype_str_to_tuple, MiniBatchTransformer
 from .utils import unique_and_compact
 
 
 @functional_datapipe("sample_subgraph")
-class SubgraphSampler(Mapper):
+class SubgraphSampler(MiniBatchTransformer):
     """A subgraph sampler used to sample a subgraph from a given set of nodes
     from a larger graph."""
 

--- a/python/dgl/graphbolt/subgraph_sampler.py
+++ b/python/dgl/graphbolt/subgraph_sampler.py
@@ -5,7 +5,8 @@ from typing import Dict
 
 from torch.utils.data import functional_datapipe
 
-from .base import etype_str_to_tuple, MiniBatchTransformer
+from .base import etype_str_to_tuple
+from .minibatch_transformer import MiniBatchTransformer
 from .utils import unique_and_compact
 
 


### PR DESCRIPTION
## Description
<!-- Brief description. Refer to the related issues if existed.
It'll be great if relevant reviewers can be assigned as well.-->

With this PR, the follow UX are supported:

import dgl.graphbolt as gb

datapipe = datapipe.transform(gb.exclude_seed_edges)
datapipe = datapipe.transform(gb.exclude_seed_edges_and_reverse(reverse_etypes={}))

## Checklist
Please feel free to remove inapplicable items for your PR.
- [ ] The PR title starts with [$CATEGORY] (such as [NN], [Model], [Doc], [Feature]])
- [ ] I've leverage the [tools](https://docs.google.com/document/d/1iHyj7zlmygKSk5gBPsqIqL5ASPzJSPREaNT_QdsiYA4/edit) to beautify the python and c++ code.
- [ ] The PR is complete and small, read the [Google eng practice (CL equals to PR)](https://google.github.io/eng-practices/review/developer/small-cls.html) to understand more about small PR. In DGL, we consider PRs with less than 200 lines of core code change are small (example, test and documentation could be exempted).
- [ ] All changes have test coverage
- [ ] Code is well-documented
- [ ] To the best of my knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change
- [ ] Related issue is referred in this PR
- [ ] If the PR is for a new model/paper, I've updated the example index [here](../examples/README.md).

## Changes
<!-- You could use following template
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)
-->
