### PR TITLE
[Misc] Eliminate compile warnings

### DIFF
--- a/graphbolt/src/macro.h
+++ b/graphbolt/src/macro.h
@@ -15,7 +15,7 @@ namespace graphbolt {
 #ifdef GRAPHBOLT_USE_CUDA
 #define GRAPHBOLT_DISPATCH_CUDA_ONLY_DEVICE(device_type, name, ...) \
   if (device_type == c10::DeviceType::CUDA) {                       \
-    const auto XPU = c10::DeviceType::CUDA;                         \
+    [[maybe_unused]] auto XPU = c10::DeviceType::CUDA;              \
     __VA_ARGS__                                                     \
   } else {                                                          \
     TORCH_CHECK(false, name, " is only available on CUDA device."); \

--- a/src/array/libra_partition.cc
+++ b/src/array/libra_partition.cc
@@ -295,7 +295,7 @@ void LibraVertexCut(
   for (int64_t c = 0; c < nc; c++) printf("%ld ", community_edges[c]);
   printf("\n");
 
-  delete community_edges;
+  delete[] community_edges;
   fclose(fp);
 }
 

--- a/src/graph/transform/compact.cc
+++ b/src/graph/transform/compact.cc
@@ -182,7 +182,7 @@ DGL_REGISTER_GLOBAL("transform._CAPI_DGLCompactGraphs")
       List<HeteroGraphRef> compacted_graph_refs;
       List<Value> induced_nodes;
 
-      for (const HeteroGraphPtr g : result_pair.first)
+      for (const HeteroGraphPtr &g : result_pair.first)
         compacted_graph_refs.push_back(HeteroGraphRef(g));
       for (const IdArray &ids : result_pair.second)
         induced_nodes.push_back(Value(MakeValue(ids)));

--- a/tests/cpp/test_partition.cc
+++ b/tests/cpp/test_partition.cc
@@ -61,7 +61,7 @@ void _TestRemainder_MapToX() {
     // every global index should have the same remainder as the part id
     ASSERT_EQ(global->shape[0], local->shape[0]);
     global = global.CopyTo(CPU);
-    for (size_t i = 0; i < global->shape[0]; ++i) {
+    for (int64_t i = 0; i < global->shape[0]; ++i) {
       EXPECT_EQ(Ptr<IdType>(global)[i] % num_parts, part_id)
           << "i=" << i << ", num_parts=" << num_parts
           << ", part_id=" << part_id;
@@ -70,7 +70,7 @@ void _TestRemainder_MapToX() {
     // the remapped local indices to should match the original
     local = local.CopyTo(CPU);
     ASSERT_EQ(local->shape[0], act_local->shape[0]);
-    for (size_t i = 0; i < act_local->shape[0]; ++i) {
+    for (int64_t i = 0; i < act_local->shape[0]; ++i) {
       EXPECT_EQ(Ptr<IdType>(local)[i], Ptr<IdType>(act_local)[i]);
     }
   }
@@ -167,7 +167,7 @@ void _TestRange_MapToX() {
 
     ASSERT_EQ(global->shape[0], local->shape[0]);
     global = global.CopyTo(CPU);
-    for (size_t i = 0; i < global->shape[0]; ++i) {
+    for (int64_t i = 0; i < global->shape[0]; ++i) {
       EXPECT_EQ(
           _FindPart(Ptr<IdType>(global)[i], Ptr<IdType>(range), num_parts),
           part_id)
@@ -178,7 +178,7 @@ void _TestRange_MapToX() {
     // the remapped local indices to should match the original
     local = local.CopyTo(CPU);
     ASSERT_EQ(local->shape[0], act_local->shape[0]);
-    for (size_t i = 0; i < act_local->shape[0]; ++i) {
+    for (int64_t i = 0; i < act_local->shape[0]; ++i) {
       EXPECT_EQ(Ptr<IdType>(local)[i], Ptr<IdType>(act_local)[i]);
     }
   }


### PR DESCRIPTION
## Description

Eliminates:

```
In file included from /localscratch/dgl-1/graphbolt/src/index_select.cc:8:
/localscratch/dgl-1/graphbolt/src/index_select.cc: In function ‘at::Tensor graphbolt::ops::IndexSelect(at::Tensor, at::Tensor)’:
/localscratch/dgl-1/graphbolt/src/./macro.h:18:16: warning: unused variable ‘XPU’ [-Wunused-variable]
   18 |     const auto XPU = c10::DeviceType::CUDA;                         \
      |                ^~~
/localscratch/dgl-1/graphbolt/src/./macro.h:18:16: note: in definition of macro ‘GRAPHBOLT_DISPATCH_CUDA_ONLY_DEVICE’
   18 |     const auto XPU = c10::DeviceType::CUDA;                         
```

and

```
/localscratch/dgl-1/tests/cpp/test_partition.cc: In instantiation of ‘void _TestRemainder_MapToX() [with DGLDeviceType XPU = kDGLCUDA; IdType = int]’:
/localscratch/dgl-1/tests/cpp/test_partition.cc:84:44:   required from here
/localscratch/dgl-1/tests/cpp/test_partition.cc:64:26: warning: comparison of integer expressions of different signedness: ‘size_t’ {aka ‘long unsigned int’} and ‘int64_t’ {aka ‘long int’} [-Wsign-compare]
   64 |     for (size_t i = 0; i < global->shape[0]; ++i) {
/localscratch/dgl-1/tests/cpp/test_partition.cc:73:26: warning: comparison of integer expressions of different signedness: ‘size_t’ {aka ‘long unsigned int’} and ‘int64_t’ {aka ‘long int’} [-Wsign-compare]
   73 |     for (size_t i = 0; i < act_local->shape[0]; ++i) {
/localscratch/dgl-1/tests/cpp/test_partition.cc: In instantiation of ‘void _TestRemainder_MapToX() [with DGLDeviceType XPU = kDGLCUDA; IdType = long int]’:
/localscratch/dgl-1/tests/cpp/test_partition.cc:85:44:   required from here
/localscratch/dgl-1/tests/cpp/test_partition.cc:64:26: warning: comparison of integer expressions of different signedness: ‘size_t’ {aka ‘long unsigned int’} and ‘int64_t’ {aka ‘long int’} [-Wsign-compare]
   64 |     for (size_t i = 0; i < global->shape[0]; ++i) {
/localscratch/dgl-1/tests/cpp/test_partition.cc:73:26: warning: comparison of integer expressions of different signedness: ‘size_t’ {aka ‘long unsigned int’} and ‘int64_t’ {aka ‘long int’} [-Wsign-compare]
   73 |     for (size_t i = 0; i < act_local->shape[0]; ++i) {
/localscratch/dgl-1/tests/cpp/test_partition.cc: In instantiation of ‘void _TestRange_MapToX() [with DGLDeviceType XPU = kDGLCUDA; IdType = int]’:
/localscratch/dgl-1/tests/cpp/test_partition.cc:192:40:   required from here
/localscratch/dgl-1/tests/cpp/test_partition.cc:170:26: warning: comparison of integer expressions of different signedness: ‘size_t’ {aka ‘long unsigned int’} and ‘int64_t’ {aka ‘long int’} [-Wsign-compare]
  170 |     for (size_t i = 0; i < global->shape[0]; ++i) {
/localscratch/dgl-1/tests/cpp/test_partition.cc:181:26: warning: comparison of integer expressions of different signedness: ‘size_t’ {aka ‘long unsigned int’} and ‘int64_t’ {aka ‘long int’} [-Wsign-compare]
  181 |     for (size_t i = 0; i < act_local->shape[0]; ++i) {
/localscratch/dgl-1/tests/cpp/test_partition.cc: In instantiation of ‘void _TestRange_MapToX() [with DGLDeviceType XPU = kDGLCUDA; IdType = long int]’:
/localscratch/dgl-1/tests/cpp/test_partition.cc:193:40:   required from here
/localscratch/dgl-1/tests/cpp/test_partition.cc:170:26: warning: comparison of integer expressions of different signedness: ‘size_t’ {aka ‘long unsigned int’} and ‘int64_t’ {aka ‘long int’} [-Wsign-compare]
  170 |     for (size_t i = 0; i < global->shape[0]; ++i) {
/localscratch/dgl-1/tests/cpp/test_partition.cc:181:26: warning: comparison of integer expressions of different signedness: ‘size_t’ {aka ‘long unsigned int’} and ‘int64_t’ {aka ‘long int’} [-Wsign-compare]
  181 |     for (size_t i = 0; i < act_local->shape[0]; ++i) {
```

```
/home/mfbalin/dgl-1/src/array/libra_partition.cc: In function ‘void dgl::aten::LibraVertexCut(int32_t, dgl::runtime::NDArray, dgl::runtime::NDArray, dgl::runtime::NDArray, dgl::runtime::NDArray, dgl::runtime::NDArray, dgl::runtime::NDArray, dgl::runtime::NDArray, int64_t, int64_t, const std::string&) [with IdType = int; IdType2 = int]’:
/home/mfbalin/dgl-1/src/array/libra_partition.cc:298:3: warning: ‘void operator delete(void*, std::size_t)’ called on pointer returned from a mismatched allocation function [-Wmismatched-new-delete]
  298 |   delete community_edges;
      |   ^~~~~~~~~~~~~~~~~~~~~~
/home/mfbalin/dgl-1/src/array/libra_partition.cc:101:30: note: returned from ‘void* operator new [](std::size_t)’
  101 |   int64_t *community_edges = new int64_t[nc]();
      |                              ^~~~~~~~~~~~~~~~~
/home/mfbalin/dgl-1/src/array/libra_partition.cc: In function ‘void dgl::aten::LibraVertexCut(int32_t, dgl::runtime::NDArray, dgl::runtime::NDArray, dgl::runtime::NDArray, dgl::runtime::NDArray, dgl::runtime::NDArray, dgl::runtime::NDArray, dgl::runtime::NDArray, int64_t, int64_t, const std::string&) [with IdType = long int; IdType2 = long int]’:
/home/mfbalin/dgl-1/src/array/libra_partition.cc:298:3: warning: ‘void operator delete(void*, std::size_t)’ called on pointer returned from a mismatched allocation function [-Wmismatched-new-delete]
  298 |   delete community_edges;
      |   ^~~~~~~~~~~~~~~~~~~~~~
/home/mfbalin/dgl-1/src/array/libra_partition.cc:101:30: note: returned from ‘void* operator new [](std::size_t)’
  101 |   int64_t *community_edges = new int64_t[nc]();
      |                              ^~~~~~~~~~~~~~~~~
/home/mfbalin/dgl-1/src/array/libra_partition.cc: In function ‘void dgl::aten::LibraVertexCut(int32_t, dgl::runtime::NDArray, dgl::runtime::NDArray, dgl::runtime::NDArray, dgl::runtime::NDArray, dgl::runtime::NDArray, dgl::runtime::NDArray, dgl::runtime::NDArray, int64_t, int64_t, const std::string&) [with IdType = long int; IdType2 = int]’:
/home/mfbalin/dgl-1/src/array/libra_partition.cc:298:3: warning: ‘void operator delete(void*, std::size_t)’ called on pointer returned from a mismatched allocation function [-Wmismatched-new-delete]
  298 |   delete community_edges;
      |   ^~~~~~~~~~~~~~~~~~~~~~
/home/mfbalin/dgl-1/src/array/libra_partition.cc:101:30: note: returned from ‘void* operator new [](std::size_t)’
  101 |   int64_t *community_edges = new int64_t[nc]();
      |                              ^~~~~~~~~~~~~~~~~
/home/mfbalin/dgl-1/src/array/libra_partition.cc: In function ‘void dgl::aten::LibraVertexCut(int32_t, dgl::runtime::NDArray, dgl::runtime::NDArray, dgl::runtime::NDArray, dgl::runtime::NDArray, dgl::runtime::NDArray, dgl::runtime::NDArray, dgl::runtime::NDArray, int64_t, int64_t, const std::string&) [with IdType = int; IdType2 = long int]’:
/home/mfbalin/dgl-1/src/array/libra_partition.cc:298:3: warning: ‘void operator delete(void*, std::size_t)’ called on pointer returned from a mismatched allocation function [-Wmismatched-new-delete]
  298 |   delete community_edges;
      |   ^~~~~~~~~~~~~~~~~~~~~~
/home/mfbalin/dgl-1/src/array/libra_partition.cc:101:30: note: returned from ‘void* operator new [](std::size_t)’
  101 |   int64_t *community_edges = new int64_t[nc]();
      |                              ^~~~~~~~~~~~~~~~~
```

```
/home/mfbalin/dgl-1/src/graph/transform/compact.cc: In lambda function:
/home/mfbalin/dgl-1/src/graph/transform/compact.cc:185:33: warning: loop variable ‘g’ creates a copy from type ‘const dgl::HeteroGraphPtr’ {aka ‘const std::shared_ptr<dgl::BaseHeteroGraph>’} [-Wrange-loop-construct]
  185 |       for (const HeteroGraphPtr g : result_pair.first)
      |                                 ^
/home/mfbalin/dgl-1/src/graph/transform/compact.cc:185:33: note: use reference type to prevent copying
  185 |       for (const HeteroGraphPtr g : result_pair.first)
      |                                 ^
      |                      
```