### PR TITLE
[GraphBolt] avoid pre-defined metadata size

### DIFF
--- a/graphbolt/include/graphbolt/fused_csc_sampling_graph.h
+++ b/graphbolt/include/graphbolt/fused_csc_sampling_graph.h
@@ -375,14 +375,6 @@ class FusedCSCSamplingGraph : public torch::CustomClassHolder {
   torch::optional<EdgeAttrMap> edge_attributes_;
 
   /**
-   * @brief Maximum number of bytes used to serialize the metadata of the
-   * member tensors, including tensor shape and dtype. The constant is estimated
-   * by multiplying the number of tensors in this class and the maximum number
-   * of bytes used to serialize the metadata of a tensor (10 * 8192 for now).
-   */
-  static constexpr int64_t SERIALIZED_METAINFO_SIZE_MAX = 10 * 81920;
-
-  /**
    * @brief Shared memory used to hold the tensor metadata and data of this
    * class. By storing its shared memory objects, the graph controls the
    * resources of shared memory, which will be released automatically when the

--- a/graphbolt/include/graphbolt/shared_memory.h
+++ b/graphbolt/include/graphbolt/shared_memory.h
@@ -46,6 +46,9 @@ class SharedMemory {
   /** @brief Get the pointer to the shared memory. */
   void* GetMemory() const { return ptr_; }
 
+  /** @brief Get the size of the shared memory. */
+  size_t GetSize() const { return size_; }
+
   /**
    * @brief Creates the shared memory object and map the shared memory.
    *
@@ -57,10 +60,8 @@ class SharedMemory {
   /**
    * @brief Open the created shared memory object and map the shared memory.
    *
-   * @param size The size of the shared memory.
-   * @return The pointer to the shared memory.
    */
-  void* Open(size_t size);
+  void* Open();
 
   /**
    * @brief Check if the shared memory exists.

--- a/graphbolt/src/fused_csc_sampling_graph.cc
+++ b/graphbolt/src/fused_csc_sampling_graph.cc
@@ -597,7 +597,7 @@ BuildGraphFromSharedMemoryHelper(SharedMemoryHelper&& helper) {
 c10::intrusive_ptr<FusedCSCSamplingGraph>
 FusedCSCSamplingGraph::CopyToSharedMemory(
     const std::string& shared_memory_name) {
-  SharedMemoryHelper helper(shared_memory_name, SERIALIZED_METAINFO_SIZE_MAX);
+  SharedMemoryHelper helper(shared_memory_name);
   helper.WriteTorchTensor(indptr_);
   helper.WriteTorchTensor(indices_);
   helper.WriteTorchTensor(node_type_offset_);
@@ -612,7 +612,7 @@ FusedCSCSamplingGraph::CopyToSharedMemory(
 c10::intrusive_ptr<FusedCSCSamplingGraph>
 FusedCSCSamplingGraph::LoadFromSharedMemory(
     const std::string& shared_memory_name) {
-  SharedMemoryHelper helper(shared_memory_name, SERIALIZED_METAINFO_SIZE_MAX);
+  SharedMemoryHelper helper(shared_memory_name);
   return BuildGraphFromSharedMemoryHelper(std::move(helper));
 }
 

--- a/graphbolt/src/shared_memory.cc
+++ b/graphbolt/src/shared_memory.cc
@@ -71,16 +71,17 @@ void* SharedMemory::Open() {
       handle_ != nullptr, "Failed to open ", decorated_name,
       ", Win32 Error: ", GetLastError());
 
+  ptr_ = MapViewOfFile(handle_, FILE_MAP_ALL_ACCESS, 0, 0, 0);
+  TORCH_CHECK(
+      ptr_ != nullptr, "Memory mapping failed, Win32 error: ", GetLastError());
+
   // Obtain the size of the memory-mapped file.
   MEMORY_BASIC_INFORMATION memInfo;
   TORCH_CHECK(
-      VirtualQuery(handle_, &memInfo, sizeof(memInfo)) != 0,
+      VirtualQuery(ptr_, &memInfo, sizeof(memInfo)) != 0,
       "Failed to get the size of shared memory: ", GetLastError());
   size_ = static_cast<size_t>(memInfo.RegionSize);
 
-  ptr_ = MapViewOfFile(handle_, FILE_MAP_ALL_ACCESS, 0, 0, size_);
-  TORCH_CHECK(
-      ptr_ != nullptr, "Memory mapping failed, Win32 error: ", GetLastError());
   return ptr_;
 }
 

--- a/graphbolt/src/shared_memory.cc
+++ b/graphbolt/src/shared_memory.cc
@@ -72,9 +72,11 @@ void* SharedMemory::Open() {
       ", Win32 Error: ", GetLastError());
 
   // Obtain the size of the memory-mapped file.
+  LARGE_INTEGER large_integer;
   TORCH_CHECK(
-      GetFileSizeEx(handle_, &size_),
+      GetFileSizeEx(handle_, &large_integer),
       "Failed to get the size of shared memory: ", GetLastError());
+  size_ = static_cast<size_t>(large_integer.QuadPart);
 
   ptr_ = MapViewOfFile(handle_, FILE_MAP_ALL_ACCESS, 0, 0, size_);
   TORCH_CHECK(

--- a/graphbolt/src/shared_memory.cc
+++ b/graphbolt/src/shared_memory.cc
@@ -72,11 +72,11 @@ void* SharedMemory::Open() {
       ", Win32 Error: ", GetLastError());
 
   // Obtain the size of the memory-mapped file.
-  LARGE_INTEGER large_integer;
+  MEMORY_BASIC_INFORMATION memInfo;
   TORCH_CHECK(
-      GetFileSizeEx(handle_, &large_integer),
+      VirtualQuery(handle_, &memInfo, sizeof(memInfo)) != 0,
       "Failed to get the size of shared memory: ", GetLastError());
-  size_ = static_cast<size_t>(large_integer.QuadPart);
+  size_ = static_cast<size_t>(memInfo.RegionSize);
 
   ptr_ = MapViewOfFile(handle_, FILE_MAP_ALL_ACCESS, 0, 0, size_);
   TORCH_CHECK(

--- a/graphbolt/src/shared_memory.cc
+++ b/graphbolt/src/shared_memory.cc
@@ -79,7 +79,7 @@ void* SharedMemory::Open() {
       "Failed to get the size of shared memory: ", GetLastError());
   size_ = fileInfo.EndOfFile.QuadPart;
 
-  ptr_ = MapViewOfFile(handle_, FILE_MAP_ALL_ACCESS, 0, 0, size);
+  ptr_ = MapViewOfFile(handle_, FILE_MAP_ALL_ACCESS, 0, 0, size_);
   TORCH_CHECK(
       ptr_ != nullptr, "Memory mapping failed, Win32 error: ", GetLastError());
   return ptr_;

--- a/graphbolt/src/shared_memory.cc
+++ b/graphbolt/src/shared_memory.cc
@@ -72,12 +72,9 @@ void* SharedMemory::Open() {
       ", Win32 Error: ", GetLastError());
 
   // Obtain the size of the memory-mapped file.
-  FILE_STANDARD_INFO fileInfo;
   TORCH_CHECK(
-      GetFileInformationByHandleEx(
-          handle_, FileStandardInfo, &fileInfo, sizeof(fileInfo)),
+      GetFileSizeEx(handle_, &size_),
       "Failed to get the size of shared memory: ", GetLastError());
-  size_ = fileInfo.EndOfFile.QuadPart;
 
   ptr_ = MapViewOfFile(handle_, FILE_MAP_ALL_ACCESS, 0, 0, size_);
   TORCH_CHECK(

--- a/graphbolt/src/shared_memory_helper.cc
+++ b/graphbolt/src/shared_memory_helper.cc
@@ -33,10 +33,10 @@ inline static int64_t GetRoundedSize(int64_t size) {
   return (size + ALIGNED_SIZE - 1) / ALIGNED_SIZE * ALIGNED_SIZE;
 }
 
-SharedMemoryHelper::SharedMemoryHelper(
-    const std::string& name, int64_t max_metadata_size)
+SharedMemoryHelper::SharedMemoryHelper(const std::string& name)
     : name_(name),
-      max_metadata_size_(max_metadata_size),
+      metadata_size_(0),
+      data_size_(0),
       metadata_shared_memory_(nullptr),
       data_shared_memory_(nullptr),
       metadata_offset_(0),
@@ -49,12 +49,13 @@ void SharedMemoryHelper::InitializeRead() {
     // Reader process opens the shared memory.
     metadata_shared_memory_ =
         std::make_unique<SharedMemory>(GetSharedMemoryMetadataName(name_));
-    metadata_shared_memory_->Open(max_metadata_size_);
+    metadata_shared_memory_->Open();
+    metadata_size_ = metadata_shared_memory_->GetSize();
     auto archive = this->ReadTorchArchive();
-    int64_t data_size = read_from_archive(archive, "data_size").toInt();
     data_shared_memory_ =
         std::make_unique<SharedMemory>(GetSharedMemoryDataName(name_));
-    data_shared_memory_->Open(data_size);
+    data_shared_memory_->Open();
+    data_size_ = data_shared_memory_->GetSize();
   } else {
     // Writer process already has the shared memory.
     // Skip the first archive recording data size before read.
@@ -146,18 +147,41 @@ SharedMemoryHelper::ReadTorchTensorDict() {
   return tensor_dict;
 }
 
-void SharedMemoryHelper::WriteTorchArchiveInternal(
-    torch::serialize::OutputArchive& archive) {
-  std::stringstream serialized;
-  archive.save_to(serialized);
-  auto serialized_str = serialized.str();
-  auto metadata_ptr = this->GetCurrentMetadataPtr();
-  static_cast<int64_t*>(metadata_ptr)[0] = serialized_str.size();
-  memcpy(
-      static_cast<char*>(metadata_ptr) + sizeof(int64_t), serialized_str.data(),
-      serialized_str.size());
-  int64_t rounded_size = GetRoundedSize(serialized_str.size());
-  this->MoveMetadataPtr(sizeof(int64_t) + rounded_size);
+void SharedMemoryHelper::WriteTorchDict(
+    torch::optional<torch::Dict<std::string, int64_t>> dict,
+    const std::string& name) {
+  torch::serialize::OutputArchive archive;
+  if (!dict.has_value()) {
+    archive.write(name + "_has_value", false);
+    this->WriteTorchArchive(std::move(archive));
+    return;
+  }
+  archive.write(name + "_has_value", true);
+  archive.write(name + "_data", dict.value());
+  this->WriteTorchArchive(std::move(archive));
+}
+
+void SharedMemoryHelper::SerializeMetadata() {
+  for (auto& archive : metadata_to_write_) {
+    std::stringstream serialized;
+    archive.save_to(serialized);
+    metadata_strings_to_write_.push_back(std::move(serialized.str()));
+  }
+  metadata_to_write_.clear();
+}
+
+void SharedMemoryHelper::WriteMetadataToSharedMemory() {
+  metadata_offset_ = 0;
+  for (const auto& str : metadata_strings_to_write_) {
+    auto metadata_ptr = this->GetCurrentMetadataPtr();
+    static_cast<int64_t*>(metadata_ptr)[0] = str.size();
+    memcpy(
+        static_cast<char*>(metadata_ptr) + sizeof(int64_t), str.data(),
+        str.size());
+    int64_t rounded_size = GetRoundedSize(str.size());
+    this->MoveMetadataPtr(sizeof(int64_t) + rounded_size);
+  }
+  metadata_strings_to_write_.clear();
 }
 
 void SharedMemoryHelper::WriteTorchTensorInternal(
@@ -182,22 +206,33 @@ void SharedMemoryHelper::Flush() {
     }
   }
   archive.write("data_size", static_cast<int64_t>(data_size));
+  metadata_to_write_.insert(metadata_to_write_.begin(), std::move(archive));
+
+  // Serialize the metadata archives.
+  SerializeMetadata();
+
+  // Create the shared memory objects.
+  const size_t metadata_size = std::accumulate(
+      metadata_strings_to_write_.begin(), metadata_strings_to_write_.end(), 0,
+      [](size_t sum, const std::string& str) {
+        return sum + sizeof(int64_t) + GetRoundedSize(str.size());
+      });
   metadata_shared_memory_ =
       std::make_unique<SharedMemory>(GetSharedMemoryMetadataName(name_));
-  metadata_shared_memory_->Create(max_metadata_size_);
-  metadata_offset_ = 0;
-  this->WriteTorchArchiveInternal(archive);
-  for (auto& archive : metadata_to_write_) {
-    this->WriteTorchArchiveInternal(archive);
-  }
+  metadata_shared_memory_->Create(metadata_size);
+  metadata_size_ = metadata_size;
+
+  WriteMetadataToSharedMemory();
 
   data_shared_memory_ =
       std::make_unique<SharedMemory>(GetSharedMemoryDataName(name_));
   data_shared_memory_->Create(data_size);
+  data_size_ = data_size;
   data_offset_ = 0;
   for (auto tensor : tensors_to_write_) {
     this->WriteTorchTensorInternal(tensor);
   }
+
   metadata_to_write_.clear();
   tensors_to_write_.clear();
 }

--- a/graphbolt/src/shared_memory_helper.h
+++ b/graphbolt/src/shared_memory_helper.h
@@ -29,8 +29,8 @@ namespace sampling {
  * solve this problem, we use two shared memory objects: one for storing the
  * metadata and the other for storing the binary buffer. The metadata includes
  * the metadata of data structures such as size and shape. The size of the
- * metadata is decided by the user via `max_metadata_size`. The size of the
- * binary buffer is decided by the size of the data structures.
+ * metadata is decided by the size of metadata. The size of the binary buffer is
+ * decided by the size of the data structures.
  *
  * To avoid repeated shared memory allocation, this helper class uses lazy data
  * structure writing. The data structures are written to the shared memory only

--- a/graphbolt/src/shared_memory_helper.h
+++ b/graphbolt/src/shared_memory_helper.h
@@ -86,10 +86,6 @@ class SharedMemoryHelper {
   torch::optional<torch::Dict<std::string, torch::Tensor>>
   ReadTorchTensorDict();
 
-  void WriteTorchDict(
-      torch::optional<torch::Dict<std::string, int64_t>> dict,
-      const std::string& name);
-
   /** @brief Flush the data structures to the shared memory. */
   void Flush();
 

--- a/tests/python/pytorch/graphbolt/impl/test_fused_csc_sampling_graph.py
+++ b/tests/python/pytorch/graphbolt/impl/test_fused_csc_sampling_graph.py
@@ -1138,9 +1138,11 @@ def test_homo_graph_on_shared_memory(
 )
 @pytest.mark.parametrize(
     "total_num_nodes, total_num_edges",
-    [(1, 1), (100, 1), (10, 50), (1000, 50000)],
+    [(1, 1), (100, 1), (10, 50), (1000, 50 * 1000), (10 * 1000, 100 * 1000)],
 )
-@pytest.mark.parametrize("num_ntypes, num_etypes", [(1, 1), (3, 5), (100, 1)])
+@pytest.mark.parametrize(
+    "num_ntypes, num_etypes", [(1, 1), (3, 5), (100, 1), (1000, 1000)]
+)
 @pytest.mark.parametrize("test_edge_attrs", [True, False])
 def test_hetero_graph_on_shared_memory(
     total_num_nodes, total_num_edges, num_ntypes, num_etypes, test_edge_attrs


### PR DESCRIPTION
## Description
<!-- Brief description. Refer to the related issues if existed.
It'll be great if relevant reviewers can be assigned as well.-->

part of #6661 

Previously we have to pre-define metadata size when creating shared memory. This will results in crash if metadata is larger than assumption(For example, large number of node/edge types are available or many fields are added into `edge_attributes`). For now, such limitation and assumption is gone.


## Checklist
Please feel free to remove inapplicable items for your PR.
- [ ] The PR title starts with [$CATEGORY] (such as [NN], [Model], [Doc], [Feature]])
- [ ] I've leverage the [tools](https://docs.google.com/document/d/1iHyj7zlmygKSk5gBPsqIqL5ASPzJSPREaNT_QdsiYA4/edit) to beautify the python and c++ code.
- [ ] The PR is complete and small, read the [Google eng practice (CL equals to PR)](https://google.github.io/eng-practices/review/developer/small-cls.html) to understand more about small PR. In DGL, we consider PRs with less than 200 lines of core code change are small (example, test and documentation could be exempted).
- [ ] All changes have test coverage
- [ ] Code is well-documented
- [ ] To the best of my knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change
- [ ] Related issue is referred in this PR
- [ ] If the PR is for a new model/paper, I've updated the example index [here](../examples/README.md).

## Changes
<!-- You could use following template
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)
-->
