### PR TITLE
[GraphBolt] Add `unique_and_compact_csc_format`.

### DIFF
--- a/python/dgl/graphbolt/__init__.py
+++ b/python/dgl/graphbolt/__init__.py
@@ -21,6 +21,7 @@ from .subgraph_sampler import *
 from .internal import (
     compact_csc_format,
     unique_and_compact,
+    unique_and_compact_csc_formats,
     unique_and_compact_node_pairs,
 )
 from .utils import add_reverse_edges, exclude_seed_edges

--- a/python/dgl/graphbolt/internal/sample_utils.py
+++ b/python/dgl/graphbolt/internal/sample_utils.py
@@ -175,6 +175,116 @@ def unique_and_compact_node_pairs(
     return unique_nodes, compacted_node_pairs
 
 
+def unique_and_compact_csc_formats(
+    csc_formats: Union[
+        Tuple[torch.Tensor, torch.Tensor],
+        Dict[str, Tuple[torch.Tensor, torch.Tensor]],
+    ],
+    unique_dst_nodes: Union[
+        torch.Tensor,
+        Dict[str, torch.Tensor],
+    ],
+):
+    """
+    Compact csc formats and return unique nodes (per type).
+    Parameters
+    ----------
+    csc_formats : Union[CSCFormatBase, Dict(str, CSCFormatBase)]
+        CSC formats representing source-destination edges.
+        - If `csc_formats` is a CSCFormatBase: It means the graph is
+        homogeneous. Also, indptr and indice in it should be torch.tensor
+        representing source and destination pairs in csc format. And IDs inside
+        are homogeneous ids.
+        - If `csc_formats` is a Dict[str, CSCFormatBase]: The keys
+        should be edge type and the values should be csc format node pairs.
+        And IDs inside are heterogeneous ids.
+    unique_dst_nodes: torch.Tensor or Dict[str, torch.Tensor]
+        Unique nodes of all destination nodes in the node pairs.
+        - If `unique_dst_nodes` is a tensor: It means the graph is homogeneous.
+        - If `csc_formats` is a dictionary: The keys are node type and the
+        values are corresponding nodes. And IDs inside are heterogeneous ids.
+    Returns
+    -------
+    Tuple[csc_formats, unique_nodes]
+        The compacted csc formats, where node IDs are replaced with mapped node
+        IDs, and the unique nodes (per type).
+        "Compacted csc formats" indicates that the node IDs in the input node
+        pairs are replaced with mapped node IDs, where each type of node is
+        mapped to a contiguous space of IDs ranging from 0 to N.
+    Examples
+    --------
+    >>> import dgl.graphbolt as gb
+    >>> N1 = torch.LongTensor([1, 2, 2])
+    >>> N2 = torch.LongTensor([5, 5, 6])
+    >>> unique_dst = {
+    ...     "n1": torch.LongTensor([1, 2]),
+    ...     "n2": torch.LongTensor([5, 6])}
+    >>> csc_formats = {
+    ...     "n1:e1:n2": CSCFormatBase(indptr=torch.tensor([0, 2, 3]),indices=N1),
+    ...     "n2:e2:n1": CSCFormatBase(indptr=torch.tensor([0, 1, 3]),indices=N2)}
+    >>> unique_nodes, compacted_csc_formats = gb.unique_and_compact_csc_formats(
+    ...     csc_formats, unique_dst
+    ... )
+    >>> print(unique_nodes)
+    {'n1': tensor([1, 2]), 'n2': tensor([5, 6])}
+    >>> print(compacted_csc_formats)
+    {"n1:e1:n2": CSCFormatBase(indptr=torch.tensor([0, 2, 3]),
+                               indices=torch.tensor([0, 1, 1])),
+     "n2:e2:n1": CSCFormatBase(indptr=torch.tensor([0, 1, 3]),
+                               indices=torch.Longtensor([0, 0, 1]))}
+    """
+    is_homogeneous = not isinstance(csc_formats, dict)
+    if is_homogeneous:
+        csc_formats = {"_N:_E:_N": csc_formats}
+        if unique_dst_nodes is not None:
+            assert isinstance(
+                unique_dst_nodes, torch.Tensor
+            ), "Edge type not supported in homogeneous graph."
+            unique_dst_nodes = {"_N": unique_dst_nodes}
+
+    # Collect all source and destination nodes for each node type.
+    indices = defaultdict(list)
+    for etype, csc_format in csc_formats.items():
+        src_type, _, _ = etype_str_to_tuple(etype)
+        indices[src_type].append(csc_format.indices)
+    indices = {ntype: torch.cat(nodes) for ntype, nodes in indices.items()}
+
+    ntypes = set(indices.keys())
+    unique_nodes = {}
+    compacted_indices = {}
+    dtype = list(indices.values())[0].dtype
+    default_tensor = torch.tensor([], dtype=dtype)
+    for ntype in ntypes:
+        indice = indices.get(ntype, default_tensor)
+        unique_dst = unique_dst_nodes.get(ntype, default_tensor)
+        (
+            unique_nodes[ntype],
+            compacted_indices[ntype],
+            _,
+        ) = torch.ops.graphbolt.unique_and_compact(
+            indice, torch.tensor([], dtype=indice.dtype), unique_dst
+        )
+
+    compacted_csc_formats = {}
+    # Map back with the same order.
+    for etype, csc_format in csc_formats.items():
+        num_elem = csc_format.indices.size(0)
+        src_type, _, _ = etype_str_to_tuple(etype)
+        indice = compacted_indices[src_type][:num_elem]
+        indptr = csc_format.indptr
+        compacted_csc_formats[etype] = CSCFormatBase(
+            indptr=indptr, indices=indice
+        )
+        compacted_indices[src_type] = compacted_indices[src_type][num_elem:]
+
+    # Return singleton for a homogeneous graph.
+    if is_homogeneous:
+        compacted_csc_formats = list(compacted_csc_formats.values())[0]
+        unique_nodes = list(unique_nodes.values())[0]
+
+    return unique_nodes, compacted_csc_formats
+
+
 def compact_csc_format(
     csc_formats: Union[CSCFormatBase, Dict[str, CSCFormatBase]],
     dst_nodes: Union[torch.Tensor, Dict[str, torch.Tensor]],

--- a/tests/python/pytorch/graphbolt/test_graphbolt_utils.py
+++ b/tests/python/pytorch/graphbolt/test_graphbolt_utils.py
@@ -184,6 +184,73 @@ def test_incomplete_unique_dst_nodes_():
         gb.unique_and_compact_node_pairs(node_pairs, unique_dst_nodes)
 
 
+def test_unique_and_compact_csc_formats_hetero():
+    N1 = torch.randint(0, 50, (30,))
+    N2 = torch.randint(0, 50, (20,))
+    N3 = torch.randint(0, 50, (10,))
+    unique_N1 = torch.unique(N1)
+    expected_unique_nodes = {
+        "n1": unique_N1,
+        "n2": N2,
+        "n3": N3,
+    }
+    csc_formats = {
+        "n1:e1:n2": gb.CSCFormatBase(
+            indptr=torch.range(0, 21),
+            indices=N1[:20],
+        ),
+        "n1:e2:n3": gb.CSCFormatBase(
+            indptr=torch.range(0, 11),
+            indices=N1[20:30],
+        ),
+        "n2:e3:n3": gb.CSCFormatBase(
+            indptr=torch.range(0, 11),
+            indices=N2[10:],
+        ),
+    }
+
+    dst_nodes = {
+        "n2": N2,
+        "n3": N3,
+    }
+
+    unique_nodes, compacted_csc_formats = gb.unique_and_compact_csc_formats(
+        csc_formats, dst_nodes
+    )
+    for ntype, nodes in unique_nodes.items():
+        expected_nodes = expected_unique_nodes[ntype]
+        assert torch.equal(torch.sort(nodes)[0], torch.sort(expected_nodes)[0])
+    for etype, pair in compacted_csc_formats.items():
+        indices = pair.indices
+        indptr = pair.indptr
+        indices_type, _, _ = gb.etype_str_to_tuple(etype)
+        indices = unique_nodes[indices_type][indices]
+        expected_indices = csc_formats[etype].indices
+        expected_indptr = csc_formats[etype].indptr
+        assert torch.equal(indices, expected_indices)
+        assert torch.equal(indptr, expected_indptr)
+
+
+def test_unique_and_compact_csc_formats_homo():
+    N = torch.cat((torch.arange(0, 10), torch.randint(10, 50, (190,))))
+    expected_unique_nodes = torch.unique(N)
+
+    csc_formats = gb.CSCFormatBase(
+        indptr=torch.arange(0, 191, 19), indices=N[10:]
+    )
+    dst_nodes = N[:10]
+    unique_nodes, compacted_csc_formats = gb.unique_and_compact_csc_formats(
+        csc_formats, dst_nodes
+    )
+    indptr = compacted_csc_formats.indptr
+    indices = unique_nodes[compacted_csc_formats.indices]
+    expected_indptr = csc_formats.indptr
+    expected_indices = csc_formats.indices
+    assert torch.equal(indptr, expected_indptr)
+    assert torch.equal(indices, expected_indices)
+    assert torch.equal(torch.sort(unique_nodes)[0], expected_unique_nodes)
+
+
 def test_compact_csc_format_hetero():
     N1 = torch.randint(0, 50, (30,))
     N2 = torch.randint(0, 50, (20,))

--- a/tests/python/pytorch/graphbolt/test_subgraph_sampler.py
+++ b/tests/python/pytorch/graphbolt/test_subgraph_sampler.py
@@ -409,7 +409,6 @@ def test_SubgraphSampler_unique_csc_format_Homo(labor):
     seeds = [torch.tensor([0, 3, 4, 5, 2]), torch.tensor([0, 3, 4])]
     for data in datapipe:
         for step, sampled_subgraph in enumerate(data.sampled_subgraphs):
-            print(sampled_subgraph)
             assert torch.equal(
                 sampled_subgraph.original_row_node_ids,
                 original_row_node_ids[step],
@@ -485,7 +484,6 @@ def test_SubgraphSampler_unique_csc_format_Hetero(labor):
 
     for data in datapipe:
         for step, sampled_subgraph in enumerate(data.sampled_subgraphs):
-            print(sampled_subgraph)
             for ntype in ["n1", "n2"]:
                 assert torch.equal(
                     sampled_subgraph.original_row_node_ids[ntype],


### PR DESCRIPTION
## Description
<!-- Brief description. Refer to the related issues if existed.
It'll be great if relevant reviewers can be assigned as well.-->
Add `unique_and_compact_csc_format` to support deduplicate and compact csc format sampled subgraph.

### Benchmark
Homo (us) :
|size| unique_compact_node_piars | unique_compact_csc_format | compact_csc_fotmat |
|----|----|----|----|
|10000| 860 | 405 | 283 |
|10000000| 236536 | 217717 | 22976 |

Hetero (us) :
|size| unique_compact_node_piars | unique_compact_csc_format | compact_csc_fotmat |
|----|----|----|----|
|10000| 880 | 778 | 604 |
|10000000| 920170 | 861199 | 106093 |

### E2E benchmark:
Homo (us):
| | 1 | 2 | 3 | 4|
| --- | --- | --- | --- | --- |
|size| 10000 | 10000000 | 10000000 | 10000000 |
|fanout| 2 | 2 | 1024 | 1024 |
|batch_size| 4 | 4 | 4 | 1024 |
| uniquet_node_piars | 550 | 558 | 558 | 554 |
| unique_csc_format | 544 | 554 | 543 | 532 |
| duplicate_csc_fotmat | 526 | 524 | 530 | 526 |

Hetero (us):
batch_size = 1024, seeds = 10 type * 1000 num
| | 1 | 2 | 3 | 4 | 5 |
| --- | --- | --- | --- | --- | --- |
|node_num| 30000 | 10000000 | 10000000 | 10000000 | 100000 |
|edge_num| 40000 | 100000000 | 100000000 | 100000000 | 1000000 |
|node_type| 3 | 1000 | 1000 | 1000000 | 10000 | 10000 |
|edge_type| 4 | 100 | 100 | 100 | 10000 |
|fanout| 2 | 2 | 1024 | 2 | 2 |
| uniquet_node_piars | 612 | 623 | 620 | 582 | 634 |
| unique_csc_format | 591 |  585 | 578 | 548 | 626 |
| duplicate_csc_fotmat | 554 | 555 | 550 | 538 | 547 |

## Checklist
Please feel free to remove inapplicable items for your PR.
- [ ] The PR title starts with [$CATEGORY] (such as [NN], [Model], [Doc], [Feature]])
- [ ] I've leverage the [tools](https://docs.google.com/document/d/1iHyj7zlmygKSk5gBPsqIqL5ASPzJSPREaNT_QdsiYA4/edit) to beautify the python and c++ code.
- [ ] The PR is complete and small, read the [Google eng practice (CL equals to PR)](https://google.github.io/eng-practices/review/developer/small-cls.html) to understand more about small PR. In DGL, we consider PRs with less than 200 lines of core code change are small (example, test and documentation could be exempted).
- [ ] All changes have test coverage
- [ ] Code is well-documented
- [ ] To the best of my knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change
- [ ] Related issue is referred in this PR
- [ ] If the PR is for a new model/paper, I've updated the example index [here](../examples/README.md).

## Changes
<!-- You could use following template
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)
-->
