### PR TITLE
[GraphBolt] enable indexing ItemSetDict in ItemSampler

### DIFF
--- a/tests/python/pytorch/graphbolt/test_item_sampler.py
+++ b/tests/python/pytorch/graphbolt/test_item_sampler.py
@@ -391,6 +391,52 @@ def test_append_with_other_datapipes():
 @pytest.mark.parametrize("batch_size", [1, 4])
 @pytest.mark.parametrize("shuffle", [True, False])
 @pytest.mark.parametrize("drop_last", [True, False])
+def test_ItemSetDict_iterable_only(batch_size, shuffle, drop_last):
+    class IterableOnly:
+        def __init__(self, start, stop):
+            self._start = start
+            self._stop = stop
+
+        def __iter__(self):
+            return iter(torch.arange(self._start, self._stop))
+
+    num_ids = 205
+    ids = {
+        "user": gb.ItemSet(IterableOnly(0, 99), names="seed_nodes"),
+        "item": gb.ItemSet(IterableOnly(99, num_ids), names="seed_nodes"),
+    }
+    chained_ids = []
+    for key, value in ids.items():
+        chained_ids += [(key, v) for v in value]
+    item_set = gb.ItemSetDict(ids)
+    item_sampler = gb.ItemSampler(
+        item_set, batch_size=batch_size, shuffle=shuffle, drop_last=drop_last
+    )
+    minibatch_ids = []
+    for i, minibatch in enumerate(item_sampler):
+        is_last = (i + 1) * batch_size >= num_ids
+        if not is_last or num_ids % batch_size == 0:
+            expected_batch_size = batch_size
+        else:
+            if not drop_last:
+                expected_batch_size = num_ids % batch_size
+            else:
+                assert False
+        assert isinstance(minibatch, gb.MiniBatch)
+        assert minibatch.seed_nodes is not None
+        ids = []
+        for _, v in minibatch.seed_nodes.items():
+            ids.append(v)
+        ids = torch.cat(ids)
+        assert len(ids) == expected_batch_size
+        minibatch_ids.append(ids)
+    minibatch_ids = torch.cat(minibatch_ids)
+    assert torch.all(minibatch_ids[:-1] <= minibatch_ids[1:]) is not shuffle
+
+
+@pytest.mark.parametrize("batch_size", [1, 4])
+@pytest.mark.parametrize("shuffle", [True, False])
+@pytest.mark.parametrize("drop_last", [True, False])
 def test_ItemSetDict_seed_nodes(batch_size, shuffle, drop_last):
     # Node IDs.
     num_ids = 205


### PR DESCRIPTION
## Description
<!-- Brief description. Refer to the related issues if existed.
It'll be great if relevant reviewers can be assigned as well.-->

```
num_users = num_ids // 2
    ids = {
        "user": gb.ItemSet(
            (torch.arange(0, num_users), torch.arange(0, num_users)),
            names=("seed_nodes", "labels"),
        ),
        "item": gb.ItemSet(
            (torch.arange(num_users, num_ids), torch.arange(num_users, num_ids)),
            names=("seed_nodes", "labels"),
        ),
    }
    item_set = gb.ItemSetDict(ids)
```

`use_indexing=False shuffle=False num_ids=10,000 batch_size=1000`: 0.1644s
`use_indexing=True shuffle=False num_ids=10,000 batch_size=1000`: 0.0027s

`use_indexing=False shuffle=True num_ids=10,000 batch_size=1000`: 0.1342s
`use_indexing=True shuffle=True num_ids=10,000 batch_size=1000`: 0.0030s

`use_indexing=False shuffle=False num_ids=100,000 batch_size=1000`: 1.1503s
`use_indexing=True shuffle=False num_ids=100,000 batch_size=1000`: 0.0129s

`use_indexing=False shuffle=True num_ids=100,000 batch_size=1000`: 1.7664s
`use_indexing=True shuffle=True num_ids=100,000 batch_size=1000`: 0.0168s

`use_indexing=False shuffle=False num_ids=1,000,000 batch_size=1000`: 11.5161s
`use_indexing=True shuffle=False num_ids=1,000,000 batch_size=1000`: 0.1176s

`use_indexing=False shuffle=True num_ids=1,000,000 batch_size=1000`: 17.1111s
`use_indexing=True shuffle=True num_ids=1,000,000 batch_size=1000`: 0.1463s

`use_indexing=False shuffle=False num_ids=10,000,000 batch_size=1000`: 115.6533s
`use_indexing=True shuffle=False num_ids=10,000,000 batch_size=1000`: 1.1510s

`use_indexing=False shuffle=True num_ids=10,000,000 batch_size=1000`: 170.5941s
`use_indexing=True shuffle=True num_ids=10,000,000 batch_size=1000`: 1.4601s
## Checklist
Please feel free to remove inapplicable items for your PR.
- [ ] The PR title starts with [$CATEGORY] (such as [NN], [Model], [Doc], [Feature]])
- [ ] I've leverage the [tools](https://docs.google.com/document/d/1iHyj7zlmygKSk5gBPsqIqL5ASPzJSPREaNT_QdsiYA4/edit) to beautify the python and c++ code.
- [ ] The PR is complete and small, read the [Google eng practice (CL equals to PR)](https://google.github.io/eng-practices/review/developer/small-cls.html) to understand more about small PR. In DGL, we consider PRs with less than 200 lines of core code change are small (example, test and documentation could be exempted).
- [ ] All changes have test coverage
- [ ] Code is well-documented
- [ ] To the best of my knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change
- [ ] Related issue is referred in this PR
- [ ] If the PR is for a new model/paper, I've updated the example index [here](../examples/README.md).

## Changes
<!-- You could use following template
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)
-->
