### PR TITLE
[Sparse] Add a graphSAGE example

### DIFF
--- a/examples/sparse/graphsage.py
+++ b/examples/sparse/graphsage.py
@@ -92,16 +92,18 @@ class SAGE(nn.Module):
                 hidden_x = F.relu(hidden_x)
                 hidden_x = self.dropout(hidden_x)
         return hidden_x
-    
+
     def inference(self, A, dataset, device, batch_size):
         """Conduct layer-wise inference to get all the node embeddings."""
         feat = dataset[0].ndata["feat"]
         inf_idx = dataset.val_idx.to(device)
-        inf_dataloader = torch.utils.data.DataLoader(inf_idx, batch_size=batch_size)
+        inf_dataloader = torch.utils.data.DataLoader(
+            inf_idx, batch_size=batch_size
+        )
 
         buffer_device = torch.device("cpu")
         pin_memory = buffer_device != device
-        
+
         node_num = A.shape[0]
         for l, layer in enumerate(self.layers):
             y = torch.empty(
@@ -115,7 +117,7 @@ class SAGE(nn.Module):
 
             for it, (dst) in enumerate(inf_dataloader):
                 # Sampling full neighbors.
-                mat = A.sample(1, fanout = node_num, ids=dst)
+                mat = A.sample(1, fanout=node_num, ids=dst)
                 # Compact the matrix.
                 mat_cmp, src = mat.compact(0)
                 x = feat[src]
@@ -161,6 +163,7 @@ def evaluate(model, dataloader, dataset, num_classes):
         num_classes=num_classes,
     )
 
+
 def layerwise_infer(device, A, dataset, model, num_classes, batch_size):
     model.eval()
     nid = dataset.test_idx
@@ -173,6 +176,7 @@ def layerwise_infer(device, A, dataset, model, num_classes, batch_size):
         return MF.accuracy(
             pred, label, task="multiclass", num_classes=num_classes
         )
+
 
 def train(device, A, dataset, model, num_classes):
     # Create sampler & dataloader.

