### PR TITLE
[GraphBolt] Add to function for SampledSubgraph

### DIFF
--- a/python/dgl/graphbolt/base.py
+++ b/python/dgl/graphbolt/base.py
@@ -77,6 +77,8 @@ def etype_str_to_tuple(c_etype):
 
 
 def apply_to(x, device):
+    """Apply `to` function to object x only if it has `to`."""
+
     return x.to(device) if hasattr(x, "to") else x
 
 

--- a/python/dgl/graphbolt/base.py
+++ b/python/dgl/graphbolt/base.py
@@ -76,7 +76,7 @@ def etype_str_to_tuple(c_etype):
     return ret
 
 
-def _to(x, device):
+def apply_to(x, device):
     return x.to(device) if hasattr(x, "to") else x
 
 
@@ -107,5 +107,5 @@ class CopyTo(IterDataPipe):
 
     def __iter__(self):
         for data in self.datapipe:
-            data = recursive_apply(data, _to, self.device)
+            data = recursive_apply(data, apply_to, self.device)
             yield data

--- a/python/dgl/graphbolt/sampled_subgraph.py
+++ b/python/dgl/graphbolt/sampled_subgraph.py
@@ -6,7 +6,7 @@ import torch
 
 from dgl.utils import recursive_apply
 
-from .base import etype_str_to_tuple, isin
+from .base import apply_to, etype_str_to_tuple, isin
 
 
 __all__ = ["SampledSubgraph"]
@@ -194,9 +194,6 @@ class SampledSubgraph:
     def to(self, device: torch.device) -> None:  # pylint: disable=invalid-name
         """Copy `SampledSubgraph` to the specified device using reflection."""
 
-        def _to(x, device):
-            return x.to(device) if hasattr(x, "to") else x
-
         for attr in dir(self):
             # Only copy member variables.
             if not callable(getattr(self, attr)) and not attr.startswith("__"):
@@ -204,7 +201,7 @@ class SampledSubgraph:
                     self,
                     attr,
                     recursive_apply(
-                        getattr(self, attr), lambda x: _to(x, device)
+                        getattr(self, attr), lambda x: apply_to(x, device)
                     ),
                 )
 

--- a/tests/python/pytorch/graphbolt/impl/test_sampled_subgraph_impl.py
+++ b/tests/python/pytorch/graphbolt/impl/test_sampled_subgraph_impl.py
@@ -1,3 +1,6 @@
+import unittest
+
+import backend as F
 import pytest
 import torch
 
@@ -132,3 +135,53 @@ def test_exclude_edges_hetero(reverse_row, reverse_column):
     )
     _assert_container_equal(result.original_row_node_ids, expected_row_node_ids)
     _assert_container_equal(result.original_edge_ids, expected_edge_ids)
+
+
+@unittest.skipIf(
+    F._default_context_str == "cpu",
+    reason="`to` function needs GPU to test.",
+)
+def test_sampled_subgraph_to_device():
+    # Initialize data.
+    node_pairs = {
+        "A:relation:B": (
+            torch.tensor([0, 1, 2]),
+            torch.tensor([2, 1, 0]),
+        )
+    }
+    original_row_node_ids = {
+        "A": torch.tensor([13, 14, 15]),
+    }
+    src_to_exclude = torch.tensor([15, 13])
+    original_column_node_ids = {
+        "B": torch.tensor([10, 11, 12]),
+    }
+    dst_to_exclude = torch.tensor([10, 12])
+    original_edge_ids = {"A:relation:B": torch.tensor([19, 20, 21])}
+    subgraph = SampledSubgraphImpl(
+        node_pairs=node_pairs,
+        original_column_node_ids=original_column_node_ids,
+        original_row_node_ids=original_row_node_ids,
+        original_edge_ids=original_edge_ids,
+    )
+    edges_to_exclude = {
+        "A:relation:B": (
+            src_to_exclude,
+            dst_to_exclude,
+        )
+    }
+    graph = subgraph.exclude_edges(edges_to_exclude)
+
+    # Copy to device.
+    graph = graph.to("cuda")
+
+    # Check.
+    for key in graph.node_pairs:
+        assert graph.node_pairs[key][0].device.type == "cuda"
+        assert graph.node_pairs[key][1].device.type == "cuda"
+    for key in graph.original_column_node_ids:
+        assert graph.original_column_node_ids[key].device.type == "cuda"
+    for key in graph.original_row_node_ids:
+        assert graph.original_row_node_ids[key].device.type == "cuda"
+    for key in graph.original_edge_ids:
+        assert graph.original_edge_ids[key].device.type == "cuda"


### PR DESCRIPTION
## Description
Added `to` device function for SampledSubgraph using reflection.

## Checklist
Please feel free to remove inapplicable items for your PR.
- [ ] The PR title starts with [$CATEGORY] (such as [NN], [Model], [Doc], [Feature]])
- [ ] I've leverage the [tools](https://docs.google.com/document/d/1iHyj7zlmygKSk5gBPsqIqL5ASPzJSPREaNT_QdsiYA4/edit) to beautify the python and c++ code.
- [ ] The PR is complete and small, read the [Google eng practice (CL equals to PR)](https://google.github.io/eng-practices/review/developer/small-cls.html) to understand more about small PR. In DGL, we consider PRs with less than 200 lines of core code change are small (example, test and documentation could be exempted).
- [ ] All changes have test coverage
- [ ] Code is well-documented
- [ ] To the best of my knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change
- [ ] Related issue is referred in this PR
- [ ] If the PR is for a new model/paper, I've updated the example index [here](../examples/README.md).

## Changes
<!-- You could use following template
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)
-->
