### PR TITLE
Improvement in running tests from the GRAPHBOLT test suite.

### DIFF
--- a/tests/python/pytorch/graphbolt/impl/__init__.py
+++ b/tests/python/pytorch/graphbolt/impl/__init__.py
@@ -1,0 +1,1 @@
+""" DGL graphbolt/impl tests"""


### PR DESCRIPTION
## Description
<!-- Brief description. Refer to the related issues if existed.
It'll be great if relevant reviewers can be assigned as well.-->
Currently, you can use `pytest`  
```
python3 -m pytest -v --junitxml=pytest_compute.xml --durations=100 tests/python/pytorch/graphbolt
```
to run all tests from the `graphbolt` directory, including those in the `graphbolt` directory including those in `graphbolt/impl/` subdirectory.  Unfortunately, attempting to run only tests from `graphbolt/impl/` or any of its files in this manner fails:
```
_________ ERROR collecting tests/python/pytorch/graphbolt/impl/test_csc_sampling_graph.py ______________________________________________________
ImportError while importing test module '/opt/dgl/dgl-source/tests/python/pytorch/graphbolt/impl/test_csc_sampling_graph.py'.
Hint: make sure your test modules/packages have valid Python names.
Traceback:
/usr/lib/python3.10/importlib/__init__.py:126: in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
tests/python/pytorch/graphbolt/impl/test_csc_sampling_graph.py:11: in <module>
    import gb_test_utils as gbt
E   ModuleNotFoundError: No module named 'gb_test_utils'
```
By adding `__init__.py` file to `tests/python/pytorch/graphbolt/impl/` directory we can fix this problem.

This fix also allows us to run a specific test from any  `../graphbolt/impl/test_file.py`:
```
python3 -m pytest -v --junitxml=pytest_compute.xml --durations=100 tests/python/pytorch/graphbolt/impl/test_file.py::test_testName
```

## Checklist
Please feel free to remove inapplicable items for your PR.
- [x] I've leverage the [tools](https://docs.google.com/document/d/1iHyj7zlmygKSk5gBPsqIqL5ASPzJSPREaNT_QdsiYA4/edit) to beautify the python and c++ code.
- [x] The PR is complete and small, read the [Google eng practice (CL equals to PR)](https://google.github.io/eng-practices/review/developer/small-cls.html) to understand more about small PR. In DGL, we consider PRs with less than 200 lines of core code change are small (example, test and documentation could be exempted).

