### PR TITLE
[Misc] Fix recursive_apply when data is a tuple

### DIFF
--- a/python/dgl/utils/internal.py
+++ b/python/dgl/utils/internal.py
@@ -1127,6 +1127,8 @@ def recursive_apply(data, fn, *args, **kwargs):
         return {
             k: recursive_apply(v, fn, *args, **kwargs) for k, v in data.items()
         }
+    elif isinstance(data, tuple):
+        return tuple(recursive_apply(v, fn, *args, **kwargs) for v in data)
     elif is_listlike(data):
         return [recursive_apply(v, fn, *args, **kwargs) for v in data]
     else:
@@ -1142,6 +1144,11 @@ def recursive_apply_pair(data1, data2, fn, *args, **kwargs):
             k: recursive_apply_pair(data1[k], data2[k], fn, *args, **kwargs)
             for k in data1.keys()
         }
+    elif isinstance(data1, tuple) and isinstance(data2, tuple):
+        return tuple(
+            recursive_apply_pair(x, y, fn, *args, **kwargs)
+            for x, y in zip(data1, data2)
+        )
     elif is_listlike(data1) and is_listlike(data2):
         return [
             recursive_apply_pair(x, y, fn, *args, **kwargs)


### PR DESCRIPTION
## Description
`recursive_apply` would turn tuple into list, which is not expected.
Now an if-branch is added to fix this bug.

## Traceback

When use `to_dgl` after `copy_to` in the graphbolt dataloader, this error will happen:

```
Traceback (most recent call last):
  File "../dgl/examples/sampling/graphbolt/node_classification.py", line 426, in <module>
    main(args)
  File "../dgl/examples/sampling/graphbolt/node_classification.py", line 408, in main
    train(args, graph, features, train_set, valid_set, num_classes, model)
  File "../dgl/examples/sampling/graphbolt/node_classification.py", line 307, in train
    data = data.to_dgl()
  File "/opt/conda/envs/dgl-dev-gpu-118/lib/python3.8/site-packages/dgl-1.2-py3.8-linux-x86_64.egg/dgl/graphbolt/minibatch.py", line 467, in to_dgl
    blocks=self._to_dgl_blocks(),
  File "/opt/conda/envs/dgl-dev-gpu-118/lib/python3.8/site-packages/dgl-1.2-py3.8-linux-x86_64.egg/dgl/graphbolt/minibatch.py", line 429, in _to_dgl_blocks
    dgl.create_block(
  File "/opt/conda/envs/dgl-dev-gpu-118/lib/python3.8/site-packages/dgl-1.2-py3.8-linux-x86_64.egg/dgl/convert.py", line 541, in create_block
    (sparse_fmt, arrays), urange, vrange = utils.graphdata2tensors(
  File "/opt/conda/envs/dgl-dev-gpu-118/lib/python3.8/site-packages/dgl-1.2-py3.8-linux-x86_64.egg/dgl/utils/data.py", line 196, in graphdata2tensors
    src, dst = elist2tensor(data, idtype)
  File "/opt/conda/envs/dgl-dev-gpu-118/lib/python3.8/site-packages/dgl-1.2-py3.8-linux-x86_64.egg/dgl/utils/data.py", line 31, in elist2tensor
    u, v = zip(*elist)
ValueError: too many values to unpack (expected 2)
```

It's because during the `copy_to`, `recursive_apply` was called and changed some tuples to lists. Then `to_dgl` will switch to different branch according to the different type of the variables. The change from tuple to list caused the program go into the wrong branch.

## Checklist
Please feel free to remove inapplicable items for your PR.
- [ ] The PR title starts with [$CATEGORY] (such as [NN], [Model], [Doc], [Feature]])
- [ ] I've leverage the [tools](https://docs.google.com/document/d/1iHyj7zlmygKSk5gBPsqIqL5ASPzJSPREaNT_QdsiYA4/edit) to beautify the python and c++ code.
- [ ] The PR is complete and small, read the [Google eng practice (CL equals to PR)](https://google.github.io/eng-practices/review/developer/small-cls.html) to understand more about small PR. In DGL, we consider PRs with less than 200 lines of core code change are small (example, test and documentation could be exempted).
- [ ] All changes have test coverage
- [ ] Code is well-documented
- [ ] To the best of my knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change
- [ ] Related issue is referred in this PR
- [ ] If the PR is for a new model/paper, I've updated the example index [here](../examples/README.md).

## Changes
<!-- You could use following template
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)
-->
