### PR TITLE
[Graphbolt] Enable Link Prediction example model.inference to accelerate the evaluation speed

### DIFF
--- a/examples/sampling/graphbolt/link_prediction.py
+++ b/examples/sampling/graphbolt/link_prediction.py
@@ -107,7 +107,7 @@ class SAGE(nn.Module):
                 # By design, our output nodes are contiguous.
                 y[
                     data.output_nodes[0] : data.output_nodes[-1] + 1
-                ] = hidden_x.to(buffer_device)
+                ] = hidden_x.to(buffer_device, non_blocking=True)
             feature = y
 
         return y
@@ -368,10 +368,7 @@ def parse_args():
     parser.add_argument("--lr", type=float, default=0.0005)
     parser.add_argument("--neg-ratio", type=int, default=1)
     parser.add_argument("--train-batch-size", type=int, default=512)
-    # TODO [Issue#6534]: Use model.inference instead of dataloader to evaluate.
-    # Since neg_ratio in valid/test set is 1000, which is too large to GPU
-    # memory, we should use small batch size to evaluate.
-    parser.add_argument("--eval-batch-size", type=int, default=2)
+    parser.add_argument("--eval-batch-size", type=int, default=1024)
     parser.add_argument("--num-workers", type=int, default=4)
     parser.add_argument(
         "--early-stop",

--- a/examples/sampling/graphbolt/link_prediction.py
+++ b/examples/sampling/graphbolt/link_prediction.py
@@ -78,6 +78,39 @@ class SAGE(nn.Module):
                 hidden_x = F.relu(hidden_x)
         return hidden_x
 
+    def inference(self, graph, features, dataloader, device):
+        """Conduct layer-wise inference to get all the node embeddings."""
+        feature = features.read("node", None, "feat")
+
+        buffer_device = torch.device("cpu")
+        # Enable pin_memory for faster CPU to GPU data transfer if the
+        # model is running on a GPU.
+        pin_memory = buffer_device != device
+
+        for layer_idx, layer in enumerate(self.layers):
+            is_last_layer = layer_idx == len(self.layers) - 1
+
+            y = torch.empty(
+                graph.total_num_nodes,
+                self.hidden_size,
+                dtype=torch.float32,
+                device=buffer_device,
+                pin_memory=pin_memory,
+            )
+            feature = feature.to(device)
+            for step, data in tqdm.tqdm(enumerate(dataloader)):
+                x = feature[data.input_nodes]
+                hidden_x = layer(data.blocks[0], x)  # len(blocks) = 1
+                if not is_last_layer:
+                    hidden_x = F.relu(hidden_x)
+                # By design, our output nodes are contiguous.
+                y[
+                    data.output_nodes[0] : data.output_nodes[-1] + 1
+                ] = hidden_x.to(buffer_device)
+            feature = y
+
+        return y
+
 
 def create_dataloader(args, graph, features, itemset, is_train=True):
     """Get a GraphBolt version of a dataloader for link prediction tasks. This
@@ -166,9 +199,12 @@ def create_dataloader(args, graph, features, itemset, is_train=True):
     # A FeatureFetcher object to fetch node features.
     # [Role]:
     # Initialize a feature fetcher for fetching features of the sampled
-    # subgraphs.
+    # subgraphs. This step is skipped in evaluation/inference because features
+    # are updated as a whole during it, thus storing features in minibatch is
+    # unnecessary.
     ############################################################################
-    datapipe = datapipe.fetch_feature(features, node_feature_keys=["feat"])
+    if is_train:
+        datapipe = datapipe.fetch_feature(features, node_feature_keys=["feat"])
 
     ############################################################################
     # [Step-4]:
@@ -223,50 +259,70 @@ def to_binary_link_dgl_computing_pack(data: gb.DGLMiniBatch):
 
 
 @torch.no_grad()
-def evaluate(args, graph, features, itemset, model):
-    evaluator = Evaluator(name="ogbl-citation2")
+def compute_mrr(args, model, evaluator, node_emb, src, dst, neg_dst):
+    """Compute the Mean Reciprocal Rank (MRR) for given source and destination
+    nodes.
 
-    # Since we need to evaluate the model, we need to set the number
-    # of layers to 3 and the fanout to -1.
-    args.fanout = [-1] * 3
-    dataloader = create_dataloader(
-        args, graph, features, itemset, is_train=False
-    )
-    pos_pred = []
-    neg_pred = []
+    This function computes the MRR for a set of node pairs, dividing the task
+    into batches to handle potentially large graphs.
+    """
+    rr = torch.zeros(src.shape[0])
+    # Loop over node pairs in batches.
+    for start in tqdm.trange(
+        0, src.shape[0], args.eval_batch_size, desc="Evaluate"
+    ):
+        end = min(start + args.eval_batch_size, src.shape[0])
 
-    model.eval()
-    for step, data in tqdm.tqdm(enumerate(dataloader)):
-        # Unpack MiniBatch.
-        compacted_pairs, _ = to_binary_link_dgl_computing_pack(data)
-        node_feature = data.node_features["feat"].float()
-        blocks = data.blocks
+        # Concatenate positive and negative destination nodes.
+        all_dst = torch.cat([dst[start:end, None], neg_dst[start:end]], 1)
 
-        # Get the embeddings of the input nodes.
-        y = model(blocks, node_feature)
-        # Calculate the score for positive and negative edges.
-        score = (
-            model.predictor(y[compacted_pairs[0]] * y[compacted_pairs[1]])
-            .squeeze()
-            .detach()
+        # Fetch embeddings for current batch of source and destination nodes.
+        h_src = node_emb[src[start:end]][:, None, :].to(args.device)
+        h_dst = (
+            node_emb[all_dst.view(-1)].view(*all_dst.shape, -1).to(args.device)
         )
 
-        # Split the score into positive and negative parts.
-        pos_score = score[: data.positive_node_pairs[0].shape[0]]
-        neg_score = score[data.positive_node_pairs[0].shape[0] :]
+        # Compute prediction scores using the model.
+        pred = model.predictor(h_src * h_dst).squeeze(-1)
 
-        # Append the score to the list.
-        pos_pred.append(pos_score)
-        neg_pred.append(neg_score)
-    pos_pred = torch.cat(pos_pred, dim=0)
-    neg_pred = torch.cat(neg_pred, dim=0).view(pos_pred.shape[0], -1)
-
-    input_dict = {"y_pred_pos": pos_pred, "y_pred_neg": neg_pred}
-    mrr = evaluator.eval(input_dict)["mrr_list"]
-    return mrr.mean()
+        # Evaluate the predictions to obtain MRR values.
+        input_dict = {"y_pred_pos": pred[:, 0], "y_pred_neg": pred[:, 1:]}
+        rr[start:end] = evaluator.eval(input_dict)["mrr_list"]
+    return rr.mean()
 
 
-def train(args, graph, features, train_set, valid_set, model):
+@torch.no_grad()
+def evaluate(args, model, graph, features, all_nodes_set, valid_set, test_set):
+    """Evaluate the model on validation and test sets."""
+    model.eval()
+    evaluator = Evaluator(name="ogbl-citation2")
+
+    # Since we need to use all neghborhoods for evaluation, we set the fanout
+    # to -1.
+    args.fanout = [-1]
+    dataloader = create_dataloader(
+        args, graph, features, all_nodes_set, is_train=False
+    )
+
+    # Compute node embeddings for the entire graph.
+    node_emb = model.inference(graph, features, dataloader, args.device)
+    results = []
+
+    # Loop over both validation and test sets.
+    for split in [valid_set, test_set]:
+        # Unpack the item set.
+        src = split._items[0][:, 0].to(node_emb.device)
+        dst = split._items[0][:, 1].to(node_emb.device)
+        neg_dst = split._items[1].to(node_emb.device)
+
+        # Compute MRR values for the current split.
+        results.append(
+            compute_mrr(args, model, evaluator, node_emb, src, dst, neg_dst)
+        )
+    return results
+
+
+def train(args, model, graph, features, train_set):
     optimizer = torch.optim.Adam(model.parameters(), lr=args.lr)
     dataloader = create_dataloader(args, graph, features, train_set)
 
@@ -276,7 +332,7 @@ def train(args, graph, features, train_set, valid_set, model):
         for step, data in enumerate(dataloader):
             # Unpack MiniBatch.
             compacted_pairs, labels = to_binary_link_dgl_computing_pack(data)
-            node_feature = data.node_features["feat"].float()
+            node_feature = data.node_features["feat"]
             # Convert sampled subgraphs to DGL blocks.
             blocks = data.blocks
 
@@ -302,11 +358,6 @@ def train(args, graph, features, train_set, valid_set, model):
                 )
             if step + 1 == args.early_stop:
                 break
-
-    # Evaluate the model.
-    print("Validation")
-    valid_mrr = evaluate(args, graph, features, valid_set, model)
-    print(f"Valid MRR {valid_mrr.item():.4f}")
 
 
 def parse_args():
@@ -352,7 +403,6 @@ def main(args):
     graph = dataset.graph
     features = dataset.feature
     train_set = dataset.tasks[0].train_set
-    valid_set = dataset.tasks[0].validation_set
     args.fanout = list(map(int, args.fanout.split(",")))
 
     in_size = features.size("node", None, "feat")[0]
@@ -362,13 +412,20 @@ def main(args):
 
     # Model training.
     print("Training...")
-    train(args, graph, features, train_set, valid_set, model)
+    train(args, model, graph, features, train_set)
 
     # Test the model.
     print("Testing...")
     test_set = dataset.tasks[0].test_set
-    test_mrr = evaluate(args, graph, features, test_set, model)
-    print(f"Test MRR {test_mrr.item():.4f}")
+    valid_set = dataset.tasks[0].validation_set
+    all_nodes_set = dataset.all_nodes_set
+    valid_mrr, test_mrr = evaluate(
+        args, model, graph, features, all_nodes_set, valid_set, test_set
+    )
+    print(
+        f"Validation MRR {valid_mrr.item():.4f}, "
+        f"Test MRR {test_mrr.item():.4f}"
+    )
 
 
 if __name__ == "__main__":

--- a/examples/sampling/graphbolt/link_prediction.py
+++ b/examples/sampling/graphbolt/link_prediction.py
@@ -42,8 +42,8 @@ main
 └───> Test set evaluation
 """
 import argparse
+import time
 
-import dgl
 import dgl.graphbolt as gb
 import dgl.nn as dglnn
 import torch
@@ -87,6 +87,7 @@ class SAGE(nn.Module):
         # model is running on a GPU.
         pin_memory = buffer_device != device
 
+        print("Start node embedding inference.")
         for layer_idx, layer in enumerate(self.layers):
             is_last_layer = layer_idx == len(self.layers) - 1
 
@@ -329,6 +330,7 @@ def train(args, model, graph, features, train_set):
     for epoch in tqdm.trange(args.epochs):
         model.train()
         total_loss = 0
+        start_epoch_time = time.time()
         for step, data in enumerate(dataloader):
             # Unpack MiniBatch.
             compacted_pairs, labels = to_binary_link_dgl_computing_pack(data)
@@ -349,15 +351,15 @@ def train(args, model, graph, features, train_set):
             optimizer.step()
 
             total_loss += loss.item()
-            if (step % 100 == 0) and (step != 0):
-                print(
-                    f"Epoch {epoch:05d} | "
-                    f"Step {step:05d} | "
-                    f"Loss {(total_loss) / (step + 1):.4f}",
-                    end="\n",
-                )
             if step + 1 == args.early_stop:
                 break
+
+        end_epoch_time = time.time()
+        print(
+            f"Epoch {epoch:05d} | "
+            f"Loss {(total_loss) / (step + 1):.4f} | "
+            f"Time {(end_epoch_time - start_epoch_time):.4f} s"
+        )
 
 
 def parse_args():


### PR DESCRIPTION

## Description
<!-- Brief description. Refer to the related issues if existed.
It'll be great if relevant reviewers can be assigned as well.-->

Given that the original sampling-based evaluation function is considerably slower compared to the DGL inference-based evaluation, enabling the `model.inference` in the Link Prediction example is crucial for a more efficient and straightforward regression test.

### Performance
The updated evaluation function significantly reduces processing time, requiring less than 1 hour as opposed to over 12 hours with the original evaluation function.

Train log:
```
$ python examples/sampling/graphbolt/link_prediction.py --early-stop 1000 --train-batch-size 1024 --eval-batch-size 4096 --epochs 10 --device cuda --num-workers 4
Training in cuda mode.
Loading data
The dataset is already preprocessed.
Training...
  0%|                               | 0/10 [00:00<?, ?it/s]
Epoch 00000 | Loss 0.1416 | Time 97.7365 s
 10%|██▎                    | 1/10 [01:37<14:39, 97.74s/it]
Epoch 00001 | Loss 0.0880 | Time 101.1375 s
 20%|████▌                  | 2/10 [03:18<13:17, 99.74s/it]
Epoch 00002 | Loss 0.0799 | Time 98.7655 s
 30%|██████▉                | 3/10 [04:57<11:35, 99.29s/it]
Epoch 00003 | Loss 0.0738 | Time 100.2421 s
 40%|█████████▏             | 4/10 [06:37<09:58, 99.67s/it]
Epoch 00004 | Loss 0.0705 | Time 99.0592 s
 50%|███████████▌           | 5/10 [08:16<08:17, 99.45s/it]
Epoch 00005 | Loss 0.0679 | Time 99.2085 s
 60%|█████████████▊         | 6/10 [09:56<06:37, 99.37s/it]
Epoch 00006 | Loss 0.0657 | Time 99.6363 s
 70%|████████████████       | 7/10 [11:35<04:58, 99.46s/it]
Epoch 00007 | Loss 0.0633 | Time 101.9516 s
 80%|█████████████████▌    | 8/10 [13:17<03:20, 100.25s/it]
Epoch 00008 | Loss 0.0618 | Time 98.2041 s
 90%|████████████████████▋  | 9/10 [14:55<01:39, 99.61s/it]
Epoch 00009 | Loss 0.0606 | Time 98.8265 s
100%|██████████████████████| 10/10 [16:34<00:00, 99.48s/it]
Testing...
Start node embedding inference.
715it [00:02, 274.28it/s]
715it [00:02, 267.21it/s]
715it [00:02, 279.65it/s]
Evaluate: 100%|████████████| 22/22 [00:16<00:00,  1.32it/s]
Evaluate: 100%|████████████| 22/22 [00:16<00:00,  1.35it/s]
Validation MRR 0.7480, Test MRR 0.7492
```

## Checklist
Please feel free to remove inapplicable items for your PR.
- [x] The PR title starts with [$CATEGORY] (such as [NN], [Model], [Doc], [Feature]])
- [x] I've leverage the [tools](https://docs.google.com/document/d/1iHyj7zlmygKSk5gBPsqIqL5ASPzJSPREaNT_QdsiYA4/edit) to beautify the python and c++ code.
- [x] The PR is complete and small, read the [Google eng practice (CL equals to PR)](https://google.github.io/eng-practices/review/developer/small-cls.html) to understand more about small PR. In DGL, we consider PRs with less than 200 lines of core code change are small (example, test and documentation could be exempted).
- [ ] All changes have test coverage
- [x] Code is well-documented
- [x] To the best of my knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change
- [x] Related issue is referred in this PR
- [x] If the PR is for a new model/paper, I've updated the example index [here](../examples/README.md).

## Changes
<!-- You could use following template
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)
-->
