### PR TITLE
[GraphBolt] Add not_deduplication compact.

### DIFF
--- a/python/dgl/graphbolt/__init__.py
+++ b/python/dgl/graphbolt/__init__.py
@@ -20,6 +20,7 @@ from .sampled_subgraph import *
 from .subgraph_sampler import *
 from .utils import (
     add_reverse_edges,
+    compact_node_pairs,
     exclude_seed_edges,
     unique_and_compact,
     unique_and_compact_node_pairs,

--- a/tests/python/pytorch/graphbolt/test_subgraph_sampler.py
+++ b/tests/python/pytorch/graphbolt/test_subgraph_sampler.py
@@ -1,3 +1,4 @@
+import dgl
 import dgl.graphbolt as gb
 import gb_test_utils
 import pytest
@@ -254,4 +255,118 @@ def test_SubgraphSampler_Random_Hetero_Graph(labor):
                 assert torch.equal(
                     torch.ge(value, torch.zeros(len(value))),
                     torch.ones(len(value)),
+                )
+
+
+@pytest.mark.parametrize("labor", [False, True])
+def test_SubgraphSampler_without_dedpulication_Homo(labor):
+    graph = dgl.graph(
+        ([5, 0, 1, 5, 6, 7, 2, 2, 4], [0, 1, 2, 2, 2, 2, 3, 4, 4])
+    )
+    graph = gb.from_dglgraph(graph, True)
+    seed_nodes = torch.LongTensor([0, 3, 4])
+
+    itemset = gb.ItemSet(seed_nodes, names="seed_nodes")
+    item_sampler = gb.ItemSampler(itemset, batch_size=len(seed_nodes))
+    num_layer = 2
+    fanouts = [torch.LongTensor([2]) for _ in range(num_layer)]
+
+    Sampler = gb.LayerNeighborSampler if labor else gb.NeighborSampler
+    datapipe = Sampler(item_sampler, graph, fanouts, deduplicate=False)
+
+    length = [17, 7]
+    compacted_indices = [
+        torch.arange(0, 10) + 7,
+        torch.arange(0, 4) + 3,
+    ]
+    indptr = [
+        torch.tensor([0, 1, 2, 4, 4, 6, 8, 10]),
+        torch.tensor([0, 1, 2, 4]),
+    ]
+    seeds = [torch.tensor([0, 3, 4, 5, 2, 2, 4]), torch.tensor([0, 3, 4])]
+    for data in datapipe:
+        for step, sampled_subgraph in enumerate(data.sampled_subgraphs):
+            assert len(sampled_subgraph.original_row_node_ids) == length[step]
+            assert torch.equal(
+                sampled_subgraph.node_pairs.indices, compacted_indices[step]
+            )
+            assert torch.equal(sampled_subgraph.node_pairs.indptr, indptr[step])
+            assert torch.equal(
+                sampled_subgraph.original_column_node_ids, seeds[step]
+            )
+
+
+@pytest.mark.parametrize("labor", [False, True])
+def test_SubgraphSampler_without_dedpulication_Hetero(labor):
+    graph = get_hetero_graph()
+    itemset = gb.ItemSetDict(
+        {"n2": gb.ItemSet(torch.arange(2), names="seed_nodes")}
+    )
+    item_sampler = gb.ItemSampler(itemset, batch_size=2)
+    num_layer = 2
+    fanouts = [torch.LongTensor([2]) for _ in range(num_layer)]
+    Sampler = gb.LayerNeighborSampler if labor else gb.NeighborSampler
+    datapipe = Sampler(item_sampler, graph, fanouts, deduplicate=False)
+    node_pairs = [
+        {
+            "n1:e1:n2": {
+                "indptr": torch.tensor([0, 2, 4]),
+                "indices": torch.tensor([4, 5, 6, 7]),
+            },
+            "n2:e2:n1": {
+                "indptr": torch.tensor([0, 2, 4, 6, 8]),
+                "indices": torch.tensor([2, 3, 4, 5, 6, 7, 8, 9]),
+            },
+        },
+        {
+            "n1:e1:n2": {
+                "indptr": torch.tensor([0, 2, 4]),
+                "indices": torch.tensor([0, 1, 2, 3]),
+            },
+            "n2:e2:n1": {
+                "indptr": torch.tensor([0]),
+                "indices": torch.tensor([], dtype=torch.int64),
+            },
+        },
+    ]
+    original_column_node_ids = [
+        {
+            "n1": torch.tensor([0, 1, 1, 0]),
+            "n2": torch.tensor([0, 1]),
+        },
+        {
+            "n1": torch.tensor([], dtype=torch.int64),
+            "n2": torch.tensor([0, 1]),
+        },
+    ]
+    original_row_node_ids = [
+        {
+            "n1": torch.tensor([0, 1, 1, 0, 0, 1, 1, 0]),
+            "n2": torch.tensor([0, 1, 0, 2, 0, 1, 0, 1, 0, 2]),
+        },
+        {
+            "n1": torch.tensor([0, 1, 1, 0]),
+            "n2": torch.tensor([0, 1]),
+        },
+    ]
+
+    for data in datapipe:
+        for step, sampled_subgraph in enumerate(data.sampled_subgraphs):
+            for ntype in ["n1", "n2"]:
+                assert torch.equal(
+                    sampled_subgraph.original_row_node_ids[ntype],
+                    original_row_node_ids[step][ntype],
+                )
+                assert torch.equal(
+                    sampled_subgraph.original_column_node_ids[ntype],
+                    original_column_node_ids[step][ntype],
+                )
+            for etype in ["n1:e1:n2", "n2:e2:n1"]:
+                assert torch.equal(
+                    sampled_subgraph.node_pairs[etype].indices,
+                    node_pairs[step][etype]["indices"],
+                )
+                assert torch.equal(
+                    sampled_subgraph.node_pairs[etype].indptr,
+                    node_pairs[step][etype]["indptr"],
                 )


### PR DESCRIPTION
## Description
<!-- Brief description. Refer to the related issues if existed.
It'll be great if relevant reviewers can be assigned as well.-->
Add function `compact_node_pairs` to support NOT deduplication when sample >1 hops neighbors.
If `deduplicate` is True, the seeds between hops will be deduplicated. Otherwise, the seeds will be a combination of original seeds and new src_nodes.

### Example:
**Data**
```
g = dgl.graph(([5, 0, 1, 5, 6, 7, 2, 2, 4], [0, 1, 2, 2, 2, 2, 3, 4, 4]))
graph = gb.from_dglgraph(g, True)

seed_nodes = torch.LongTensor([0, 3, 4])
seed_nodes = torch.LongTensor([5, 2, 2, 4])

itemset = gb.ItemSet(seed_nodes, names="seed_nodes")
item_sampler = gb.ItemSampler(itemset, batch_size=len(seed_nodes))
num_layer = 2
fanouts = [torch.LongTensor([2]) for _ in range(num_layer)]
```
**Deduplicated**
```
datapipe = item_sampler.sample_neighbor(graph, fanouts)
```
**Deduplicated Output**
```
MiniBatch(seed_nodes=tensor([0, 3, 4]),
          sampled_subgraphs=[SampledSubgraphImpl(node_pairs=(tensor([3, 4, 4, 2, 5, 3]), tensor([0, 1, 2, 2, 4, 4])),
                                                original_column_node_ids=tensor([0, 3, 4, 5, 2]),
                                                original_edge_ids=None,
                                                original_row_node_ids=tensor([0, 3, 4, 5, 2, 1]),),
                            SampledSubgraphImpl(node_pairs=(tensor([3, 4, 4, 2]), tensor([0, 1, 2, 2])),
                                                original_column_node_ids=tensor([0, 3, 4]),
                                                original_edge_ids=None,
                                                original_row_node_ids=tensor([0, 3, 4, 5, 2]),)],
          node_pairs=None,
          node_features=None,
          negative_srcs=None,
          negative_dsts=None,
          labels=None,
          input_nodes=tensor([0, 3, 4, 5, 2, 1]),
          edge_features=None,
          compacted_node_pairs=None,
          compacted_negative_srcs=None,
          compacted_negative_dsts=None,
       )
```
**NOT Deduplicated**
```
datapipe = item_sampler.sample_neighbor(graph, fanouts, deduplicated=False)
```
**NOT Deduplicated Output**
```
MiniBatch(seed_nodes=tensor([0, 3, 4]),
          sampled_subgraphs=[SampledSubgraphImpl(node_pairs=CSCFormatBase(indptr=tensor([ 0,  1,  2,  4,  4,  6,  8, 10]), indices=tensor([ 7,  8,  9, 10, 11, 12, 13, 14, 15, 16])),
                                                original_column_node_ids=tensor([0, 3, 4, 5, 2, 2, 4]),
                                                original_edge_ids=None,
                                                original_row_node_ids=tensor([0, 3, 4, 5, 2, 2, 4, 5, 2, 2, 4, 6, 7, 5, 1, 2, 4]),),
                            SampledSubgraphImpl(node_pairs=CSCFormatBase(indptr=tensor([0, 1, 2, 4]), indices=tensor([3, 4, 5, 6])),
                                                original_edge_ids=None,
                                                original_row_node_ids=tensor([0, 3, 4, 5, 2, 2, 4]),)],
          node_pairs=None,
          node_features=None,
          negative_srcs=None,
          negative_dsts=None,
          labels=None,
          input_nodes=tensor([0, 3, 4, 5, 2, 2, 4, 5, 2, 2, 4, 6, 7, 5, 1, 2, 4]),
          edge_features=None,
          compacted_node_pairs=None,
          compacted_negative_srcs=None,
          compacted_negative_dsts=None,
       )
```

## Checklist
Please feel free to remove inapplicable items for your PR.
- [ ] The PR title starts with [$CATEGORY] (such as [NN], [Model], [Doc], [Feature]])
- [ ] I've leverage the [tools](https://docs.google.com/document/d/1iHyj7zlmygKSk5gBPsqIqL5ASPzJSPREaNT_QdsiYA4/edit) to beautify the python and c++ code.
- [ ] The PR is complete and small, read the [Google eng practice (CL equals to PR)](https://google.github.io/eng-practices/review/developer/small-cls.html) to understand more about small PR. In DGL, we consider PRs with less than 200 lines of core code change are small (example, test and documentation could be exempted).
- [ ] All changes have test coverage
- [ ] Code is well-documented
- [ ] To the best of my knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change
- [ ] Related issue is referred in this PR
- [ ] If the PR is for a new model/paper, I've updated the example index [here](../examples/README.md).

## Changes
<!-- You could use following template
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)
-->
