### PR TITLE
[Performance] Do not fuse neighbor sampler for 1 thread

### DIFF
--- a/python/dgl/dataloading/neighbor_sampler.py
+++ b/python/dgl/dataloading/neighbor_sampler.py
@@ -3,6 +3,7 @@ from .. import backend as F
 from ..base import EID, NID
 from ..heterograph import DGLGraph
 from ..transforms import to_block
+from ..utils import get_num_threads
 from .base import BlockSampler
 
 
@@ -150,8 +151,9 @@ class NeighborSampler(BlockSampler):
     def sample_blocks(self, g, seed_nodes, exclude_eids=None):
         output_nodes = seed_nodes
         blocks = []
-
-        if self.fused:
+        # sample_neighbors_fused function requires multithreading to be more efficient
+        # than sample_neighbors
+        if self.fused and get_num_threads() > 1:
             cpu = F.device_type(g.device) == "cpu"
             if isinstance(seed_nodes, dict):
                 for ntype in list(seed_nodes.keys()):


### PR DESCRIPTION
## Description
It fixes the issue https://github.com/dmlc/dgl/issues/6315 (at least for CPU-only configuration)

The fused version of NeighborSampler (sample_neighbors_fused) is prepared as multithreaded, so we can not use it when the number of available threads is lower than 2.
This way we can achieve the same performance as previously with not fused version (which is also multithreaded but with less overhead).

Performance results of the script from the issue https://github.com/dmlc/dgl/issues/6315 (modified to be allowed to run on CPU-only configuration) on AWS EC2 instance r6i.32xlarge (2 socket Intel(R) Xeon(R) Platinum 8375C) are as follow :
  
![image](https://github.com/dmlc/dgl/assets/58251767/9948a5e3-83ae-45d2-9e8f-ba9fd5cbfda0)



## Checklist
Please feel free to remove inapplicable items for your PR.
- [x] The PR title starts with [$CATEGORY] (such as [NN], [Model], [Doc], [Feature]])
- [x] I've leverage the [tools](https://docs.google.com/document/d/1iHyj7zlmygKSk5gBPsqIqL5ASPzJSPREaNT_QdsiYA4/edit) to beautify the python and c++ code.
- [x] The PR is complete and small, read the [Google eng practice (CL equals to PR)](https://google.github.io/eng-practices/review/developer/small-cls.html) to understand more about small PR. In DGL, we consider PRs with less than 200 lines of core code change are small (example, test and documentation could be exempted).
- [x] All changes have test coverage
- [x] Code is well-documented
- [x] To the best of my knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change
- [x] Related issue is referred in this PR
- [x] If the PR is for a new model/paper, I've updated the example index [here](../examples/README.md).
