### PR TITLE
[GraphBolt] enable indexing on ItemSet instance

### DIFF
--- a/python/dgl/graphbolt/itemset.py
+++ b/python/dgl/graphbolt/itemset.py
@@ -89,10 +89,7 @@ class ItemSet:
         items: Union[int, Iterable, Tuple[Iterable]],
         names: Union[str, Tuple[str]] = None,
     ) -> None:
-        if isinstance(items, int):
-            self._items = items
-            self._internal_items = None  # For indexing.
-        elif isinstance(items, tuple):
+        if isinstance(items, int) or isinstance(items, tuple):
             self._items = items
         else:
             self._items = (items,)
@@ -154,13 +151,12 @@ class ItemSet:
                 f"{type(self).__name__} instance doesn't support indexing."
             )
         if isinstance(self._items, int):
-            # [TODO][Rui] Indexing probably could be further optimized. For
-            # example, if the index is an integer or list, we can directly
-            # return the items without instantiating the whole range. This
-            # is the most common case in GraphBolt(``ItemSampler``).
-            if self._internal_items is None:
-                self._internal_items = torch.arange(self._items)
-            return self._internal_items[idx]
+            assert isinstance(idx, int) or isinstance(idx, torch.Tensor), (
+                f"Indexing of integer-initialized {type(self).__name__} "
+                f"instance must be int or torch.Tensor."
+            )
+            # [Warning] Index range is not checked.
+            return idx
         if len(self._items) == 1:
             return self._items[0][idx]
         return tuple(item[idx] for item in self._items)

--- a/python/dgl/graphbolt/itemset.py
+++ b/python/dgl/graphbolt/itemset.py
@@ -37,7 +37,7 @@ class ItemSet:
     >>> list(item_set)
     [tensor(0), tensor(1), tensor(2), tensor(3), tensor(4), tensor(5),
      tensor(6), tensor(7), tensor(8), tensor(9)]
-    >>> item_set[:]
+    >>> item_set[torch.arange(0, num)]
     tensor([0, 1, 2, 3, 4, 5, 6, 7, 8, 9])
     >>> item_set.names
     ('seed_nodes',)

--- a/python/dgl/graphbolt/itemset.py
+++ b/python/dgl/graphbolt/itemset.py
@@ -35,7 +35,10 @@ class ItemSet:
     >>> num = 10
     >>> item_set = gb.ItemSet(num, names="seed_nodes")
     >>> list(item_set)
-    [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
+    [tensor(0), tensor(1), tensor(2), tensor(3), tensor(4), tensor(5),
+     tensor(6), tensor(7), tensor(8), tensor(9)]
+    >>> item_set[:]
+    tensor([0, 1, 2, 3, 4, 5, 6, 7, 8, 9])
     >>> item_set.names
     ('seed_nodes',)
 
@@ -44,6 +47,8 @@ class ItemSet:
     >>> item_set = gb.ItemSet(node_ids, names="seed_nodes")
     >>> list(item_set)
     [tensor(0), tensor(1), tensor(2), tensor(3), tensor(4)]
+    >>> item_set[:]
+    tensor([0, 1, 2, 3, 4])
     >>> item_set.names
     ('seed_nodes',)
 
@@ -55,6 +60,8 @@ class ItemSet:
     >>> list(item_set)
     [(tensor(0), tensor(5)), (tensor(1), tensor(6)), (tensor(2), tensor(7)),
      (tensor(3), tensor(8)), (tensor(4), tensor(9))]
+    >>> item_set[:]
+    (tensor([0, 1, 2, 3, 4]), tensor([5, 6, 7, 8, 9]))
     >>> item_set.names
     ('seed_nodes', 'labels')
 
@@ -69,6 +76,10 @@ class ItemSet:
      (tensor([4, 5]), tensor([16, 17, 18])),
      (tensor([6, 7]), tensor([19, 20, 21])),
      (tensor([8, 9]), tensor([22, 23, 24]))]
