### PR TITLE
[GraphBolt] update example to use built-in dataset

### DIFF
--- a/examples/sampling/graphbolt/link_prediction.py
+++ b/examples/sampling/graphbolt/link_prediction.py
@@ -328,9 +328,7 @@ def main(args):
 
     # Load and preprocess dataset.
     print("Loading data")
-    dataset = gb.OnDiskDataset(
-        "/home/ubuntu/wklwork/work#4/example_ogbl_citation2"
-    ).load()
+    dataset = gb.BuiltinDataset("ogbl-citation2").load()
     graph = dataset.graph
     features = dataset.feature
     train_set = dataset.tasks[0].train_set


### PR DESCRIPTION
## Description
<!-- Brief description. Refer to the related issues if existed.
It'll be great if relevant reviewers can be assigned as well.-->
```
~/workspace/dgl_2$ DGL_HOME=/home/ubuntu/workspace/dgl_2 DGL_LIBRARY_PATH=$DGL_HOME/build PYTHONPATH=tests:$DGL_HOME/python:tests/python/pytorch/graphbolt:$PYTHONPATH python3 examples/sampling/graphbolt/link_prediction.py 

Training in cpu mode.
Loading data
Downloading datasets/ogbl-citation2.zip from https://data.dgl.ai/dataset/graphbolt/ogbl-citation2.zip...
Extracting file to datasets
The dataset is already preprocessed.
Training...
  0%|                                                                                                                                                            | 0/10 [00:00<?, ?it/s]Epoch 00000 | Step 00100 | Loss 0.3516
  0%|                                   
```
## Checklist
Please feel free to remove inapplicable items for your PR.
- [ ] The PR title starts with [$CATEGORY] (such as [NN], [Model], [Doc], [Feature]])
- [ ] I've leverage the [tools](https://docs.google.com/document/d/1iHyj7zlmygKSk5gBPsqIqL5ASPzJSPREaNT_QdsiYA4/edit) to beautify the python and c++ code.
- [ ] The PR is complete and small, read the [Google eng practice (CL equals to PR)](https://google.github.io/eng-practices/review/developer/small-cls.html) to understand more about small PR. In DGL, we consider PRs with less than 200 lines of core code change are small (example, test and documentation could be exempted).
- [ ] All changes have test coverage
- [ ] Code is well-documented
- [ ] To the best of my knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change
- [ ] Related issue is referred in this PR
- [ ] If the PR is for a new model/paper, I've updated the example index [here](../examples/README.md).

## Changes
<!-- You could use following template
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)
-->
