### PR TITLE
[Misc.] Avoid calling `IsPinned` in the coo/csr constructor from every sampling process

### DIFF
--- a/include/dgl/aten/coo.h
+++ b/include/dgl/aten/coo.h
@@ -56,8 +56,7 @@ struct COOMatrix {
   /** @brief constructor */
   COOMatrix(
       int64_t nrows, int64_t ncols, IdArray rarr, IdArray carr,
-      IdArray darr = NullArray(), bool rsorted = false, bool csorted = false,
-      bool pin_memory = false)
+      IdArray darr = NullArray(), bool rsorted = false, bool csorted = false)
       : num_rows(nrows),
         num_cols(ncols),
         row(rarr),

--- a/include/dgl/aten/csr.h
+++ b/include/dgl/aten/csr.h
@@ -60,8 +60,7 @@ struct CSRMatrix {
         indptr(parr),
         indices(iarr),
         data(darr),
-        sorted(sorted_flag),
-        is_pinned(pin_memory) {
+        sorted(sorted_flag) {
     CheckValidity();
   }
 
@@ -125,10 +124,11 @@ struct CSRMatrix {
            aten::IsNullArray(data);
   }
 
-  inline bool IsPinned() const {
-    return (aten::IsNullArray(indptr) || indptr.IsPinned()) &&
-           (aten::IsNullArray(indices) || indices.IsPinned()) &&
-           (aten::IsNullArray(data) || data.IsPinned());
+  inline bool CheckIfPinnedInCUDA() {
+    is_pinned = (aten::IsNullArray(indptr) || indptr.IsPinned()) &&
+                (aten::IsNullArray(indices) || indices.IsPinned()) &&
+                (aten::IsNullArray(data) || data.IsPinned());
+    return is_pinned;
   }
 
   /** @brief Return a copy of this matrix on the give device context. */
@@ -145,9 +145,8 @@ struct CSRMatrix {
       if (is_pinned) return *this;
       auto new_csr = CSRMatrix(
           num_rows, num_cols, indptr.PinMemory(), indices.PinMemory(),
-          aten::IsNullArray(data) ? data : data.PinMemory(), sorted,
-          /*is_pinned=*/true);
-      CHECK(new_csr.IsPinned())
+          aten::IsNullArray(data) ? data : data.PinMemory(), sorted);
+      CHECK(new_csr.CheckIfPinnedInCUDA())
           << "An internal DGL error has occured while trying to pin a CSR "
              "matrix. Please file a bug at "
              "'https://github.com/dmlc/dgl/issues' "

--- a/include/dgl/aten/csr.h
+++ b/include/dgl/aten/csr.h
@@ -53,8 +53,7 @@ struct CSRMatrix {
   /** @brief constructor */
   CSRMatrix(
       int64_t nrows, int64_t ncols, IdArray parr, IdArray iarr,
-      IdArray darr = NullArray(), bool sorted_flag = false,
-      bool pin_memory = false)
+      IdArray darr = NullArray(), bool sorted_flag = false)
       : num_rows(nrows),
         num_cols(ncols),
         indptr(parr),
@@ -124,6 +123,8 @@ struct CSRMatrix {
            aten::IsNullArray(data);
   }
 
+  // Check and update the internal flag is_pinned.
+  // This function will initialize a cuda context.
   inline bool CheckIfPinnedInCUDA() {
     is_pinned = (aten::IsNullArray(indptr) || indptr.IsPinned()) &&
                 (aten::IsNullArray(indices) || indices.IsPinned()) &&

--- a/include/dgl/aten/csr.h
+++ b/include/dgl/aten/csr.h
@@ -145,7 +145,8 @@ struct CSRMatrix {
       if (is_pinned) return *this;
       auto new_csr = CSRMatrix(
           num_rows, num_cols, indptr.PinMemory(), indices.PinMemory(),
-          aten::IsNullArray(data) ? data : data.PinMemory(), sorted, /*is_pinned=*/true);
+          aten::IsNullArray(data) ? data : data.PinMemory(), sorted,
+          /*is_pinned=*/true);
       CHECK(new_csr.IsPinned())
           << "An internal DGL error has occured while trying to pin a CSR "
              "matrix. Please file a bug at "


### PR DESCRIPTION
## Description
This PR addresses https://github.com/dmlc/dgl/issues/6561.
It moves the `IsPinned` checking block out of the coo/csr constructor, to avoid initialize cuda instances at sampling(child) processes and align with PyTorch dataloader convention.

## Checklist
Please feel free to remove inapplicable items for your PR.
- [x] The PR title starts with [$CATEGORY] (such as [NN], [Model], [Doc], [Feature]])
- [x] I've leverage the [tools](https://docs.google.com/document/d/1iHyj7zlmygKSk5gBPsqIqL5ASPzJSPREaNT_QdsiYA4/edit) to beautify the python and c++ code.
- [x] The PR is complete and small, read the [Google eng practice (CL equals to PR)](https://google.github.io/eng-practices/review/developer/small-cls.html) to understand more about small PR. In DGL, we consider PRs with less than 200 lines of core code change are small (example, test and documentation could be exempted).
- [x] All changes have test coverage
- [ ] Code is well-documented
- [x] To the best of my knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change
- [x] Related issue is referred in this PR
- [ ] If the PR is for a new model/paper, I've updated the example index [here](../examples/README.md).

