### PR TITLE
[GraphBolt] Modify `from_dglgraph()`

### DIFF
--- a/python/dgl/graphbolt/impl/csc_sampling_graph.py
+++ b/python/dgl/graphbolt/impl/csc_sampling_graph.py
@@ -828,7 +828,9 @@ def from_dglgraph(
 
     homo_g, ntype_count, _ = to_homogeneous(g, return_count=True)
 
-    if not is_homogeneous:
+    if is_homogeneous:
+        metadata = None
+    else:
         # Initialize metadata.
         node_type_to_id = {ntype: g.get_ntype_id(ntype) for ntype in g.ntypes}
         edge_type_to_id = {
@@ -858,5 +860,5 @@ def from_dglgraph(
             type_per_edge,
             edge_attributes,
         ),
-        None if is_homogeneous else metadata,
+        metadata,
     )

--- a/python/dgl/graphbolt/impl/csc_sampling_graph.py
+++ b/python/dgl/graphbolt/impl/csc_sampling_graph.py
@@ -825,14 +825,17 @@ def from_dglgraph(
     include_original_edge_id: bool = False,
 ) -> CSCSamplingGraph:
     """Convert a DGLGraph to CSCSamplingGraph."""
+
     homo_g, ntype_count, _ = to_homogeneous(g, return_count=True)
-    # Initialize metadata.
-    node_type_to_id = {ntype: g.get_ntype_id(ntype) for ntype in g.ntypes}
-    edge_type_to_id = {
-        etype_tuple_to_str(etype): g.get_etype_id(etype)
-        for etype in g.canonical_etypes
-    }
-    metadata = GraphMetadata(node_type_to_id, edge_type_to_id)
+
+    if not is_homogeneous:
+        # Initialize metadata.
+        node_type_to_id = {ntype: g.get_ntype_id(ntype) for ntype in g.ntypes}
+        edge_type_to_id = {
+            etype_tuple_to_str(etype): g.get_etype_id(etype)
+            for etype in g.canonical_etypes
+        }
+        metadata = GraphMetadata(node_type_to_id, edge_type_to_id)
 
     # Obtain CSC matrix.
     indptr, indices, edge_ids = homo_g.adj_tensors("csc")
@@ -855,5 +858,5 @@ def from_dglgraph(
             type_per_edge,
             edge_attributes,
         ),
-        metadata,
+        None if is_homogeneous else metadata,
     )

--- a/tests/python/pytorch/graphbolt/impl/test_csc_sampling_graph.py
+++ b/tests/python/pytorch/graphbolt/impl/test_csc_sampling_graph.py
@@ -1321,6 +1321,7 @@ def test_from_dglgraph_homogeneous():
     assert gb_g.total_num_edges == dgl_g.num_edges()
     assert torch.equal(gb_g.node_type_offset, torch.tensor([0, 1000]))
     assert gb_g.type_per_edge is None
+    assert gb_g.metadata == None
 
 
 @unittest.skipIf(

--- a/tests/python/pytorch/graphbolt/impl/test_csc_sampling_graph.py
+++ b/tests/python/pytorch/graphbolt/impl/test_csc_sampling_graph.py
@@ -1321,7 +1321,7 @@ def test_from_dglgraph_homogeneous():
     assert gb_g.total_num_edges == dgl_g.num_edges()
     assert torch.equal(gb_g.node_type_offset, torch.tensor([0, 1000]))
     assert gb_g.type_per_edge is None
-    assert gb_g.metadata == None
+    assert gb_g.metadata is None
 
 
 @unittest.skipIf(

--- a/tests/python/pytorch/graphbolt/impl/test_csc_sampling_graph.py
+++ b/tests/python/pytorch/graphbolt/impl/test_csc_sampling_graph.py
@@ -1321,8 +1321,6 @@ def test_from_dglgraph_homogeneous():
     assert gb_g.total_num_edges == dgl_g.num_edges()
     assert torch.equal(gb_g.node_type_offset, torch.tensor([0, 1000]))
     assert gb_g.type_per_edge is None
-    assert gb_g.metadata.node_type_to_id == {"_N": 0}
-    assert gb_g.metadata.edge_type_to_id == {"_N:_E:_N": 0}
 
 
 @unittest.skipIf(


### PR DESCRIPTION
## Description
<!-- Brief description. Refer to the related issues if existed.
It'll be great if relevant reviewers can be assigned as well.-->
Modify function `from_dglgraph()` in `python/dgl/graphbolt/impl/csc_sampling_graph.py`, forbidding Initializing and passing metadata in case of homogenous graph.

## Checklist
Please feel free to remove inapplicable items for your PR.
- [ ] The PR title starts with [$CATEGORY] (such as [NN], [Model], [Doc], [Feature]])
- [ ] I've leverage the [tools](https://docs.google.com/document/d/1iHyj7zlmygKSk5gBPsqIqL5ASPzJSPREaNT_QdsiYA4/edit) to beautify the python and c++ code.
- [ ] The PR is complete and small, read the [Google eng practice (CL equals to PR)](https://google.github.io/eng-practices/review/developer/small-cls.html) to understand more about small PR. In DGL, we consider PRs with less than 200 lines of core code change are small (example, test and documentation could be exempted).
- [ ] All changes have test coverage
- [ ] Code is well-documented
- [ ] To the best of my knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change
- [ ] Related issue is referred in this PR
- [ ] If the PR is for a new model/paper, I've updated the example index [here](../examples/README.md).

## Changes
<!-- You could use following template
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)
-->
