### PR TITLE
[GraphBolt] Enable `CSCSamplingGraph::edge_attributes` save and load.

### DIFF
--- a/graphbolt/src/csc_sampling_graph.cc
+++ b/graphbolt/src/csc_sampling_graph.cc
@@ -115,8 +115,7 @@ void CSCSamplingGraph::Save(torch::serialize::OutputArchive& archive) const {
   archive.write(
       "CSCSamplingGraph/has_edge_attributes", edge_attributes_.has_value());
   if (edge_attributes_) {
-    archive.write(
-        "CSCSamplingGraph/edge_attributes", edge_attributes_.value());
+    archive.write("CSCSamplingGraph/edge_attributes", edge_attributes_.value());
   }
 }
 

--- a/graphbolt/src/csc_sampling_graph.cc
+++ b/graphbolt/src/csc_sampling_graph.cc
@@ -115,9 +115,8 @@ void CSCSamplingGraph::Save(torch::serialize::OutputArchive& archive) const {
   archive.write(
       "CSCSamplingGraph/has_edge_attributes", edge_attributes_.has_value());
   if (edge_attributes_) {
-    std::cout << "Try to write\n";
-    archive.write("CSCSamplingGraph/edge_attributes", edge_attributes_.value());
-    std::cout << "Finish to write\n";
+    archive.write(
+        "CSCSamplingGraph/edge_attributes", edge_attributes_.value());
   }
 }
 

--- a/graphbolt/src/csc_sampling_graph.cc
+++ b/graphbolt/src/csc_sampling_graph.cc
@@ -80,9 +80,13 @@ void CSCSamplingGraph::Load(torch::serialize::InputArchive& archive) {
     type_per_edge_ =
         read_from_archive(archive, "CSCSamplingGraph/type_per_edge").toTensor();
   }
-  if (read_from_archive(archive, "CSCSamplingGraph/has_edge_attributes")
-          .toBool()) {
-    c10::Dict<c10::IValue, c10::IValue> generic_dict =
+
+  // Optional edge attributes.
+  torch::IValue has_edge_attributes;
+  if (archive.try_read(
+          "CSCSamplingGraph/has_edge_attributes", has_edge_attributes) &&
+      has_edge_attributes.toBool()) {
+    torch::Dict<torch::IValue, torch::IValue> generic_dict =
         read_from_archive(archive, "CSCSamplingGraph/edge_attributes")
             .toGenericDict();
     EdgeAttrMap target_dict;

--- a/tests/python/pytorch/graphbolt/impl/test_ondisk_dataset.py
+++ b/tests/python/pytorch/graphbolt/impl/test_ondisk_dataset.py
@@ -1577,6 +1577,10 @@ def test_OnDiskDataset_load_graph():
         with open(yaml_file, "w") as f:
             f.write(yaml_content)
 
+        # Check if the CSCSamplingGraph.edge_attributes loaded.
+        dataset = gb.OnDiskDataset(test_dir).load()
+        assert dataset.graph.edge_attributes is not None
+
         # Case1. Test modify the `type` field.
         dataset = gb.OnDiskDataset(test_dir)
         dataset.yaml_data["graph_topology"]["type"] = "fake_type"


### PR DESCRIPTION
## Description
<!-- Brief description. Refer to the related issues if existed.
It'll be great if relevant reviewers can be assigned as well.-->
As highlighted in [Issue: [GraphBolt] Enable CSCSamplingGraph::edge_attributes save and load](https://github.com/dmlc/dgl/issues/6406), the original `CSCSamplingGraph::Load` and `CSCSamplingGraph::Save` methods do not support saving and loading `CSCSamplingGraph::edge_attributes`.

I've updated the function to address this. However, the latest `BuiltinDataset` doesn't include `edge_attributes`, which I'll address later.

I believe there's room for improvement in my implementation. Please review and suggest refinements.

## Checklist
Please feel free to remove inapplicable items for your PR.
- [x] The PR title starts with [$CATEGORY] (such as [NN], [Model], [Doc], [Feature]])
- [x] I've leverage the [tools](https://docs.google.com/document/d/1iHyj7zlmygKSk5gBPsqIqL5ASPzJSPREaNT_QdsiYA4/edit) to beautify the python and c++ code.
- [x] The PR is complete and small, read the [Google eng practice (CL equals to PR)](https://google.github.io/eng-practices/review/developer/small-cls.html) to understand more about small PR. In DGL, we consider PRs with less than 200 lines of core code change are small (example, test and documentation could be exempted).
- [ ] All changes have test coverage
- [x] Code is well-documented
- [ ] To the best of my knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change
- [x] Related issue is referred in this PR
- [ ] If the PR is for a new model/paper, I've updated the example index [here](../examples/README.md).

## Changes
<!-- You could use following template
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)
-->
