### PR TITLE
[GraphBolt] rename from_fused_csc as fused_csc_sampling_graph

### DIFF
--- a/graphbolt/src/python_binding.cc
+++ b/graphbolt/src/python_binding.cc
@@ -65,7 +65,7 @@ TORCH_LIBRARY(graphbolt, m) {
             g->SetState(state);
             return g;
           });
-  m.def("from_fused_csc", &FusedCSCSamplingGraph::Create);
+  m.def("fused_csc_sampling_graph", &FusedCSCSamplingGraph::Create);
   m.def(
       "load_from_shared_memory", &FusedCSCSamplingGraph::LoadFromSharedMemory);
   m.def("unique_and_compact", &UniqueAndCompact);

--- a/python/dgl/distributed/partition.py
+++ b/python/dgl/distributed/partition.py
@@ -1268,7 +1268,7 @@ def convert_dgl_partition_to_csc_sampling_graph(part_config):
         type_per_edge = type_per_edge.to(RESERVED_FIELD_DTYPE[ETYPE])
         # Sanity check.
         assert len(type_per_edge) == graph.num_edges()
-        csc_graph = graphbolt.from_fused_csc(
+        csc_graph = graphbolt.fused_csc_sampling_graph(
             indptr,
             indices,
             node_type_offset=None,

--- a/python/dgl/graphbolt/impl/fused_csc_sampling_graph.py
+++ b/python/dgl/graphbolt/impl/fused_csc_sampling_graph.py
@@ -21,7 +21,7 @@ from .sampled_subgraph_impl import (
 
 __all__ = [
     "FusedCSCSamplingGraph",
-    "from_fused_csc",
+    "fused_csc_sampling_graph",
     "load_from_shared_memory",
     "from_dglgraph",
 ]
@@ -88,7 +88,7 @@ class FusedCSCSamplingGraph(SamplingGraph):
         >>> node_type_offset = torch.LongTensor([0, 2, 5])
         >>> type_per_edge = torch.LongTensor(
         ...     [0, 0, 2, 2, 2, 1, 1, 1, 3, 1, 3, 3])
-        >>> graph = gb.from_fused_csc(indptr, indices,
+        >>> graph = gb.fused_csc_sampling_graph(indptr, indices,
         ...     node_type_offset=node_type_offset,
         ...     type_per_edge=type_per_edge,
         ...     node_type_to_id=ntypes,
@@ -139,7 +139,7 @@ class FusedCSCSamplingGraph(SamplingGraph):
         >>> type_per_edge = torch.LongTensor(
         ...     [0, 0, 2, 2, 2, 1, 1, 1, 3, 1, 3, 3])
         >>> metadata = gb.GraphMetadata(ntypes, etypes)
-        >>> graph = gb.from_fused_csc(indptr, indices, node_type_offset,
+        >>> graph = gb.fused_csc_sampling_graph(indptr, indices, node_type_offset,
         ...     type_per_edge, None, metadata)
         >>> print(graph.num_edges)
         {'N0:R0:N0': 2, 'N0:R1:N1': 1, 'N1:R2:N0': 2, 'N1:R3:N1': 3}
@@ -337,7 +337,7 @@ class FusedCSCSamplingGraph(SamplingGraph):
         >>> node_type_offset = torch.LongTensor([0, 2, 5])
         >>> type_per_edge = torch.LongTensor(
         ...     [0, 0, 2, 2, 2, 1, 1, 1, 3, 1, 3, 3])
-        >>> graph = gb.from_fused_csc(indptr, indices,
+        >>> graph = gb.fused_csc_sampling_graph(indptr, indices,
         ...     node_type_offset=node_type_offset,
         ...     type_per_edge=type_per_edge,
         ...     node_type_to_id=ntypes,
@@ -577,7 +577,7 @@ class FusedCSCSamplingGraph(SamplingGraph):
         >>> indices = torch.LongTensor([2, 4, 2, 3, 0, 1, 1, 0, 1])
         >>> node_type_offset = torch.LongTensor([0, 2, 5])
         >>> type_per_edge = torch.LongTensor([1, 1, 1, 1, 0, 0, 0, 0, 0])
-        >>> graph = gb.from_fused_csc(indptr, indices,
+        >>> graph = gb.fused_csc_sampling_graph(indptr, indices,
         ...     node_type_offset=node_type_offset,
         ...     type_per_edge=type_per_edge,
         ...     node_type_to_id=ntypes,
@@ -765,7 +765,7 @@ class FusedCSCSamplingGraph(SamplingGraph):
         >>> indices = torch.LongTensor([2, 4, 2, 3, 0, 1, 1, 0, 1])
         >>> node_type_offset = torch.LongTensor([0, 2, 5])
         >>> type_per_edge = torch.LongTensor([1, 1, 1, 1, 0, 0, 0, 0, 0])
-        >>> graph = gb.from_fused_csc(indptr, indices,
+        >>> graph = gb.fused_csc_sampling_graph(indptr, indices,
         ...     node_type_offset=node_type_offset,
         ...     type_per_edge=type_per_edge,
         ...     node_type_to_id=ntypes,
@@ -893,7 +893,7 @@ class FusedCSCSamplingGraph(SamplingGraph):
         return self
 
 
-def from_fused_csc(
+def fused_csc_sampling_graph(
     csc_indptr: torch.Tensor,
     indices: torch.Tensor,
     node_type_offset: Optional[torch.tensor] = None,
@@ -936,7 +936,7 @@ def from_fused_csc(
     >>> indices = torch.tensor([1, 3, 0, 1, 2, 0, 3])
     >>> node_type_offset = torch.tensor([0, 1, 2, 3])
     >>> type_per_edge = torch.tensor([0, 1, 0, 1, 1, 0, 0])
-    >>> graph = graphbolt.from_fused_csc(csc_indptr, indices,
+    >>> graph = graphbolt.fused_csc_sampling_graph(csc_indptr, indices,
     ...             node_type_offset=node_type_offset,
     ...             type_per_edge=type_per_edge,
     ...             node_type_to_id=ntypes, edge_type_to_id=etypes,
@@ -984,7 +984,7 @@ def from_fused_csc(
                 0
             ), "node_type_offset length should be |ntypes| + 1."
     return FusedCSCSamplingGraph(
-        torch.ops.graphbolt.from_fused_csc(
+        torch.ops.graphbolt.fused_csc_sampling_graph(
             csc_indptr,
             indices,
             node_type_offset,
@@ -1086,7 +1086,7 @@ def from_dglgraph(
         edge_attributes[ORIGINAL_EDGE_ID] = homo_g.edata[EID][edge_ids]
 
     return FusedCSCSamplingGraph(
-        torch.ops.graphbolt.from_fused_csc(
+        torch.ops.graphbolt.fused_csc_sampling_graph(
             indptr,
             indices,
             node_type_offset,

--- a/python/dgl/graphbolt/impl/in_subgraph_sampler.py
+++ b/python/dgl/graphbolt/impl/in_subgraph_sampler.py
@@ -31,7 +31,7 @@ class InSubgraphSampler(SubgraphSampler):
     >>> import torch
     >>> indptr = torch.LongTensor([0, 3, 5, 7, 9, 12, 14])
     >>> indices = torch.LongTensor([0, 1, 4, 2, 3, 0, 5, 1, 2, 0, 3, 5, 1, 4])
-    >>> graph = gb.from_fused_csc(indptr, indices)
+    >>> graph = gb.fused_csc_sampling_graph(indptr, indices)
     >>> item_set = gb.ItemSet(len(indptr) - 1, names="seed_nodes")
     >>> item_sampler = gb.ItemSampler(item_set, batch_size=2)
     >>> insubgraph_sampler = gb.InSubgraphSampler(item_sampler, graph)

--- a/python/dgl/graphbolt/impl/neighbor_sampler.py
+++ b/python/dgl/graphbolt/impl/neighbor_sampler.py
@@ -64,7 +64,7 @@ class NeighborSampler(SubgraphSampler):
     >>> from dgl import graphbolt as gb
     >>> indptr = torch.LongTensor([0, 2, 4, 5, 6, 7 ,8])
     >>> indices = torch.LongTensor([1, 2, 0, 3, 5, 4, 3, 5])
-    >>> graph = gb.from_fused_csc(indptr, indices)
+    >>> graph = gb.fused_csc_sampling_graph(indptr, indices)
     >>> node_pairs = torch.LongTensor([[0, 1], [1, 2]])
     >>> item_set = gb.ItemSet(node_pairs, names="node_pairs")
     >>> item_sampler = gb.ItemSampler(
@@ -229,7 +229,7 @@ class LayerNeighborSampler(NeighborSampler):
     >>> from dgl import graphbolt as gb
     >>> indptr = torch.LongTensor([0, 2, 4, 5, 6, 7 ,8])
     >>> indices = torch.LongTensor([1, 2, 0, 3, 5, 4, 3, 5])
-    >>> graph = gb.from_fused_csc(indptr, indices)
+    >>> graph = gb.fused_csc_sampling_graph(indptr, indices)
     >>> data_format = gb.LinkPredictionEdgeFormat.INDEPENDENT
     >>> node_pairs = torch.LongTensor([[0, 1], [1, 2]])
     >>> item_set = gb.ItemSet(node_pairs, names="node_pairs")

--- a/python/dgl/graphbolt/impl/uniform_negative_sampler.py
+++ b/python/dgl/graphbolt/impl/uniform_negative_sampler.py
@@ -32,7 +32,7 @@ class UniformNegativeSampler(NegativeSampler):
     >>> from dgl import graphbolt as gb
     >>> indptr = torch.LongTensor([0, 2, 4, 5])
     >>> indices = torch.LongTensor([1, 2, 0, 2, 0])
-    >>> graph = gb.from_fused_csc(indptr, indices)
+    >>> graph = gb.fused_csc_sampling_graph(indptr, indices)
     >>> node_pairs = (torch.tensor([0, 1]), torch.tensor([1, 2]))
     >>> item_set = gb.ItemSet(node_pairs, names="node_pairs")
     >>> item_sampler = gb.ItemSampler(

--- a/tests/python/pytorch/graphbolt/gb_test_utils.py
+++ b/tests/python/pytorch/graphbolt/gb_test_utils.py
@@ -18,7 +18,7 @@ def rand_csc_graph(N, density, bidirection_edge=False):
     indptr = torch.LongTensor(adj.indptr)
     indices = torch.LongTensor(adj.indices)
 
-    graph = gb.from_fused_csc(indptr, indices)
+    graph = gb.fused_csc_sampling_graph(indptr, indices)
 
     return graph
 

--- a/tests/python/pytorch/graphbolt/impl/test_fused_csc_sampling_graph.py
+++ b/tests/python/pytorch/graphbolt/impl/test_fused_csc_sampling_graph.py
@@ -27,7 +27,7 @@ mp.set_sharing_strategy("file_system")
 def test_empty_graph(total_num_nodes):
     csc_indptr = torch.zeros((total_num_nodes + 1,), dtype=int)
     indices = torch.tensor([])
-    graph = gb.from_fused_csc(csc_indptr, indices)
+    graph = gb.fused_csc_sampling_graph(csc_indptr, indices)
     assert graph.total_num_edges == 0
     assert graph.total_num_nodes == total_num_nodes
     assert torch.equal(graph.csc_indptr, csc_indptr)
@@ -55,7 +55,7 @@ def test_hetero_empty_graph(total_num_nodes):
         node_type_offset[0] = 0
         node_type_offset[-1] = total_num_nodes
     type_per_edge = torch.tensor([])
-    graph = gb.from_fused_csc(
+    graph = gb.fused_csc_sampling_graph(
         csc_indptr,
         indices,
         node_type_offset=node_type_offset,
@@ -83,7 +83,7 @@ def test_hetero_empty_graph(total_num_nodes):
 )
 def test_type_to_id_with_ntype_exception(ntypes):
     with pytest.raises(AssertionError):
-        gb.from_fused_csc(
+        gb.fused_csc_sampling_graph(
             None, None, node_type_to_id=ntypes, edge_type_to_id={"e1": 1}
         )
 
@@ -106,7 +106,7 @@ def test_type_to_id_with_ntype_exception(ntypes):
 )
 def test_type_to_id_with_etype_exception(etypes):
     with pytest.raises(Exception):
-        gb.from_fused_csc(
+        gb.fused_csc_sampling_graph(
             None,
             None,
             node_type_to_id={"n1": 0, "n2": 1, "n3": 2},
@@ -130,7 +130,7 @@ def test_homo_graph(total_num_nodes, total_num_edges):
         "A1": torch.randn(total_num_edges),
         "A2": torch.randn(total_num_edges),
     }
-    graph = gb.from_fused_csc(
+    graph = gb.fused_csc_sampling_graph(
         csc_indptr, indices, edge_attributes=edge_attributes
     )
 
@@ -171,7 +171,7 @@ def test_hetero_graph(total_num_nodes, total_num_edges, num_ntypes, num_etypes):
         "A1": torch.randn(total_num_edges),
         "A2": torch.randn(total_num_edges),
     }
-    graph = gb.from_fused_csc(
+    graph = gb.fused_csc_sampling_graph(
         csc_indptr,
         indices,
         node_type_offset=node_type_offset,
@@ -209,7 +209,7 @@ def test_num_nodes_edges_homo(total_num_nodes, total_num_edges):
         "A1": torch.randn(total_num_edges),
         "A2": torch.randn(total_num_edges),
     }
-    graph = gb.from_fused_csc(
+    graph = gb.fused_csc_sampling_graph(
         csc_indptr, indices, edge_attributes=edge_attributes
     )
 
@@ -260,7 +260,7 @@ def test_num_nodes_hetero():
     assert all(type_per_edge < len(etypes))
 
     # Construct FusedCSCSamplingGraph.
-    graph = gb.from_fused_csc(
+    graph = gb.fused_csc_sampling_graph(
         indptr,
         indices,
         node_type_offset=node_type_offset,
@@ -309,7 +309,7 @@ def test_node_type_offset_wrong_legnth(node_type_offset):
         edge_type_to_id,
     ) = gbt.random_hetero_graph(10, 50, num_ntypes, 5)
     with pytest.raises(Exception):
-        gb.from_fused_csc(
+        gb.fused_csc_sampling_graph(
             csc_indptr,
             indices,
             node_type_offset=node_type_offset,
@@ -331,7 +331,7 @@ def test_load_save_homo_graph(total_num_nodes, total_num_edges):
     csc_indptr, indices = gbt.random_homo_graph(
         total_num_nodes, total_num_edges
     )
-    graph = gb.from_fused_csc(csc_indptr, indices)
+    graph = gb.fused_csc_sampling_graph(csc_indptr, indices)
 
     with tempfile.TemporaryDirectory() as test_dir:
         filename = os.path.join(test_dir, "fused_csc_sampling_graph.pt")
@@ -373,7 +373,7 @@ def test_load_save_hetero_graph(
     ) = gbt.random_hetero_graph(
         total_num_nodes, total_num_edges, num_ntypes, num_etypes
     )
-    graph = gb.from_fused_csc(
+    graph = gb.fused_csc_sampling_graph(
         csc_indptr,
         indices,
         node_type_offset=node_type_offset,
@@ -410,7 +410,7 @@ def test_pickle_homo_graph(total_num_nodes, total_num_edges):
     csc_indptr, indices = gbt.random_homo_graph(
         total_num_nodes, total_num_edges
     )
-    graph = gb.from_fused_csc(csc_indptr, indices)
+    graph = gb.fused_csc_sampling_graph(csc_indptr, indices)
 
     serialized = pickle.dumps(graph)
     graph2 = pickle.loads(serialized)
@@ -454,7 +454,7 @@ def test_pickle_hetero_graph(
         "a": torch.randn((total_num_edges,)),
         "b": torch.randint(1, 10, (total_num_edges,)),
     }
-    graph = gb.from_fused_csc(
+    graph = gb.fused_csc_sampling_graph(
         csc_indptr,
         indices,
         node_type_offset=node_type_offset,
@@ -511,7 +511,7 @@ def test_multiprocessing():
     edge_attributes = {
         "a": torch.randn((total_num_edges,)),
     }
-    graph = gb.from_fused_csc(
+    graph = gb.fused_csc_sampling_graph(
         csc_indptr,
         indices,
         node_type_offset=node_type_offset,
@@ -549,7 +549,7 @@ def test_in_subgraph_homogeneous():
     assert indptr[-1] == len(indices)
 
     # Construct FusedCSCSamplingGraph.
-    graph = gb.from_fused_csc(indptr, indices)
+    graph = gb.fused_csc_sampling_graph(indptr, indices)
 
     # Extract in subgraph.
     nodes = torch.LongTensor([4, 1, 3])
@@ -611,7 +611,7 @@ def test_in_subgraph_heterogeneous():
     assert all(type_per_edge < len(etypes))
 
     # Construct FusedCSCSamplingGraph.
-    graph = gb.from_fused_csc(
+    graph = gb.fused_csc_sampling_graph(
         indptr,
         indices,
         node_type_offset=node_type_offset,
@@ -686,7 +686,7 @@ def test_sample_neighbors_homo(labor, indptr_dtype, indices_dtype):
     assert len(indptr) == total_num_nodes + 1
 
     # Construct FusedCSCSamplingGraph.
-    graph = gb.from_fused_csc(indptr, indices)
+    graph = gb.fused_csc_sampling_graph(indptr, indices)
 
     # Generate subgraph via sample neighbors.
     nodes = torch.tensor([1, 3, 4], dtype=indices_dtype)
@@ -730,7 +730,7 @@ def test_sample_neighbors_hetero(labor, indptr_dtype, indices_dtype):
     assert indptr[-1] == len(indices)
 
     # Construct FusedCSCSamplingGraph.
-    graph = gb.from_fused_csc(
+    graph = gb.fused_csc_sampling_graph(
         indptr,
         indices,
         node_type_offset=node_type_offset,
@@ -838,7 +838,7 @@ def test_sample_neighbors_fanouts(
     assert indptr[-1] == len(indices)
 
     # Construct FusedCSCSamplingGraph.
-    graph = gb.from_fused_csc(
+    graph = gb.fused_csc_sampling_graph(
         indptr,
         indices,
         node_type_offset=node_type_offset,
@@ -895,7 +895,7 @@ def test_sample_neighbors_replace(
     assert indptr[-1] == len(indices)
 
     # Construct FusedCSCSamplingGraph.
-    graph = gb.from_fused_csc(
+    graph = gb.fused_csc_sampling_graph(
         indptr,
         indices,
         node_type_offset=node_type_offset,
@@ -938,7 +938,9 @@ def test_sample_neighbors_return_eids_homo(labor):
     edge_attributes = {gb.ORIGINAL_EDGE_ID: torch.randperm(total_num_edges)}
 
     # Construct FusedCSCSamplingGraph.
-    graph = gb.from_fused_csc(indptr, indices, edge_attributes=edge_attributes)
+    graph = gb.fused_csc_sampling_graph(
+        indptr, indices, edge_attributes=edge_attributes
+    )
 
     # Generate subgraph via sample neighbors.
     nodes = torch.LongTensor([1, 3, 4])
@@ -984,7 +986,7 @@ def test_sample_neighbors_return_eids_hetero(labor):
     assert indptr[-1] == len(indices)
 
     # Construct FusedCSCSamplingGraph.
-    graph = gb.from_fused_csc(
+    graph = gb.fused_csc_sampling_graph(
         indptr,
         indices,
         node_type_offset=node_type_offset,
@@ -1043,7 +1045,9 @@ def test_sample_neighbors_probs(replace, labor, probs_name):
     }
 
     # Construct FusedCSCSamplingGraph.
-    graph = gb.from_fused_csc(indptr, indices, edge_attributes=edge_attributes)
+    graph = gb.fused_csc_sampling_graph(
+        indptr, indices, edge_attributes=edge_attributes
+    )
 
     # Generate subgraph via sample neighbors.
     nodes = torch.LongTensor([1, 3, 4])
@@ -1088,7 +1092,9 @@ def test_sample_neighbors_zero_probs(replace, labor, probs_or_mask):
     edge_attributes = {"probs_or_mask": probs_or_mask}
 
     # Construct FusedCSCSamplingGraph.
-    graph = gb.from_fused_csc(indptr, indices, edge_attributes=edge_attributes)
+    graph = gb.fused_csc_sampling_graph(
+        indptr, indices, edge_attributes=edge_attributes
+    )
 
     # Generate subgraph via sample neighbors.
     nodes = torch.LongTensor([1, 3, 4])
@@ -1143,7 +1149,7 @@ def test_homo_graph_on_shared_memory(
         }
     else:
         edge_attributes = None
-    graph = gb.from_fused_csc(
+    graph = gb.fused_csc_sampling_graph(
         csc_indptr, indices, edge_attributes=edge_attributes
     )
 
@@ -1218,7 +1224,7 @@ def test_hetero_graph_on_shared_memory(
         }
     else:
         edge_attributes = None
-    graph = gb.from_fused_csc(
+    graph = gb.fused_csc_sampling_graph(
         csc_indptr,
         indices,
         node_type_offset=node_type_offset,
@@ -1343,7 +1349,7 @@ def test_multiprocessing_with_shared_memory():
     node_type_offset.share_memory_()
     type_per_edge.share_memory_()
 
-    graph = gb.from_fused_csc(
+    graph = gb.fused_csc_sampling_graph(
         csc_indptr,
         indices,
         node_type_offset=node_type_offset,
@@ -1559,7 +1565,9 @@ def test_sample_neighbors_homo_pick_number(fanouts, replace, labor, probs_name):
     }
 
     # Construct FusedCSCSamplingGraph.
-    graph = gb.from_fused_csc(indptr, indices, edge_attributes=edge_attributes)
+    graph = gb.fused_csc_sampling_graph(
+        indptr, indices, edge_attributes=edge_attributes
+    )
 
     # Generate subgraph via sample neighbors.
     nodes = torch.LongTensor([0, 1])
@@ -1642,7 +1650,7 @@ def test_sample_neighbors_hetero_pick_number(
     }
 
     # Construct FusedCSCSamplingGraph.
-    graph = gb.from_fused_csc(
+    graph = gb.fused_csc_sampling_graph(
         indptr,
         indices,
         edge_attributes=edge_attributes,
@@ -1731,7 +1739,7 @@ def test_csc_sampling_graph_to_device():
     }
 
     # Construct FusedCSCSamplingGraph.
-    graph = gb.from_fused_csc(
+    graph = gb.fused_csc_sampling_graph(
         indptr,
         indices,
         edge_attributes=edge_attributes,
@@ -1774,7 +1782,7 @@ def test_sample_neighbors_homo_csc_format():
     assert indptr[-1] == len(indices)
 
     # Construct FusedCSCSamplingGraph.
-    graph = gb.from_fused_csc(indptr, indices)
+    graph = gb.fused_csc_sampling_graph(indptr, indices)
 
     # Generate subgraph via sample neighbors.
     nodes = torch.LongTensor([1, 3, 4])
@@ -1819,7 +1827,7 @@ def test_sample_neighbors_hetero_csc_format(labor):
     assert indptr[-1] == len(indices)
 
     # Construct FusedCSCSamplingGraph.
-    graph = gb.from_fused_csc(
+    graph = gb.fused_csc_sampling_graph(
         indptr,
         indices,
         node_type_offset=node_type_offset,
@@ -1924,7 +1932,7 @@ def test_sample_neighbors_fanouts_csc_format(
     assert indptr[-1] == len(indices)
 
     # Construct FusedCSCSamplingGraph.
-    graph = gb.from_fused_csc(
+    graph = gb.fused_csc_sampling_graph(
         indptr,
         indices,
         node_type_offset=node_type_offset,
@@ -1985,7 +1993,7 @@ def test_sample_neighbors_replace_csc_format(
     assert indptr[-1] == len(indices)
 
     # Construct FusedCSCSamplingGraph.
-    graph = gb.from_fused_csc(
+    graph = gb.fused_csc_sampling_graph(
         indptr,
         indices,
         node_type_offset=node_type_offset,
@@ -2034,7 +2042,9 @@ def test_sample_neighbors_return_eids_homo_csc_format(labor):
     edge_attributes = {gb.ORIGINAL_EDGE_ID: torch.randperm(total_num_edges)}
 
     # Construct FusedCSCSamplingGraph.
-    graph = gb.from_fused_csc(indptr, indices, edge_attributes=edge_attributes)
+    graph = gb.fused_csc_sampling_graph(
+        indptr, indices, edge_attributes=edge_attributes
+    )
 
     # Generate subgraph via sample neighbors.
     nodes = torch.LongTensor([1, 3, 4])
@@ -2083,7 +2093,7 @@ def test_sample_neighbors_return_eids_hetero_csc_format(labor):
     assert indptr[-1] == len(indices)
 
     # Construct FusedCSCSamplingGraph.
-    graph = gb.from_fused_csc(
+    graph = gb.fused_csc_sampling_graph(
         indptr,
         indices,
         node_type_offset=node_type_offset,
@@ -2142,7 +2152,9 @@ def test_sample_neighbors_probs_csc_format(replace, labor, probs_name):
     }
 
     # Construct FusedCSCSamplingGraph.
-    graph = gb.from_fused_csc(indptr, indices, edge_attributes=edge_attributes)
+    graph = gb.fused_csc_sampling_graph(
+        indptr, indices, edge_attributes=edge_attributes
+    )
 
     # Generate subgraph via sample neighbors.
     nodes = torch.LongTensor([1, 3, 4])
@@ -2190,7 +2202,9 @@ def test_sample_neighbors_zero_probs_csc_format(replace, labor, probs_or_mask):
     edge_attributes = {"probs_or_mask": probs_or_mask}
 
     # Construct FusedCSCSamplingGraph.
-    graph = gb.from_fused_csc(indptr, indices, edge_attributes=edge_attributes)
+    graph = gb.fused_csc_sampling_graph(
+        indptr, indices, edge_attributes=edge_attributes
+    )
 
     # Generate subgraph via sample neighbors.
     nodes = torch.LongTensor([1, 3, 4])
@@ -2257,7 +2271,9 @@ def test_sample_neighbors_homo_pick_number_csc_format(
     }
 
     # Construct FusedCSCSamplingGraph.
-    graph = gb.from_fused_csc(indptr, indices, edge_attributes=edge_attributes)
+    graph = gb.fused_csc_sampling_graph(
+        indptr, indices, edge_attributes=edge_attributes
+    )
 
     # Generate subgraph via sample neighbors.
     nodes = torch.LongTensor([0, 1])
@@ -2341,7 +2357,7 @@ def test_sample_neighbors_hetero_pick_number_csc_format(
     }
 
     # Construct FusedCSCSamplingGraph.
-    graph = gb.from_fused_csc(
+    graph = gb.fused_csc_sampling_graph(
         indptr,
         indices,
         edge_attributes=edge_attributes,

--- a/tests/python/pytorch/graphbolt/impl/test_in_subgraph_sampler.py
+++ b/tests/python/pytorch/graphbolt/impl/test_in_subgraph_sampler.py
@@ -15,7 +15,7 @@ def test_InSubgraphSampler_homo():
     """
     indptr = torch.LongTensor([0, 3, 5, 7, 9, 12, 14])
     indices = torch.LongTensor([0, 1, 4, 2, 3, 0, 5, 1, 2, 0, 3, 5, 1, 4])
-    graph = gb.from_fused_csc(indptr, indices)
+    graph = gb.fused_csc_sampling_graph(indptr, indices)
 
     seed_nodes = torch.LongTensor([0, 5, 3])
     item_set = gb.ItemSet(seed_nodes, names="seed_nodes")
@@ -80,7 +80,7 @@ def test_InSubgraphSampler_hetero():
     indices = torch.LongTensor([0, 1, 4, 2, 3, 0, 5, 1, 2, 0, 3, 5, 1, 4])
     node_type_offset = torch.LongTensor([0, 3, 6])
     type_per_edge = torch.LongTensor([0, 0, 2, 0, 2, 0, 2, 1, 1, 1, 3, 3, 1, 3])
-    graph = gb.from_fused_csc(
+    graph = gb.fused_csc_sampling_graph(
         csc_indptr=indptr,
         indices=indices,
         node_type_offset=node_type_offset,

--- a/tests/python/pytorch/graphbolt/impl/test_negative_sampler.py
+++ b/tests/python/pytorch/graphbolt/impl/test_negative_sampler.py
@@ -110,7 +110,7 @@ def get_hetero_graph():
     indices = torch.LongTensor([2, 4, 2, 3, 0, 1, 1, 0, 0, 1])
     type_per_edge = torch.LongTensor([1, 1, 1, 1, 0, 0, 0, 0, 0, 0])
     node_type_offset = torch.LongTensor([0, 2, 5])
-    return gb.from_fused_csc(
+    return gb.fused_csc_sampling_graph(
         indptr,
         indices,
         node_type_offset=node_type_offset,

--- a/tests/python/pytorch/graphbolt/impl/test_ondisk_dataset.py
+++ b/tests/python/pytorch/graphbolt/impl/test_ondisk_dataset.py
@@ -1006,7 +1006,7 @@ def test_OnDiskDataset_Graph_Exceptions():
 def test_OnDiskDataset_Graph_homogeneous():
     """Test homogeneous graph topology."""
     csc_indptr, indices = gbt.random_homo_graph(1000, 10 * 1000)
-    graph = gb.from_fused_csc(csc_indptr, indices)
+    graph = gb.fused_csc_sampling_graph(csc_indptr, indices)
 
     with tempfile.TemporaryDirectory() as test_dir:
         graph_path = os.path.join(test_dir, "fused_csc_sampling_graph.pt")
@@ -1044,7 +1044,7 @@ def test_OnDiskDataset_Graph_heterogeneous():
         node_type_to_id,
         edge_type_to_id,
     ) = gbt.random_hetero_graph(1000, 10 * 1000, 3, 4)
-    graph = gb.from_fused_csc(
+    graph = gb.fused_csc_sampling_graph(
         csc_indptr,
         indices,
         node_type_offset=node_type_offset,
@@ -1833,7 +1833,7 @@ def test_OnDiskDataset_load_tasks():
 def test_OnDiskDataset_all_nodes_set_homo():
     """Test homograph's all nodes set of OnDiskDataset."""
     csc_indptr, indices = gbt.random_homo_graph(1000, 10 * 1000)
-    graph = gb.from_fused_csc(csc_indptr, indices)
+    graph = gb.fused_csc_sampling_graph(csc_indptr, indices)
 
     with tempfile.TemporaryDirectory() as test_dir:
         graph_path = os.path.join(test_dir, "fused_csc_sampling_graph.pt")
@@ -1864,7 +1864,7 @@ def test_OnDiskDataset_all_nodes_set_hetero():
         node_type_to_id,
         edge_type_to_id,
     ) = gbt.random_hetero_graph(1000, 10 * 1000, 3, 4)
-    graph = gb.from_fused_csc(
+    graph = gb.fused_csc_sampling_graph(
         csc_indptr,
         indices,
         node_type_offset=node_type_offset,

--- a/tests/python/pytorch/graphbolt/test_feature_fetcher.py
+++ b/tests/python/pytorch/graphbolt/test_feature_fetcher.py
@@ -145,7 +145,7 @@ def get_hetero_graph():
     indices = torch.LongTensor([2, 4, 2, 3, 0, 1, 1, 0, 0, 1])
     type_per_edge = torch.LongTensor([1, 1, 1, 1, 0, 0, 0, 0, 0, 0])
     node_type_offset = torch.LongTensor([0, 2, 5])
-    return gb.from_fused_csc(
+    return gb.fused_csc_sampling_graph(
         indptr,
         indices,
         node_type_offset=node_type_offset,

--- a/tests/python/pytorch/graphbolt/test_integration.py
+++ b/tests/python/pytorch/graphbolt/test_integration.py
@@ -38,7 +38,7 @@ def test_integration_link_prediction():
     )
 
     item_set = gb.ItemSet(node_pairs, names="node_pairs")
-    graph = gb.from_fused_csc(indptr, indices)
+    graph = gb.fused_csc_sampling_graph(indptr, indices)
 
     node_feature = gb.TorchBasedFeature(node_feature_data)
     edge_feature = gb.TorchBasedFeature(edge_feature_data)
@@ -154,7 +154,7 @@ def test_integration_node_classification():
     )
 
     item_set = gb.ItemSet(node_pairs, names="node_pairs")
-    graph = gb.from_fused_csc(indptr, indices)
+    graph = gb.fused_csc_sampling_graph(indptr, indices)
 
     node_feature = gb.TorchBasedFeature(node_feature_data)
     edge_feature = gb.TorchBasedFeature(edge_feature_data)

--- a/tests/python/pytorch/graphbolt/test_subgraph_sampler.py
+++ b/tests/python/pytorch/graphbolt/test_subgraph_sampler.py
@@ -121,7 +121,7 @@ def get_hetero_graph():
     indices = torch.LongTensor([2, 4, 2, 3, 0, 1, 1, 0, 0, 1])
     type_per_edge = torch.LongTensor([1, 1, 1, 1, 0, 0, 0, 0, 0, 0])
     node_type_offset = torch.LongTensor([0, 2, 5])
-    return gb.from_fused_csc(
+    return gb.fused_csc_sampling_graph(
         indptr,
         indices,
         node_type_offset=node_type_offset,
@@ -216,7 +216,7 @@ def test_SubgraphSampler_Random_Hetero_Graph(labor):
         "A1": torch.randn(num_edges),
         "A2": torch.randn(num_edges),
     }
-    graph = gb.from_fused_csc(
+    graph = gb.fused_csc_sampling_graph(
         csc_indptr,
         indices,
         node_type_offset=node_type_offset,


### PR DESCRIPTION
## Description
<!-- Brief description. Refer to the related issues if existed.
It'll be great if relevant reviewers can be assigned as well.-->

## Checklist
Please feel free to remove inapplicable items for your PR.
- [ ] The PR title starts with [$CATEGORY] (such as [NN], [Model], [Doc], [Feature]])
- [ ] I've leverage the [tools](https://docs.google.com/document/d/1iHyj7zlmygKSk5gBPsqIqL5ASPzJSPREaNT_QdsiYA4/edit) to beautify the python and c++ code.
- [ ] The PR is complete and small, read the [Google eng practice (CL equals to PR)](https://google.github.io/eng-practices/review/developer/small-cls.html) to understand more about small PR. In DGL, we consider PRs with less than 200 lines of core code change are small (example, test and documentation could be exempted).
- [ ] All changes have test coverage
- [ ] Code is well-documented
- [ ] To the best of my knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change
- [ ] Related issue is referred in this PR
- [ ] If the PR is for a new model/paper, I've updated the example index [here](../examples/README.md).

## Changes
<!-- You could use following template
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)
-->
