### PR TITLE
[Misc] Modify num_nodes API of CSCSamplingGraph

### DIFF
--- a/python/dgl/graphbolt/sampling_graph.py
+++ b/python/dgl/graphbolt/sampling_graph.py
@@ -1,0 +1,30 @@
+"""Sampling Graphs."""
+
+
+class SamplingGraph:
+    r"""Class for sampling graph."""
+
+    def __init__(self):
+        pass
+
+    @property
+    def num_nodes(self) -> int:
+        """Returns the number of nodes in the graph.
+
+        Returns
+        -------
+        int
+            The number of rows in the dense format.
+        """
+        raise NotImplementedError
+
+    @property
+    def num_edges(self) -> int:
+        """Returns the number of edges in the graph.
+
+        Returns
+        -------
+        int
+            The number of edges in the graph.
+        """
+        raise NotImplementedError


### PR DESCRIPTION
## Description
<!-- Brief description. Refer to the related issues if existed.
It'll be great if relevant reviewers can be assigned as well.-->
A draft for modified API `num_nodes` in class `CSCSamplingGraph`. Now it supports returning a dictionary indicating the numbers of all types of nodes in a heterogenous graph.

## Checklist
Please feel free to remove inapplicable items for your PR.
- [x] The PR title starts with [$CATEGORY] (such as [NN], [Model], [Doc], [Feature]])
- [x] I've leverage the [tools](https://docs.google.com/document/d/1iHyj7zlmygKSk5gBPsqIqL5ASPzJSPREaNT_QdsiYA4/edit) to beautify the python and c++ code.
- [x] The PR is complete and small, read the [Google eng practice (CL equals to PR)](https://google.github.io/eng-practices/review/developer/small-cls.html) to understand more about small PR. In DGL, we consider PRs with less than 200 lines of core code change are small (example, test and documentation could be exempted).
- [ ] All changes have test coverage
- [x] Code is well-documented
- [ ] To the best of my knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change
- [ ] Related issue is referred in this PR
- [ ] If the PR is for a new model/paper, I've updated the example index [here](../examples/README.md).

## Changes
<!-- You could use following template
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)
-->
