### PR TITLE
[Graphbolt] Support return reverse edge ids in sampling

### DIFF
--- a/python/dgl/graphbolt/base.py
+++ b/python/dgl/graphbolt/base.py
@@ -7,12 +7,14 @@ from ..utils import recursive_apply
 
 __all__ = [
     "CANONICAL_ETYPE_DELIMITER",
+    "ORIGINAL_EDGE_ID",
     "etype_str_to_tuple",
     "etype_tuple_to_str",
     "CopyTo",
 ]
 
 CANONICAL_ETYPE_DELIMITER = ":"
+ORIGINAL_EDGE_ID = "_ORIGINAL_EDGE_ID"
 
 
 def etype_tuple_to_str(c_etype):

--- a/python/dgl/graphbolt/impl/csc_sampling_graph.py
+++ b/python/dgl/graphbolt/impl/csc_sampling_graph.py
@@ -8,10 +8,10 @@ from typing import Dict, Optional, Union
 
 import torch
 
-from ...base import EID, ETYPE
+from ...base import ETYPE
 from ...convert import to_homogeneous
 from ...heterograph import DGLGraph
-from ..base import etype_str_to_tuple, etype_tuple_to_str
+from ..base import etype_str_to_tuple, etype_tuple_to_str, ORIGINAL_EDGE_ID
 from .sampled_subgraph_impl import SampledSubgraphImpl
 
 
@@ -233,7 +233,9 @@ class CSCSamplingGraph:
         reverse_edge_ids = C_sampled_subgraph.reverse_edge_ids
         return_eids = reverse_edge_ids is not None
         if return_eids:
-            reverse_edge_ids = self.edge_attributes[EID][reverse_edge_ids]
+            reverse_edge_ids = self.edge_attributes[ORIGINAL_EDGE_ID][
+                reverse_edge_ids
+            ]
         if type_per_edge is None:
             # The sampled graph is already a homogeneous graph.
             node_pairs = (row, column)
