### PR TITLE
[GraphBolt] Fix Link Prediction eample evaluation function bug and Enable cuda execution

### DIFF
--- a/examples/sampling/graphbolt/link_prediction.py
+++ b/examples/sampling/graphbolt/link_prediction.py
@@ -103,7 +103,9 @@ def create_dataloader(args, graph, features, itemset, is_train=True):
     # Initialize the ItemSampler to sample mini-batche from the dataset.
     ############################################################################
     datapipe = gb.ItemSampler(
-        itemset, batch_size=args.batch_size, shuffle=is_train
+        itemset,
+        batch_size=args.train_batch_size if is_train else args.eval_batch_size,
+        shuffle=is_train,
     )
 
     ############################################################################
@@ -311,7 +313,8 @@ def parse_args():
     parser.add_argument("--epochs", type=int, default=10)
     parser.add_argument("--lr", type=float, default=0.0005)
     parser.add_argument("--neg-ratio", type=int, default=1)
-    parser.add_argument("--batch-size", type=int, default=512)
+    parser.add_argument("--train-batch-size", type=int, default=512)
+    parser.add_argument("--eval-batch-size", type=int, default=2)
     parser.add_argument("--num-workers", type=int, default=4)
     parser.add_argument(
         "--early-stop",

--- a/examples/sampling/graphbolt/link_prediction.py
+++ b/examples/sampling/graphbolt/link_prediction.py
@@ -207,7 +207,7 @@ def create_dataloader(args, graph, features, itemset, is_train=True):
     return dataloader
 
 
-def to_binary_link_dgl_computing_pack(data: gb.MiniBatch):
+def to_binary_link_dgl_computing_pack(data: gb.DGLMiniBatch):
     """Convert the minibatch to a training pair and a label tensor."""
     pos_src, pos_dst = data.positive_node_pairs
     neg_src, neg_dst = data.negative_node_pairs
@@ -353,6 +353,7 @@ def main(args):
 
     in_size = features.size("node", None, "feat")[0]
     hidden_channels = 256
+    args.device = torch.device(args.device)
     model = SAGE(in_size, hidden_channels).to(args.device)
 
     # Model training.

--- a/examples/sampling/graphbolt/link_prediction.py
+++ b/examples/sampling/graphbolt/link_prediction.py
@@ -314,6 +314,9 @@ def parse_args():
     parser.add_argument("--lr", type=float, default=0.0005)
     parser.add_argument("--neg-ratio", type=int, default=1)
     parser.add_argument("--train-batch-size", type=int, default=512)
+    # TODO [Issue#6534]: Use model.inference instead of dataloader to evaluate.
+    # Since neg_ratio in valid/test set is 1000, which is too large to GPU
+    # memory, we should use small batch size to evaluate.
     parser.add_argument("--eval-batch-size", type=int, default=2)
     parser.add_argument("--num-workers", type=int, default=4)
     parser.add_argument(

--- a/examples/sampling/graphbolt/link_prediction.py
+++ b/examples/sampling/graphbolt/link_prediction.py
@@ -249,8 +249,8 @@ def evaluate(args, graph, features, itemset, model):
         )
 
         # Split the score into positive and negative parts.
-        pos_score = score[: data.compacted_node_pairs[0].shape[0]]
-        neg_score = score[data.compacted_node_pairs[0].shape[0] :]
+        pos_score = score[: data.positive_node_pairs[0].shape[0]]
+        neg_score = score[data.positive_node_pairs[0].shape[0] :]
 
         # Append the score to the list.
         pos_pred.append(pos_score)
@@ -350,7 +350,7 @@ def main(args):
 
     in_size = features.size("node", None, "feat")[0]
     hidden_channels = 256
-    model = SAGE(in_size, hidden_channels)
+    model = SAGE(in_size, hidden_channels).to(args.device)
 
     # Model training.
     print("Training...")

--- a/python/dgl/graphbolt/subgraph_sampler.py
+++ b/python/dgl/graphbolt/subgraph_sampler.py
@@ -106,8 +106,10 @@ class SubgraphSampler(MiniBatchTransformer):
             # Collect nodes from all types of input.
             nodes = list(node_pairs)
             if has_neg_src:
+                neg_src_shape = neg_src.shape
                 nodes.append(neg_src.view(-1))
             if has_neg_dst:
+                neg_dst_shape = neg_dst.shape
                 nodes.append(neg_dst.view(-1))
             # Unique and compact the collected nodes.
             seeds, compacted = unique_and_compact(nodes)
@@ -116,8 +118,14 @@ class SubgraphSampler(MiniBatchTransformer):
             compacted = compacted[2:]
             if has_neg_src:
                 compacted_negative_srcs = compacted.pop(0)
+                compacted_negative_srcs = compacted_negative_srcs.view(
+                    neg_src_shape
+                )
             if has_neg_dst:
                 compacted_negative_dsts = compacted.pop(0)
+                compacted_negative_dsts = compacted_negative_dsts.view(
+                    neg_dst_shape
+                )
         return (
             seeds,
             compacted_node_pairs,

--- a/python/dgl/graphbolt/subgraph_sampler.py
+++ b/python/dgl/graphbolt/subgraph_sampler.py
@@ -106,10 +106,8 @@ class SubgraphSampler(MiniBatchTransformer):
             # Collect nodes from all types of input.
             nodes = list(node_pairs)
             if has_neg_src:
-                neg_src_shape = neg_src.shape
                 nodes.append(neg_src.view(-1))
             if has_neg_dst:
-                neg_dst_shape = neg_dst.shape
                 nodes.append(neg_dst.view(-1))
             # Unique and compact the collected nodes.
             seeds, compacted = unique_and_compact(nodes)
@@ -118,13 +116,16 @@ class SubgraphSampler(MiniBatchTransformer):
             compacted = compacted[2:]
             if has_neg_src:
                 compacted_negative_srcs = compacted.pop(0)
+                # Since we need to calculate the neg_ratio according to the
+                # compacted_negatvie_srcs shape, we need to reshape it back.
                 compacted_negative_srcs = compacted_negative_srcs.view(
-                    neg_src_shape
+                    neg_src.shape
                 )
             if has_neg_dst:
                 compacted_negative_dsts = compacted.pop(0)
+                # Same as above.
                 compacted_negative_dsts = compacted_negative_dsts.view(
-                    neg_dst_shape
+                    neg_dst.shape
                 )
         return (
             seeds,

--- a/tests/python/pytorch/graphbolt/impl/test_minibatch.py
+++ b/tests/python/pytorch/graphbolt/impl/test_minibatch.py
@@ -153,8 +153,8 @@ def test_minibatch_representation():
     negative_dsts = torch.tensor([[2], [8], [8]])
     input_nodes = torch.tensor([8, 1, 6, 5, 9, 0, 2, 4])
     compacted_node_pairs = (torch.tensor([0, 1, 2]), torch.tensor([3, 4, 5]))
-    compacted_negative_srcs = torch.tensor([0, 1, 2])
-    compacted_negative_dsts = torch.tensor([6, 0, 0])
+    compacted_negative_srcs = torch.tensor([[0], [1], [2]])
+    compacted_negative_dsts = torch.tensor([[6], [0], [0]])
     labels = torch.tensor([0.0, 1.0, 2.0])
     # Test minibatch without data.
     minibatch = gb.MiniBatch()
@@ -217,8 +217,12 @@ def test_minibatch_representation():
                                        [8],
                                        [8]])}],
           compacted_node_pairs=(tensor([0, 1, 2]), tensor([3, 4, 5])),
