### PR TITLE
[BUGFIX] Fix the lazy device copy issue of DGL node/edge features.

### DIFF
--- a/python/dgl/heterograph.py
+++ b/python/dgl/heterograph.py
@@ -5767,7 +5767,7 @@ class DGLGraph(object):
         """
         for frame in itertools.chain(self._node_frames, self._edge_frames):
             for col in frame._columns.values():
-                col.data
+                col.data # pylint: disable=pointless-statement
         return self
 
     def pin_memory_(self):

--- a/python/dgl/heterograph.py
+++ b/python/dgl/heterograph.py
@@ -5767,7 +5767,7 @@ class DGLGraph(object):
         """
         for frame in itertools.chain(self._node_frames, self._edge_frames):
             for col in frame._columns.values():
-                col.data # pylint: disable=pointless-statement
+                col.data  # pylint: disable=pointless-statement
         return self
 
     def pin_memory_(self):

--- a/python/dgl/heterograph.py
+++ b/python/dgl/heterograph.py
@@ -5661,6 +5661,9 @@ class DGLGraph(object):
         If the graph is already on the specified device, the function directly returns it.
         Otherwise, it returns a cloned graph on the specified device.
 
+        Note that data of node and edge features are not moved to the specified
+        device before being accessed or `materialize_data()` is called.
+
         Parameters
         ----------
         device : Framework-specific device context object
@@ -5751,6 +5754,21 @@ class DGLGraph(object):
         to
         """
         return self.to(F.cpu())
+
+    def materialize_data(self):
+        """Materialize the graph data on the current device.
+
+        This method is a no-op if the graph data is already materialized.
+
+        Returns
+        -------
+        DGLGraph
+            The graph on the current device.
+        """
+        for frame in itertools.chain(self._node_frames, self._edge_frames):
+            for col in frame._columns.values():
+                col.data
+        return self
 
     def pin_memory_(self):
         """Pin the graph structure and node/edge data to the page-locked memory for


### PR DESCRIPTION
## Description
Resolve #6542.

In the following code snippet
```
import dgl
import torch
from dgl.dataloading import GraphDataLoader


dataset = dgl.data.QM9EdgeDataset()
dataloader = GraphDataLoader(dataset, batch_size=64)

graph_list = []

for batch_graph, _ in dataloader:
    batch_graph = batch_graph.to('cuda:0')
    split_graphs = dgl.unbatch(batch_graph)

    graph_list.extend([graph.cpu() for graph in split_graphs])

    print(f'memory allocation: {torch.cuda.memory_allocated() / 1024**2} Mb')

    torch.cuda.empty_cache()
```
The GPU memory of node and edge features of `split_graphs` is not released properly. This is because when copying the split graphs to CPU, the `Column`, which is the DGL internal feature storage, does not copy data to CPU when [Column.to()](https://github.com/dmlc/dgl/blob/2f47c2413eb0764066651c56a9727f456b7794bf/python/dgl/frame.py#L280) is called. The copy only happen when [Column.data](https://github.com/dmlc/dgl/blob/2f47c2413eb0764066651c56a9727f456b7794bf/python/dgl/frame.py#L258) is called. In my fix, I simply copy the data to the device in `Column.to`. I am not sure whether there is any risk to do in this way. @BarclayII, do you have concerns?

## Checklist
Please feel free to remove inapplicable items for your PR.
- [ ] The PR title starts with [$CATEGORY] (such as [NN], [Model], [Doc], [Feature]])
- [ ] I've leverage the [tools](https://docs.google.com/document/d/1iHyj7zlmygKSk5gBPsqIqL5ASPzJSPREaNT_QdsiYA4/edit) to beautify the python and c++ code.
- [ ] The PR is complete and small, read the [Google eng practice (CL equals to PR)](https://google.github.io/eng-practices/review/developer/small-cls.html) to understand more about small PR. In DGL, we consider PRs with less than 200 lines of core code change are small (example, test and documentation could be exempted).
- [ ] All changes have test coverage
- [ ] Code is well-documented
- [ ] To the best of my knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change
- [ ] Related issue is referred in this PR
- [ ] If the PR is for a new model/paper, I've updated the example index [here](../examples/README.md).

## Changes
<!-- You could use following template
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)
-->
