### PR TITLE
Revert "[GraphBolt] Add NOT deduplication func to homo graph."

### DIFF
--- a/python/dgl/graphbolt/impl/neighbor_sampler.py
+++ b/python/dgl/graphbolt/impl/neighbor_sampler.py
@@ -116,21 +116,22 @@ class NeighborSampler(SubgraphSampler):
                 self.fanouts[hop],
                 self.replace,
                 self.prob_name,
-                self.deduplicate,
             )
             if self.deduplicate:
                 (
                     original_row_node_ids,
                     compacted_node_pairs,
                 ) = unique_and_compact_node_pairs(subgraph.node_pairs, seeds)
-                subgraph = SampledSubgraphImpl(
-                    node_pairs=compacted_node_pairs,
-                    original_column_node_ids=seeds,
-                    original_row_node_ids=original_row_node_ids,
-                    original_edge_ids=subgraph.original_edge_ids,
-                )
+            else:
+                raise RuntimeError("Not implemented yet.")
+            subgraph = SampledSubgraphImpl(
+                node_pairs=compacted_node_pairs,
+                original_column_node_ids=seeds,
+                original_row_node_ids=original_row_node_ids,
+                original_edge_ids=subgraph.original_edge_ids,
+            )
             subgraphs.insert(0, subgraph)
-            seeds = subgraph.original_row_node_ids
+            seeds = original_row_node_ids
         return seeds, subgraphs
 
 

--- a/tests/python/pytorch/graphbolt/test_subgraph_sampler.py
+++ b/tests/python/pytorch/graphbolt/test_subgraph_sampler.py
@@ -1,4 +1,3 @@
-import dgl
 import dgl.graphbolt as gb
 import gb_test_utils
 import pytest
@@ -193,36 +192,3 @@ def test_SubgraphSampler_Link_Hetero_With_Negative(labor):
     Sampler = gb.LayerNeighborSampler if labor else gb.NeighborSampler
     neighbor_dp = Sampler(negative_dp, graph, fanouts)
     assert len(list(neighbor_dp)) == 5
-
-
-@pytest.mark.parametrize("labor", [False, True])
-def test_test_SubgraphSampler_without_dedpulication(labor):
-    graph = dgl.graph(
-        ([5, 0, 1, 5, 6, 7, 2, 2, 4], [0, 1, 2, 2, 2, 2, 3, 4, 4])
-    )
-    graph = gb.from_dglgraph(graph, True)
-    seed_nodes = torch.LongTensor([0, 3, 4])
-
-    itemset = gb.ItemSet(seed_nodes, names="seed_nodes")
-    item_sampler = gb.ItemSampler(itemset, batch_size=len(seed_nodes))
-    num_layer = 2
-    fanouts = [torch.LongTensor([2]) for _ in range(num_layer)]
-
-    Sampler = gb.LayerNeighborSampler if labor else gb.NeighborSampler
-    datapipe = Sampler(item_sampler, graph, fanouts, deduplicate=False)
-
-    length = [17, 7]
-    compacted_dst = [
-        torch.tensor([0, 1, 2, 2, 4, 4, 5, 5, 6, 6]),
-        torch.tensor([0, 1, 2, 2]),
-    ]
-    seeds = [torch.tensor([0, 3, 4, 5, 2, 2, 4]), torch.tensor([0, 3, 4])]
-    for data in datapipe:
-        for step, sampled_subgraph in enumerate(data.sampled_subgraphs):
-            assert len(sampled_subgraph.original_row_node_ids) == length[step]
-            assert torch.equal(
-                sampled_subgraph.node_pairs[1], compacted_dst[step]
-            )
-            assert torch.equal(
-                sampled_subgraph.original_column_node_ids, seeds[step]
-            )


### PR DESCRIPTION
Reverts dmlc/dgl#6436

As discussed, it is better to implement a compact function rather than hack it in csc_sampling_graph since in the future there could be other sampler that need this not deduplicate support. 