-          compacted_negative_srcs=tensor([0, 1, 2]),
-          compacted_negative_dsts=tensor([6, 0, 0]),
+          compacted_negative_srcs=tensor([[0],
+                                          [1],
+                                          [2]]),
+          compacted_negative_dsts=tensor([[6],
+                                          [0],
+                                          [0]]),
        )"""
     )
     result = str(minibatch)
@@ -267,8 +271,8 @@ def test_dgl_minibatch_representation():
     negative_dsts = torch.tensor([[2], [8], [8]])
     input_nodes = torch.tensor([8, 1, 6, 5, 9, 0, 2, 4])
     compacted_node_pairs = (torch.tensor([0, 1, 2]), torch.tensor([3, 4, 5]))
-    compacted_negative_srcs = torch.tensor([0, 1, 2])
-    compacted_negative_dsts = torch.tensor([6, 0, 0])
+    compacted_negative_srcs = torch.tensor([[0], [1], [2]])
+    compacted_negative_dsts = torch.tensor([[6], [0], [0]])
     labels = torch.tensor([0.0, 1.0, 2.0])
     # Test dglminibatch with all attributes.
     minibatch = gb.MiniBatch(


### PR DESCRIPTION
## Description
<!-- Brief description. Refer to the related issues if existed.
It'll be great if relevant reviewers can be assigned as well.-->

This PR try to address the following issues:
- [x] Fix the bug in `evaluate` function. (In the original code, compacted_neg_src and compacted_neg_dst are 1D tensors, which will cause the bug in `evaluate` function. We need to reserve the original shape of neg_src and neg_dst to reshape the compacted_neg_src and compacted_neg_dst)
- [x] Enable the example cude execution. (Since, `neg_ratio` in eval/test set is $1000$, which is too large for GPU memory. We need to set different batch size for evaluation stage.)
- [x] Update the test code to keep consistent with the above changes.

Trainning Log:
```
$ python examples/sampling/graphbolt/link_prediction.py --device cuda --early-stop 1000 --epochs 10 --num-workers 8
...
later
```

## Checklist
Please feel free to remove inapplicable items for your PR.
- [ ] The PR title starts with [$CATEGORY] (such as [NN], [Model], [Doc], [Feature]])
- [ ] I've leverage the [tools](https://docs.google.com/document/d/1iHyj7zlmygKSk5gBPsqIqL5ASPzJSPREaNT_QdsiYA4/edit) to beautify the python and c++ code.
- [ ] The PR is complete and small, read the [Google eng practice (CL equals to PR)](https://google.github.io/eng-practices/review/developer/small-cls.html) to understand more about small PR. In DGL, we consider PRs with less than 200 lines of core code change are small (example, test and documentation could be exempted).
- [ ] All changes have test coverage
- [ ] Code is well-documented
- [ ] To the best of my knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change
- [ ] Related issue is referred in this PR
- [ ] If the PR is for a new model/paper, I've updated the example index [here](../examples/README.md).

## Changes
<!-- You could use following template
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)
-->
