### PR TITLE
[GraphBolt] Ensure the contiguity of the `TorchBasedFeature._tensor`.

### DIFF
--- a/python/dgl/graphbolt/impl/torch_based_feature_store.py
+++ b/python/dgl/graphbolt/impl/torch_based_feature_store.py
@@ -69,6 +69,12 @@ class TorchBasedFeature(Feature):
             f"dimension of torch_feature in TorchBasedFeature must be greater "
             f"than 1, but got {torch_feature.dim()} dimension."
         )
+        if not torch_feature.is_contiguous():
+            Warning(
+                f"torch_feature in TorchBasedFeature is not contiguous, "
+                f"so it will be copied to contiguous memory."
+            )
+            torch_feature = torch_feature.contiguous()
         self._tensor = torch_feature
 
     def read(self, ids: torch.Tensor = None):

--- a/tests/python/pytorch/graphbolt/impl/test_torch_based_feature_store.py
+++ b/tests/python/pytorch/graphbolt/impl/test_torch_based_feature_store.py
@@ -86,6 +86,44 @@ def test_torch_based_feature(in_memory):
         a = b = None
         feature_a = feature_b = None
 
+        # Test loaded tensors' contiguity from C/Fortran contiguous ndarray.
+        C_contiguous_numpy = np.array([[1, 2, 3], [4, 5, 6]], order="C")
+        Fortran_contiguous_numpy = np.array([[1, 2, 3], [4, 5, 6]], order="F")
+        assert C_contiguous_numpy.flags["C_CONTIGUOUS"]
+        assert Fortran_contiguous_numpy.flags["F_CONTIGUOUS"]
+        np.save(
+            os.path.join(test_dir, "C_contiguous_numpy.npy"), C_contiguous_numpy
+        )
+        np.save(
+            os.path.join(test_dir, "Fortran_contiguous_numpy.npy"),
+            Fortran_contiguous_numpy,
+        )
+
+        cur_mmap_mode = None
+        if not in_memory:
+            cur_mmap_mode = "r+"
+        feature_a = gb.TorchBasedFeature(
+            torch.from_numpy(
+                np.load(
+                    os.path.join(test_dir, "C_contiguous_numpy.npy"),
+                    mmap_mode=cur_mmap_mode,
+                )
+            )
+        )
+        feature_b = gb.TorchBasedFeature(
+            torch.from_numpy(
+                np.load(
+                    os.path.join(test_dir, "Fortran_contiguous_numpy.npy"),
+                    mmap_mode=cur_mmap_mode,
+                )
+            )
+        )
+        assert feature_a._tensor.is_contiguous()
+        assert feature_b._tensor.is_contiguous()
+
+        C_contiguous_numpy = Fortran_contiguous_numpy = None
+        feature_a = feature_b = None
+
 
 def write_tensor_to_disk(dir, name, t, fmt="torch"):
     if fmt == "torch":


### PR DESCRIPTION
## Description
<!-- Brief description. Refer to the related issues if existed.
It'll be great if relevant reviewers can be assigned as well.-->
The features of the raw OGB dataset may not always be **C-contiguous**; sometimes, they are **Fortran-contiguous** (column-major order). A tensor derived from NumPy will be contiguous if the original numpy.ndarray is C-contiguous. Operations can significantly slow down when the tensor is not contiguous.

The time complexity of `is_contiguous` is $O(dim)$ ([refer to PyTorch](https://github.com/pytorch/pytorch/blob/a7f6b0ab4fa4e43a2fa7bcb53825277db88b55f0/torch/lib/TH/generic/THTensor.c#L639-L654)), which is essentially cost-free.

Therefore, we have added some checks and transformations in `TorchBasedFeature` to ensure contiguity.

---
The following code can be used to check the contiguity of a `numpy.ndarray`:
```shell
In [x]: raw_ogb_feat.flags
Out[x]: 
  C_CONTIGUOUS : False
  F_CONTIGUOUS : True
  OWNDATA : False
  WRITEABLE : True
  ALIGNED : True
  WRITEBACKIFCOPY : False
```


## Checklist
Please feel free to remove inapplicable items for your PR.
- [x] The PR title starts with [$CATEGORY] (such as [NN], [Model], [Doc], [Feature]])
- [x] I've leverage the [tools](https://docs.google.com/document/d/1iHyj7zlmygKSk5gBPsqIqL5ASPzJSPREaNT_QdsiYA4/edit) to beautify the python and c++ code.
- [x] The PR is complete and small, read the [Google eng practice (CL equals to PR)](https://google.github.io/eng-practices/review/developer/small-cls.html) to understand more about small PR. In DGL, we consider PRs with less than 200 lines of core code change are small (example, test and documentation could be exempted).
- [x] All changes have test coverage
- [x] Code is well-documented
- [x] To the best of my knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change
- [ ] Related issue is referred in this PR
- [ ] If the PR is for a new model/paper, I've updated the example index [here](../examples/README.md).

## Changes
<!-- You could use following template
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)
-->
