### PR TITLE
[Misc] Add compare-to-graphbolt mode for regression test

### DIFF
--- a/examples/sampling/node_classification.py
+++ b/examples/sampling/node_classification.py
@@ -177,8 +177,8 @@ def layerwise_infer(device, graph, nid, model, num_classes, batch_size):
 
 def train(args, device, g, dataset, model, num_classes, use_uva):
     # Create sampler & dataloader.
-    train_idx = dataset.train_idx.to(device)
-    val_idx = dataset.val_idx.to(device)
+    train_idx = dataset.train_idx.to(g.device if not use_uva else device)
+    val_idx = dataset.val_idx.to(g.device if not use_uva else device)
     #####################################################################
     # (HIGHLIGHT) Instantiate a NeighborSampler object for efficient
     # training of Graph Neural Networks (GNNs) on large-scale graphs.
@@ -267,7 +267,7 @@ if __name__ == "__main__":
     parser.add_argument(
         "--mode",
         default="mixed",
-        choices=["cpu", "mixed", "gpu"],
+        choices=["cpu", "mixed", "gpu", "non-uva"],
         help="Training mode. 'cpu' for CPU training, 'mixed' for "
         "CPU-GPU mixed training, 'gpu' for pure-GPU training.",
     )


### PR DESCRIPTION
## Description
<!-- Brief description. Refer to the related issues if existed.
It'll be great if relevant reviewers can be assigned as well.-->
Add non-uva mode in `examples/sampling/node_classification.py`, which is consistent with 'cuda' mode in `examples/sampling/graphbolt/node_classification.py`, for regression test.

## Checklist
Please feel free to remove inapplicable items for your PR.
- [ ] The PR title starts with [$CATEGORY] (such as [NN], [Model], [Doc], [Feature]])
- [ ] I've leverage the [tools](https://docs.google.com/document/d/1iHyj7zlmygKSk5gBPsqIqL5ASPzJSPREaNT_QdsiYA4/edit) to beautify the python and c++ code.
- [ ] The PR is complete and small, read the [Google eng practice (CL equals to PR)](https://google.github.io/eng-practices/review/developer/small-cls.html) to understand more about small PR. In DGL, we consider PRs with less than 200 lines of core code change are small (example, test and documentation could be exempted).
- [ ] All changes have test coverage
- [ ] Code is well-documented
- [ ] To the best of my knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change
- [ ] Related issue is referred in this PR
- [ ] If the PR is for a new model/paper, I've updated the example index [here](../examples/README.md).

## Changes
<!-- You could use following template
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)
-->
