### PR TITLE
[DO NOT MERGE][GraphBolt] support converting coo to csc

### DIFF
--- a/python/dgl/graphbolt/internal/utils.py
+++ b/python/dgl/graphbolt/internal/utils.py
@@ -124,10 +124,10 @@ def get_attributes(_obj) -> list:
 
 def convert_coo_to_csc_homo(src, dst, include_original_edge_id: bool = False):
     """Convert COO format data (homogenious) to CSC format."""
-    if not isinstance(src, torch.LongTensor):
-        src = torch.tensor(src, dtype=torch.int64)
-    if not isinstance(dst, torch.LongTensor):
-        dst = torch.tensor(dst, dtype=torch.int64)
+    if not isinstance(src, torch.Tensor):
+        src = torch.tensor(src)
+    if not isinstance(dst, torch.Tensor):
+        dst = torch.tensor(dst)
     assert len(src) == len(
         dst
     ), "COO data incorrect: Amount of src and dst incompactable."

--- a/python/dgl/graphbolt/internal/utils.py
+++ b/python/dgl/graphbolt/internal/utils.py
@@ -124,10 +124,9 @@ def get_attributes(_obj) -> list:
 
 def convert_coo_to_csc_homo(src, dst, include_original_edge_id: bool = False):
     """Convert COO format data (homogenious) to CSC format."""
-    assert (
-        len(src) == len(dst),
-        "COO data incorrect: Amount of src and dst incompactable.",
-    )
+    assert len(src) == len(
+        dst
+    ), "COO data incorrect: Amount of src and dst incompactable."
     indices = torch.tensor([src, dst])
     eid = torch.arange(0, len(src))
     coo = torch.sparse_coo_tensor(indices, values=eid)

--- a/python/dgl/graphbolt/internal/utils.py
+++ b/python/dgl/graphbolt/internal/utils.py
@@ -124,10 +124,14 @@ def get_attributes(_obj) -> list:
 
 def convert_coo_to_csc_homo(src, dst, include_original_edge_id: bool = False):
     """Convert COO format data (homogenious) to CSC format."""
+    if not isinstance(src, torch.LongTensor):
+        src = torch.tensor(src, dtype=torch.int64)
+    if not isinstance(dst, torch.LongTensor):
+        dst = torch.tensor(dst, dtype=torch.int64)
     assert len(src) == len(
         dst
     ), "COO data incorrect: Amount of src and dst incompactable."
-    indices = torch.tensor([src, dst])
+    indices = torch.stack((src, dst), dim=0)
     eid = torch.arange(0, len(src))
     coo = torch.sparse_coo_tensor(indices, values=eid)
     csc = coo.to_sparse_csc()

--- a/python/dgl/graphbolt/internal/utils.py
+++ b/python/dgl/graphbolt/internal/utils.py
@@ -120,3 +120,23 @@ def get_attributes(_obj) -> list:
         and not callable(getattr(_obj, attribute))
     ]
     return attributes
+
+
+def convert_coo_to_csc_homo(src, dst, include_original_edge_id: bool = False):
+    """Convert COO format data (homogenious) to CSC format."""
+    assert (
+        len(src) == len(dst),
+        "COO data incorrect: Amount of src and dst incompactable.",
+    )
+    indices = torch.tensor([src, dst])
+    eid = torch.arange(0, len(src))
+    coo = torch.sparse_coo_tensor(indices, values=eid)
+    csc = coo.to_sparse_csc()
+    if include_original_edge_id:
+        return (
+            csc.ccol_indices(),
+            csc.row_indices(),
+            csc.values(),
+        )
+    else:
+        return (csc.ccol_indices(), csc.row_indices())

--- a/tests/python/pytorch/graphbolt/utils/test_internal.py
+++ b/tests/python/pytorch/graphbolt/utils/test_internal.py
@@ -146,7 +146,7 @@ def test_copy_or_convert_data(data_fmt, save_fmt, is_feature):
 def test_convert_coo_to_csc_homo():
     src = [0, 0, 1, 1, 2, 2, 2, 2, 3, 5]
     dst = [1, 3, 0, 4, 1, 2, 3, 5, 5, 4]
-    indptr, indices, edge_id = internal.utils.convert_coo_to_csc_homo(
+    indptr, indices, edge_ids = internal.utils.convert_coo_to_csc_homo(
         src, dst, include_original_edge_id=True
     )
     assert torch.equal(indptr, torch.LongTensor([0, 1, 3, 4, 6, 8, 10]))
@@ -154,5 +154,5 @@ def test_convert_coo_to_csc_homo():
         indices, torch.LongTensor([1, 0, 2, 2, 0, 2, 1, 5, 2, 3])
     )
     assert torch.equal(
-        edge_id, torch.LongTensor([2, 0, 4, 5, 1, 6, 3, 9, 7, 8])
+        edge_ids, torch.LongTensor([2, 0, 4, 5, 1, 6, 3, 9, 7, 8])
     )

--- a/tests/python/pytorch/graphbolt/utils/test_internal.py
+++ b/tests/python/pytorch/graphbolt/utils/test_internal.py
@@ -141,3 +141,18 @@ def test_copy_or_convert_data(data_fmt, save_fmt, is_feature):
         data = None
         tensor_data = None
         out_data = None
+
+
+def test_convert_coo_to_csc_homo():
+    src = [0, 0, 1, 1, 2, 2, 2, 2, 3, 5]
+    dst = [1, 3, 0, 4, 1, 2, 3, 5, 5, 4]
+    indptr, indices, edge_id = internal.utils.convert_coo_to_csc_homo(
+        src, dst, include_original_edge_id=True
+    )
+    assert torch.equal(indptr, torch.LongTensor([0, 1, 3, 4, 6, 8, 10]))
+    assert torch.equal(
+        indices, torch.LongTensor([1, 0, 2, 2, 0, 2, 1, 5, 2, 3])
+    )
+    assert torch.equal(
+        edge_id, torch.LongTensor([2, 0, 4, 5, 1, 6, 3, 9, 7, 8])
+    )


### PR DESCRIPTION
## Description
<!-- Brief description. Refer to the related issues if existed.
It'll be great if relevant reviewers can be assigned as well.-->
Added a script to convert coo to csc using PyTorch.
**DO NOT MERGE**  because currently it would automatically coalesce duplicate edges into one edge, resulting in inconsistency.

## Checklist
Please feel free to remove inapplicable items for your PR.
- [ ] The PR title starts with [$CATEGORY] (such as [NN], [Model], [Doc], [Feature]])
- [ ] I've leverage the [tools](https://docs.google.com/document/d/1iHyj7zlmygKSk5gBPsqIqL5ASPzJSPREaNT_QdsiYA4/edit) to beautify the python and c++ code.
- [ ] The PR is complete and small, read the [Google eng practice (CL equals to PR)](https://google.github.io/eng-practices/review/developer/small-cls.html) to understand more about small PR. In DGL, we consider PRs with less than 200 lines of core code change are small (example, test and documentation could be exempted).
- [ ] All changes have test coverage
- [ ] Code is well-documented
- [ ] To the best of my knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change
- [ ] Related issue is referred in this PR
- [ ] If the PR is for a new model/paper, I've updated the example index [here](../examples/README.md).

## Changes
<!-- You could use following template
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)
-->
