### PR TITLE
[Sparse] Add CUDA compilation support.

### DIFF
--- a/dgl_sparse/CMakeLists.txt
+++ b/dgl_sparse/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.8)
 project(dgl_sparse C CXX)
 
 # Find PyTorch cmake files and PyTorch versions with the python interpreter $PYTHON_INTERP
@@ -20,8 +20,11 @@ string(REPLACE "." ";" TORCH_VERSION_LIST ${TORCH_VER})
 list(GET TORCH_VERSION_LIST 0 TORCH_VERSION_MAJOR)
 list(GET TORCH_VERSION_LIST 1 TORCH_VERSION_MINOR)
 
+set(SPARSE_LINKER_LIBS "")
+
 if(USE_CUDA)
   add_definitions(-DDGL_USE_CUDA)
+  enable_language(CUDA)
 endif()
 
 set(Torch_DIR "${TORCH_PREFIX}/Torch")
@@ -32,6 +35,7 @@ set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${TORCH_CXX_FLAGS}")
 set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -O0 -g3 -ggdb")
 
 set(LIB_DGL_SPARSE_NAME "dgl_sparse_pytorch_${TORCH_VER}")
+list(APPEND SPARSE_LINKER_LIBS ${TORCH_LIBRARIES})
 
 set(SPARSE_DIR "${CMAKE_CURRENT_SOURCE_DIR}/src")
 set(SPARSE_INCLUDE "${CMAKE_CURRENT_SOURCE_DIR}/include")
@@ -40,10 +44,17 @@ file(GLOB SPARSE_SRC
   ${SPARSE_DIR}/*.cc
   ${SPARSE_DIR}/cpu/*.cc
 )
+if(USE_CUDA)
+  file(GLOB SPARSE_CUDA_SRC
+    ${SPARSE_DIR}/cuda/*.cu
+  )
+  list(APPEND SPARSE_SRC ${SPARSE_CUDA_SRC})
+endif()
+
 add_library(${LIB_DGL_SPARSE_NAME} SHARED ${SPARSE_SRC} ${SPARSE_HEADERS})
 target_include_directories(
   ${LIB_DGL_SPARSE_NAME} PRIVATE ${SPARSE_DIR} ${SPARSE_HEADERS})
-target_link_libraries(${LIB_DGL_SPARSE_NAME} "${TORCH_LIBRARIES}")
+target_link_libraries(${LIB_DGL_SPARSE_NAME} ${SPARSE_LINKER_LIBS})
 target_compile_definitions(${LIB_DGL_SPARSE_NAME} PRIVATE TORCH_VERSION_MAJOR=${TORCH_VERSION_MAJOR})
 target_compile_definitions(${LIB_DGL_SPARSE_NAME} PRIVATE TORCH_VERSION_MINOR=${TORCH_VERSION_MINOR})
 


### PR DESCRIPTION
## Description

Support the compilations of sparse native operators. After this PR, CUDA operators can be added in `dgl_sparse/src/cuda`. I didn't refactor the compilation of CUDA as suggested by [@yaox12 in this PR](https://github.com/dmlc/dgl/pull/6300#issuecomment-1711143917) to get rid of `FindCUDA` because it cannot find some CUDA flags like `CUDA_NVCC_EXECUTABLE`.

## Checklist
Please feel free to remove inapplicable items for your PR.
- [ ] The PR title starts with [$CATEGORY] (such as [NN], [Model], [Doc], [Feature]])
- [ ] I've leverage the [tools](https://docs.google.com/document/d/1iHyj7zlmygKSk5gBPsqIqL5ASPzJSPREaNT_QdsiYA4/edit) to beautify the python and c++ code.
- [ ] The PR is complete and small, read the [Google eng practice (CL equals to PR)](https://google.github.io/eng-practices/review/developer/small-cls.html) to understand more about small PR. In DGL, we consider PRs with less than 200 lines of core code change are small (example, test and documentation could be exempted).
- [ ] All changes have test coverage
- [ ] Code is well-documented
- [ ] To the best of my knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change
- [ ] Related issue is referred in this PR
- [ ] If the PR is for a new model/paper, I've updated the example index [here](../examples/README.md).

## Changes
<!-- You could use following template
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)
-->