--- a/examples/sparse/graphsage.py
+++ b/examples/sparse/graphsage.py
@@ -1,0 +1,236 @@
+"""
+This script trains and tests a GraphSAGE model based on the information of 
+a full graph.
+
+This flowchart describes the main functional sequence of the provided example.
+main
+│
+├───> Load and preprocess full dataset
+│
+├───> Instantiate SAGE model
+│
+├───> train
+│     │
+│     └───> Training loop
+│           │
+│           └───> SAGE.forward
+└───> test
+      │
+      └───> Evaluate the model
+"""
+import argparse
+
+import dgl.sparse as dglsp
+
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+from dgl import AddSelfLoop, graph
+from dgl.data import CiteseerGraphDataset, CoraGraphDataset, PubmedGraphDataset
+
+
+class SAGE(nn.Module):
+    def __init__(self, in_size, hidden_size, out_size):
+        super().__init__()
+        self.layers = nn.ModuleList()
+        # Two-layer GraphSAGE-gcn.
+        self.layers.append(SAGEConv(in_size, hidden_size, "gcn"))
+        self.layers.append(SAGEConv(hidden_size, out_size, "gcn"))
+        self.dropout = nn.Dropout(0.5)
+
+    def forward(self, graph, x):
+        hidden_x = x
+        for layer_idx, layer in enumerate(self.layers):
+            hidden_x = layer(graph, hidden_x)
+            is_last_layer = layer_idx == len(self.layers) - 1
+            if not is_last_layer:
+                hidden_x = F.relu(hidden_x)
+                hidden_x = self.dropout(hidden_x)
+        return hidden_x
+
+
+def evaluate(A, features, labels, mask, model):
+    model.eval()
+    with torch.no_grad():
+        logits = model(A, features)
+        logits = logits[mask]
+        labels = labels[mask]
+        _, indices = torch.max(logits, dim=1)
+        correct = torch.sum(indices == labels)
+        return correct.item() * 1.0 / len(labels)
+
+
+def train(A, features, labels, masks, model):
+    # Define train/val samples, loss function and optimizer.
+    train_mask, val_mask = masks
+    loss_fcn = nn.CrossEntropyLoss()
+    optimizer = torch.optim.Adam(model.parameters(), lr=1e-2, weight_decay=5e-4)
+
+    # Training loop.
+    for epoch in range(100):
+        model.train()
+        logits = model(A, features)
+        loss = loss_fcn(logits[train_mask], labels[train_mask])
+        optimizer.zero_grad()
+        loss.backward()
+        optimizer.step()
+        acc = evaluate(A, features, labels, val_mask, model)
+        print(
+            f"Epoch {epoch:05d} | Loss {loss.item():.4f} | Accuracy {acc:.4f} "
+        )
+
+
+class SAGEConv(nn.Module):
+    r"""GraphSAGE layer from `Inductive Representation Learning on
+    Large Graphs <https://arxiv.org/pdf/1706.02216.pdf>`__
+    """
+
+    def __init__(
+        self,
+        in_feats,
+        out_feats,
+        aggregator_type="gcn",
+        feat_drop=0.0,
+        bias=True,
+        norm=None,
+        activation=None,
+    ):
+        super(SAGEConv, self).__init__()
+        self._in_src_feats, self._in_dst_feats = in_feats, in_feats
+        self._out_feats = out_feats
+        self._aggre_type = aggregator_type
+        self.norm = norm
+        self.feat_drop = nn.Dropout(feat_drop)
+        self.activation = activation
+
+        # aggregator type: mean/gcn
+        self.fc_neigh = nn.Linear(self._in_src_feats, out_feats, bias=False)
+
+        if aggregator_type != "gcn":
+            self.fc_self = nn.Linear(self._in_dst_feats, out_feats, bias=bias)
+        elif bias:
+            self.bias = nn.parameter.Parameter(torch.zeros(self._out_feats))
+        else:
+            self.register_buffer("bias", None)
+
+        self.reset_parameters()
+
+    def reset_parameters(self):
+        gain = nn.init.calculate_gain("relu")
+        if self._aggre_type != "gcn":
+            nn.init.xavier_uniform_(self.fc_self.weight, gain=gain)
+        nn.init.xavier_uniform_(self.fc_neigh.weight, gain=gain)
+
+    def forward(self, A, feat):
+        feat_src = feat_dst = self.feat_drop(feat)
+        feat_dst = feat_src[: A.shape[0]]
+
+        h_self = feat_dst
+        lin_before_mp = self._in_src_feats > self._out_feats
+        srcdata, dstdata = {}, {}
+        if self._aggre_type == "mean":
+            srcdata["h"] = (
+                self.fc_neigh(feat_src) if lin_before_mp else feat_src
+            )
+            # Div by degree
+            D_hat = dglsp.diag(A_hat.sum(0)) ** -1
+            A_div = A_hat @ D_hat
+            dstdata["neigh"] = A_div.T @ srcdata["h"]
+            h_neigh = graph.dstdata["neigh"]
+            if not lin_before_mp:
+                h_neigh = self.fc_neigh(h_neigh)
+        elif self._aggre_type == "gcn":
+            srcdata["h"] = (
+                self.fc_neigh(feat_src) if lin_before_mp else feat_src
+            )
+            # Add self loop
+            I = dglsp.identity(A.shape)
+            A_hat = A + I
+            # Div by degree
+            D_hat = dglsp.diag(A_hat.sum(0)) ** -1
+            A_div = A_hat @ D_hat
+            dstdata["neigh"] = A_div.T @ srcdata["h"]
+            h_neigh = dstdata["neigh"]
+            if not lin_before_mp:
+                h_neigh = self.fc_neigh(h_neigh)
+        else:
+            raise KeyError(
+                "Aggregator type {} not recognized.".format(self._aggre_type)
+            )
+
+        if self._aggre_type == "gcn":
+            rst = h_neigh
+            # add bias manually for GCN
+            if self.bias is not None:
+                rst = rst + self.bias
+        else:
+            rst = self.fc_self(h_self) + h_neigh
+
+        # activation
+        if self.activation is not None:
+            rst = self.activation(rst)
+        # normalization
+        if self.norm is not None:
+            rst = self.norm(rst)
+        return rst
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="GraphSAGE")
+    parser.add_argument(
+        "--dataset",
+        type=str,
+        default="cora",
+        help="Dataset name ('cora', 'citeseer', 'pubmed')",
+    )
+    args = parser.parse_args()
+    print(f"Training with DGL built-in GraphSage module")
+
+    #####################################################################
+    # (HIGHLIGHT) Node classification task is a supervise learning task
+    # in which the model try to predict the label of a certain node.
+    # In this example, graph sage algorithm is applied to this task.
+    # A good accuracy can be achieved after a few steps of training.
+    #
+    # First, the whole graph is loaded and transformed. Then the training
+    # process is performed on a model which is composed of 2 GraphSAGE-gcn
+    # layer. Finally, the performance of the model is evaluated on test set.
+    #####################################################################
+
+    # Load and preprocess dataset.
+    transform = (
+        AddSelfLoop()
+    )  # By default, it will first remove self-loops to prevent duplication.
+    if args.dataset == "cora":
+        data = CoraGraphDataset(transform=transform)
+    elif args.dataset == "citeseer":
+        data = CiteseerGraphDataset(transform=transform)
+    elif args.dataset == "pubmed":
+        data = PubmedGraphDataset(transform=transform)
+    else:
+        raise ValueError(f"Unknown dataset: {args.dataset}")
+    g = data[0]
+    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+    g = g.long().to(device)
+    features = g.ndata["feat"]
+    labels = g.ndata["label"]
+    masks = (g.ndata["train_mask"], g.ndata["val_mask"])
+
+    # Create GraphSAGE model.
+    in_size = features.shape[1]
+    out_size = data.num_classes
+    model = SAGE(in_size, 16, out_size).to(device)
+
+    # Create sparse
+    indices = torch.stack(g.edges())
+    N = g.num_nodes()
+    A = dglsp.spmatrix(indices, shape=(N, N))
+
+    # Model training.
+    print("Training...")
+    train(A, features, labels, masks, model)
+
+    # Test the model.
+    print("Testing...")
+    acc = evaluate(A, features, labels, g.ndata["test_mask"], model)
+    print(f"Test accuracy {acc:.4f}")

