### PR TITLE
[Example] Add early stop option for better regression test.

### DIFF
--- a/examples/sampling/link_prediction.py
+++ b/examples/sampling/link_prediction.py
@@ -370,6 +370,8 @@ def train(args, device, g, reverse_eids, seed_edges, model, use_uva):
             loss.backward()
             opt.step()
             total_loss += loss.item()
+            if (it + 1) == args.early_stop:
+                break
         print(f"Epoch {epoch:05d} | Loss {total_loss / (it + 1):.4f}")
 
 
@@ -386,6 +388,12 @@ def parse_args():
         type=int,
         default=512,
         help="Batch size. Default: 512",
+    )
+    parser.add_argument(
+        "--early-stop",
+        type=int,
+        default=0,
+        help="0 means no early stop, otherwise stop at the input-th step",
     )
     parser.add_argument(
         "--mode",


### PR DESCRIPTION
## Description
<!-- Brief description. Refer to the related issues if existed.
It'll be great if relevant reviewers can be assigned as well.-->
Given that the entire training set in `ogbl-citation2` is excessively large, requiring substantial computational resources, we have introduced an `early-stop` option in the new GraphBolt link prediction example to manage and reduce the time cost during the training stage.

Currently, I need to implement a regression test. To maintain consistency, I believe it is crucial to include this option in the DGL version example as well.

## Checklist
Please feel free to remove inapplicable items for your PR.
- [x] The PR title starts with [$CATEGORY] (such as [NN], [Model], [Doc], [Feature]])
- [x] I've leverage the [tools](https://docs.google.com/document/d/1iHyj7zlmygKSk5gBPsqIqL5ASPzJSPREaNT_QdsiYA4/edit) to beautify the python and c++ code.
- [x] The PR is complete and small, read the [Google eng practice (CL equals to PR)](https://google.github.io/eng-practices/review/developer/small-cls.html) to understand more about small PR. In DGL, we consider PRs with less than 200 lines of core code change are small (example, test and documentation could be exempted).
- [ ] All changes have test coverage
- [x] Code is well-documented
- [ ] To the best of my knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change
- [ ] Related issue is referred in this PR
- [ ] If the PR is for a new model/paper, I've updated the example index [here](../examples/README.md).

## Changes
<!-- You could use following template
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)
-->
