### PR TITLE
Improved GraphBolt `ondisk_dataset` tests.

### DIFF
--- a/tests/python/pytorch/graphbolt/impl/test_ondisk_dataset.py
+++ b/tests/python/pytorch/graphbolt/impl/test_ondisk_dataset.py
@@ -30,7 +30,7 @@ def load_dataset(dataset):
         return dataset.load()
 
 
-def loadDataset(yaml_content, dir):
+def write_yaml_and_load_dataset(yaml_content, dir):
     write_yaml_file(yaml_content, dir)
     return load_dataset(gb.OnDiskDataset(dir))
 
@@ -120,7 +120,7 @@ def test_OnDiskDataset_multiple_tasks():
                         in_memory: true
                         path: {train_labels_path}
         """
-        dataset = loadDataset(yaml_content, test_dir)
+        dataset = write_yaml_and_load_dataset(yaml_content, test_dir)
         assert len(dataset.tasks) == 2
 
         for task_id in range(2):
@@ -170,7 +170,7 @@ def test_OnDiskDataset_TVTSet_ItemSet_names():
                         in_memory: true
                         path: {train_labels_path}
         """
-        dataset = loadDataset(yaml_content, test_dir)
+        dataset = write_yaml_and_load_dataset(yaml_content, test_dir)
 
         # Verify train set.
         train_set = dataset.tasks[0].train_set
@@ -212,7 +212,7 @@ def test_OnDiskDataset_TVTSet_ItemSetDict_names():
                         in_memory: true
                         path: {train_labels_path}
         """
-        dataset = loadDataset(yaml_content, test_dir)
+        dataset = write_yaml_and_load_dataset(yaml_content, test_dir)
 
         # Verify train set.
         train_set = dataset.tasks[0].train_set
@@ -293,7 +293,7 @@ def test_OnDiskDataset_TVTSet_ItemSet_id_label():
                         in_memory: true
                         path: {test_labels_path}
         """
-        dataset = loadDataset(yaml_content, test_dir)
+        dataset = write_yaml_and_load_dataset(yaml_content, test_dir)
 
         # Verify tasks.
         assert len(dataset.tasks) == 1
@@ -341,7 +341,7 @@ def test_OnDiskDataset_TVTSet_ItemSet_id_label():
                       - format: numpy
                         path: {train_ids_path}
         """
-        dataset = loadDataset(yaml_content, test_dir)
+        dataset = write_yaml_and_load_dataset(yaml_content, test_dir)
         assert dataset.tasks[0].train_set is not None
         assert dataset.tasks[0].validation_set is None
         assert dataset.tasks[0].test_set is None
@@ -410,7 +410,7 @@ def test_OnDiskDataset_TVTSet_ItemSet_node_pairs_labels():
                         in_memory: true
                         path: {test_labels_path}
         """
-        dataset = loadDataset(yaml_content, test_dir)
+        dataset = write_yaml_and_load_dataset(yaml_content, test_dir)
 
         # Verify train set.
         train_set = dataset.tasks[0].train_set
@@ -513,7 +513,7 @@ def test_OnDiskDataset_TVTSet_ItemSet_node_pairs_negs():
                         in_memory: true
                         path: {test_neg_dst_path}
         """
-        dataset = loadDataset(yaml_content, test_dir)
+        dataset = write_yaml_and_load_dataset(yaml_content, test_dir)
 
         # Verify train set.
         train_set = dataset.tasks[0].train_set
@@ -610,7 +610,7 @@ def test_OnDiskDataset_TVTSet_ItemSetDict_id_label():
                         format: numpy
                         path: {test_path}
         """
-        dataset = loadDataset(yaml_content, test_dir)
+        dataset = write_yaml_and_load_dataset(yaml_content, test_dir)
 
         # Verify train set.
         train_set = dataset.tasks[0].train_set
@@ -746,7 +746,7 @@ def test_OnDiskDataset_TVTSet_ItemSetDict_node_pairs_labels():
                         in_memory: true
                         path: {test_labels_path}
         """
-        dataset = loadDataset(yaml_content, test_dir)
+        dataset = write_yaml_and_load_dataset(yaml_content, test_dir)
 
         # Verify train set.
         train_set = dataset.tasks[0].train_set
@@ -851,7 +851,7 @@ def test_OnDiskDataset_Feature_heterograph():
                 in_memory: true
                 path: {edge_data_label_path}
         """
-        dataset = loadDataset(yaml_content, test_dir)
+        dataset = write_yaml_and_load_dataset(yaml_content, test_dir)
 
         # Verify feature data storage.
         feature_data = dataset.feature
@@ -946,7 +946,7 @@ def test_OnDiskDataset_Feature_homograph():
                 in_memory: true
                 path: {edge_data_label_path}
         """
-        dataset = loadDataset(yaml_content, test_dir)
+        dataset = write_yaml_and_load_dataset(yaml_content, test_dir)
 
         # Verify feature data storage.
         feature_data = dataset.feature
@@ -1016,7 +1016,7 @@ def test_OnDiskDataset_Graph_homogeneous():
               type: FusedCSCSamplingGraph
               path: {graph_path}
         """
