### PR TITLE
[GraphBolot] Support ondisk datasets with 1D features.

### DIFF
--- a/python/dgl/graphbolt/impl/ondisk_dataset.py
+++ b/python/dgl/graphbolt/impl/ondisk_dataset.py
@@ -5,6 +5,7 @@ from copy import deepcopy
 from typing import Dict, List
 
 import pandas as pd
+import numpy as np
 import torch
 import yaml
 

--- a/python/dgl/graphbolt/impl/ondisk_dataset.py
+++ b/python/dgl/graphbolt/impl/ondisk_dataset.py
@@ -6,6 +6,7 @@ from copy import deepcopy
 from typing import Dict, List
 
 import pandas as pd
+import numpy as np
 import torch
 import yaml
 
@@ -42,13 +43,12 @@ def _copy_or_convert_data(
 ):
     """Copy or convert the data from input_path to output_path."""
     os.makedirs(os.path.dirname(output_path), exist_ok=True)
-    if input_format == "numpy":
-        # If the original format is numpy, just copy the file.
-        shutil.copyfile(input_path, output_path)
-    else:
-        # If the original format is not numpy, convert it to numpy.
-        data = read_data(input_path, input_format, in_memory)
-        save_data(data, output_path, output_format)
+    # Read data. If the original format is not numpy, convert it to numpy. If
+    # dim of the data is 1, reshape it to n * 1 and save it to output_path.
+    data = read_data(input_path, input_format, in_memory)
+    if data.dim() == 1:
+        data = data.reshape(-1, 1)
+    save_data(data, output_path, output_format)
 
 
 def preprocess_ondisk_dataset(dataset_dir: str) -> str:

--- a/python/dgl/graphbolt/impl/ondisk_dataset.py
+++ b/python/dgl/graphbolt/impl/ondisk_dataset.py
@@ -5,7 +5,6 @@ from copy import deepcopy
 from typing import Dict, List
 
 import pandas as pd
-import numpy as np
 import torch
 import yaml
 

--- a/python/dgl/graphbolt/impl/ondisk_dataset.py
+++ b/python/dgl/graphbolt/impl/ondisk_dataset.py
@@ -1,12 +1,10 @@
 """GraphBolt OnDiskDataset."""
 
 import os
-import shutil
 from copy import deepcopy
 from typing import Dict, List
 
 import pandas as pd
-import numpy as np
 import torch
 import yaml
 

--- a/python/dgl/graphbolt/utils/internal.py
+++ b/python/dgl/graphbolt/utils/internal.py
@@ -35,10 +35,10 @@ def save_data(data, path, fmt):
         raise RuntimeError(f"Unsupported format: {fmt}")
 
     # Perform necessary conversion.
-    if fmt == "numpy" and isinstance(element, torch.Tensor):
-        element = element.cpu().numpy()
-    elif fmt == "torch" and isinstance(element, np.ndarray):
-        element = torch.from_numpy(element).cpu()
+    if fmt == "numpy" and isinstance(data, torch.Tensor):
+        data = data.cpu().numpy()
+    elif fmt == "torch" and isinstance(data, np.ndarray):
+        data = torch.from_numpy(data).cpu()
 
     # Save the data.
     if fmt == "numpy":

--- a/tests/python/pytorch/graphbolt/impl/test_ondisk_dataset.py
+++ b/tests/python/pytorch/graphbolt/impl/test_ondisk_dataset.py
@@ -1737,9 +1737,9 @@ def test_OnDiskDataset_load_1D_feature():
         np.save(os.path.join(test_dir, node_feat_path), node_feats)
 
         dataset = gb.OnDiskDataset(test_dir).load()
-        assert dataset.feature.size("node", None, "feat") == torch.Size([1]), (
-            print(dataset.feature.size("node", None, "feat"))
-        )
+        assert dataset.feature.size("node", None, "feat") == torch.Size(
+            [1]
+        ), print(dataset.feature.size("node", None, "feat"))
 
 
 def test_BuiltinDataset():