--- a/examples/sparse/graphsage.py
+++ b/examples/sparse/graphsage.py
@@ -25,8 +25,50 @@ import dgl.sparse as dglsp
 import torch
 import torch.nn as nn
 import torch.nn.functional as F
-from dgl import AddSelfLoop, graph
+from dgl import AddSelfLoop
 from dgl.data import CiteseerGraphDataset, CoraGraphDataset, PubmedGraphDataset
+
+
+class SAGEConv(nn.Module):
+    r"""GraphSAGE layer from `Inductive Representation Learning on
+    Large Graphs <https://arxiv.org/pdf/1706.02216.pdf>`__
+    """
+
+    def __init__(
+        self,
+        in_feats,
+        out_feats,
+    ):
+        super(SAGEConv, self).__init__()
+        self._in_src_feats, self._in_dst_feats = in_feats, in_feats
+        self._out_feats = out_feats
+
+        self.fc_neigh = nn.Linear(self._in_src_feats, out_feats, bias=False)
+        self.fc_self = nn.Linear(self._in_dst_feats, out_feats, bias=True)
+        self.reset_parameters()
+
+    def reset_parameters(self):
+        gain = nn.init.calculate_gain("relu")
+        nn.init.xavier_uniform_(self.fc_self.weight, gain=gain)
+        nn.init.xavier_uniform_(self.fc_neigh.weight, gain=gain)
+
+    def forward(self, A, feat):
+        feat_src = feat_dst = feat
+        feat_dst = feat_src[: A.shape[0]]
+
+        # Aggregator type: mean
+        h_self = feat_dst
+        srcdata, dstdata = {}, {}
+        srcdata["h"] = self.fc_neigh(feat_src)
+        # Divided by degree.
+        D_hat = dglsp.diag(A.sum(0)) ** -1
+        A_div = A @ D_hat
+        dstdata["neigh"] = A_div.T @ srcdata["h"]
+        h_neigh = dstdata["neigh"]
+
+        rst = self.fc_self(h_self) + h_neigh
+
+        return rst
 
 
 class SAGE(nn.Module):
