### PR TITLE
[GraphBolt] Update the param to make the code consistent

### DIFF
--- a/examples/sampling/graphbolt/lightning/node_classification.py
+++ b/examples/sampling/graphbolt/lightning/node_classification.py
@@ -211,7 +211,7 @@ if __name__ == "__main__":
     dataset = gb.BuiltinDataset("ogbn-products").load()
     datamodule = DataModule(
         dataset,
-        [15, 10, 5],
+        [10, 10, 10],
         args.batch_size,
         args.num_workers,
     )

--- a/examples/sampling/graphbolt/node_classification.py
+++ b/examples/sampling/graphbolt/node_classification.py
@@ -311,20 +311,20 @@ def parse_args():
         help="Learning rate for optimization.",
     )
     parser.add_argument(
-        "--batch-size", type=int, default=256, help="Batch size for training."
+        "--batch-size", type=int, default=1024, help="Batch size for training."
     )
     parser.add_argument(
         "--num-workers",
         type=int,
-        default=4,
+        default=0,
         help="Number of workers for data loading.",
     )
     parser.add_argument(
         "--fanout",
         type=str,
-        default="15,10,5",
+        default="10,10,10",
         help="Fan-out of neighbor sampling. It is IMPORTANT to keep len(fanout)"
-        " identical with the number of layers in your model. Default: 15,10,5",
+        " identical with the number of layers in your model. Default: 10,10,10",
     )
     return parser.parse_args()
 
@@ -344,7 +344,7 @@ def main(args):
     num_classes = dataset.tasks[0].metadata["num_classes"]
 
     in_size = features.size("node", None, "feat")[0]
-    hidden_size = 128
+    hidden_size = 256
     out_size = num_classes
 
     model = SAGE(in_size, hidden_size, out_size)


### PR DESCRIPTION
## Description
<!-- Brief description. Refer to the related issues if existed.
It'll be great if relevant reviewers can be assigned as well.-->
During benchmarking, I noticed several discrepancies between DGL and GraphBolt in the node classification example, which could cause potential errors. To prevent this, I'll refine the examples for consistency.

The train log is as following:
```
The dataset is already preprocessed.
Training...
193it [02:18,  1.39it/s]                                                      | 0/10 [00:00<?, ?it/s]
39it [00:16,  2.36it/s]]
Epoch 00000 | Loss 1.7883 | Accuracy 0.8264 
193it [02:20,  1.37it/s]                                             | 1/10 [02:35<23:16, 155.20s/it]
39it [00:16,  2.39it/s]]
Epoch 00001 | Loss 0.7776 | Accuracy 0.8584 
193it [02:08,  1.50it/s]                                             | 2/10 [05:12<20:50, 156.28s/it]
39it [00:16,  2.37it/s]]
Epoch 00002 | Loss 0.6224 | Accuracy 0.8705 
193it [02:08,  1.50it/s]▏                                            | 3/10 [07:37<17:38, 151.21s/it]
39it [00:14,  2.66it/s]]
Epoch 00003 | Loss 0.5487 | Accuracy 0.8784 
193it [02:15,  1.42it/s]██████▌                                      | 4/10 [10:00<14:48, 148.13s/it]
39it [00:16,  2.43it/s]]
Epoch 00004 | Loss 0.5071 | Accuracy 0.8829 
193it [02:10,  1.47it/s]█████████████                                | 5/10 [12:32<12:26, 149.36s/it]
39it [00:16,  2.37it/s]]
Epoch 00005 | Loss 0.4752 | Accuracy 0.8865 
193it [02:16,  1.42it/s]███████████████████▍                         | 6/10 [14:59<09:54, 148.73s/it]
39it [00:15,  2.46it/s]]
Epoch 00006 | Loss 0.4461 | Accuracy 0.8901 
193it [02:10,  1.47it/s]█████████████████████████▊                   | 7/10 [17:31<07:29, 149.80s/it]
39it [00:16,  2.35it/s]]
Epoch 00007 | Loss 0.4272 | Accuracy 0.8926 
193it [02:13,  1.45it/s]████████████████████████████████▏            | 8/10 [19:59<04:58, 149.07s/it]
39it [00:15,  2.46it/s]]
Epoch 00008 | Loss 0.4138 | Accuracy 0.8951 
193it [02:13,  1.45it/s]██████████████████████████████████████▌      | 9/10 [22:28<02:29, 149.03s/it]
39it [00:16,  2.39it/s]]
Epoch 00009 | Loss 0.4020 | Accuracy 0.8962 
100%|███████████████████████████████████████████████████████████████| 10/10 [24:57<00:00, 149.77s/it]
Testing...
2392it [00:26, 91.83it/s] 
2392it [01:03, 37.94it/s]
2392it [01:02, 38.29it/s]
Test Accuracy is 0.7562
```


## Checklist
Please feel free to remove inapplicable items for your PR.
- [x] The PR title starts with [$CATEGORY] (such as [NN], [Model], [Doc], [Feature]])
- [x] I've leverage the [tools](https://docs.google.com/document/d/1iHyj7zlmygKSk5gBPsqIqL5ASPzJSPREaNT_QdsiYA4/edit) to beautify the python and c++ code.
- [x] The PR is complete and small, read the [Google eng practice (CL equals to PR)](https://google.github.io/eng-practices/review/developer/small-cls.html) to understand more about small PR. In DGL, we consider PRs with less than 200 lines of core code change are small (example, test and documentation could be exempted).
- [ ] All changes have test coverage
- [ ] Code is well-documented
- [ ] To the best of my knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change
- [ ] Related issue is referred in this PR
- [ ] If the PR is for a new model/paper, I've updated the example index [here](../examples/README.md).

## Changes
<!-- You could use following template
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)
-->
