### PR TITLE
[Graphbolt] Add a load option `original_edge_id` for `preprocess` and `from_dglgraph`

### DIFF
--- a/python/dgl/graphbolt/impl/csc_sampling_graph.py
+++ b/python/dgl/graphbolt/impl/csc_sampling_graph.py
@@ -819,7 +819,9 @@ def save_csc_sampling_graph(graph, filename):
     print(f"CSCSamplingGraph has been saved to {filename}.")
 
 
-def from_dglgraph(g: DGLGraph, is_homogeneous=False) -> CSCSamplingGraph:
+def from_dglgraph(
+    g: DGLGraph, is_homogeneous: bool = False, original_edge_id: bool = False
+) -> CSCSamplingGraph:
     """Convert a DGLGraph to CSCSamplingGraph."""
     homo_g, ntype_count, _ = to_homogeneous(g, return_count=True)
     # Initialize metadata.
@@ -838,8 +840,10 @@ def from_dglgraph(g: DGLGraph, is_homogeneous=False) -> CSCSamplingGraph:
     # Assign edge type according to the order of CSC matrix.
     type_per_edge = None if is_homogeneous else homo_g.edata[ETYPE][edge_ids]
 
-    # Assign edge attributes according to the original eids mapping.
-    edge_attributes = {ORIGINAL_EDGE_ID: homo_g.edata[EID][edge_ids]}
+    edge_attributes = {}
+    if original_edge_id:
+        # Assign edge attributes according to the original eids mapping.
+        edge_attributes[ORIGINAL_EDGE_ID] = homo_g.edata[EID][edge_ids]
 
     return CSCSamplingGraph(
         torch.ops.graphbolt.from_csc(

--- a/python/dgl/graphbolt/impl/csc_sampling_graph.py
+++ b/python/dgl/graphbolt/impl/csc_sampling_graph.py
@@ -820,7 +820,9 @@ def save_csc_sampling_graph(graph, filename):
 
 
 def from_dglgraph(
-    g: DGLGraph, is_homogeneous: bool = False, original_edge_id: bool = False
+    g: DGLGraph,
+    is_homogeneous: bool = False,
+    include_original_edge_id: bool = False,
 ) -> CSCSamplingGraph:
     """Convert a DGLGraph to CSCSamplingGraph."""
     homo_g, ntype_count, _ = to_homogeneous(g, return_count=True)
@@ -841,7 +843,7 @@ def from_dglgraph(
     type_per_edge = None if is_homogeneous else homo_g.edata[ETYPE][edge_ids]
 
     edge_attributes = {}
-    if original_edge_id:
+    if include_original_edge_id:
         # Assign edge attributes according to the original eids mapping.
         edge_attributes[ORIGINAL_EDGE_ID] = homo_g.edata[EID][edge_ids]
 

--- a/python/dgl/graphbolt/impl/ondisk_dataset.py
+++ b/python/dgl/graphbolt/impl/ondisk_dataset.py
@@ -12,7 +12,7 @@ import yaml
 import dgl
 
 from ...data.utils import download, extract_archive
-from ..base import etype_str_to_tuple, ORIGINAL_EDGE_ID
+from ..base import etype_str_to_tuple
 from ..dataset import Dataset, Task
 from ..itemset import ItemSet, ItemSetDict
 from ..utils import read_data, save_data

--- a/python/dgl/graphbolt/impl/ondisk_dataset.py
+++ b/python/dgl/graphbolt/impl/ondisk_dataset.py
@@ -52,7 +52,7 @@ def _copy_or_convert_data(
 
 
 def preprocess_ondisk_dataset(
-    dataset_dir: str, original_edge_id: bool = False
+    dataset_dir: str, include_original_edge_id: bool = False
 ) -> str:
     """Preprocess the on-disk dataset. Parse the input config file,
     load the data, and save the data in the format that GraphBolt supports.
@@ -154,7 +154,9 @@ def preprocess_ondisk_dataset(
                 g.edata[graph_feature["name"]] = edge_data
 
     # 4. Convert the DGLGraph to a CSCSamplingGraph.
-    csc_sampling_graph = from_dglgraph(g, is_homogeneous, original_edge_id)
+    csc_sampling_graph = from_dglgraph(
+        g, is_homogeneous, include_original_edge_id
+    )
 
     # 5. Save the CSCSamplingGraph and modify the output_config.
     output_config["graph_topology"] = {}
@@ -353,11 +355,13 @@ class OnDiskDataset(Dataset):
         The YAML file path.
     """
 
-    def __init__(self, path: str, original_edge_id: bool = False) -> None:
+    def __init__(
+        self, path: str, include_original_edge_id: bool = False
+    ) -> None:
         # Always call the preprocess function first. If already preprocessed,
         # the function will return the original path directly.
         self._dataset_dir = path
-        yaml_path = preprocess_ondisk_dataset(path, original_edge_id)
+        yaml_path = preprocess_ondisk_dataset(path, include_original_edge_id)
         with open(yaml_path) as f:
             self._yaml_data = yaml.load(f, Loader=yaml.loader.SafeLoader)
 

--- a/python/dgl/graphbolt/impl/ondisk_dataset.py
+++ b/python/dgl/graphbolt/impl/ondisk_dataset.py
@@ -12,7 +12,7 @@ import yaml
 import dgl
 
 from ...data.utils import download, extract_archive
-from ..base import etype_str_to_tuple
+from ..base import etype_str_to_tuple, ORIGINAL_EDGE_ID
 from ..dataset import Dataset, Task
 from ..itemset import ItemSet, ItemSetDict
 from ..utils import read_data, save_data
@@ -51,7 +51,9 @@ def _copy_or_convert_data(
         save_data(data, output_path, output_format)
 
 
-def preprocess_ondisk_dataset(dataset_dir: str) -> str:
+def preprocess_ondisk_dataset(
+    dataset_dir: str, original_edge_id: bool = False
+) -> str:
     """Preprocess the on-disk dataset. Parse the input config file,
     load the data, and save the data in the format that GraphBolt supports.
 
@@ -152,7 +154,7 @@ def preprocess_ondisk_dataset(dataset_dir: str) -> str:
                 g.edata[graph_feature["name"]] = edge_data
 
     # 4. Convert the DGLGraph to a CSCSamplingGraph.
-    csc_sampling_graph = from_dglgraph(g, is_homogeneous)
+    csc_sampling_graph = from_dglgraph(g, is_homogeneous, original_edge_id)
 
     # 5. Save the CSCSamplingGraph and modify the output_config.
     output_config["graph_topology"] = {}
@@ -351,11 +353,11 @@ class OnDiskDataset(Dataset):
         The YAML file path.
     """
 
-    def __init__(self, path: str) -> None:
+    def __init__(self, path: str, original_edge_id: bool = False) -> None:
         # Always call the preprocess function first. If already preprocessed,
         # the function will return the original path directly.
         self._dataset_dir = path
-        yaml_path = preprocess_ondisk_dataset(path)
+        yaml_path = preprocess_ondisk_dataset(path, original_edge_id)
         with open(yaml_path) as f:
             self._yaml_data = yaml.load(f, Loader=yaml.loader.SafeLoader)
 

--- a/tests/python/pytorch/graphbolt/impl/test_csc_sampling_graph.py
+++ b/tests/python/pytorch/graphbolt/impl/test_csc_sampling_graph.py
@@ -1297,13 +1297,17 @@ def test_from_dglgraph_homogeneous():
 
     # Check if the original edge id exist in edge attributes when the
     # original_edge_id is set to False.
-    gb_g = gb.from_dglgraph(dgl_g, is_homogeneous=False, original_edge_id=False)
+    gb_g = gb.from_dglgraph(
+        dgl_g, is_homogeneous=False, include_original_edge_id=False
+    )
     assert (
         gb_g.edge_attributes is None
         or gb.ORIGINAL_EDGE_ID not in gb_g.edge_attributes
     )
 
-    gb_g = gb.from_dglgraph(dgl_g, is_homogeneous=True, original_edge_id=True)
+    gb_g = gb.from_dglgraph(
+        dgl_g, is_homogeneous=True, include_original_edge_id=True
+    )
     # Get the COO representation of the CSCSamplingGraph.
     num_columns = gb_g.csc_indptr[1:] - gb_g.csc_indptr[:-1]
     rows = gb_g.indices
@@ -1345,13 +1349,17 @@ def test_from_dglgraph_heterogeneous():
     )
     # Check if the original edge id exist in edge attributes when the
     # original_edge_id is set to False.
-    gb_g = gb.from_dglgraph(dgl_g, is_homogeneous=False, original_edge_id=False)
+    gb_g = gb.from_dglgraph(
+        dgl_g, is_homogeneous=False, include_original_edge_id=False
+    )
     assert (
         gb_g.edge_attributes is None
         or gb.ORIGINAL_EDGE_ID not in gb_g.edge_attributes
     )
 
-    gb_g = gb.from_dglgraph(dgl_g, is_homogeneous=False, original_edge_id=True)
+    gb_g = gb.from_dglgraph(
+        dgl_g, is_homogeneous=False, include_original_edge_id=True
+    )
 
     # `reverse_node_id` is used to map the node id in CSCSamplingGraph to the
     # node id in Hetero-DGLGraph.

--- a/tests/python/pytorch/graphbolt/impl/test_csc_sampling_graph.py
+++ b/tests/python/pytorch/graphbolt/impl/test_csc_sampling_graph.py
@@ -1294,8 +1294,16 @@ def test_multiprocessing_with_shared_memory():
 )
 def test_from_dglgraph_homogeneous():
     dgl_g = dgl.rand_graph(1000, 10 * 1000)
-    gb_g = gb.from_dglgraph(dgl_g, is_homogeneous=True)
 
+    # Check if the original edge id exist in edge attributes when the
+    # original_edge_id is set to False.
+    gb_g = gb.from_dglgraph(dgl_g, is_homogeneous=False, original_edge_id=False)
+    assert (
+        gb_g.edge_attributes is None
+        or gb.ORIGINAL_EDGE_ID not in gb_g.edge_attributes
+    )
+
+    gb_g = gb.from_dglgraph(dgl_g, is_homogeneous=True, original_edge_id=True)
     # Get the COO representation of the CSCSamplingGraph.
     num_columns = gb_g.csc_indptr[1:] - gb_g.csc_indptr[:-1]
     rows = gb_g.indices
@@ -1335,7 +1343,15 @@ def test_from_dglgraph_heterogeneous():
             ),
         }
     )