@@ -34,8 +76,8 @@ class SAGE(nn.Module):
         super().__init__()
         self.layers = nn.ModuleList()
         # Two-layer GraphSAGE-gcn.
-        self.layers.append(SAGEConv(in_size, hidden_size, "gcn"))
-        self.layers.append(SAGEConv(hidden_size, out_size, "gcn"))
+        self.layers.append(SAGEConv(in_size, hidden_size))
+        self.layers.append(SAGEConv(hidden_size, out_size))
         self.dropout = nn.Dropout(0.5)
 
     def forward(self, graph, x):
@@ -78,101 +120,6 @@ def train(A, features, labels, masks, model):
         print(
             f"Epoch {epoch:05d} | Loss {loss.item():.4f} | Accuracy {acc:.4f} "
         )
-
-
-class SAGEConv(nn.Module):
-    r"""GraphSAGE layer from `Inductive Representation Learning on
-    Large Graphs <https://arxiv.org/pdf/1706.02216.pdf>`__
-    """
-
-    def __init__(
-        self,
-        in_feats,
-        out_feats,
-        aggregator_type="gcn",
-        feat_drop=0.0,
-        bias=True,
-        norm=None,
-        activation=None,
-    ):
-        super(SAGEConv, self).__init__()
-        self._in_src_feats, self._in_dst_feats = in_feats, in_feats
-        self._out_feats = out_feats
-        self._aggre_type = aggregator_type
-        self.norm = norm
-        self.feat_drop = nn.Dropout(feat_drop)
-        self.activation = activation
-
-        # aggregator type: mean/gcn
-        self.fc_neigh = nn.Linear(self._in_src_feats, out_feats, bias=False)
-
-        if aggregator_type != "gcn":
-            self.fc_self = nn.Linear(self._in_dst_feats, out_feats, bias=bias)
-        elif bias:
-            self.bias = nn.parameter.Parameter(torch.zeros(self._out_feats))
-        else:
-            self.register_buffer("bias", None)
-
-        self.reset_parameters()
-
-    def reset_parameters(self):
-        gain = nn.init.calculate_gain("relu")
-        if self._aggre_type != "gcn":
-            nn.init.xavier_uniform_(self.fc_self.weight, gain=gain)
-        nn.init.xavier_uniform_(self.fc_neigh.weight, gain=gain)
-
-    def forward(self, A, feat):
-        feat_src = feat_dst = self.feat_drop(feat)
-        feat_dst = feat_src[: A.shape[0]]
-
-        h_self = feat_dst
-        lin_before_mp = self._in_src_feats > self._out_feats
-        srcdata, dstdata = {}, {}
-        if self._aggre_type == "mean":
-            srcdata["h"] = (
-                self.fc_neigh(feat_src) if lin_before_mp else feat_src
-            )
-            # Div by degree
-            D_hat = dglsp.diag(A_hat.sum(0)) ** -1
-            A_div = A_hat @ D_hat
-            dstdata["neigh"] = A_div.T @ srcdata["h"]
-            h_neigh = graph.dstdata["neigh"]
-            if not lin_before_mp:
-                h_neigh = self.fc_neigh(h_neigh)
-        elif self._aggre_type == "gcn":
-            srcdata["h"] = (
-                self.fc_neigh(feat_src) if lin_before_mp else feat_src
-            )
-            # Add self loop
-            I = dglsp.identity(A.shape)
-            A_hat = A + I
-            # Div by degree
-            D_hat = dglsp.diag(A_hat.sum(0)) ** -1
-            A_div = A_hat @ D_hat
-            dstdata["neigh"] = A_div.T @ srcdata["h"]
-            h_neigh = dstdata["neigh"]
-            if not lin_before_mp:
-                h_neigh = self.fc_neigh(h_neigh)
-        else:
-            raise KeyError(
-                "Aggregator type {} not recognized.".format(self._aggre_type)
-            )
-
-        if self._aggre_type == "gcn":
-            rst = h_neigh
-            # add bias manually for GCN
-            if self.bias is not None:
-                rst = rst + self.bias
-        else:
-            rst = self.fc_self(h_self) + h_neigh
-
-        # activation
-        if self.activation is not None:
-            rst = self.activation(rst)
-        # normalization
-        if self.norm is not None:
-            rst = self.norm(rst)
-        return rst
 
 
 if __name__ == "__main__":
