### PR TITLE
[GraphBolt] support both pydantic 1.x and 2.x

### DIFF
--- a/python/dgl/graphbolt/__init__.py
+++ b/python/dgl/graphbolt/__init__.py
@@ -28,14 +28,14 @@ from .utils import (
 
 def load_graphbolt():
     """Load Graphbolt C++ library"""
-    version = torch.__version__.split("+", maxsplit=1)[0]
+    vers = torch.__version__.split("+", maxsplit=1)[0]
 
     if sys.platform.startswith("linux"):
-        basename = f"libgraphbolt_pytorch_{version}.so"
+        basename = f"libgraphbolt_pytorch_{vers}.so"
     elif sys.platform.startswith("darwin"):
-        basename = f"libgraphbolt_pytorch_{version}.dylib"
+        basename = f"libgraphbolt_pytorch_{vers}.dylib"
     elif sys.platform.startswith("win"):
-        basename = f"graphbolt_pytorch_{version}.dll"
+        basename = f"graphbolt_pytorch_{vers}.dll"
     else:
         raise NotImplementedError("Unsupported system: %s" % sys.platform)
 

--- a/python/dgl/graphbolt/impl/ondisk_metadata.py
+++ b/python/dgl/graphbolt/impl/ondisk_metadata.py
@@ -5,6 +5,8 @@ from typing import Any, Dict, List, Optional
 
 import pydantic
 
+from ...utils import version
+
 __all__ = [
     "OnDiskFeatureDataFormat",
     "OnDiskTVTSetData",
@@ -80,15 +82,32 @@ class OnDiskTaskData(pydantic.BaseModel, extra="allow"):
     test_set: Optional[List[OnDiskTVTSet]] = []
     extra_fields: Optional[Dict[str, Any]] = {}
 
-    @pydantic.model_validator(mode="before")
-    @classmethod
-    def build_extra(cls, values: Dict[str, Any]) -> Dict[str, Any]:
-        """Build extra fields."""
-        for key in list(values.keys()):
-            if key not in cls.model_fields:
-                values["extra_fields"] = values.get("extra_fields", {})
-                values["extra_fields"][key] = values.pop(key)
-        return values
+    # As pydantic 2.0 has changed the API of validators, we need to use
+    # different validators for different versions to be compatible with
+    # previous versions.
+    if version.parse(pydantic.__version__) >= version.parse("2.0"):
+
+        @pydantic.model_validator(mode="before")
+        @classmethod
+        def build_extra(cls, values: Dict[str, Any]) -> Dict[str, Any]:
+            """Build extra fields."""
+            for key in list(values.keys()):
+                if key not in cls.model_fields:
+                    values["extra_fields"] = values.get("extra_fields", {})
+                    values["extra_fields"][key] = values.pop(key)
+            return values
+
+    else:
+
+        @pydantic.root_validator(pre=True)
+        @classmethod
+        def build_extra(cls, values: Dict[str, Any]) -> Dict[str, Any]:
+            """Build extra fields."""
+            for key in list(values.keys()):
+                if key not in ["train_set", "validation_set", "test_set"]:
+                    values["extra_fields"] = values.get("extra_fields", {})
+                    values["extra_fields"][key] = values.pop(key)
+            return values
 
 
 class OnDiskMetaData(pydantic.BaseModel):

--- a/tests/python/pytorch/graphbolt/impl/test_ondisk_dataset.py
+++ b/tests/python/pytorch/graphbolt/impl/test_ondisk_dataset.py
@@ -1582,7 +1582,8 @@ def test_OnDiskDataset_load_graph():
         dataset.yaml_data["graph_topology"]["type"] = "fake_type"
         with pytest.raises(
             pydantic.ValidationError,
-            match="Input should be 'CSCSamplingGraph'",
+            # As error message diffs in pydantic 1.x and 2.x, we just match keyword only.
+            match="'CSCSamplingGraph'",
         ):
             dataset.load()
 

--- a/tests/python/pytorch/graphbolt/impl/test_ondisk_dataset.py
+++ b/tests/python/pytorch/graphbolt/impl/test_ondisk_dataset.py
@@ -1582,7 +1582,8 @@ def test_OnDiskDataset_load_graph():
         dataset.yaml_data["graph_topology"]["type"] = "fake_type"
         with pytest.raises(
             pydantic.ValidationError,
-            # As error message diffs in pydantic 1.x and 2.x, we just match keyword only.
+            # As error message diffs in pydantic 1.x and 2.x, we just match
+            # keyword only.
             match="'CSCSamplingGraph'",
         ):
             dataset.load()


### PR DESCRIPTION
## Description
<!-- Brief description. Refer to the related issues if existed.
It'll be great if relevant reviewers can be assigned as well.-->
to avoid import error when pydantic 1.10 is installed.
```
AttributeError                            Traceback (most recent call last)

[<ipython-input-1-326679278365>](https://localhost:8080/#) in <cell line: 10>()
     10 try:
     11     import dgl
---> 12     import dgl.graphbolt as gb
     13     installed = True
     14 except ImportError as e:

4 frames

[/usr/local/lib/python3.10/dist-packages/dgl/graphbolt/impl/ondisk_metadata.py](https://localhost:8080/#) in OnDiskTaskData()
     81     extra_fields: Optional[Dict[str, Any]] = {}
     82 
---> 83     @pydantic.model_validator(mode="before")
     84     @classmethod
     85     def build_extra(cls, values: Dict[str, Any]) -> Dict[str, Any]:

AttributeError: module 'pydantic' has no attribute 'model_validator'
```
## Checklist
Please feel free to remove inapplicable items for your PR.
- [ ] The PR title starts with [$CATEGORY] (such as [NN], [Model], [Doc], [Feature]])
- [ ] I've leverage the [tools](https://docs.google.com/document/d/1iHyj7zlmygKSk5gBPsqIqL5ASPzJSPREaNT_QdsiYA4/edit) to beautify the python and c++ code.
- [ ] The PR is complete and small, read the [Google eng practice (CL equals to PR)](https://google.github.io/eng-practices/review/developer/small-cls.html) to understand more about small PR. In DGL, we consider PRs with less than 200 lines of core code change are small (example, test and documentation could be exempted).
- [ ] All changes have test coverage
- [ ] Code is well-documented
- [ ] To the best of my knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change
- [ ] Related issue is referred in this PR
- [ ] If the PR is for a new model/paper, I've updated the example index [here](../examples/README.md).

## Changes
<!-- You could use following template
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)
-->