-        dataset = loadDataset(yaml_content, test_dir)
+        dataset = write_yaml_and_load_dataset(yaml_content, test_dir)
         graph2 = dataset.graph
 
         assert graph.total_num_nodes == graph2.total_num_nodes
@@ -1054,7 +1054,7 @@ def test_OnDiskDataset_Graph_heterogeneous():
               type: FusedCSCSamplingGraph
               path: {graph_path}
         """
-        dataset = loadDataset(yaml_content, test_dir)
+        dataset = write_yaml_and_load_dataset(yaml_content, test_dir)
         graph2 = dataset.graph
 
         assert graph.total_num_nodes == graph2.total_num_nodes
@@ -1076,14 +1076,14 @@ def test_OnDiskDataset_Metadata():
         yaml_content = f"""
             dataset_name: {dataset_name}
         """
-        dataset = loadDataset(yaml_content, test_dir)
+        dataset = write_yaml_and_load_dataset(yaml_content, test_dir)
         assert dataset.dataset_name == dataset_name
 
         # Only dataset_name is specified.
         yaml_content = f"""
             dataset_name: {dataset_name}
         """
-        dataset = loadDataset(yaml_content, test_dir)
+        dataset = write_yaml_and_load_dataset(yaml_content, test_dir)
         assert dataset.dataset_name == dataset_name
 
 
@@ -1844,7 +1844,7 @@ def test_OnDiskDataset_all_nodes_set_homo():
               type: FusedCSCSamplingGraph
               path: {graph_path}
         """
-        dataset = loadDataset(yaml_content, test_dir)
+        dataset = write_yaml_and_load_dataset(yaml_content, test_dir)
         all_nodes_set = dataset.all_nodes_set
         assert isinstance(all_nodes_set, gb.ItemSet)
         assert all_nodes_set.names == ("seed_nodes",)
@@ -1881,7 +1881,7 @@ def test_OnDiskDataset_all_nodes_set_hetero():
               type: FusedCSCSamplingGraph
               path: {graph_path}
         """
-        dataset = loadDataset(yaml_content, test_dir)
+        dataset = write_yaml_and_load_dataset(yaml_content, test_dir)
         all_nodes_set = dataset.all_nodes_set
         assert isinstance(all_nodes_set, gb.ItemSetDict)
         assert all_nodes_set.names == ("seed_nodes",)

--- a/tests/python/pytorch/graphbolt/impl/test_ondisk_dataset.py
+++ b/tests/python/pytorch/graphbolt/impl/test_ondisk_dataset.py
@@ -1,10 +1,10 @@
 import os
 import pickle
-import warnings
 import random
 import re
 import tempfile
 import unittest
+import warnings
 
 import gb_test_utils as gbt
 import numpy as np
@@ -16,20 +16,24 @@ import yaml
 
 from dgl import graphbolt as gb
 
+
 def write_yaml_file(yaml_content, dir):
     os.makedirs(os.path.join(dir, "preprocessed"), exist_ok=True)
     yaml_file = os.path.join(dir, "preprocessed/metadata.yaml")
     with open(yaml_file, "w") as f:
         f.write(yaml_content)
 
+
 def load_dataset(dataset):
     with warnings.catch_warnings():
         warnings.simplefilter("ignore", category=UserWarning)
         return dataset.load()
 
+
 def loadDataset(yaml_content, dir):
     write_yaml_file(yaml_content, dir)
     return load_dataset(gb.OnDiskDataset(dir))
+
 
 def test_OnDiskDataset_TVTSet_exceptions():
     """Test excpetions thrown when parsing TVTSet."""


### PR DESCRIPTION
## Description
<!-- Brief description. Refer to the related issues if existed.
It'll be great if relevant reviewers can be assigned as well.-->

Multiple tests from `test_ondisk_dataset.py` generate the following warning:
```
tests/python/pytorch/graphbolt/impl/test_ondisk_dataset.py: 10 warnings
  /usr/local/lib/python3.10/dist-packages/dgl/graphbolt/impl/ondisk_dataset.py:480: DGLWarning: `all_node_set` is returned as None, since graph is None.
```
These changes resolve these warnings and some code duplication.

## Checklist
Please feel free to remove inapplicable items for your PR.
- [x] I've leverage the [tools](https://docs.google.com/document/d/1iHyj7zlmygKSk5gBPsqIqL5ASPzJSPREaNT_QdsiYA4/edit) to beautify the python and c++ code.
- [x] The PR is complete and small, read the [Google eng practice (CL equals to PR)](https://google.github.io/eng-practices/review/developer/small-cls.html) to understand more about small PR. In DGL, we consider PRs with less than 200 lines of core code change are small (example, test and documentation could be exempted).
- [x] To the best of my knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change
