### PR TITLE
[Graphbolt] Add proper error message for BuildinDataset.

### DIFF
--- a/python/dgl/graphbolt/impl/ondisk_dataset.py
+++ b/python/dgl/graphbolt/impl/ondisk_dataset.py
@@ -378,7 +378,6 @@ class OnDiskDataset(Dataset):
 
     def load(self):
         """Load the dataset."""
-        self._loaded = True
         self._convert_yaml_path_to_absolute_path()
         self._meta = OnDiskMetaData(**self._yaml_data)
         self._dataset_name = self._meta.dataset_name
@@ -386,6 +385,7 @@ class OnDiskDataset(Dataset):
         self._feature = TorchBasedFeatureStore(self._meta.feature_data)
         self._tasks = self._init_tasks(self._meta.tasks)
         self._all_nodes_set = self._init_all_nodes_set(self._graph)
+        self._loaded = True
         return self
 
     @property


### PR DESCRIPTION
## Description
<!-- Brief description. Refer to the related issues if existed.
It'll be great if relevant reviewers can be assigned as well.-->
```
Traceback (most recent call last):
  File "examples/sampling/graphbolt/quickstart/node_classification.py", line 125, in <module>
    in_size = dataset.feature.size("node", None, "feat")[0]
  File "/home/ubuntu/github/dgl/python/dgl/graphbolt/impl/ondisk_dataset.py", line 411, in feature
    self._check_loaded()
  File "/home/ubuntu/github/dgl/python/dgl/graphbolt/impl/ondisk_dataset.py", line 444, in _check_loaded
    "Please ensure that you have called the OnDiskDataset.load() method"
AssertionError: Please ensure that you have called the OnDiskDataset.load() method to properly load the data.
```

## Checklist
Please feel free to remove inapplicable items for your PR.
- [ ] The PR title starts with [$CATEGORY] (such as [NN], [Model], [Doc], [Feature]])
- [ ] I've leverage the [tools](https://docs.google.com/document/d/1iHyj7zlmygKSk5gBPsqIqL5ASPzJSPREaNT_QdsiYA4/edit) to beautify the python and c++ code.
- [ ] The PR is complete and small, read the [Google eng practice (CL equals to PR)](https://google.github.io/eng-practices/review/developer/small-cls.html) to understand more about small PR. In DGL, we consider PRs with less than 200 lines of core code change are small (example, test and documentation could be exempted).
- [ ] All changes have test coverage
- [ ] Code is well-documented
- [ ] To the best of my knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change
- [ ] Related issue is referred in this PR
- [ ] If the PR is for a new model/paper, I've updated the example index [here](../examples/README.md).

## Changes
<!-- You could use following template
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)
-->
