### PR TITLE
[Graphbolt][CUDA] Optimize UVA by using CUB sort

### DIFF
--- a/graphbolt/src/cuda/common.h
+++ b/graphbolt/src/cuda/common.h
@@ -19,7 +19,7 @@ namespace cuda {
 How to use this class to get a nonblocking thrust execution policy that uses
 torch's memory pool and the current cuda stream:
 
-cuda::CUDAWorkspaceAllocator allocator(ctx);
+cuda::CUDAWorkspaceAllocator allocator;
 const auto stream = torch::cuda::getDefaultCUDAStream();
 const auto exec_policy = thrust::cuda::par_nosync(allocator).on(stream);
 
@@ -43,7 +43,7 @@ class CUDAWorkspaceAllocator {
   CUDAWorkspaceAllocator& operator=(const CUDAWorkspaceAllocator&) = default;
 
   template <typename T>
-  std::unique_ptr<T, CUDAWorkspaceAllocator> alloc_unique(
+  std::unique_ptr<T, CUDAWorkspaceAllocator> AllocateStorage(
       std::size_t size) const {
     auto t = torch::empty(
         sizeof(T) * size, torch::TensorOptions()

--- a/graphbolt/src/cuda/common.h
+++ b/graphbolt/src/cuda/common.h
@@ -15,20 +15,24 @@
 namespace graphbolt {
 namespace cuda {
 
-/*
-How to use this class to get a nonblocking thrust execution policy that uses
-torch's memory pool and the current cuda stream:
-
-cuda::CUDAWorkspaceAllocator allocator;
-const auto stream = torch::cuda::getDefaultCUDAStream();
-const auto exec_policy = thrust::cuda::par_nosync(allocator).on(stream);
-
-Now, one can pass exec_policy to thrust functions
-
-To get an integer array of size 1000 whose lifetime is managed by unique_ptr,
-use: auto int_array = allocator.alloc_unique<int>(1000); int_array.get() gives
-the raw pointer.
-*/
+/**
+ * @brief This class is designed to allocate workspace storage
+ * and to get a nonblocking thrust execution policy
+ * that uses torch's CUDA memory pool and the current cuda stream:
+ *
+ * cuda::CUDAWorkspaceAllocator allocator;
+ * const auto stream = torch::cuda::getDefaultCUDAStream();
+ * const auto exec_policy = thrust::cuda::par_nosync(allocator).on(stream);
+ *
+ * Now, one can pass exec_policy to thrust functions
+ *
+ * To get an integer array of size 1000 whose lifetime is managed by unique_ptr,
+ * use:
+ *
+ * auto int_array = allocator.AllocateStorage<int>(1000);
+ *
+ * int_array.get() gives the raw pointer.
+ */
 class CUDAWorkspaceAllocator {
   using ptr_map_t = std::unordered_map<void*, torch::Tensor>;
   std::shared_ptr<ptr_map_t> pointers;

--- a/graphbolt/src/cuda/common.h
+++ b/graphbolt/src/cuda/common.h
@@ -9,8 +9,62 @@
 #include <c10/cuda/CUDAException.h>
 #include <cuda_runtime.h>
 
+#include <memory>
+#include <unordered_map>
+
 namespace graphbolt {
 namespace cuda {
+
+/*
+How to use this class to get a nonblocking thrust execution policy that uses
+DGL's memory pool and the current cuda stream
+
+cuda::CUDAWorkspaceAllocator allocator(ctx);
+const auto stream = torch::cuda::getDefaultCUDAStream();
+const auto exec_policy = thrust::cuda::par_nosync(allocator).on(stream);
+
+now, one can pass exec_policy to thrust functions
+
+to get an integer array of size 1000 whose lifetime is managed by unique_ptr,
+use: auto int_array = allocator.alloc_unique<int>(1000); int_array.get() gives
+the raw pointer.
+*/
+class CUDAWorkspaceAllocator {
+  using ptr_map_t = std::unordered_map<void*, torch::Tensor>;
+  std::shared_ptr<ptr_map_t> pointers;
+
+ public:
+  using value_type = char;
+
+  void operator()(void* ptr) const { pointers->erase(ptr); }
+
+  explicit CUDAWorkspaceAllocator() : pointers(std::make_shared<ptr_map_t>()) {}
+
+  CUDAWorkspaceAllocator& operator=(const CUDAWorkspaceAllocator&) = default;
+
+  template <typename T>
+  std::unique_ptr<T, CUDAWorkspaceAllocator> alloc_unique(
+      std::size_t size) const {
+    auto t = torch::empty(
+        size, torch::TensorOptions()
+                  .dtype(torch::kByte)
+                  .device(c10::DeviceType::CUDA));
+    pointers->operator[](t.data_ptr()) = t;
+    return std::unique_ptr<T, CUDAWorkspaceAllocator>(
+        reinterpret_cast<T*>(t.data_ptr()), *this);
+  }
+
+  char* allocate(std::ptrdiff_t size) const {
+    auto t = torch::empty(
+        size, torch::TensorOptions()
+                  .dtype(torch::kByte)
+                  .device(c10::DeviceType::CUDA));
+    pointers->operator[](t.data_ptr()) = t;
+    return reinterpret_cast<char*>(t.data_ptr());
+  }
+
+  void deallocate(char* ptr, std::size_t) const { pointers->erase(ptr); }
+};
 
 template <typename T>
 inline bool is_zero(T size) {
@@ -21,6 +75,13 @@ template <>
 inline bool is_zero<dim3>(dim3 size) {
   return size.x == 0 || size.y == 0 || size.z == 0;
 }
+
+#define CUDA_CALL(func)                                      \
+  {                                                          \
+    cudaError_t e = (func);                                  \
+    CHECK(e == cudaSuccess || e == cudaErrorCudartUnloading) \
+        << "CUDA: " << cudaGetErrorString(e);                \
+  }
 
 #define CUDA_KERNEL_CALL(kernel, nblks, nthrs, shmem, stream, ...)    \
   {                                                                   \

--- a/graphbolt/src/cuda/common.h
+++ b/graphbolt/src/cuda/common.h
@@ -76,12 +76,7 @@ inline bool is_zero<dim3>(dim3 size) {
   return size.x == 0 || size.y == 0 || size.z == 0;
 }
 
-#define CUDA_CALL(func)                                      \
-  {                                                          \
-    cudaError_t e = (func);                                  \
-    CHECK(e == cudaSuccess || e == cudaErrorCudartUnloading) \
-        << "CUDA: " << cudaGetErrorString(e);                \
-  }
+#define CUDA_CALL(func) C10_CUDA_CHECK((func))
 
 #define CUDA_KERNEL_CALL(kernel, nblks, nthrs, shmem, stream, ...)    \
   {                                                                   \

--- a/graphbolt/src/cuda/common.h
+++ b/graphbolt/src/cuda/common.h
@@ -17,15 +17,15 @@ namespace cuda {
 
 /*
 How to use this class to get a nonblocking thrust execution policy that uses
-DGL's memory pool and the current cuda stream
+torch's memory pool and the current cuda stream:
 
 cuda::CUDAWorkspaceAllocator allocator(ctx);
 const auto stream = torch::cuda::getDefaultCUDAStream();
 const auto exec_policy = thrust::cuda::par_nosync(allocator).on(stream);
 
-now, one can pass exec_policy to thrust functions
+Now, one can pass exec_policy to thrust functions
 
-to get an integer array of size 1000 whose lifetime is managed by unique_ptr,
+To get an integer array of size 1000 whose lifetime is managed by unique_ptr,
 use: auto int_array = allocator.alloc_unique<int>(1000); int_array.get() gives
 the raw pointer.
 */
@@ -46,9 +46,9 @@ class CUDAWorkspaceAllocator {
   std::unique_ptr<T, CUDAWorkspaceAllocator> alloc_unique(
       std::size_t size) const {
     auto t = torch::empty(
-        size, torch::TensorOptions()
-                  .dtype(torch::kByte)
-                  .device(c10::DeviceType::CUDA));
+        sizeof(T) * size, torch::TensorOptions()
+                              .dtype(torch::kByte)
+                              .device(c10::DeviceType::CUDA));
     pointers->operator[](t.data_ptr()) = t;
     return std::unique_ptr<T, CUDAWorkspaceAllocator>(
         reinterpret_cast<T*>(t.data_ptr()), *this);

--- a/graphbolt/src/cuda/index_select_impl.cu
+++ b/graphbolt/src/cuda/index_select_impl.cu
@@ -39,10 +39,10 @@ std::pair<torch::Tensor, torch::Tensor> Sort(
         CUDA_CALL(cub::DeviceRadixSort::SortPairs(
             nullptr, workspace_size, keys_in, keys_out, values_in, values_out,
             n_items, 0, num_bits, stream));
-        auto temporary_storage = allocator.alloc_unique<char>(workspace_size);
+        auto temp = allocator.AllocateStorage<char>(workspace_size);
         CUDA_CALL(cub::DeviceRadixSort::SortPairs(
-            temporary_storage.get(), workspace_size, keys_in, keys_out,
-            values_in, values_out, n_items, 0, num_bits, stream));
+            temp.get(), workspace_size, keys_in, keys_out, values_in,
+            values_out, n_items, 0, num_bits, stream));
       }));
   return std::make_pair(sorted_array, sorted_idx);
 }

--- a/graphbolt/src/cuda/index_select_impl.cu
+++ b/graphbolt/src/cuda/index_select_impl.cu
@@ -7,11 +7,6 @@
 #include <c10/cuda/CUDAStream.h>
 #include <torch/script.h>
 
-// This should be defined in CMakeLists.txt
-// #ifndef THRUST_CUB_WRAPPED_NAMESPACE
-// static_assert(false, "THRUST_CUB_WRAPPED_NAMESPACE must be defined for
-// DGL."); #endif
-
 #include <numeric>
 
 #include "../index_select.h"

--- a/graphbolt/src/cuda/index_select_impl.cu
+++ b/graphbolt/src/cuda/index_select_impl.cu
@@ -7,14 +7,50 @@
 #include <c10/cuda/CUDAStream.h>
 #include <torch/script.h>
 
+// This should be defined in CMakeLists.txt
+// #ifndef THRUST_CUB_WRAPPED_NAMESPACE
+// static_assert(false, "THRUST_CUB_WRAPPED_NAMESPACE must be defined for
+// DGL."); #endif
+
 #include <numeric>
 
 #include "../index_select.h"
 #include "./common.h"
 #include "./utils.h"
+#include "cub/cub.cuh"
 
 namespace graphbolt {
 namespace ops {
+
+std::pair<torch::Tensor, torch::Tensor> Sort(
+    torch::Tensor input, int num_bits) {
+  int64_t n_items = input.size(0);
+  auto orig_idx = torch::arange(n_items, input.options().dtype(torch::kLong));
+  auto sorted_array = torch::empty_like(input);
+  auto sorted_idx = torch::empty_like(orig_idx);
+  cuda::CUDAWorkspaceAllocator allocator;
+  AT_DISPATCH_INDEX_TYPES(
+      input.scalar_type(), "SortImpl", ([&] {
+        using IdType = index_t;
+        const auto keys_in = input.data_ptr<index_t>();
+        const int64_t* values_in = orig_idx.data_ptr<int64_t>();
+        IdType* keys_out = sorted_array.data_ptr<index_t>();
+        int64_t* values_out = sorted_idx.data_ptr<int64_t>();
+        cudaStream_t stream = torch::cuda::getDefaultCUDAStream();
+        if (num_bits == 0) {
+          num_bits = sizeof(index_t) * 8;
+        }
+        size_t workspace_size = 0;
+        CUDA_CALL(cub::DeviceRadixSort::SortPairs(
+            nullptr, workspace_size, keys_in, keys_out, values_in, values_out,
+            n_items, 0, num_bits, stream));
+        auto temporary_storage = allocator.alloc_unique<char>(workspace_size);
+        CUDA_CALL(cub::DeviceRadixSort::SortPairs(
+            temporary_storage.get(), workspace_size, keys_in, keys_out,
+            values_in, values_out, n_items, 0, num_bits, stream));
+      }));
+  return std::make_pair(sorted_array, sorted_idx);
+}
 
 /** @brief Index select operator implementation for feature size 1. */
 template <typename DType, typename IdType>
@@ -115,7 +151,8 @@ torch::Tensor UVAIndexSelectImpl_(torch::Tensor input, torch::Tensor index) {
 
   // Sort the index to improve the memory access pattern.
   torch::Tensor sorted_index, permutation;
-  std::tie(sorted_index, permutation) = torch::sort(index);
+  std::tie(sorted_index, permutation) =
+      Sort(index, cuda::NumberOfBits(input_len));
   const IdType* index_sorted_ptr = sorted_index.data_ptr<IdType>();
   const int64_t* permutation_ptr = permutation.data_ptr<int64_t>();
 

--- a/graphbolt/src/cuda/index_select_impl.cu
+++ b/graphbolt/src/cuda/index_select_impl.cu
@@ -5,7 +5,6 @@
  */
 #include <c10/core/ScalarType.h>
 #include <c10/cuda/CUDAStream.h>
-#include <torch/script.h>
 
 #include <numeric>
 
@@ -19,30 +18,32 @@ namespace ops {
 
 std::pair<torch::Tensor, torch::Tensor> Sort(
     torch::Tensor input, int num_bits) {
-  int64_t n_items = input.size(0);
-  auto orig_idx = torch::arange(n_items, input.options().dtype(torch::kLong));
+  int64_t num_items = input.size(0);
+  // We utilize int64_t for the values array. (torch::kLong == int64_t)
+  auto original_idx =
+      torch::arange(num_items, input.options().dtype(torch::kLong));
   auto sorted_array = torch::empty_like(input);
-  auto sorted_idx = torch::empty_like(orig_idx);
+  auto sorted_idx = torch::empty_like(original_idx);
   cuda::CUDAWorkspaceAllocator allocator;
   AT_DISPATCH_INDEX_TYPES(
       input.scalar_type(), "SortImpl", ([&] {
         using IdType = index_t;
-        const auto keys_in = input.data_ptr<index_t>();
-        const int64_t* values_in = orig_idx.data_ptr<int64_t>();
-        IdType* keys_out = sorted_array.data_ptr<index_t>();
-        int64_t* values_out = sorted_idx.data_ptr<int64_t>();
+        const auto input_keys = input.data_ptr<index_t>();
+        const int64_t* input_values = original_idx.data_ptr<int64_t>();
+        IdType* sorted_keys = sorted_array.data_ptr<index_t>();
+        int64_t* sorted_values = sorted_idx.data_ptr<int64_t>();
         cudaStream_t stream = torch::cuda::getDefaultCUDAStream();
         if (num_bits == 0) {
           num_bits = sizeof(index_t) * 8;
         }
         size_t workspace_size = 0;
         CUDA_CALL(cub::DeviceRadixSort::SortPairs(
-            nullptr, workspace_size, keys_in, keys_out, values_in, values_out,
-            n_items, 0, num_bits, stream));
+            nullptr, workspace_size, input_keys, sorted_keys, input_values,
+            sorted_values, num_items, 0, num_bits, stream));
         auto temp = allocator.AllocateStorage<char>(workspace_size);
         CUDA_CALL(cub::DeviceRadixSort::SortPairs(
-            temp.get(), workspace_size, keys_in, keys_out, values_in,
-            values_out, n_items, 0, num_bits, stream));
+            temp.get(), workspace_size, input_keys, sorted_keys, input_values,
+            sorted_values, num_items, 0, num_bits, stream));
       }));
   return std::make_pair(sorted_array, sorted_idx);
 }

--- a/graphbolt/src/cuda/utils.h
+++ b/graphbolt/src/cuda/utils.h
@@ -31,6 +31,22 @@ inline int FindNumThreads(int size) {
   return ret;
 }
 
+template <typename T>
+int NumberOfBits(const T& range) {
+  if (range <= 1) {
+    // ranges of 0 or 1 require no bits to store
+    return 0;
+  }
+
+  int bits = 1;
+  const auto urange = static_cast<std::make_unsigned_t<T>>(range);
+  while (bits < static_cast<int>(sizeof(T) * 8) && (1ull << bits) < urange) {
+    ++bits;
+  }
+
+  return bits;
+}
+
 }  // namespace cuda
 }  // namespace graphbolt
 

--- a/graphbolt/src/cuda/utils.h
+++ b/graphbolt/src/cuda/utils.h
@@ -31,6 +31,11 @@ inline int FindNumThreads(int size) {
   return ret;
 }
 
+/**
+ * @brief Calculate the smallest number of bits needed to represent a given
+ * range of integers [0, range).
+ *
+ */
 template <typename T>
 int NumberOfBits(const T& range) {
   if (range <= 1) {


### PR DESCRIPTION
The current implementation utilizes torch::sort which is slower than cub sort. This PR improves on the current code by swapping torch::sort with cub sort. The following throughput numbers are taken from #6590, the NVIDIA T4 results.

### Testing `USE_TORCH_SORT` on random datasets.

* params:  n_rows=100000, feat_size=100, num_indices=1, feature_device=Device.Pinned, indices_device=Device.GPU

|            |USE_TORCH_SORT=1|USE_TORCH_SORT=0|
|------------|------------|------------|
|USE_PERM=1  |       3.364|       4.454|
* params:  n_rows=100000, feat_size=100, num_indices=1000, feature_device=Device.Pinned, indices_device=Device.GPU

|            |USE_TORCH_SORT=1|USE_TORCH_SORT=0|
|------------|------------|------------|
|USE_PERM=1  |    1605.974|    2421.417|
* params:  n_rows=100000, feat_size=100, num_indices=10000, feature_device=Device.Pinned, indices_device=Device.GPU

|            |USE_TORCH_SORT=1|USE_TORCH_SORT=0|
|------------|------------|------------|
|USE_PERM=1  |    3983.310|    4744.072|
* params:  n_rows=100000, feat_size=300, num_indices=1, feature_device=Device.Pinned, indices_device=Device.GPU

|            |USE_TORCH_SORT=1|USE_TORCH_SORT=0|
|------------|------------|------------|
|USE_PERM=1  |      11.516|      15.274|
* params:  n_rows=100000, feat_size=300, num_indices=1000, feature_device=Device.Pinned, indices_device=Device.GPU

|            |USE_TORCH_SORT=1|USE_TORCH_SORT=0|
|------------|------------|------------|
|USE_PERM=1  |    3498.823|    4165.763|
* params:  n_rows=100000, feat_size=300, num_indices=10000, feature_device=Device.Pinned, indices_device=Device.GPU

|            |USE_TORCH_SORT=1|USE_TORCH_SORT=0|
|------------|------------|------------|
|USE_PERM=1  |    5421.254|    5651.394|

Additional results on A100 with #6644, note that when num_indices is 1 or 1000, the runtime is < 100us, meaning not enough work so throughput is not meaningful and we are measuring latency, even `num_indices=100000` sometimes is not enough work for the GPU to get full throughput.

Before this PR with #6644:
```
* params:  dataset=ogbn-products n_rows=2449029 feat_size=100 dtype=torch.float32 num_indices=518094 feature_device=Device.Pinned, indices_device=Device.GPU

Runtime in us: 9024, Throughput in MB/s: 21901


* params:  n_rows=2000000, feat_size=1, dtype=torch.float32, num_indices=1, feature_device=Device.Pinned, indices_device=Device.GPU

Runtime in us: 78, Throughput in MB/s: 0


* params:  n_rows=2000000, feat_size=1, dtype=torch.float32, num_indices=1000, feature_device=Device.Pinned, indices_device=Device.GPU

Runtime in us: 69, Throughput in MB/s: 54


* params:  n_rows=2000000, feat_size=1, dtype=torch.float32, num_indices=100000, feature_device=Device.Pinned, indices_device=Device.GPU

Runtime in us: 315, Throughput in MB/s: 1208


* params:  n_rows=2000000, feat_size=1, dtype=torch.float32, num_indices=1000000, feature_device=Device.Pinned, indices_device=Device.GPU

Runtime in us: 660, Throughput in MB/s: 5771


* params:  n_rows=2000000, feat_size=1, dtype=torch.int8, num_indices=1, feature_device=Device.Pinned, indices_device=Device.GPU

Runtime in us: 75, Throughput in MB/s: 0


* params:  n_rows=2000000, feat_size=1, dtype=torch.int8, num_indices=1000, feature_device=Device.Pinned, indices_device=Device.GPU

Runtime in us: 71, Throughput in MB/s: 13


* params:  n_rows=2000000, feat_size=1, dtype=torch.int8, num_indices=100000, feature_device=Device.Pinned, indices_device=Device.GPU

Runtime in us: 217, Throughput in MB/s: 437


* params:  n_rows=2000000, feat_size=1, dtype=torch.int8, num_indices=1000000, feature_device=Device.Pinned, indices_device=Device.GPU

Runtime in us: 434, Throughput in MB/s: 2195


* params:  n_rows=2000000, feat_size=4, dtype=torch.float32, num_indices=1, feature_device=Device.Pinned, indices_device=Device.GPU

Runtime in us: 79, Throughput in MB/s: 0


* params:  n_rows=2000000, feat_size=4, dtype=torch.float32, num_indices=1000, feature_device=Device.Pinned, indices_device=Device.GPU

Runtime in us: 73, Throughput in MB/s: 206


* params:  n_rows=2000000, feat_size=4, dtype=torch.float32, num_indices=100000, feature_device=Device.Pinned, indices_device=Device.GPU

Runtime in us: 487, Throughput in MB/s: 3130


* params:  n_rows=2000000, feat_size=4, dtype=torch.float32, num_indices=1000000, feature_device=Device.Pinned, indices_device=Device.GPU

Runtime in us: 1399, Throughput in MB/s: 10901


* params:  n_rows=2000000, feat_size=4, dtype=torch.int8, num_indices=1, feature_device=Device.Pinned, indices_device=Device.GPU

Runtime in us: 74, Throughput in MB/s: 0


* params:  n_rows=2000000, feat_size=4, dtype=torch.int8, num_indices=1000, feature_device=Device.Pinned, indices_device=Device.GPU

Runtime in us: 71, Throughput in MB/s: 53


* params:  n_rows=2000000, feat_size=4, dtype=torch.int8, num_indices=100000, feature_device=Device.Pinned, indices_device=Device.GPU

Runtime in us: 313, Throughput in MB/s: 1218


* params:  n_rows=2000000, feat_size=4, dtype=torch.int8, num_indices=1000000, feature_device=Device.Pinned, indices_device=Device.GPU

Runtime in us: 658, Throughput in MB/s: 5791


* params:  n_rows=2000000, feat_size=47, dtype=torch.float32, num_indices=1, feature_device=Device.Pinned, indices_device=Device.GPU

Runtime in us: 73, Throughput in MB/s: 2


* params:  n_rows=2000000, feat_size=47, dtype=torch.float32, num_indices=1000, feature_device=Device.Pinned, indices_device=Device.GPU

Runtime in us: 68, Throughput in MB/s: 2617


* params:  n_rows=2000000, feat_size=47, dtype=torch.float32, num_indices=100000, feature_device=Device.Pinned, indices_device=Device.GPU

Runtime in us: 1130, Throughput in MB/s: 15860


* params:  n_rows=2000000, feat_size=47, dtype=torch.float32, num_indices=1000000, feature_device=Device.Pinned, indices_device=Device.GPU

Runtime in us: 8065, Throughput in MB/s: 22230


* params:  n_rows=2000000, feat_size=47, dtype=torch.int8, num_indices=1, feature_device=Device.Pinned, indices_device=Device.GPU

Runtime in us: 74, Throughput in MB/s: 0


* params:  n_rows=2000000, feat_size=47, dtype=torch.int8, num_indices=1000, feature_device=Device.Pinned, indices_device=Device.GPU

Runtime in us: 68, Throughput in MB/s: 653


* params:  n_rows=2000000, feat_size=47, dtype=torch.int8, num_indices=100000, feature_device=Device.Pinned, indices_device=Device.GPU

Runtime in us: 538, Throughput in MB/s: 8323


* params:  n_rows=2000000, feat_size=47, dtype=torch.int8, num_indices=1000000, feature_device=Device.Pinned, indices_device=Device.GPU

Runtime in us: 3167, Throughput in MB/s: 14149


* params:  n_rows=2000000, feat_size=256, dtype=torch.float32, num_indices=1, feature_device=Device.Pinned, indices_device=Device.GPU

Runtime in us: 74, Throughput in MB/s: 13


* params:  n_rows=2000000, feat_size=256, dtype=torch.float32, num_indices=1000, feature_device=Device.Pinned, indices_device=Device.GPU

Runtime in us: 96, Throughput in MB/s: 10119


* params:  n_rows=2000000, feat_size=256, dtype=torch.float32, num_indices=100000, feature_device=Device.Pinned, indices_device=Device.GPU

Runtime in us: 4005, Throughput in MB/s: 24382


* params:  n_rows=2000000, feat_size=256, dtype=torch.float32, num_indices=1000000, feature_device=Device.Pinned, indices_device=Device.GPU

Runtime in us: 32188, Throughput in MB/s: 30338


* params:  n_rows=2000000, feat_size=256, dtype=torch.int8, num_indices=1, feature_device=Device.Pinned, indices_device=Device.GPU

Runtime in us: 73, Throughput in MB/s: 3


* params:  n_rows=2000000, feat_size=256, dtype=torch.int8, num_indices=1000, feature_device=Device.Pinned, indices_device=Device.GPU

Runtime in us: 67, Throughput in MB/s: 3603


* params:  n_rows=2000000, feat_size=256, dtype=torch.int8, num_indices=100000, feature_device=Device.Pinned, indices_device=Device.GPU

Runtime in us: 1205, Throughput in MB/s: 20247


* params:  n_rows=2000000, feat_size=256, dtype=torch.int8, num_indices=1000000, feature_device=Device.Pinned, indices_device=Device.GPU

Runtime in us: 8851, Throughput in MB/s: 27581


* params:  n_rows=2000000, feat_size=353, dtype=torch.float32, num_indices=1, feature_device=Device.Pinned, indices_device=Device.GPU

Runtime in us: 73, Throughput in MB/s: 18


* params:  n_rows=2000000, feat_size=353, dtype=torch.float32, num_indices=1000, feature_device=Device.Pinned, indices_device=Device.GPU

Runtime in us: 113, Throughput in MB/s: 11894


* params:  n_rows=2000000, feat_size=353, dtype=torch.float32, num_indices=100000, feature_device=Device.Pinned, indices_device=Device.GPU

Runtime in us: 5715, Throughput in MB/s: 23561


* params:  n_rows=2000000, feat_size=353, dtype=torch.float32, num_indices=1000000, feature_device=Device.Pinned, indices_device=Device.GPU

Runtime in us: 52995, Throughput in MB/s: 25409


* params:  n_rows=2000000, feat_size=353, dtype=torch.int8, num_indices=1, feature_device=Device.Pinned, indices_device=Device.GPU

Runtime in us: 75, Throughput in MB/s: 4


* params:  n_rows=2000000, feat_size=353, dtype=torch.int8, num_indices=1000, feature_device=Device.Pinned, indices_device=Device.GPU

Runtime in us: 75, Throughput in MB/s: 4455


* params:  n_rows=2000000, feat_size=353, dtype=torch.int8, num_indices=100000, feature_device=Device.Pinned, indices_device=Device.GPU

Runtime in us: 1822, Throughput in MB/s: 18468


* params:  n_rows=2000000, feat_size=353, dtype=torch.int8, num_indices=1000000, feature_device=Device.Pinned, indices_device=Device.GPU

Runtime in us: 15684, Throughput in MB/s: 21463


* params:  n_rows=20000000, feat_size=1, dtype=torch.float32, num_indices=1, feature_device=Device.Pinned, indices_device=Device.GPU

Runtime in us: 72, Throughput in MB/s: 0


* params:  n_rows=20000000, feat_size=1, dtype=torch.float32, num_indices=1000, feature_device=Device.Pinned, indices_device=Device.GPU

Runtime in us: 68, Throughput in MB/s: 55


* params:  n_rows=20000000, feat_size=1, dtype=torch.float32, num_indices=100000, feature_device=Device.Pinned, indices_device=Device.GPU

Runtime in us: 572, Throughput in MB/s: 666


* params:  n_rows=20000000, feat_size=1, dtype=torch.float32, num_indices=1000000, feature_device=Device.Pinned, indices_device=Device.GPU

Runtime in us: 2066, Throughput in MB/s: 1846


* params:  n_rows=20000000, feat_size=1, dtype=torch.int8, num_indices=1, feature_device=Device.Pinned, indices_device=Device.GPU

Runtime in us: 73, Throughput in MB/s: 0


* params:  n_rows=20000000, feat_size=1, dtype=torch.int8, num_indices=1000, feature_device=Device.Pinned, indices_device=Device.GPU

Runtime in us: 68, Throughput in MB/s: 13


* params:  n_rows=20000000, feat_size=1, dtype=torch.int8, num_indices=100000, feature_device=Device.Pinned, indices_device=Device.GPU

Runtime in us: 432, Throughput in MB/s: 220


* params:  n_rows=20000000, feat_size=1, dtype=torch.int8, num_indices=1000000, feature_device=Device.Pinned, indices_device=Device.GPU

Runtime in us: 1135, Throughput in MB/s: 839


* params:  n_rows=20000000, feat_size=4, dtype=torch.float32, num_indices=1, feature_device=Device.Pinned, indices_device=Device.GPU

Runtime in us: 72, Throughput in MB/s: 0


* params:  n_rows=20000000, feat_size=4, dtype=torch.float32, num_indices=1000, feature_device=Device.Pinned, indices_device=Device.GPU

Runtime in us: 68, Throughput in MB/s: 223


* params:  n_rows=20000000, feat_size=4, dtype=torch.float32, num_indices=100000, feature_device=Device.Pinned, indices_device=Device.GPU

Runtime in us: 630, Throughput in MB/s: 2419


* params:  n_rows=20000000, feat_size=4, dtype=torch.float32, num_indices=1000000, feature_device=Device.Pinned, indices_device=Device.GPU

Runtime in us: 3569, Throughput in MB/s: 4274


* params:  n_rows=20000000, feat_size=4, dtype=torch.int8, num_indices=1, feature_device=Device.Pinned, indices_device=Device.GPU

Runtime in us: 79, Throughput in MB/s: 0


* params:  n_rows=20000000, feat_size=4, dtype=torch.int8, num_indices=1000, feature_device=Device.Pinned, indices_device=Device.GPU

Runtime in us: 70, Throughput in MB/s: 54


* params:  n_rows=20000000, feat_size=4, dtype=torch.int8, num_indices=100000, feature_device=Device.Pinned, indices_device=Device.GPU

Runtime in us: 571, Throughput in MB/s: 666


* params:  n_rows=20000000, feat_size=4, dtype=torch.int8, num_indices=1000000, feature_device=Device.Pinned, indices_device=Device.GPU

Runtime in us: 2070, Throughput in MB/s: 1842


* params:  n_rows=20000000, feat_size=47, dtype=torch.float32, num_indices=1, feature_device=Device.Pinned, indices_device=Device.GPU

Runtime in us: 74, Throughput in MB/s: 2


* params:  n_rows=20000000, feat_size=47, dtype=torch.float32, num_indices=1000, feature_device=Device.Pinned, indices_device=Device.GPU

Runtime in us: 80, Throughput in MB/s: 2220


* params:  n_rows=20000000, feat_size=47, dtype=torch.float32, num_indices=100000, feature_device=Device.Pinned, indices_device=Device.GPU

Runtime in us: 1245, Throughput in MB/s: 14399


* params:  n_rows=20000000, feat_size=47, dtype=torch.float32, num_indices=1000000, feature_device=Device.Pinned, indices_device=Device.GPU

Runtime in us: 9343, Throughput in MB/s: 19188


* params:  n_rows=20000000, feat_size=47, dtype=torch.int8, num_indices=1, feature_device=Device.Pinned, indices_device=Device.GPU

Runtime in us: 73, Throughput in MB/s: 0


* params:  n_rows=20000000, feat_size=47, dtype=torch.int8, num_indices=1000, feature_device=Device.Pinned, indices_device=Device.GPU

Runtime in us: 72, Throughput in MB/s: 620


* params:  n_rows=20000000, feat_size=47, dtype=torch.int8, num_indices=100000, feature_device=Device.Pinned, indices_device=Device.GPU

Runtime in us: 692, Throughput in MB/s: 6469


* params:  n_rows=20000000, feat_size=47, dtype=torch.int8, num_indices=1000000, feature_device=Device.Pinned, indices_device=Device.GPU

Runtime in us: 4412, Throughput in MB/s: 10157


* params:  n_rows=20000000, feat_size=256, dtype=torch.float32, num_indices=1, feature_device=Device.Pinned, indices_device=Device.GPU

Runtime in us: 74, Throughput in MB/s: 13


* params:  n_rows=20000000, feat_size=256, dtype=torch.float32, num_indices=1000, feature_device=Device.Pinned, indices_device=Device.GPU

Runtime in us: 96, Throughput in MB/s: 10160


* params:  n_rows=20000000, feat_size=256, dtype=torch.float32, num_indices=100000, feature_device=Device.Pinned, indices_device=Device.GPU

Runtime in us: 4044, Throughput in MB/s: 24144


* params:  n_rows=20000000, feat_size=256, dtype=torch.float32, num_indices=1000000, feature_device=Device.Pinned, indices_device=Device.GPU

Runtime in us: 38530, Throughput in MB/s: 25345


* params:  n_rows=20000000, feat_size=256, dtype=torch.int8, num_indices=1, feature_device=Device.Pinned, indices_device=Device.GPU

Runtime in us: 75, Throughput in MB/s: 3


* params:  n_rows=20000000, feat_size=256, dtype=torch.int8, num_indices=1000, feature_device=Device.Pinned, indices_device=Device.GPU

Runtime in us: 75, Throughput in MB/s: 3225


* params:  n_rows=20000000, feat_size=256, dtype=torch.int8, num_indices=100000, feature_device=Device.Pinned, indices_device=Device.GPU

Runtime in us: 1812, Throughput in MB/s: 13472


* params:  n_rows=20000000, feat_size=256, dtype=torch.int8, num_indices=1000000, feature_device=Device.Pinned, indices_device=Device.GPU

Runtime in us: 9898, Throughput in MB/s: 24664


* params:  n_rows=20000000, feat_size=353, dtype=torch.float32, num_indices=1, feature_device=Device.Pinned, indices_device=Device.GPU

Runtime in us: 73, Throughput in MB/s: 18


* params:  n_rows=20000000, feat_size=353, dtype=torch.float32, num_indices=1000, feature_device=Device.Pinned, indices_device=Device.GPU

Runtime in us: 118, Throughput in MB/s: 11381


* params:  n_rows=20000000, feat_size=353, dtype=torch.float32, num_indices=100000, feature_device=Device.Pinned, indices_device=Device.GPU

Runtime in us: 5697, Throughput in MB/s: 23633


* params:  n_rows=20000000, feat_size=353, dtype=torch.float32, num_indices=1000000, feature_device=Device.Pinned, indices_device=Device.GPU

Runtime in us: 55568, Throughput in MB/s: 24232


* params:  n_rows=20000000, feat_size=353, dtype=torch.int8, num_indices=1, feature_device=Device.Pinned, indices_device=Device.GPU

Runtime in us: 77, Throughput in MB/s: 4


* params:  n_rows=20000000, feat_size=353, dtype=torch.int8, num_indices=1000, feature_device=Device.Pinned, indices_device=Device.GPU

Runtime in us: 84, Throughput in MB/s: 3979


* params:  n_rows=20000000, feat_size=353, dtype=torch.int8, num_indices=100000, feature_device=Device.Pinned, indices_device=Device.GPU

Runtime in us: 2089, Throughput in MB/s: 16110


* params:  n_rows=20000000, feat_size=353, dtype=torch.int8, num_indices=1000000, feature_device=Device.Pinned, indices_device=Device.GPU

Runtime in us: 15645, Throughput in MB/s: 21516


Total runtimes in us:  311991
```

After this PR with #6644:
```
* params:  dataset=ogbn-products n_rows=2449029 feat_size=100 dtype=torch.float32 num_indices=518134 feature_device=Device.Pinned, indices_device=Device.GPU

Runtime in us: 8758, Throughput in MB/s: 22566


* params:  n_rows=2000000, feat_size=1, dtype=torch.float32, num_indices=1, feature_device=Device.Pinned, indices_device=Device.GPU

Runtime in us: 64, Throughput in MB/s: 0


* params:  n_rows=2000000, feat_size=1, dtype=torch.float32, num_indices=1000, feature_device=Device.Pinned, indices_device=Device.GPU

Runtime in us: 69, Throughput in MB/s: 55


* params:  n_rows=2000000, feat_size=1, dtype=torch.float32, num_indices=100000, feature_device=Device.Pinned, indices_device=Device.GPU

Runtime in us: 245, Throughput in MB/s: 1555


* params:  n_rows=2000000, feat_size=1, dtype=torch.float32, num_indices=1000000, feature_device=Device.Pinned, indices_device=Device.GPU

Runtime in us: 471, Throughput in MB/s: 8090


* params:  n_rows=2000000, feat_size=1, dtype=torch.int8, num_indices=1, feature_device=Device.Pinned, indices_device=Device.GPU

Runtime in us: 69, Throughput in MB/s: 0


* params:  n_rows=2000000, feat_size=1, dtype=torch.int8, num_indices=1000, feature_device=Device.Pinned, indices_device=Device.GPU

Runtime in us: 76, Throughput in MB/s: 12


* params:  n_rows=2000000, feat_size=1, dtype=torch.int8, num_indices=100000, feature_device=Device.Pinned, indices_device=Device.GPU

Runtime in us: 146, Throughput in MB/s: 653


* params:  n_rows=2000000, feat_size=1, dtype=torch.int8, num_indices=1000000, feature_device=Device.Pinned, indices_device=Device.GPU

Runtime in us: 237, Throughput in MB/s: 4008


* params:  n_rows=2000000, feat_size=4, dtype=torch.float32, num_indices=1, feature_device=Device.Pinned, indices_device=Device.GPU

Runtime in us: 65, Throughput in MB/s: 0


* params:  n_rows=2000000, feat_size=4, dtype=torch.float32, num_indices=1000, feature_device=Device.Pinned, indices_device=Device.GPU

Runtime in us: 65, Throughput in MB/s: 234


* params:  n_rows=2000000, feat_size=4, dtype=torch.float32, num_indices=100000, feature_device=Device.Pinned, indices_device=Device.GPU

Runtime in us: 417, Throughput in MB/s: 3657


* params:  n_rows=2000000, feat_size=4, dtype=torch.float32, num_indices=1000000, feature_device=Device.Pinned, indices_device=Device.GPU

Runtime in us: 1124, Throughput in MB/s: 13572


* params:  n_rows=2000000, feat_size=4, dtype=torch.int8, num_indices=1, feature_device=Device.Pinned, indices_device=Device.GPU

Runtime in us: 65, Throughput in MB/s: 0


* params:  n_rows=2000000, feat_size=4, dtype=torch.int8, num_indices=1000, feature_device=Device.Pinned, indices_device=Device.GPU

Runtime in us: 67, Throughput in MB/s: 56


* params:  n_rows=2000000, feat_size=4, dtype=torch.int8, num_indices=100000, feature_device=Device.Pinned, indices_device=Device.GPU

Runtime in us: 243, Throughput in MB/s: 1564


* params:  n_rows=2000000, feat_size=4, dtype=torch.int8, num_indices=1000000, feature_device=Device.Pinned, indices_device=Device.GPU

Runtime in us: 469, Throughput in MB/s: 8132


* params:  n_rows=2000000, feat_size=47, dtype=torch.float32, num_indices=1, feature_device=Device.Pinned, indices_device=Device.GPU

Runtime in us: 64, Throughput in MB/s: 2


* params:  n_rows=2000000, feat_size=47, dtype=torch.float32, num_indices=1000, feature_device=Device.Pinned, indices_device=Device.GPU

Runtime in us: 64, Throughput in MB/s: 2800


* params:  n_rows=2000000, feat_size=47, dtype=torch.float32, num_indices=100000, feature_device=Device.Pinned, indices_device=Device.GPU

Runtime in us: 929, Throughput in MB/s: 19279


* params:  n_rows=2000000, feat_size=47, dtype=torch.float32, num_indices=1000000, feature_device=Device.Pinned, indices_device=Device.GPU

Runtime in us: 7487, Throughput in MB/s: 23945


* params:  n_rows=2000000, feat_size=47, dtype=torch.int8, num_indices=1, feature_device=Device.Pinned, indices_device=Device.GPU

Runtime in us: 63, Throughput in MB/s: 0


* params:  n_rows=2000000, feat_size=47, dtype=torch.int8, num_indices=1000, feature_device=Device.Pinned, indices_device=Device.GPU

Runtime in us: 63, Throughput in MB/s: 703


* params:  n_rows=2000000, feat_size=47, dtype=torch.int8, num_indices=100000, feature_device=Device.Pinned, indices_device=Device.GPU

Runtime in us: 468, Throughput in MB/s: 9571


* params:  n_rows=2000000, feat_size=47, dtype=torch.int8, num_indices=1000000, feature_device=Device.Pinned, indices_device=Device.GPU

Runtime in us: 3050, Throughput in MB/s: 14691


* params:  n_rows=2000000, feat_size=256, dtype=torch.float32, num_indices=1, feature_device=Device.Pinned, indices_device=Device.GPU

Runtime in us: 64, Throughput in MB/s: 15


* params:  n_rows=2000000, feat_size=256, dtype=torch.float32, num_indices=1000, feature_device=Device.Pinned, indices_device=Device.GPU

Runtime in us: 64, Throughput in MB/s: 15085


* params:  n_rows=2000000, feat_size=256, dtype=torch.float32, num_indices=100000, feature_device=Device.Pinned, indices_device=Device.GPU

Runtime in us: 3923, Throughput in MB/s: 24888


* params:  n_rows=2000000, feat_size=256, dtype=torch.float32, num_indices=1000000, feature_device=Device.Pinned, indices_device=Device.GPU

Runtime in us: 31976, Throughput in MB/s: 30539


* params:  n_rows=2000000, feat_size=256, dtype=torch.int8, num_indices=1, feature_device=Device.Pinned, indices_device=Device.GPU

Runtime in us: 64, Throughput in MB/s: 3


* params:  n_rows=2000000, feat_size=256, dtype=torch.int8, num_indices=1000, feature_device=Device.Pinned, indices_device=Device.GPU

Runtime in us: 64, Throughput in MB/s: 3809


* params:  n_rows=2000000, feat_size=256, dtype=torch.int8, num_indices=100000, feature_device=Device.Pinned, indices_device=Device.GPU

Runtime in us: 1023, Throughput in MB/s: 23864


* params:  n_rows=2000000, feat_size=256, dtype=torch.int8, num_indices=1000000, feature_device=Device.Pinned, indices_device=Device.GPU

Runtime in us: 7892, Throughput in MB/s: 30931


* params:  n_rows=2000000, feat_size=353, dtype=torch.float32, num_indices=1, feature_device=Device.Pinned, indices_device=Device.GPU

Runtime in us: 65, Throughput in MB/s: 20


* params:  n_rows=2000000, feat_size=353, dtype=torch.float32, num_indices=1000, feature_device=Device.Pinned, indices_device=Device.GPU

Runtime in us: 76, Throughput in MB/s: 17491


* params:  n_rows=2000000, feat_size=353, dtype=torch.float32, num_indices=100000, feature_device=Device.Pinned, indices_device=Device.GPU

Runtime in us: 5636, Throughput in MB/s: 23892


* params:  n_rows=2000000, feat_size=353, dtype=torch.float32, num_indices=1000000, feature_device=Device.Pinned, indices_device=Device.GPU

Runtime in us: 52611, Throughput in MB/s: 25595


* params:  n_rows=2000000, feat_size=353, dtype=torch.int8, num_indices=1, feature_device=Device.Pinned, indices_device=Device.GPU

Runtime in us: 64, Throughput in MB/s: 5


* params:  n_rows=2000000, feat_size=353, dtype=torch.int8, num_indices=1000, feature_device=Device.Pinned, indices_device=Device.GPU

Runtime in us: 64, Throughput in MB/s: 5258


* params:  n_rows=2000000, feat_size=353, dtype=torch.int8, num_indices=100000, feature_device=Device.Pinned, indices_device=Device.GPU

Runtime in us: 1768, Throughput in MB/s: 19037


* params:  n_rows=2000000, feat_size=353, dtype=torch.int8, num_indices=1000000, feature_device=Device.Pinned, indices_device=Device.GPU

Runtime in us: 15807, Throughput in MB/s: 21296


* params:  n_rows=20000000, feat_size=1, dtype=torch.float32, num_indices=1, feature_device=Device.Pinned, indices_device=Device.GPU

Runtime in us: 64, Throughput in MB/s: 0


* params:  n_rows=20000000, feat_size=1, dtype=torch.float32, num_indices=1000, feature_device=Device.Pinned, indices_device=Device.GPU

Runtime in us: 65, Throughput in MB/s: 57


* params:  n_rows=20000000, feat_size=1, dtype=torch.float32, num_indices=100000, feature_device=Device.Pinned, indices_device=Device.GPU

Runtime in us: 513, Throughput in MB/s: 742


* params:  n_rows=20000000, feat_size=1, dtype=torch.float32, num_indices=1000000, feature_device=Device.Pinned, indices_device=Device.GPU

Runtime in us: 1916, Throughput in MB/s: 1990


* params:  n_rows=20000000, feat_size=1, dtype=torch.int8, num_indices=1, feature_device=Device.Pinned, indices_device=Device.GPU

Runtime in us: 64, Throughput in MB/s: 0


* params:  n_rows=20000000, feat_size=1, dtype=torch.int8, num_indices=1000, feature_device=Device.Pinned, indices_device=Device.GPU

Runtime in us: 64, Throughput in MB/s: 14


* params:  n_rows=20000000, feat_size=1, dtype=torch.int8, num_indices=100000, feature_device=Device.Pinned, indices_device=Device.GPU

Runtime in us: 374, Throughput in MB/s: 254


* params:  n_rows=20000000, feat_size=1, dtype=torch.int8, num_indices=1000000, feature_device=Device.Pinned, indices_device=Device.GPU

Runtime in us: 877, Throughput in MB/s: 1086


* params:  n_rows=20000000, feat_size=4, dtype=torch.float32, num_indices=1, feature_device=Device.Pinned, indices_device=Device.GPU

Runtime in us: 64, Throughput in MB/s: 0


* params:  n_rows=20000000, feat_size=4, dtype=torch.float32, num_indices=1000, feature_device=Device.Pinned, indices_device=Device.GPU

Runtime in us: 64, Throughput in MB/s: 235


* params:  n_rows=20000000, feat_size=4, dtype=torch.float32, num_indices=100000, feature_device=Device.Pinned, indices_device=Device.GPU

Runtime in us: 571, Throughput in MB/s: 2671


* params:  n_rows=20000000, feat_size=4, dtype=torch.float32, num_indices=1000000, feature_device=Device.Pinned, indices_device=Device.GPU

Runtime in us: 3403, Throughput in MB/s: 4483


* params:  n_rows=20000000, feat_size=4, dtype=torch.int8, num_indices=1, feature_device=Device.Pinned, indices_device=Device.GPU

Runtime in us: 65, Throughput in MB/s: 0


* params:  n_rows=20000000, feat_size=4, dtype=torch.int8, num_indices=1000, feature_device=Device.Pinned, indices_device=Device.GPU

Runtime in us: 64, Throughput in MB/s: 58


* params:  n_rows=20000000, feat_size=4, dtype=torch.int8, num_indices=100000, feature_device=Device.Pinned, indices_device=Device.GPU

Runtime in us: 513, Throughput in MB/s: 742


* params:  n_rows=20000000, feat_size=4, dtype=torch.int8, num_indices=1000000, feature_device=Device.Pinned, indices_device=Device.GPU

Runtime in us: 1922, Throughput in MB/s: 1984


* params:  n_rows=20000000, feat_size=47, dtype=torch.float32, num_indices=1, feature_device=Device.Pinned, indices_device=Device.GPU

Runtime in us: 64, Throughput in MB/s: 2


* params:  n_rows=20000000, feat_size=47, dtype=torch.float32, num_indices=1000, feature_device=Device.Pinned, indices_device=Device.GPU

Runtime in us: 65, Throughput in MB/s: 2756


* params:  n_rows=20000000, feat_size=47, dtype=torch.float32, num_indices=100000, feature_device=Device.Pinned, indices_device=Device.GPU

Runtime in us: 1197, Throughput in MB/s: 14973


* params:  n_rows=20000000, feat_size=47, dtype=torch.float32, num_indices=1000000, feature_device=Device.Pinned, indices_device=Device.GPU

Runtime in us: 9201, Throughput in MB/s: 19484


* params:  n_rows=20000000, feat_size=47, dtype=torch.int8, num_indices=1, feature_device=Device.Pinned, indices_device=Device.GPU

Runtime in us: 70, Throughput in MB/s: 0


* params:  n_rows=20000000, feat_size=47, dtype=torch.int8, num_indices=1000, feature_device=Device.Pinned, indices_device=Device.GPU

Runtime in us: 65, Throughput in MB/s: 682


* params:  n_rows=20000000, feat_size=47, dtype=torch.int8, num_indices=100000, feature_device=Device.Pinned, indices_device=Device.GPU

Runtime in us: 625, Throughput in MB/s: 7170


* params:  n_rows=20000000, feat_size=47, dtype=torch.int8, num_indices=1000000, feature_device=Device.Pinned, indices_device=Device.GPU

Runtime in us: 4234, Throughput in MB/s: 10585


* params:  n_rows=20000000, feat_size=256, dtype=torch.float32, num_indices=1, feature_device=Device.Pinned, indices_device=Device.GPU

Runtime in us: 65, Throughput in MB/s: 14


* params:  n_rows=20000000, feat_size=256, dtype=torch.float32, num_indices=1000, feature_device=Device.Pinned, indices_device=Device.GPU

Runtime in us: 64, Throughput in MB/s: 15080


* params:  n_rows=20000000, feat_size=256, dtype=torch.float32, num_indices=100000, feature_device=Device.Pinned, indices_device=Device.GPU

Runtime in us: 3973, Throughput in MB/s: 24576


* params:  n_rows=20000000, feat_size=256, dtype=torch.float32, num_indices=1000000, feature_device=Device.Pinned, indices_device=Device.GPU

Runtime in us: 38279, Throughput in MB/s: 25511


* params:  n_rows=20000000, feat_size=256, dtype=torch.int8, num_indices=1, feature_device=Device.Pinned, indices_device=Device.GPU

Runtime in us: 68, Throughput in MB/s: 3


* params:  n_rows=20000000, feat_size=256, dtype=torch.int8, num_indices=1000, feature_device=Device.Pinned, indices_device=Device.GPU

Runtime in us: 69, Throughput in MB/s: 3532


* params:  n_rows=20000000, feat_size=256, dtype=torch.int8, num_indices=100000, feature_device=Device.Pinned, indices_device=Device.GPU

Runtime in us: 1764, Throughput in MB/s: 13838


* params:  n_rows=20000000, feat_size=256, dtype=torch.int8, num_indices=1000000, feature_device=Device.Pinned, indices_device=Device.GPU

Runtime in us: 9699, Throughput in MB/s: 25169


* params:  n_rows=20000000, feat_size=353, dtype=torch.float32, num_indices=1, feature_device=Device.Pinned, indices_device=Device.GPU

Runtime in us: 65, Throughput in MB/s: 20


* params:  n_rows=20000000, feat_size=353, dtype=torch.float32, num_indices=1000, feature_device=Device.Pinned, indices_device=Device.GPU

Runtime in us: 78, Throughput in MB/s: 17207


* params:  n_rows=20000000, feat_size=353, dtype=torch.float32, num_indices=100000, feature_device=Device.Pinned, indices_device=Device.GPU

Runtime in us: 5613, Throughput in MB/s: 23990


* params:  n_rows=20000000, feat_size=353, dtype=torch.float32, num_indices=1000000, feature_device=Device.Pinned, indices_device=Device.GPU

Runtime in us: 55142, Throughput in MB/s: 24420


* params:  n_rows=20000000, feat_size=353, dtype=torch.int8, num_indices=1, feature_device=Device.Pinned, indices_device=Device.GPU

Runtime in us: 65, Throughput in MB/s: 5


* params:  n_rows=20000000, feat_size=353, dtype=torch.int8, num_indices=1000, feature_device=Device.Pinned, indices_device=Device.GPU

Runtime in us: 65, Throughput in MB/s: 5157


* params:  n_rows=20000000, feat_size=353, dtype=torch.int8, num_indices=100000, feature_device=Device.Pinned, indices_device=Device.GPU

Runtime in us: 2021, Throughput in MB/s: 16649


* params:  n_rows=20000000, feat_size=353, dtype=torch.int8, num_indices=1000000, feature_device=Device.Pinned, indices_device=Device.GPU

Runtime in us: 15483, Throughput in MB/s: 21741


Total runtimes in us:  304671
```

In summary, with this PR, the average runtime of UVA copies goes from 312ms to 305ms. We can test alternative optimizations with the benchmark script in #6644 on a per-PR basis.