### PR TITLE
[GraphBolt] Improving the node prediction example

### DIFF
--- a/examples/sampling/graphbolt/lightning/README.md
+++ b/examples/sampling/graphbolt/lightning/README.md
@@ -14,5 +14,5 @@ python3 node_classification.py --labor
 
 ### Results
 ```
-Valid Accuracy: 0.905
+Valid Accuracy: 0.907
 ```

--- a/examples/sampling/graphbolt/lightning/README.md
+++ b/examples/sampling/graphbolt/lightning/README.md
@@ -7,7 +7,12 @@
 python3 node_classification.py
 ```
 
+### Command
+```
+python3 node_classification.py --labor
+```
+
 ### Results
 ```
-Valid Accuracy: 0.877
+Valid Accuracy: 0.904
 ```

--- a/examples/sampling/graphbolt/lightning/README.md
+++ b/examples/sampling/graphbolt/lightning/README.md
@@ -14,5 +14,5 @@ python3 node_classification.py --labor
 
 ### Results
 ```
-Valid Accuracy: 0.904
+Valid Accuracy: 0.905
 ```

--- a/examples/sampling/graphbolt/lightning/README.md
+++ b/examples/sampling/graphbolt/lightning/README.md
@@ -7,11 +7,6 @@
 python3 node_classification.py
 ```
 
