### PR TITLE
[Misc] Modify `create_dataloader()`

### DIFF
--- a/examples/sampling/graphbolt/node_classification.py
+++ b/examples/sampling/graphbolt/node_classification.py
@@ -236,7 +236,7 @@ def layerwise_infer(
         graph=graph,
         features=features,
         itemset=all_nodes_set,
-        batch_size=args.batch_size,
+        batch_size=4 * args.batch_size,
         fanout=[-1],
         device=args.device,
         num_workers=args.num_workers,


### PR DESCRIPTION
## Description
<!-- Brief description. Refer to the related issues if existed.
It'll be great if relevant reviewers can be assigned as well.-->
Currently, in `examples/sampling/graphbolt/node_classification.py`, function `create_dataloader()` has a parameter `args`, which contains the arguments parsed from the command line. This PR intends to decouple `create_dataloader()` from parameter `args`, bringing the following benefits:
1. Allow user to set different values for parameters(e.g. batch_size, num_workers) in trainning, evaluating and inference.
2. Make it easier to migrate function `create_dataloader()` to other code.

## Checklist
Please feel free to remove inapplicable items for your PR.
- [ ] The PR title starts with [$CATEGORY] (such as [NN], [Model], [Doc], [Feature]])
- [ ] I've leverage the [tools](https://docs.google.com/document/d/1iHyj7zlmygKSk5gBPsqIqL5ASPzJSPREaNT_QdsiYA4/edit) to beautify the python and c++ code.
- [ ] The PR is complete and small, read the [Google eng practice (CL equals to PR)](https://google.github.io/eng-practices/review/developer/small-cls.html) to understand more about small PR. In DGL, we consider PRs with less than 200 lines of core code change are small (example, test and documentation could be exempted).
- [ ] All changes have test coverage
- [ ] Code is well-documented
- [ ] To the best of my knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change
- [ ] Related issue is referred in this PR
- [ ] If the PR is for a new model/paper, I've updated the example index [here](../examples/README.md).

## Changes
<!-- You could use following template
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)
-->