--- a/tests/python/pytorch/graphbolt/impl/test_ondisk_dataset.py
+++ b/tests/python/pytorch/graphbolt/impl/test_ondisk_dataset.py
@@ -1737,7 +1737,9 @@ def test_OnDiskDataset_load_1D_feature():
         np.save(os.path.join(test_dir, node_feat_path), node_feats)
 
         dataset = gb.OnDiskDataset(test_dir).load()
-        assert dataset.feature.size("node", None, "feat") == torch.Size([1])
+        assert dataset.feature.size("node", None, "feat") == torch.Size([1]), (
+            print(dataset.feature.size("node", None, "feat"))
+        )
 
 
 def test_BuiltinDataset():

--- a/tests/python/pytorch/graphbolt/impl/test_ondisk_dataset.py
+++ b/tests/python/pytorch/graphbolt/impl/test_ondisk_dataset.py
@@ -1711,6 +1711,35 @@ def test_OnDiskDataset_load_tasks():
         dataset = None
 
 
+def test_OnDiskDataset_load_1D_feature():
+    with tempfile.TemporaryDirectory() as test_dir:
+        # All metadata fields are specified.
+        dataset_name = "graphbolt_test"
+        num_nodes = 4000
+        num_edges = 20000
+        num_classes = 1
+
+        # Generate random graph.
+        yaml_content = gbt.random_homo_graphbolt_graph(
+            test_dir,
+            dataset_name,
+            num_nodes,
+            num_edges,
+            num_classes,
+        )
+        yaml_file = os.path.join(test_dir, "metadata.yaml")
+        with open(yaml_file, "w") as f:
+            f.write(yaml_content)
+
+        # Regenerate random 1D node-feats.
+        node_feats = np.random.rand(num_nodes, num_classes).reshape(1, -1)[0]
+        node_feat_path = os.path.join("data", "node-feat.npy")
+        np.save(os.path.join(test_dir, node_feat_path), node_feats)
+
+        dataset = gb.OnDiskDataset(test_dir).load()
+        assert dataset.feature.size("node", None, "feat") == torch.Size([1])
+
+
 def test_BuiltinDataset():
     """Test BuiltinDataset."""
     with tempfile.TemporaryDirectory() as test_dir:

--- a/tests/python/pytorch/graphbolt/impl/test_ondisk_dataset.py
+++ b/tests/python/pytorch/graphbolt/impl/test_ondisk_dataset.py
@@ -1731,7 +1731,7 @@ def test_OnDiskDataset_load_1D_feature():
         with open(yaml_file, "w") as f:
             f.write(yaml_content)
 
-        # Regenerate random 1D node-feats.
+        # Regenerate random 1-D node-feats.
         node_feats = np.random.rand(num_nodes, num_classes).reshape(1, -1)[0]
         node_feat_path = os.path.join("data", "node-feat.npy")
         np.save(os.path.join(test_dir, node_feat_path), node_feats)


### PR DESCRIPTION
## Description
<!-- Brief description. Refer to the related issues if existed.
It'll be great if relevant reviewers can be assigned as well.-->
Support load the **ondisk** datasets with 1D features.

## Checklist
Please feel free to remove inapplicable items for your PR.
- [ ] The PR title starts with [$CATEGORY] (such as [NN], [Model], [Doc], [Feature]])
- [ ] I've leverage the [tools](https://docs.google.com/document/d/1iHyj7zlmygKSk5gBPsqIqL5ASPzJSPREaNT_QdsiYA4/edit) to beautify the python and c++ code.
- [ ] The PR is complete and small, read the [Google eng practice (CL equals to PR)](https://google.github.io/eng-practices/review/developer/small-cls.html) to understand more about small PR. In DGL, we consider PRs with less than 200 lines of core code change are small (example, test and documentation could be exempted).
- [ ] All changes have test coverage
- [ ] Code is well-documented
- [ ] To the best of my knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change
- [ ] Related issue is referred in this PR
- [ ] If the PR is for a new model/paper, I've updated the example index [here](../examples/README.md).

## Changes
<!-- You could use following template
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)
-->