-### Command
-```
-python3 node_classification.py --labor
-```
-
 ### Results
 ```
 Valid Accuracy: 0.907

--- a/examples/sampling/graphbolt/lightning/node_classification.py
+++ b/examples/sampling/graphbolt/lightning/node_classification.py
@@ -202,13 +202,13 @@ if __name__ == "__main__":
         "--batch_size",
         type=int,
         default=1024,
-        help="input batch size for training (default: 32)",
+        help="input batch size for training (default: 1024)",
     )
     parser.add_argument(
         "--epochs",
         type=int,
         default=10,
-        help="number of epochs to train (default: 100)",
+        help="number of epochs to train (default: 10)",
     )
     parser.add_argument(
         "--num_workers",

--- a/examples/sampling/graphbolt/lightning/node_classification.py
+++ b/examples/sampling/graphbolt/lightning/node_classification.py
@@ -221,9 +221,7 @@ if __name__ == "__main__":
     model = SAGE(100, 256, datamodule.num_classes)
 
     # Train.
-    checkpoint_callback = ModelCheckpoint(
-        monitor="val_acc", mode="max", save_top_k=1
-    )
+    checkpoint_callback = ModelCheckpoint(monitor="val_acc", mode="max")
     early_stopping_callback = EarlyStopping(monitor="val_acc", mode="max")
     ########################################################################
     # (HIGHLIGHT) The `Trainer` is the key Class in lightning, which automates

--- a/examples/sampling/graphbolt/lightning/node_classification.py
+++ b/examples/sampling/graphbolt/lightning/node_classification.py
@@ -221,7 +221,9 @@ if __name__ == "__main__":
     model = SAGE(100, 256, datamodule.num_classes)
 
     # Train.
-    checkpoint_callback = ModelCheckpoint(monitor="val_acc", save_top_k=1)
+    checkpoint_callback = ModelCheckpoint(
+        monitor="val_acc", mode="max", save_top_k=1
+    )
     early_stopping_callback = EarlyStopping(monitor="val_acc", mode="max")
     ########################################################################
     # (HIGHLIGHT) The `Trainer` is the key Class in lightning, which automates

--- a/examples/sampling/graphbolt/lightning/node_classification.py
+++ b/examples/sampling/graphbolt/lightning/node_classification.py
@@ -43,7 +43,7 @@ import torch
 import torch.nn as nn
 import torch.nn.functional as F
 from pytorch_lightning import LightningDataModule, LightningModule, Trainer
-from pytorch_lightning.callbacks import ModelCheckpoint, EarlyStopping
+from pytorch_lightning.callbacks import EarlyStopping, ModelCheckpoint
 from torchmetrics import Accuracy
 
 
@@ -165,7 +165,7 @@ class DataModule(LightningDataModule):
             datapipe, num_workers=self.num_workers
         )
         return dataloader
-    
+
     ########################################################################
     # (HIGHLIGHT) The 'train_dataloader' and 'val_dataloader' hooks are
     # essential components of the Lightning framework, defining how data is

--- a/examples/sampling/graphbolt/lightning/node_classification.py
+++ b/examples/sampling/graphbolt/lightning/node_classification.py
@@ -151,8 +151,8 @@ class DataModule(LightningDataModule):
         datapipe = gb.ItemSampler(
             node_set,
             batch_size=self.batch_size,
-            shuffle=is_train,
-            drop_last=is_train,
+            shuffle=True,
+            drop_last=True,
         )
         sampler = (
             datapipe.sample_layer_neighbor

--- a/examples/sampling/graphbolt/lightning/node_classification.py
+++ b/examples/sampling/graphbolt/lightning/node_classification.py
@@ -156,7 +156,7 @@ class DataModule(LightningDataModule):
         )
         sampler = (
             datapipe.sample_layer_neighbor
-            if self.labor
+            if self.labor and is_train
             else datapipe.sample_neighbor
         )
         datapipe = sampler(self.graph, self.fanouts)

--- a/examples/sampling/graphbolt/lightning/node_classification.py
+++ b/examples/sampling/graphbolt/lightning/node_classification.py
@@ -201,7 +201,7 @@ if __name__ == "__main__":
     parser.add_argument(
         "--batch_size",
         type=int,
-        default=32,
+        default=1024,
         help="input batch size for training (default: 32)",
     )
     parser.add_argument(

--- a/examples/sampling/graphbolt/lightning/node_classification.py
+++ b/examples/sampling/graphbolt/lightning/node_classification.py
@@ -95,7 +95,7 @@ class SAGE(LightningModule):
     def training_step(self, batch, batch_idx):
         # TODO: Move this to the data pipeline as a stage.
         blocks = [block.to("cuda") for block in batch.to_dgl_blocks()]
-        x = blocks[0].srcdata["feat"]
+        x = blocks[0].srcdata["feat"].float()
         y = batch.labels.to("cuda")
         y_hat = self(blocks, x)
         loss = F.cross_entropy(y_hat, y)
@@ -112,7 +112,7 @@ class SAGE(LightningModule):
 
     def validation_step(self, batch, batch_idx):
         blocks = [block.to("cuda") for block in batch.to_dgl_blocks()]
-        x = blocks[0].srcdata["feat"]
+        x = blocks[0].srcdata["feat"].float()
         y = batch.labels.to("cuda")
         y_hat = self(blocks, x)
         self.val_acc(torch.argmax(y_hat, 1), y)


### PR DESCRIPTION
## Description

Using `sample_layer_neighbor` for training is not only faster but also gives the same accuracy as `sample_neighbor`. Since graphbolt layer neighbor sampler has the same quality of implementation as neighbor sampler, there is no reason we shouldn't recommend and show the users the new sampler for the node prediction example. Graphbolt should showcase the best available functionality to the users for each use case especially if there are no drawbacks of doing so. It is not an advanced functionality either, just replace `sample_neighbor` with `sample_layer_neighbor`.

The added `log_node_and_edge_counts` function shows the user how many nodes and edges are sampled. It is not crucial to keep it in case it creates unwanted output.

Results with early stopping:

```
mfbalin@BALIN-PC:~/dgl-1/examples/sampling/graphbolt/lightning$ time python node_classification.py --batch_size=1024 --labor
The dataset is already preprocessed.
GPU available: True (cuda), used: True
TPU available: False, using: 0 TPU cores
IPU available: False, using: 0 IPUs
HPU available: False, using: 0 HPUs
You are using a CUDA device ('NVIDIA GeForce RTX 4090') that has Tensor Cores. To properly utilize them, you should set `torch.set_float32_matmul_precision('medium' | 'high')` which will trade-off precision for performance. For more details, read https://pytorch.org/docs/stable/generated/torch.set_float32_matmul_precision.html#torch.set_float32_matmul_precision
LOCAL_RANK: 0 - CUDA_VISIBLE_DEVICES: [0]

  | Name      | Type               | Params
