### PR TITLE
Update doc network_emb.py

### DIFF
--- a/python/dgl/nn/pytorch/network_emb.py
+++ b/python/dgl/nn/pytorch/network_emb.py
@@ -39,7 +39,7 @@ class DeepWalk(nn.Module):
     neg_weight : float, optional
         Weight of the loss term for negative samples in the total loss. Default: 1.0
     negative_size : int, optional
-        Number of negative samples to use for each positive sample. Default: 1
+        Number of negative samples to use for each positive sample. Default: 5
     fast_neg : bool, optional
         If True, it samples negative node pairs within a batch of random walks. Default: True
     sparse : bool, optional


### PR DESCRIPTION
## Description
<!-- Brief description. Refer to the related issues if existed.
It'll be great if relevant reviewers can be assigned as well.-->
The default value descrbed in the documentation of the DeepWalk code was wrong. Indeed, the default value for the negative_size parameter is 5 and not 1.

## Checklist
Please feel free to remove inapplicable items for your PR.
- [ ] The PR title starts with [$CATEGORY] (such as [NN], [Model], [Doc], [Feature]])
- [ ] I've leverage the [tools](https://docs.google.com/document/d/1iHyj7zlmygKSk5gBPsqIqL5ASPzJSPREaNT_QdsiYA4/edit) to beautify the python and c++ code.
- [x ] The PR is complete and small, read the [Google eng practice (CL equals to PR)](https://google.github.io/eng-practices/review/developer/small-cls.html) to understand more about small PR. In DGL, we consider PRs with less than 200 lines of core code change are small (example, test and documentation could be exempted).
- [ ] All changes have test coverage
- [x] Code is well-documented
- [ ] To the best of my knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change
- [ ] Related issue is referred in this PR
- [ ] If the PR is for a new model/paper, I've updated the example index [here](../examples/README.md).

## Changes
<!-- You could use following template
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)
-->