@@ -379,16 +381,16 @@ class CSCSamplingGraph:
             greater than or equal to 0."
         if return_eids:
             assert (
-                EID in self.edge_attributes
-            ), f"The Edge attribute '{EID}' must be provided when the \
-                `return_eids` option is set."
+                ORIGINAL_EDGE_ID in self.edge_attributes
+            ), f"The Edge attribute '{ORIGINAL_EDGE_ID}' must be provided \
+                when the `return_eids` option is set."
             assert (
-                self.edge_attributes[EID].dim() == 1
-            ), "`EID` attribute should be 1-D tensor."
+                self.edge_attributes[ORIGINAL_EDGE_ID].dim() == 1
+            ), "`ORIGINAL_EDGE_ID` attribute should be 1-D tensor."
             assert (
-                self.edge_attributes[EID].size(0) == self.num_edges
-            ), "`EID` attribute should have the same number of elements as \
-                the number of edges."
+                self.edge_attributes[ORIGINAL_EDGE_ID].size(0) == self.num_edges
+            ), "`ORIGINAL_EDGE_ID` attribute should have the same number of \
+                elements as the number of edges."
         if probs_name:
             assert (
                 probs_name in self.edge_attributes

--- a/tests/python/pytorch/graphbolt/impl/test_csc_sampling_graph.py
+++ b/tests/python/pytorch/graphbolt/impl/test_csc_sampling_graph.py
@@ -750,17 +750,15 @@ def test_sample_neighbors_return_eids_homo(labor):
 
     # Generate subgraph via sample neighbors.
     nodes = torch.LongTensor([1, 3, 4])
-    subgraph = graph.sample_neighbors(
-        nodes, fanouts=torch.LongTensor([-1]), return_eids=True
-    )
+    subgraph = graph.sample_neighbors(nodes, fanouts=torch.LongTensor([-1]))
 
     # Verify in subgraph.
     expected_reverse_edge_ids = edge_attributes[gb.ORIGINAL_EDGE_ID][
         torch.tensor([3, 4, 7, 8, 9, 10, 11])
     ]
-    assert torch.equal(expected_reverse_edge_ids, subgraph.reverse_edge_ids)
-    assert subgraph.reverse_column_node_ids is None
-    assert subgraph.reverse_row_node_ids is None
+    assert torch.equal(expected_reverse_edge_ids, subgraph.original_edge_ids)
+    assert subgraph.original_column_node_ids is None
+    assert subgraph.original_row_node_ids is None
 
 
 @unittest.skipIf(
@@ -809,18 +807,18 @@ def test_sample_neighbors_return_eids_hetero(labor):
     nodes = {"n1": torch.LongTensor([0]), "n2": torch.LongTensor([0])}
     fanouts = torch.tensor([-1, -1])
     sampler = graph.sample_layer_neighbors if labor else graph.sample_neighbors
-    subgraph = sampler(nodes, fanouts, return_eids=True)
+    subgraph = sampler(nodes, fanouts)
 
     # Verify in subgraph.
     expected_reverse_edge_ids = {
         "n2:e2:n1": edge_attributes[gb.ORIGINAL_EDGE_ID][torch.tensor([0, 1])],
         "n1:e1:n2": edge_attributes[gb.ORIGINAL_EDGE_ID][torch.tensor([4, 5])],
     }
-    assert subgraph.reverse_column_node_ids is None
-    assert subgraph.reverse_row_node_ids is None
+    assert subgraph.original_column_node_ids is None
+    assert subgraph.original_row_node_ids is None
     for etype in etypes.keys():
         assert torch.equal(
-            subgraph.reverse_edge_ids[etype], expected_reverse_edge_ids[etype]
+            subgraph.original_edge_ids[etype], expected_reverse_edge_ids[etype]
         )
 
 

--- a/tests/python/pytorch/graphbolt/impl/test_csc_sampling_graph.py
+++ b/tests/python/pytorch/graphbolt/impl/test_csc_sampling_graph.py
@@ -739,7 +739,7 @@ def test_sample_neighbors_return_eids_homo(labor):
     assert indptr[-1] == len(indices)
 
     # Add edge id mapping from CSC graph -> original graph.
-    edge_attributes = {dgl.EID: torch.randperm(num_edges)}
+    edge_attributes = {gb.ORIGINAL_EDGE_ID: torch.randperm(num_edges)}
 
     # Construct CSCSamplingGraph.
     graph = gb.from_csc(indptr, indices, edge_attributes=edge_attributes)
@@ -751,7 +751,7 @@ def test_sample_neighbors_return_eids_homo(labor):
     )
 
     # Verify in subgraph.
-    expected_reverse_edge_ids = edge_attributes[dgl.EID][
+    expected_reverse_edge_ids = edge_attributes[gb.ORIGINAL_EDGE_ID][
         torch.tensor([3, 4, 7, 8, 9, 10, 11])
     ]
     assert torch.equal(expected_reverse_edge_ids, subgraph.reverse_edge_ids)
@@ -786,7 +786,7 @@ def test_sample_neighbors_return_eids_hetero(labor):
     type_per_edge = torch.LongTensor([1, 1, 1, 1, 0, 0, 0, 0, 0])
     node_type_offset = torch.LongTensor([0, 2, 5])
     edge_attributes = {
-        dgl.EID: torch.cat([torch.randperm(4), torch.randperm(5)])
+        gb.ORIGINAL_EDGE_ID: torch.cat([torch.randperm(4), torch.randperm(5)])
     }
     assert indptr[-1] == num_edges
     assert indptr[-1] == len(indices)
@@ -809,8 +809,8 @@ def test_sample_neighbors_return_eids_hetero(labor):
 
     # Verify in subgraph.
     expected_reverse_edge_ids = {
-        "n2:e2:n1": edge_attributes[dgl.EID][torch.tensor([0, 1])],
-        "n1:e1:n2": edge_attributes[dgl.EID][torch.tensor([4, 5])],
+        "n2:e2:n1": edge_attributes[gb.ORIGINAL_EDGE_ID][torch.tensor([0, 1])],
+        "n1:e1:n2": edge_attributes[gb.ORIGINAL_EDGE_ID][torch.tensor([4, 5])],
     }
     assert subgraph.reverse_column_node_ids is None
     assert subgraph.reverse_row_node_ids is None


### PR DESCRIPTION
## Description
Support return reverse edge ids in sampling, which always used when need edge features.

## Checklist
Please feel free to remove inapplicable items for your PR.
- [ ] The PR title starts with [$CATEGORY] (such as [NN], [Model], [Doc], [Feature]])
- [ ] I've leverage the [tools](https://docs.google.com/document/d/1iHyj7zlmygKSk5gBPsqIqL5ASPzJSPREaNT_QdsiYA4/edit) to beautify the python and c++ code.
- [ ] The PR is complete and small, read the [Google eng practice (CL equals to PR)](https://google.github.io/eng-practices/review/developer/small-cls.html) to understand more about small PR. In DGL, we consider PRs with less than 200 lines of core code change are small (example, test and documentation could be exempted).
- [ ] All changes have test coverage
- [ ] Code is well-documented
- [ ] To the best of my knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change
- [ ] Related issue is referred in this PR
- [ ] If the PR is for a new model/paper, I've updated the example index [here](../examples/README.md).

## Changes
<!-- You could use following template
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)
-->
