### PR TITLE
[GraphBolt] Store `ORIGINAL_EDGE_ID` in CSCSamplingGraph's `edge_attributes`.

### DIFF
--- a/python/dgl/graphbolt/impl/csc_sampling_graph.py
+++ b/python/dgl/graphbolt/impl/csc_sampling_graph.py
@@ -8,7 +8,7 @@ from typing import Dict, Optional, Union
 
 import torch
 
-from ...base import ETYPE, EID
+from ...base import EID, ETYPE
 from ...convert import to_homogeneous
 from ...heterograph import DGLGraph
 from ..base import etype_str_to_tuple, etype_tuple_to_str, ORIGINAL_EDGE_ID
@@ -761,7 +761,7 @@ def from_dglgraph(g: DGLGraph, is_homogeneous=False) -> CSCSamplingGraph:
     type_per_edge = None if is_homogeneous else homo_g.edata[ETYPE][edge_ids]
 
     # Assign edge attributes according to the original eids mapping.
-    edge_attributes = {ORIGINAL_EDGE_ID : homo_g.edata[EID][edge_ids]}
+    edge_attributes = {ORIGINAL_EDGE_ID: homo_g.edata[EID][edge_ids]}
 
     return CSCSamplingGraph(
         torch.ops.graphbolt.from_csc(

--- a/python/dgl/graphbolt/impl/csc_sampling_graph.py
+++ b/python/dgl/graphbolt/impl/csc_sampling_graph.py
@@ -741,7 +741,7 @@ def save_csc_sampling_graph(graph, filename):
     print(f"CSCSamplingGraph has been saved to {filename}.")
 
 
-def from_dglgraph(g: DGLGraph, is_homogeneous=False): # -> CSCSamplingGraph:
+def from_dglgraph(g: DGLGraph, is_homogeneous=False) -> CSCSamplingGraph:
     """Convert a DGLGraph to CSCSamplingGraph."""
     homo_g, ntype_count, _ = to_homogeneous(g, return_count=True)
     # Initialize metadata.

--- a/python/dgl/graphbolt/impl/csc_sampling_graph.py
+++ b/python/dgl/graphbolt/impl/csc_sampling_graph.py
@@ -8,7 +8,7 @@ from typing import Dict, Optional, Union
 
 import torch
 
-from ...base import ETYPE
+from ...base import ETYPE, EID
 from ...convert import to_homogeneous
 from ...heterograph import DGLGraph
 from ..base import etype_str_to_tuple, etype_tuple_to_str, ORIGINAL_EDGE_ID
@@ -738,7 +738,7 @@ def save_csc_sampling_graph(graph, filename):
     print(f"CSCSamplingGraph has been saved to {filename}.")
 
 
-def from_dglgraph(g: DGLGraph, is_homogeneous=False) -> CSCSamplingGraph:
+def from_dglgraph(g: DGLGraph, is_homogeneous=False): # -> CSCSamplingGraph:
     """Convert a DGLGraph to CSCSamplingGraph."""
     homo_g, ntype_count, _ = to_homogeneous(g, return_count=True)
     # Initialize metadata.
@@ -757,13 +757,16 @@ def from_dglgraph(g: DGLGraph, is_homogeneous=False) -> CSCSamplingGraph:
     # Assign edge type according to the order of CSC matrix.
     type_per_edge = None if is_homogeneous else homo_g.edata[ETYPE][edge_ids]
 
+    # Assign edge attributes according to the original eids mapping.
+    edge_attributes = {ORIGINAL_EDGE_ID : homo_g.edata[EID][edge_ids]}
+
     return CSCSamplingGraph(
         torch.ops.graphbolt.from_csc(
             indptr,
             indices,
             node_type_offset,
             type_per_edge,
-            None,
+            edge_attributes,
         ),
         metadata,
     )


### PR DESCRIPTION
## Description
<!-- Brief description. Refer to the related issues if existed.
It'll be great if relevant reviewers can be assigned as well.-->

I've made modification to `gb.from_dglgraph` function to store the `ORIGINAL_EDGE_ID` within the CSCSamplingGraph.

Additionally, I've implemented the requisite unit test to validate the correctness of the `ORIGINAL_EDGE_ID` mapping. By utilizing the `CSCSamplingGraph` and the mapping, we can retrieve node pairs from the `DGLGraph` and verify their equalities. 

More Specifically:

### For HomoGraph Test
```mermaid
graph TD;
    Start(Start) --> GetCOO[Generate COO Representation];
    GetCOO --> CheckEdgeMapping[Verify Edge Mapping using ORIGINAL_EDGE_ID];
    CheckEdgeMapping --> End(End);
```

### For HeteroGraph Test
```mermaid
graph TD;
    Start(Start) --> MapNodeIDs["Create Node ID Mapping (GB -> DGL)"];
    MapNodeIDs --> GetCOO[Generate COO Representation by Node ID Mapping];
    GetCOO --> VerifyEtypes[Verify GraphBolt and DGL Edge Type Order];
    VerifyEtypes --> CheckEdgeMapping[Validate Edge Mapping using ORIGINAL_EDGE_ID];
    CheckEdgeMapping --> End(End);
```

## Checklist
Please feel free to remove inapplicable items for your PR.
- [x] The PR title starts with [$CATEGORY] (such as [NN], [Model], [Doc], [Feature]])
- [x] I've leverage the [tools](https://docs.google.com/document/d/1iHyj7zlmygKSk5gBPsqIqL5ASPzJSPREaNT_QdsiYA4/edit) to beautify the python and c++ code.
- [x] The PR is complete and small, read the [Google eng practice (CL equals to PR)](https://google.github.io/eng-practices/review/developer/small-cls.html) to understand more about small PR. In DGL, we consider PRs with less than 200 lines of core code change are small (example, test and documentation could be exempted).
- [x] All changes have test coverage
- [x] Code is well-documented
- [x] To the best of my knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change
- [ ] Related issue is referred in this PR
- [ ] If the PR is for a new model/paper, I've updated the example index [here](../examples/README.md).

## Changes
<!-- You could use following template
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)
-->
