### PR TITLE
[GraphBolt] Add names to `ItemSets` in `_init_all_nodes_set`

### DIFF
--- a/examples/sampling/graphbolt/link_prediction.py
+++ b/examples/sampling/graphbolt/link_prediction.py
@@ -348,7 +348,7 @@ def main(args):
     valid_set = dataset.tasks[0].validation_set
     args.fanout = list(map(int, args.fanout.split(",")))
 
-    in_size = 128
+    in_size = features.size("node", None, "feat")[0]
     hidden_channels = 256
     model = SAGE(in_size, hidden_channels)
 

--- a/python/dgl/graphbolt/impl/ondisk_dataset.py
+++ b/python/dgl/graphbolt/impl/ondisk_dataset.py
@@ -2,9 +2,9 @@
 
 import os
 import shutil
+import warnings
 from copy import deepcopy
 from typing import Dict, List, Union
-import warnings
 
 import pandas as pd
 import torch
@@ -493,15 +493,16 @@ class OnDiskDataset(Dataset):
         if graph is None:
             warnings.warn(
                 "Initializing `all_nodes_set` with a graph whose type does "
-                "not belong to SamplingGraph", Warning
+                "not belong to SamplingGraph",
+                Warning,
             )
             return None
         num_nodes = graph.num_nodes
         if isinstance(num_nodes, int):
-            return ItemSet(num_nodes)
+            return ItemSet(num_nodes, names="seed_nodes")
         else:
             data = {
-                node_type: ItemSet(num_node)
+                node_type: ItemSet(num_node, names="seed_nodes")
                 for node_type, num_node in num_nodes.items()
             }
             return ItemSetDict(data)

--- a/python/dgl/graphbolt/impl/ondisk_dataset.py
+++ b/python/dgl/graphbolt/impl/ondisk_dataset.py
@@ -2,7 +2,6 @@
 
 import os
 import shutil
-import warnings
 from copy import deepcopy
 from typing import Dict, List, Union
 
@@ -12,6 +11,7 @@ import yaml
 
 import dgl
 
+from ...base import dgl_warning
 from ...data.utils import download, extract_archive
 from ..base import etype_str_to_tuple
 from ..dataset import Dataset, Task
@@ -499,10 +499,9 @@ class OnDiskDataset(Dataset):
 
     def _init_all_nodes_set(self, graph) -> Union[ItemSet, ItemSetDict]:
         if graph is None:
-            warnings.warn(
+            dgl_warning(
                 "Initializing `all_nodes_set` with a graph whose type does "
-                "not belong to SamplingGraph",
-                Warning,
+                "not belong to SamplingGraph"
             )
             return None
         num_nodes = graph.num_nodes

--- a/python/dgl/graphbolt/impl/ondisk_dataset.py
+++ b/python/dgl/graphbolt/impl/ondisk_dataset.py
@@ -500,8 +500,7 @@ class OnDiskDataset(Dataset):
     def _init_all_nodes_set(self, graph) -> Union[ItemSet, ItemSetDict]:
         if graph is None:
             dgl_warning(
-                "Initializing `all_nodes_set` with a graph whose type does "
-                "not belong to SamplingGraph"
+                "`all_node_set` is returned as None, since graph is None."
             )
             return None
         num_nodes = graph.num_nodes

--- a/python/dgl/graphbolt/impl/ondisk_dataset.py
+++ b/python/dgl/graphbolt/impl/ondisk_dataset.py
@@ -4,6 +4,7 @@ import os
 import shutil
 from copy import deepcopy
 from typing import Dict, List, Union
+import warnings
 
 import pandas as pd
 import torch
@@ -490,6 +491,9 @@ class OnDiskDataset(Dataset):
 
     def _init_all_nodes_set(self, graph) -> Union[ItemSet, ItemSetDict]:
         if graph is None:
+            warnings.warn(
+                "The dataset does not contain a SamplingGraph", Warning
+            )
             return None
         num_nodes = graph.num_nodes
         if isinstance(num_nodes, int):

--- a/python/dgl/graphbolt/impl/ondisk_dataset.py
+++ b/python/dgl/graphbolt/impl/ondisk_dataset.py
@@ -492,7 +492,8 @@ class OnDiskDataset(Dataset):
     def _init_all_nodes_set(self, graph) -> Union[ItemSet, ItemSetDict]:
         if graph is None:
             warnings.warn(
-                "The dataset does not contain a SamplingGraph", Warning
+                "Initializing `all_nodes_set` with a graph whose type does "
+                "not belong to SamplingGraph", Warning
             )
             return None
         num_nodes = graph.num_nodes

--- a/tests/python/pytorch/graphbolt/impl/test_ondisk_dataset.py
+++ b/tests/python/pytorch/graphbolt/impl/test_ondisk_dataset.py
@@ -1806,6 +1806,7 @@ def test_OnDiskDataset_all_nodes_set_homo():
         dataset = gb.OnDiskDataset(test_dir).load()
         all_nodes_set = dataset.all_nodes_set
         assert isinstance(all_nodes_set, gb.ItemSet)
+        assert all_nodes_set.names == ("seed_nodes",)
         for i, item in enumerate(all_nodes_set):
             assert i == item
 
@@ -1842,6 +1843,7 @@ def test_OnDiskDataset_all_nodes_set_hetero():
         dataset = gb.OnDiskDataset(test_dir).load()
         all_nodes_set = dataset.all_nodes_set
         assert isinstance(all_nodes_set, gb.ItemSetDict)
+        assert all_nodes_set.names == ("seed_nodes",)
         for i, item in enumerate(all_nodes_set):
             assert len(item) == 1
             assert isinstance(item, dict)


### PR DESCRIPTION
## Description
<!-- Brief description. Refer to the related issues if existed.
It'll be great if relevant reviewers can be assigned as well.-->
1. Add warning to `_init_all_nodes_set` of `OnDiskDataset` when `graph` is None.
2. Add names to `ItemSet`s in `_init_all_nodes_set`.

## Checklist
Please feel free to remove inapplicable items for your PR.
- [ ] The PR title starts with [$CATEGORY] (such as [NN], [Model], [Doc], [Feature]])
- [ ] I've leverage the [tools](https://docs.google.com/document/d/1iHyj7zlmygKSk5gBPsqIqL5ASPzJSPREaNT_QdsiYA4/edit) to beautify the python and c++ code.
- [ ] The PR is complete and small, read the [Google eng practice (CL equals to PR)](https://google.github.io/eng-practices/review/developer/small-cls.html) to understand more about small PR. In DGL, we consider PRs with less than 200 lines of core code change are small (example, test and documentation could be exempted).
- [ ] All changes have test coverage
- [ ] Code is well-documented
- [ ] To the best of my knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change
- [ ] Related issue is referred in this PR
- [ ] If the PR is for a new model/paper, I've updated the example index [here](../examples/README.md).

## Changes
<!-- You could use following template
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)
-->