-    gb_g = gb.from_dglgraph(dgl_g, is_homogeneous=False)
+    # Check if the original edge id exist in edge attributes when the
+    # original_edge_id is set to False.
+    gb_g = gb.from_dglgraph(dgl_g, is_homogeneous=False, original_edge_id=False)
+    assert (
+        gb_g.edge_attributes is None
+        or gb.ORIGINAL_EDGE_ID not in gb_g.edge_attributes
+    )
+
+    gb_g = gb.from_dglgraph(dgl_g, is_homogeneous=False, original_edge_id=True)
 
     # `reverse_node_id` is used to map the node id in CSCSamplingGraph to the
     # node id in Hetero-DGLGraph.

--- a/tests/python/pytorch/graphbolt/impl/test_ondisk_dataset.py
+++ b/tests/python/pytorch/graphbolt/impl/test_ondisk_dataset.py
@@ -2,7 +2,6 @@ import os
 import pickle
 import random
 import re
-import shutil
 import tempfile
 import unittest
 
@@ -1074,7 +1073,7 @@ def test_OnDiskDataset_preprocess_homogeneous():
         with open(yaml_file, "w") as f:
             f.write(yaml_content)
         output_file = gb.ondisk_dataset.preprocess_ondisk_dataset(
-            test_dir, original_edge_id=False
+            test_dir, include_original_edge_id=False
         )
 
         with open(output_file, "rb") as f:
