### PR TITLE
[GraphBolt] Set persistent_workers in MultiProcessDataLoader

### DIFF
--- a/examples/multigpu/graphbolt/node_classification.py
+++ b/examples/multigpu/graphbolt/node_classification.py
@@ -148,20 +148,10 @@ def create_dataloader(
 
 
 @torch.no_grad()
-def evaluate(rank, args, model, graph, features, itemset, num_classes, device):
+def evaluate(rank, model, dataloader, num_classes, device):
     model.eval()
     y = []
     y_hats = []
-    dataloader = create_dataloader(
-        args,
-        graph,
-        features,
-        itemset,
-        drop_last=False,
-        shuffle=False,
-        drop_uneven_inputs=False,
-        device=device,
-    )
 
     for step, data in (
         tqdm.tqdm(enumerate(dataloader)) if rank == 0 else enumerate(dataloader)
@@ -185,26 +175,13 @@ def train(
     world_size,
     rank,
     args,
-    graph,
-    features,
-    train_set,
-    valid_set,
+    train_dataloader,
+    valid_dataloader,
     num_classes,
     model,
     device,
 ):
     optimizer = torch.optim.Adam(model.parameters(), lr=args.lr)
-    # Create training data loader.
-    dataloader = create_dataloader(
-        args,
-        graph,
-        features,
-        train_set,
-        device,
-        drop_last=False,
-        shuffle=True,
-        drop_uneven_inputs=False,
-    )
 
     for epoch in range(args.epochs):
         epoch_start = time.time()
@@ -227,9 +204,9 @@ def train(
         ########################################################################
         with Join([model]):
             for step, data in (
-                tqdm.tqdm(enumerate(dataloader))
+                tqdm.tqdm(enumerate(train_dataloader))
                 if rank == 0
-                else enumerate(dataloader)
+                else enumerate(train_dataloader)
             ):
                 # The input features are from the source nodes in the first
                 # layer's computation graph.
@@ -258,11 +235,8 @@ def train(
         acc = (
             evaluate(
                 rank,
-                args,
                 model,
-                graph,
-                features,
-                valid_set,
+                valid_dataloader,
                 num_classes,
                 device,
             )
@@ -305,6 +279,7 @@ def run(rank, world_size, args, devices, dataset):
     features = dataset.feature
     train_set = dataset.tasks[0].train_set
     valid_set = dataset.tasks[0].validation_set
+    test_set = dataset.tasks[0].test_set
     args.fanout = list(map(int, args.fanout.split(",")))
     num_classes = dataset.tasks[0].metadata["num_classes"]
 
@@ -316,6 +291,40 @@ def run(rank, world_size, args, devices, dataset):
     model = SAGE(in_size, hidden_size, out_size).to(device)
     model = DDP(model)
 
+    # Create training data loader.
+    train_dataloader = create_dataloader(
+        args,
+        graph,
+        features,
+        train_set,
+        device,
+        drop_last=False,
+        shuffle=True,
+        drop_uneven_inputs=False,
+    )
+    # Create validation data loader.
+    valid_dataloader = create_dataloader(
+        args,
+        graph,
+        features,
+        valid_set,
+        drop_last=False,
+        shuffle=False,
+        drop_uneven_inputs=False,
+        device=device,
+    )
+    # Create testing data loader.
+    test_dataloader = create_dataloader(
+        args,
+        graph,
+        features,
+        test_set,
+        drop_last=False,
+        shuffle=False,
+        drop_uneven_inputs=False,
+        device=device,
+    )
+
     # Model training.
     if rank == 0:
         print("Training...")
@@ -323,10 +332,8 @@ def run(rank, world_size, args, devices, dataset):
         world_size,
         rank,
         args,
-        graph,
-        features,
-        train_set,
-        valid_set,
+        train_dataloader,
+        valid_dataloader,
         num_classes,
         model,
         device,
@@ -335,15 +342,11 @@ def run(rank, world_size, args, devices, dataset):
     # Test the model.
     if rank == 0:
         print("Testing...")
-    test_set = dataset.tasks[0].test_set
     test_acc = (
         evaluate(
             rank,
-            args,
             model,
-            graph,
-            features,
-            itemset=test_set,
+            test_dataloader,
             num_classes=num_classes,
             device=device,
         )

--- a/python/dgl/graphbolt/dataloader.py
+++ b/python/dgl/graphbolt/dataloader.py
@@ -81,18 +81,16 @@ class MultiprocessingWrapper(dp.iter.IterDataPipe):
     persistent_workers : bool, optional
         If True, the data loader will not shut down the worker processes after a
         dataset has been consumed once. This allows to maintain the workers
-        instances alive. If None, it will default to True when num_workers > 0.
+        instances alive.
     """
 
-    def __init__(self, datapipe, num_workers=0, persistent_workers=None):
+    def __init__(self, datapipe, num_workers=0, persistent_workers=True):
         self.datapipe = datapipe
         self.dataloader = torch.utils.data.DataLoader(
             datapipe,
             batch_size=None,
             num_workers=num_workers,
-            persistent_workers=(num_workers > 0)
-            if persistent_workers is None
-            else persistent_workers,
+            persistent_workers=(num_workers > 0) and persistent_workers,
         )
 
     def __iter__(self):
@@ -119,10 +117,10 @@ class MultiProcessDataLoader(torch.utils.data.DataLoader):
     persistent_workers : bool, optional
         If True, the data loader will not shut down the worker processes after a
         dataset has been consumed once. This allows to maintain the workers
-        instances alive. If None, it will default to True when num_workers > 0.
+        instances alive.
     """
 
-    def __init__(self, datapipe, num_workers=0, persistent_workers=None):
+    def __init__(self, datapipe, num_workers=0, persistent_workers=True):
         # Multiprocessing requires two modifications to the datapipe:
         #
         # 1. Insert a stage after ItemSampler to distribute the

--- a/python/dgl/graphbolt/dataloader.py
+++ b/python/dgl/graphbolt/dataloader.py
@@ -78,21 +78,21 @@ class MultiprocessingWrapper(dp.iter.IterDataPipe):
     num_workers : int, optional
         The number of worker processes. Default is 0, meaning that there
         will be no multiprocessing.
-    persistant_workers : bool, optional
+    persistent_workers : bool, optional
         If True, the data loader will not shut down the worker processes after a
         dataset has been consumed once. This allows to maintain the workers
         instances alive. If None, it will default to True when num_workers > 0.
     """
 
-    def __init__(self, datapipe, num_workers=0, persistant_workers=None):
+    def __init__(self, datapipe, num_workers=0, persistent_workers=None):
         self.datapipe = datapipe
         self.dataloader = torch.utils.data.DataLoader(
             datapipe,
             batch_size=None,
             num_workers=num_workers,
             persistent_workers=(num_workers > 0)
-            if persistant_workers is None
-            else persistant_workers,
+            if persistent_workers is None
+            else persistent_workers,
         )
 
     def __iter__(self):
@@ -116,13 +116,13 @@ class MultiProcessDataLoader(torch.utils.data.DataLoader):
     num_workers : int, optional
         Number of worker processes. Default is 0, which is identical to
         :class:`SingleProcessDataLoader`.
-    persistant_workers : bool, optional
+    persistent_workers : bool, optional
         If True, the data loader will not shut down the worker processes after a
         dataset has been consumed once. This allows to maintain the workers
         instances alive. If None, it will default to True when num_workers > 0.
     """
 
-    def __init__(self, datapipe, num_workers=0, persistant_workers=None):
+    def __init__(self, datapipe, num_workers=0, persistent_workers=None):
         # Multiprocessing requires two modifications to the datapipe:
         #
         # 1. Insert a stage after ItemSampler to distribute the
@@ -155,7 +155,7 @@ class MultiProcessDataLoader(torch.utils.data.DataLoader):
             FeatureFetcher,
             MultiprocessingWrapper,
             num_workers=num_workers,
-            persistant_workers=persistant_workers,
+            persistent_workers=persistent_workers,
         )
 
         # (3) Cut datapipe at CopyTo and wrap with prefetcher. This enables the


### PR DESCRIPTION
## Description
Given that the starting of workers is slow, we can set `persistent_workers` to True to avoid restarting at each epoch.
The multigpu example is also modified correspondingly.

## Checklist
Please feel free to remove inapplicable items for your PR.
- [ ] The PR title starts with [$CATEGORY] (such as [NN], [Model], [Doc], [Feature]])
- [ ] I've leverage the [tools](https://docs.google.com/document/d/1iHyj7zlmygKSk5gBPsqIqL5ASPzJSPREaNT_QdsiYA4/edit) to beautify the python and c++ code.
- [ ] The PR is complete and small, read the [Google eng practice (CL equals to PR)](https://google.github.io/eng-practices/review/developer/small-cls.html) to understand more about small PR. In DGL, we consider PRs with less than 200 lines of core code change are small (example, test and documentation could be exempted).
- [ ] All changes have test coverage
- [ ] Code is well-documented
- [ ] To the best of my knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change
- [ ] Related issue is referred in this PR
- [ ] If the PR is for a new model/paper, I've updated the example index [here](../examples/README.md).

## Changes
<!-- You could use following template
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)
-->