@@ -221,7 +168,7 @@ if __name__ == "__main__":
     out_size = data.num_classes
     model = SAGE(in_size, 16, out_size).to(device)
 
-    # Create sparse
+    # Create sparse.
     indices = torch.stack(g.edges())
     N = g.num_nodes()
     A = dglsp.spmatrix(indices, shape=(N, N))

--- a/examples/sparse/sampling/graphsage.py
+++ b/examples/sparse/sampling/graphsage.py
@@ -1,7 +1,7 @@
 """
-This script demonstrate how to use sparse to sample on graph and train model.
-It trains and tests a GraphSAGE model using the sparse sample and compact 
-operators to sample submatrix from the whole matrix.
+This script demonstrate how to use dgl sparse library to sample on graph and 
+train model. It trains and tests a GraphSAGE model using the sparse sample and 
+compact operators to sample submatrix from the whole matrix.
 
 This flowchart describes the main functional sequence of the provided example.
 main
@@ -142,7 +142,6 @@ def evaluate(model, A, dataloader, ndata, num_classes):
 
 
 def validate(device, A, ndata, dataset, model, batch_size):
-    model.eval()
     inf_id = dataset.test_idx.to(device)
     inf_dataloader = torch.utils.data.DataLoader(inf_id, batch_size=batch_size)
     acc = evaluate(model, A, inf_dataloader, ndata, dataset.num_classes)


### PR DESCRIPTION
## Description
A sparse graphSAGE example. 
Run example: 
```
$ python examples/sparse/graphsage.py
Training in gpu mode.
Loading data
Training...
[W TensorAdvancedIndexing.cpp:1615] Warning: scatter_reduce() is in beta and the API may change at any time. (function operator())
Epoch 00000 | Loss 2.0963 | Accuracy 0.7756 
Epoch 00001 | Loss 0.8108 | Accuracy 0.8443 
Epoch 00002 | Loss 0.6264 | Accuracy 0.8593 
Epoch 00003 | Loss 0.5662 | Accuracy 0.8675 
Epoch 00004 | Loss 0.5311 | Accuracy 0.8721 
Epoch 00005 | Loss 0.5047 | Accuracy 0.8744 
Epoch 00006 | Loss 0.4846 | Accuracy 0.8759 
Epoch 00007 | Loss 0.4766 | Accuracy 0.8756 
Epoch 00008 | Loss 0.4674 | Accuracy 0.8796 
Epoch 00009 | Loss 0.4528 | Accuracy 0.8799 
Testing...
Test accuracy 0.7216
```
## Checklist
Please feel free to remove inapplicable items for your PR.
- [ ] The PR title starts with [$CATEGORY] (such as [NN], [Model], [Doc], [Feature]])
- [ ] I've leverage the [tools](https://docs.google.com/document/d/1iHyj7zlmygKSk5gBPsqIqL5ASPzJSPREaNT_QdsiYA4/edit) to beautify the python and c++ code.
- [ ] The PR is complete and small, read the [Google eng practice (CL equals to PR)](https://google.github.io/eng-practices/review/developer/small-cls.html) to understand more about small PR. In DGL, we consider PRs with less than 200 lines of core code change are small (example, test and documentation could be exempted).
- [ ] All changes have test coverage
- [ ] Code is well-documented
- [ ] To the best of my knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change
- [ ] Related issue is referred in this PR
- [ ] If the PR is for a new model/paper, I've updated the example index [here](../examples/README.md).

## Changes