@@ -1123,7 +1122,7 @@ def test_OnDiskDataset_preprocess_homogeneous():
             f.write(yaml_content)
         # Test do not generate original_edge_id.
         output_file = gb.ondisk_dataset.preprocess_ondisk_dataset(
-            test_dir, original_edge_id=False
+            test_dir, include_original_edge_id=False
         )
         with open(output_file, "rb") as f:
             processed_dataset = yaml.load(f, Loader=yaml.Loader)
@@ -1618,7 +1617,9 @@ def test_OnDiskDataset_load_graph():
             f.write(yaml_content)
 
         # Check the different original_edge_id option to load edge_attributes.
-        dataset = gb.OnDiskDataset(test_dir, original_edge_id=True).load()
+        dataset = gb.OnDiskDataset(
+            test_dir, include_original_edge_id=True
+        ).load()
         assert (
             dataset.graph.edge_attributes is not None
             and gb.ORIGINAL_EDGE_ID in dataset.graph.edge_attributes
@@ -1683,7 +1684,9 @@ def test_OnDiskDataset_load_graph():
             f.write(yaml_content)
 
         # Test do not generate original_edge_id.
-        dataset = gb.OnDiskDataset(test_dir, original_edge_id=False).load()
+        dataset = gb.OnDiskDataset(
+            test_dir, include_original_edge_id=False
+        ).load()
         assert (
             dataset.graph.edge_attributes is None
             or gb.ORIGINAL_EDGE_ID not in dataset.graph.edge_attributes

--- a/tests/python/pytorch/graphbolt/impl/test_ondisk_dataset.py
+++ b/tests/python/pytorch/graphbolt/impl/test_ondisk_dataset.py
@@ -1103,9 +1103,24 @@ def test_OnDiskDataset_preprocess_homogeneous():
         )
         assert len(subgraph.node_pairs[0]) <= num_samples
 
-        # Delete the preprocessed directory to re-preprocess.
-        shutil.rmtree(os.path.join(test_dir, "preprocessed"))
-        assert not os.path.exists(os.path.join(test_dir, "preprocessed"))
+    with tempfile.TemporaryDirectory() as test_dir:
+        # All metadata fields are specified.
+        dataset_name = "graphbolt_test"
+        num_nodes = 4000
+        num_edges = 20000
+        num_classes = 10
+
+        # Generate random graph.
+        yaml_content = gbt.random_homo_graphbolt_graph(
+            test_dir,
+            dataset_name,
+            num_nodes,
+            num_edges,
+            num_classes,
+        )
+        yaml_file = os.path.join(test_dir, "metadata.yaml")
+        with open(yaml_file, "w") as f:
+            f.write(yaml_content)
         # Test do not generate original_edge_id.
         output_file = gb.ondisk_dataset.preprocess_ondisk_dataset(
             test_dir, original_edge_id=False
@@ -1119,6 +1134,7 @@ def test_OnDiskDataset_preprocess_homogeneous():
             csc_sampling_graph.edge_attributes is not None
             and gb.ORIGINAL_EDGE_ID not in csc_sampling_graph.edge_attributes
         )
+        csc_sampling_graph = None
 
 
 def test_OnDiskDataset_preprocess_path():
@@ -1607,14 +1623,6 @@ def test_OnDiskDataset_load_graph():
             dataset.graph.edge_attributes is not None
             and gb.ORIGINAL_EDGE_ID in dataset.graph.edge_attributes
         )
