### PR TITLE
[examples] create dataloader before train epoch

### DIFF
--- a/examples/sampling/graphbolt/rgcn/hetero_rgcn.py
+++ b/examples/sampling/graphbolt/rgcn/hetero_rgcn.py
@@ -537,6 +537,18 @@ def run(
     print("start to run...")
     category = "paper"
 
+    data_loader = create_dataloader(
+        name,
+        g,
+        features,
+        train_set,
+        device,
+        batch_size=1024,
+        fanouts=[25, 10],
+        shuffle=True,
+        num_workers=num_workers,
+    )
+
     # Typically, the best Validation performance is obtained after
     # the 1st or 2nd epoch. This is why the max epoch is set to 3.
     for epoch in range(3):
@@ -544,18 +556,7 @@ def run(
         model.train()
 
         total_loss = 0
-
-        data_loader = create_dataloader(
-            name,
-            g,
-            features,
-            train_set,
-            device,
-            batch_size=1024,
-            fanouts=[25, 10],
-            shuffle=True,
-            num_workers=num_workers,
-        )
+        
         for data in tqdm(data_loader, desc=f"Training~Epoch {epoch:02d}"):
             # Convert MiniBatch to DGL Blocks.
             blocks = [block.to(device) for block in data.blocks]

--- a/examples/sampling/graphbolt/rgcn/hetero_rgcn.py
+++ b/examples/sampling/graphbolt/rgcn/hetero_rgcn.py
@@ -556,7 +556,7 @@ def run(
         model.train()
 
         total_loss = 0
-        
+
         for data in tqdm(data_loader, desc=f"Training~Epoch {epoch:02d}"):
             # Convert MiniBatch to DGL Blocks.
             blocks = [block.to(device) for block in data.blocks]


### PR DESCRIPTION
## Description
<!-- Brief description. Refer to the related issues if existed.
It'll be great if relevant reviewers can be assigned as well.-->

## Checklist
Please feel free to remove inapplicable items for your PR.
- [ ] The PR title starts with [$CATEGORY] (such as [NN], [Model], [Doc], [Feature]])
- [ ] I've leverage the [tools](https://docs.google.com/document/d/1iHyj7zlmygKSk5gBPsqIqL5ASPzJSPREaNT_QdsiYA4/edit) to beautify the python and c++ code.
- [ ] The PR is complete and small, read the [Google eng practice (CL equals to PR)](https://google.github.io/eng-practices/review/developer/small-cls.html) to understand more about small PR. In DGL, we consider PRs with less than 200 lines of core code change are small (example, test and documentation could be exempted).
- [ ] All changes have test coverage
- [ ] Code is well-documented
- [ ] To the best of my knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change
- [ ] Related issue is referred in this PR
- [ ] If the PR is for a new model/paper, I've updated the example index [here](../examples/README.md).

## Changes
<!-- You could use following template
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)
-->