-------------------------------------------------
0 | layers    | ModuleList         | 206 K 
1 | dropout   | Dropout            | 0     
2 | train_acc | MulticlassAccuracy | 0     
3 | val_acc   | MulticlassAccuracy | 0     
-------------------------------------------------
206 K     Trainable params
0         Non-trainable params
206 K     Total params
0.828     Total estimated model params size (MB)
Sanity Checking: 0it [00:00, ?it/s]/home/mfbalin/.local/lib/python3.10/site-packages/pytorch_lightning/trainer/connectors/data_connector.py:432: PossibleUserWarning: The dataloader, val_dataloader, does not have many workers which may be a bottleneck. Consider increasing the value of the `num_workers` argument` (try 32 which is the number of cpus on this machine) in the `DataLoader` init to improve performance.
  rank_zero_warn(
/home/mfbalin/.local/lib/python3.10/site-packages/pytorch_lightning/trainer/connectors/data_connector.py:432: PossibleUserWarning: The dataloader, train_dataloader, does not have many workers which may be a bottleneck. Consider increasing the value of the `num_workers` argument` (try 32 which is the number of cpus on this machine) in the `DataLoader` init to improve performance.
  rank_zero_warn(
Epoch 19: : 192it [00:34,  5.63it/s, v_num=18, train_acc=0.909, num_nodes/0=2.13e+5, num_edges/0=2.71e+5, num_nodes/1=54285.0, num_edges/1=62336.0, num_nodes/2=6304.0, num_edges/2=5945.0, num_nodes/3=411.0, val_acc=0.908]   
                                                  
real    11m36.656s
user    108m24.251s
sys     10m12.523s
```
```
mfbalin@BALIN-PC:~/dgl-1/examples/sampling/graphbolt/lightning$ time python node_classification.py --batch_size=1024
The dataset is already preprocessed.
GPU available: True (cuda), used: True
TPU available: False, using: 0 TPU cores
IPU available: False, using: 0 IPUs
HPU available: False, using: 0 HPUs
You are using a CUDA device ('NVIDIA GeForce RTX 4090') that has Tensor Cores. To properly utilize them, you should set `torch.set_float32_matmul_precision('medium' | 'high')` which will trade-off precision for performance. For more details, read https://pytorch.org/docs/stable/generated/torch.set_float32_matmul_precision.html#torch.set_float32_matmul_precision
LOCAL_RANK: 0 - CUDA_VISIBLE_DEVICES: [0]

  | Name      | Type               | Params
-------------------------------------------------
0 | layers    | ModuleList         | 206 K 
1 | dropout   | Dropout            | 0     
2 | train_acc | MulticlassAccuracy | 0     
3 | val_acc   | MulticlassAccuracy | 0     
-------------------------------------------------
206 K     Trainable params
0         Non-trainable params
206 K     Total params
0.828     Total estimated model params size (MB)
Sanity Checking: 0it [00:00, ?it/s]/home/mfbalin/.local/lib/python3.10/site-packages/pytorch_lightning/trainer/connectors/data_connector.py:432: PossibleUserWarning: The dataloader, val_dataloader, does not have many workers which may be a bottleneck. Consider increasing the value of the `num_workers` argument` (try 32 which is the number of cpus on this machine) in the `DataLoader` init to improve performance.
  rank_zero_warn(
/home/mfbalin/.local/lib/python3.10/site-packages/pytorch_lightning/trainer/connectors/data_connector.py:432: PossibleUserWarning: The dataloader, train_dataloader, does not have many workers which may be a bottleneck. Consider increasing the value of the `num_workers` argument` (try 32 which is the number of cpus on this machine) in the `DataLoader` init to improve performance.
  rank_zero_warn(
Epoch 16: : 192it [00:54,  3.49it/s, v_num=19, train_acc=0.918, num_nodes/0=2.13e+5, num_edges/0=2.72e+5, num_nodes/1=54492.0, num_edges/1=62341.0, num_nodes/2=6305.0, num_edges/2=5945.0, num_nodes/3=411.0, val_acc=0.907]   
                                                  
real    15m12.837s
user    140m40.762s
sys     14m33.066s
```