-        # Delete the preprocessed directory to re-preprocess.
-        shutil.rmtree(os.path.join(test_dir, "preprocessed"))
-        assert not os.path.exists(os.path.join(test_dir, "preprocessed"))
-        dataset = gb.OnDiskDataset(test_dir, original_edge_id=False).load()
-        assert (
-            dataset.graph.edge_attributes is None
-            or gb.ORIGINAL_EDGE_ID not in dataset.graph.edge_attributes
-        )
 
         # Case1. Test modify the `type` field.
         dataset = gb.OnDiskDataset(test_dir)
@@ -1653,6 +1661,33 @@ def test_OnDiskDataset_load_graph():
         )
         original_graph = None
         modify_graph = None
+        dataset = None
+
+    with tempfile.TemporaryDirectory() as test_dir:
+        # All metadata fields are specified.
+        dataset_name = "graphbolt_test"
+        num_nodes = 4000
+        num_edges = 20000
+        num_classes = 10
+
+        # Generate random graph.
+        yaml_content = gbt.random_homo_graphbolt_graph(
+            test_dir,
+            dataset_name,
+            num_nodes,
+            num_edges,
+            num_classes,
+        )
+        yaml_file = os.path.join(test_dir, "metadata.yaml")
+        with open(yaml_file, "w") as f:
+            f.write(yaml_content)
+
+        # Test do not generate original_edge_id.
+        dataset = gb.OnDiskDataset(test_dir, original_edge_id=False).load()
+        assert (
+            dataset.graph.edge_attributes is None
+            or gb.ORIGINAL_EDGE_ID not in dataset.graph.edge_attributes
+        )
         dataset = None
 
 


### PR DESCRIPTION
## Description
<!-- Brief description. Refer to the related issues if existed.
It'll be great if relevant reviewers can be assigned as well.-->
Add a load option `original_edge_id` for `preprocess` and `from_dglgraph`. 

After adding this option, we should determine the need for `gb.ORIGINAL_EDGE_ID` before preprocessing.

- [x] This is the final PR to address this Issue: [[GraphBolt] Enable CSCSamplingGraph::edge_attributes save and load. #6406](https://github.com/dmlc/dgl/issues/6406)




## Checklist
Please feel free to remove inapplicable items for your PR.
- [x] The PR title starts with [$CATEGORY] (such as [NN], [Model], [Doc], [Feature]])
- [x] I've leverage the [tools](https://docs.google.com/document/d/1iHyj7zlmygKSk5gBPsqIqL5ASPzJSPREaNT_QdsiYA4/edit) to beautify the python and c++ code.
- [x] The PR is complete and small, read the [Google eng practice (CL equals to PR)](https://google.github.io/eng-practices/review/developer/small-cls.html) to understand more about small PR. In DGL, we consider PRs with less than 200 lines of core code change are small (example, test and documentation could be exempted).
- [x] All changes have test coverage
- [x] Code is well-documented
- [x] To the best of my knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change
- [x] Related issue is referred in this PR
- [x] If the PR is for a new model/paper, I've updated the example index [here](../examples/README.md).

## Changes
<!-- You could use following template
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)
-->