+    >>> item_set[:]
+    (tensor([[0, 1], [2, 3], [4, 5], [6, 7],[8, 9]]),
+     tensor([[10, 11, 12], [13, 14, 15], [16, 17, 18], [19, 20, 21],
+        [22, 23, 24]]))
     >>> item_set.names
     ('node_pairs', 'negative_dsts')
     """

--- a/python/dgl/graphbolt/itemset.py
+++ b/python/dgl/graphbolt/itemset.py
@@ -89,7 +89,7 @@ class ItemSet:
         items: Union[int, Iterable, Tuple[Iterable]],
         names: Union[str, Tuple[str]] = None,
     ) -> None:
-        if isinstance(items, int) or isinstance(items, tuple):
+        if isinstance(items, (int, tuple)):
             self._items = items
         else:
             self._items = (items,)
@@ -151,7 +151,7 @@ class ItemSet:
                 f"{type(self).__name__} instance doesn't support indexing."
             )
         if isinstance(self._items, int):
-            assert isinstance(idx, int) or isinstance(idx, torch.Tensor), (
+            assert isinstance(idx, (int, torch.Tensor)), (
                 f"Indexing of integer-initialized {type(self).__name__} "
                 f"instance must be int or torch.Tensor."
             )

--- a/tests/python/pytorch/graphbolt/test_itemset.py
+++ b/tests/python/pytorch/graphbolt/test_itemset.py
@@ -114,8 +114,15 @@ def test_ItemSet_seed_nodes():
         assert i == item.item()
         assert i == item_set[i]
     # Indexing with a slice.
-    assert torch.equal(item_set[:], torch.arange(0, 5))
-    # Indexing with an Iterable.
+    with pytest.raises(
+        AssertionError,
+        match=(
+            "Indexing of integer-initialized ItemSet instance must be int or "
+            "torch.Tensor."
+        ),
+    ):
+        _ = item_set[:]
+    # Indexing with an Tensor.
     assert torch.equal(item_set[torch.arange(0, 5)], torch.arange(0, 5))
 
 

--- a/tests/python/pytorch/graphbolt/test_itemset.py
+++ b/tests/python/pytorch/graphbolt/test_itemset.py
@@ -94,7 +94,7 @@ def test_ItemSet_length():
 
 
 def test_ItemSet_seed_nodes():
-    # Node IDs.
+    # Node IDs with tensor.
     item_set = gb.ItemSet(torch.arange(0, 5), names="seed_nodes")
     assert item_set.names == ("seed_nodes",)
     # Iterating over ItemSet and indexing one by one.
@@ -103,6 +103,20 @@ def test_ItemSet_seed_nodes():
         assert i == item_set[i]
     # Indexing with a slice.
     assert torch.equal(item_set[:], torch.arange(0, 5))
+    # Indexing with an Iterable.
+    assert torch.equal(item_set[torch.arange(0, 5)], torch.arange(0, 5))
+
+    # Node IDs with single integer.
+    item_set = gb.ItemSet(5, names="seed_nodes")
+    assert item_set.names == ("seed_nodes",)
+    # Iterating over ItemSet and indexing one by one.
+    for i, item in enumerate(item_set):
+        assert i == item.item()
+        assert i == item_set[i]
+    # Indexing with a slice.
+    assert torch.equal(item_set[:], torch.arange(0, 5))
+    # Indexing with an Iterable.
+    assert torch.equal(item_set[torch.arange(0, 5)], torch.arange(0, 5))
 
 
 def test_ItemSet_seed_nodes_labels():
@@ -120,6 +134,9 @@ def test_ItemSet_seed_nodes_labels():
     # Indexing with a slice.
     assert torch.equal(item_set[:][0], seed_nodes)
     assert torch.equal(item_set[:][1], labels)
+    # Indexing with an Iterable.
+    assert torch.equal(item_set[torch.arange(0, 5)][0], seed_nodes)
+    assert torch.equal(item_set[torch.arange(0, 5)][1], labels)
 
 
 def test_ItemSet_node_pairs():
@@ -135,6 +152,8 @@ def test_ItemSet_node_pairs():
         assert node_pairs[i][1] == item_set[i][1]
     # Indexing with a slice.
     assert torch.equal(item_set[:], node_pairs)
+    # Indexing with an Iterable.
+    assert torch.equal(item_set[torch.arange(0, 5)], node_pairs)
 
 
 def test_ItemSet_node_pairs_labels():
@@ -152,6 +171,9 @@ def test_ItemSet_node_pairs_labels():
     # Indexing with a slice.
     assert torch.equal(item_set[:][0], node_pairs)
     assert torch.equal(item_set[:][1], labels)
+    # Indexing with an Iterable.
+    assert torch.equal(item_set[torch.arange(0, 5)][0], node_pairs)
+    assert torch.equal(item_set[torch.arange(0, 5)][1], labels)
 
 
 def test_ItemSet_node_pairs_neg_dsts():
@@ -171,6 +193,9 @@ def test_ItemSet_node_pairs_neg_dsts():
     # Indexing with a slice.
     assert torch.equal(item_set[:][0], node_pairs)
     assert torch.equal(item_set[:][1], neg_dsts)
+    # Indexing with an Iterable.
+    assert torch.equal(item_set[torch.arange(0, 5)][0], node_pairs)
+    assert torch.equal(item_set[torch.arange(0, 5)][1], neg_dsts)
 
 
 def test_ItemSet_graphs():

--- a/tests/python/pytorch/graphbolt/test_itemset.py
+++ b/tests/python/pytorch/graphbolt/test_itemset.py
@@ -26,9 +26,7 @@ def test_ItemSet_names():
     # Integer-initiated ItemSet with excessive names.
     with pytest.raises(
         AssertionError,
-        match=re.escape(
-            "Number of names mustn't exceed 1 when item is an integer."
-        ),
+        match=re.escape("Number of items (1) and names (2) must match."),
     ):
         _ = gb.ItemSet(5, names=("seed_nodes", "labels"))
 
@@ -69,61 +67,94 @@ def test_ItemSet_length():
 
     # Single iterable with invalid length.
     item_set = gb.ItemSet(InvalidLength())
-    with pytest.raises(TypeError):
+    with pytest.raises(
+        TypeError, match="ItemSet instance doesn't have valid length."
+    ):
         _ = len(item_set)
+    with pytest.raises(
+        TypeError, match="ItemSet instance doesn't support indexing."
+    ):
+        _ = item_set[0]
     for i, item in enumerate(item_set):
         assert i == item
 
     # Tuple of iterables with invalid length.
     item_set = gb.ItemSet((InvalidLength(), InvalidLength()))
-    with pytest.raises(TypeError):
+    with pytest.raises(
+        TypeError, match="ItemSet instance doesn't have valid length."
+    ):
         _ = len(item_set)
+    with pytest.raises(
+        TypeError, match="ItemSet instance doesn't support indexing."
+    ):
+        _ = item_set[0]
     for i, (item1, item2) in enumerate(item_set):
         assert i == item1
         assert i == item2
 
 
-def test_ItemSet_iteration_seed_nodes():
+def test_ItemSet_seed_nodes():
     # Node IDs.
     item_set = gb.ItemSet(torch.arange(0, 5), names="seed_nodes")
     assert item_set.names == ("seed_nodes",)
+    # Iterating over ItemSet and indexing one by one.
     for i, item in enumerate(item_set):
         assert i == item.item()
+        assert i == item_set[i]
+    # Indexing with a slice.
+    assert torch.equal(item_set[:], torch.arange(0, 5))
 
 
-def test_ItemSet_iteration_seed_nodes_labels():
+def test_ItemSet_seed_nodes_labels():
     # Node IDs and labels.
     seed_nodes = torch.arange(0, 5)
     labels = torch.randint(0, 3, (5,))
     item_set = gb.ItemSet((seed_nodes, labels), names=("seed_nodes", "labels"))
     assert item_set.names == ("seed_nodes", "labels")
+    # Iterating over ItemSet and indexing one by one.
     for i, (seed_node, label) in enumerate(item_set):
         assert seed_node == seed_nodes[i]
         assert label == labels[i]
+        assert seed_node == item_set[i][0]
+        assert label == item_set[i][1]
+    # Indexing with a slice.
+    assert torch.equal(item_set[:][0], seed_nodes)
+    assert torch.equal(item_set[:][1], labels)
 
 
-def test_ItemSet_iteration_node_pairs():
+def test_ItemSet_node_pairs():
     # Node pairs.
     node_pairs = torch.arange(0, 10).reshape(-1, 2)
     item_set = gb.ItemSet(node_pairs, names="node_pairs")
     assert item_set.names == ("node_pairs",)
+    # Iterating over ItemSet and indexing one by one.
     for i, (src, dst) in enumerate(item_set):
         assert node_pairs[i][0] == src
         assert node_pairs[i][1] == dst
+        assert node_pairs[i][0] == item_set[i][0]
+        assert node_pairs[i][1] == item_set[i][1]
+    # Indexing with a slice.
+    assert torch.equal(item_set[:], node_pairs)
 
 
-def test_ItemSet_iteration_node_pairs_labels():
+def test_ItemSet_node_pairs_labels():
     # Node pairs and labels
     node_pairs = torch.arange(0, 10).reshape(-1, 2)
     labels = torch.randint(0, 3, (5,))
     item_set = gb.ItemSet((node_pairs, labels), names=("node_pairs", "labels"))
     assert item_set.names == ("node_pairs", "labels")
+    # Iterating over ItemSet and indexing one by one.
     for i, (node_pair, label) in enumerate(item_set):
         assert torch.equal(node_pairs[i], node_pair)
         assert labels[i] == label
+        assert torch.equal(node_pairs[i], item_set[i][0])
+        assert labels[i] == item_set[i][1]
+    # Indexing with a slice.
+    assert torch.equal(item_set[:][0], node_pairs)
+    assert torch.equal(item_set[:][1], labels)
 
 
-def test_ItemSet_iteration_node_pairs_neg_dsts():
+def test_ItemSet_node_pairs_neg_dsts():
     # Node pairs and negative destinations.
     node_pairs = torch.arange(0, 10).reshape(-1, 2)
     neg_dsts = torch.arange(10, 25).reshape(-1, 3)
@@ -131,18 +162,28 @@ def test_ItemSet_iteration_node_pairs_neg_dsts():
         (node_pairs, neg_dsts), names=("node_pairs", "negative_dsts")
     )
     assert item_set.names == ("node_pairs", "negative_dsts")
+    # Iterating over ItemSet and indexing one by one.
     for i, (node_pair, neg_dst) in enumerate(item_set):
         assert torch.equal(node_pairs[i], node_pair)
         assert torch.equal(neg_dsts[i], neg_dst)
+        assert torch.equal(node_pairs[i], item_set[i][0])
+        assert torch.equal(neg_dsts[i], item_set[i][1])
+    # Indexing with a slice.
+    assert torch.equal(item_set[:][0], node_pairs)
+    assert torch.equal(item_set[:][1], neg_dsts)
 
 
-def test_ItemSet_iteration_graphs():
+def test_ItemSet_graphs():
     # Graphs.
     graphs = [dgl.rand_graph(10, 20) for _ in range(5)]
     item_set = gb.ItemSet(graphs)
     assert item_set.names is None
+    # Iterating over ItemSet and indexing one by one.
     for i, item in enumerate(item_set):
         assert graphs[i] == item
+        assert graphs[i] == item_set[i]
+    # Indexing with a slice.
+    assert item_set[:] == graphs
 
 
 def test_ItemSetDict_names():


### PR DESCRIPTION
## Description
<!-- Brief description. Refer to the related issues if existed.
It'll be great if relevant reviewers can be assigned as well.-->
This PR is part of performance improvement for shuffle/batching in `ItemSampler`.

see more details in https://quip-amazon.com/bIfOAW6GMsIG/Benchmark-on-rgcnhetero#temp:C:FIGba38038eb04347578db86f3f1
## Checklist
Please feel free to remove inapplicable items for your PR.
- [ ] The PR title starts with [$CATEGORY] (such as [NN], [Model], [Doc], [Feature]])
- [ ] I've leverage the [tools](https://docs.google.com/document/d/1iHyj7zlmygKSk5gBPsqIqL5ASPzJSPREaNT_QdsiYA4/edit) to beautify the python and c++ code.
- [ ] The PR is complete and small, read the [Google eng practice (CL equals to PR)](https://google.github.io/eng-practices/review/developer/small-cls.html) to understand more about small PR. In DGL, we consider PRs with less than 200 lines of core code change are small (example, test and documentation could be exempted).
- [ ] All changes have test coverage
- [ ] Code is well-documented
- [ ] To the best of my knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change
- [ ] Related issue is referred in this PR
- [ ] If the PR is for a new model/paper, I've updated the example index [here](../examples/README.md).

## Changes
<!-- You could use following template
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)
-->
