### PR TITLE
Improving the JKNET example.

### DIFF
--- a/examples/pytorch/jknet/model.py
+++ b/examples/pytorch/jknet/model.py
@@ -41,6 +41,9 @@ class JKNet(nn.Module):
             feats = self.dropout(layer(g, feats))
             feat_lst.append(feats)
 
+        if self.mode == "lstm":
+            self.jump.lstm.flatten_parameters()
+
         g.ndata["h"] = self.jump(feat_lst)
         g.update_all(fn.copy_u("h", "m"), fn.sum("m", "h"))
 


### PR DESCRIPTION
## Description
<!-- Brief description. Refer to the related issues if existed.
It'll be great if relevant reviewers can be assigned as well.-->
Elimination of the `UserWarning`:
```
/usr/local/lib/python3.10/dist-packages/torch/nn/modules/rnn.py:881: UserWarning: RNN module weights are not part of single contiguous chunk of memory. This means they need to be compacted at every call, possibly greatly increasing memory usage. To compact weights again call flatten_parameters(). (Triggered internally at /opt/pytorch/pytorch/aten/src/ATen/native/cudnn/RNN.cpp:982.)
``` 
by using `flatten_parameters()` call for `lstm` mode.
## Checklist
Please feel free to remove inapplicable items for your PR.
- [x] I've leverage the [tools](https://docs.google.com/document/d/1iHyj7zlmygKSk5gBPsqIqL5ASPzJSPREaNT_QdsiYA4/edit) to beautify the python and c++ code.
- [x] The PR is complete and small, read the [Google eng practice (CL equals to PR)](https://google.github.io/eng-practices/review/developer/small-cls.html) to understand more about small PR. In DGL, we consider PRs with less than 200 lines of core code change are small (example, test and documentation could be exempted).
- [x] To the best of my knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change
