### PR TITLE
[Sparse] Fix Windows.h dependency issue

### DIFF
--- a/dgl_sparse/include/sparse/sddmm.h
+++ b/dgl_sparse/include/sparse/sddmm.h
@@ -7,7 +7,6 @@
 #define SPARSE_SDDMM_H_
 
 #include <sparse/sparse_matrix.h>
-#include <torch/script.h>
 
 namespace dgl {
 namespace sparse {

--- a/dgl_sparse/include/sparse/sparse_format.h
+++ b/dgl_sparse/include/sparse/sparse_format.h
@@ -8,10 +8,8 @@
 
 // clang-format off
 #include <sparse/dgl_headers.h>
+#include <sparse/torch_headers.h>
 // clang-format on
-
-#include <torch/custom_class.h>
-#include <torch/script.h>
 
 #include <memory>
 #include <utility>

--- a/dgl_sparse/include/sparse/sparse_matrix.h
+++ b/dgl_sparse/include/sparse/sparse_matrix.h
@@ -8,11 +8,10 @@
 
 // clang-format off
 #include <sparse/dgl_headers.h>
+#include <sparse/torch_headers.h>
 // clang-format on
 
 #include <sparse/sparse_format.h>
-#include <torch/custom_class.h>
-#include <torch/script.h>
 
 #include <memory>
 #include <tuple>

--- a/dgl_sparse/include/sparse/spmm.h
+++ b/dgl_sparse/include/sparse/spmm.h
@@ -7,7 +7,6 @@
 #define SPARSE_SPMM_H_
 
 #include <sparse/sparse_matrix.h>
-#include <torch/script.h>
 
 namespace dgl {
 namespace sparse {

--- a/dgl_sparse/include/sparse/spspmm.h
+++ b/dgl_sparse/include/sparse/spspmm.h
@@ -7,7 +7,6 @@
 #define SPARSE_SPSPMM_H_
 
 #include <sparse/sparse_matrix.h>
-#include <torch/script.h>
 
 namespace dgl {
 namespace sparse {

--- a/dgl_sparse/include/sparse/torch_headers.h
+++ b/dgl_sparse/include/sparse/torch_headers.h
@@ -1,0 +1,29 @@
+/**
+ *  Copyright (c) 2022 by Contributors
+ * @file sparse/torch_headers.h
+ * @brief Pytorch headers used in the sparse library. Since Pytorch 2.1.0
+ * introduced a dependency on <windows.h>, we need to define NOMINMAX to avoid
+ * the conflict with std::min/std::max macros before including Pytorch headers.
+ * See more in
+ * https://stackoverflow.com/questions/4913922/possible-problems-with-nominmax-on-visual-c.
+ */
+
+#ifndef SPARSE_TORCH_HEADERS_H_
+#define SPARSE_TORCH_HEADERS_H_
+
+#ifdef _WIN32
+#ifndef NOMINMAX
+#define NOMINMAX
+#endif  // NOMINMAX
+#endif  // _WIN32
+
+#include <ATen/DLConvertor.h>
+#include <c10/util/Logging.h>
+#include <torch/custom_class.h>
+#include <torch/script.h>
+
+#ifdef _WIN32
+#undef NOMINMAX
+#endif  // _WIN32
+
+#endif  // SPARSE_TORCH_HEADERS_H_

--- a/dgl_sparse/include/sparse/torch_headers.h
+++ b/dgl_sparse/include/sparse/torch_headers.h
@@ -13,6 +13,7 @@
 
 #ifdef _WIN32
 #ifndef NOMINMAX
+#define SPARSE_TORCH_HEADERS_H_NOMINMAX
 #define NOMINMAX
 #endif  // NOMINMAX
 #endif  // _WIN32
@@ -22,8 +23,8 @@
 #include <torch/custom_class.h>
 #include <torch/script.h>
 
-#ifdef _WIN32
+#ifdef SPARSE_TORCH_HEADERS_H_NOMINMAX
 #undef NOMINMAX
-#endif  // _WIN32
+#endif  // SPARSE_TORCH_HEADERS_H_NOMINMAX
 
 #endif  // SPARSE_TORCH_HEADERS_H_

--- a/dgl_sparse/src/elemenwise_op.cc
+++ b/dgl_sparse/src/elemenwise_op.cc
@@ -7,7 +7,6 @@
 #include <sparse/elementwise_op.h>
 #include <sparse/matrix_ops.h>
 #include <sparse/sparse_matrix.h>
-#include <torch/script.h>
 
 #include <memory>
 

--- a/dgl_sparse/src/matmul.cc
+++ b/dgl_sparse/src/matmul.cc
@@ -7,10 +7,10 @@
 
 // clang-format off
 #include <sparse/dgl_headers.h>
+#include <sparse/torch_headers.h>
 // clang-format on
 
 #include <sparse/sparse_matrix.h>
-#include <torch/script.h>
 
 #include "./utils.h"
 

--- a/dgl_sparse/src/matmul.h
+++ b/dgl_sparse/src/matmul.h
@@ -7,7 +7,6 @@
 #define DGL_SPARSE_MATMUL_H_
 
 #include <sparse/sparse_matrix.h>
-#include <torch/script.h>
 
 #include <string>
 

--- a/dgl_sparse/src/matrix_ops.cc
+++ b/dgl_sparse/src/matrix_ops.cc
@@ -4,7 +4,6 @@
  * @brief DGL C++ matrix operators.
  */
 #include <sparse/matrix_ops.h>
-#include <torch/script.h>
 
 namespace dgl {
 namespace sparse {

--- a/dgl_sparse/src/python_binding.cc
+++ b/dgl_sparse/src/python_binding.cc
@@ -5,6 +5,7 @@
  */
 // clang-format off
 #include <sparse/dgl_headers.h>
+#include <sparse/torch_headers.h>
 // clang-format on
 
 #include <sparse/elementwise_op.h>
@@ -15,8 +16,6 @@
 #include <sparse/sparse_matrix.h>
 #include <sparse/spmm.h>
 #include <sparse/spspmm.h>
-#include <torch/custom_class.h>
-#include <torch/script.h>
 
 namespace dgl {
 namespace sparse {

--- a/dgl_sparse/src/reduction.cc
+++ b/dgl_sparse/src/reduction.cc
@@ -5,12 +5,12 @@
  */
 // clang-format off
 #include <sparse/dgl_headers.h>
+#include <sparse/torch_headers.h>
 // clang-format on
 
 #include <sparse/elementwise_op.h>
 #include <sparse/reduction.h>
 #include <sparse/sparse_matrix.h>
-#include <torch/script.h>
 
 #include <string>
 #include <vector>

--- a/dgl_sparse/src/sddmm.cc
+++ b/dgl_sparse/src/sddmm.cc
@@ -5,7 +5,6 @@
  */
 #include <sparse/sparse_matrix.h>
 #include <sparse/spmm.h>
-#include <torch/script.h>
 
 #include <sstream>
 

--- a/dgl_sparse/src/softmax.cc
+++ b/dgl_sparse/src/softmax.cc
@@ -6,7 +6,6 @@
 
 #include <sparse/reduction.h>
 #include <sparse/sparse_matrix.h>
-#include <torch/script.h>
 
 #include "./matmul.h"
 #include "./utils.h"

--- a/dgl_sparse/src/sparse_matrix.cc
+++ b/dgl_sparse/src/sparse_matrix.cc
@@ -7,10 +7,8 @@
 #include <sparse/dgl_headers.h>
 // clang-format on
 
-#include <c10/util/Logging.h>
 #include <sparse/elementwise_op.h>
 #include <sparse/sparse_matrix.h>
-#include <torch/script.h>
 
 #include "./utils.h"
 

--- a/dgl_sparse/src/spmm.cc
+++ b/dgl_sparse/src/spmm.cc
@@ -7,7 +7,6 @@
 #include <sparse/sddmm.h>
 #include <sparse/sparse_matrix.h>
 #include <sparse/spmm.h>
-#include <torch/script.h>
 
 #include <sstream>
 

--- a/dgl_sparse/src/spspmm.cc
+++ b/dgl_sparse/src/spspmm.cc
@@ -7,7 +7,6 @@
 #include <sparse/sddmm.h>
 #include <sparse/sparse_matrix.h>
 #include <sparse/spspmm.h>
-#include <torch/script.h>
 
 #include "./matmul.h"
 #include "./utils.h"

--- a/dgl_sparse/src/utils.h
+++ b/dgl_sparse/src/utils.h
@@ -8,12 +8,10 @@
 
 // clang-format off
 #include <sparse/dgl_headers.h>
+#include <sparse/torch_headers.h>
 // clang-format on
 
-#include <ATen/DLConvertor.h>
 #include <sparse/sparse_matrix.h>
-#include <torch/custom_class.h>
-#include <torch/script.h>
 
 namespace dgl {
 namespace sparse {


### PR DESCRIPTION
## Description

Fix the build fail issue when building DGL sparse on windows with Pytorch 2.1.1.

## Checklist
Please feel free to remove inapplicable items for your PR.
- [ ] The PR title starts with [$CATEGORY] (such as [NN], [Model], [Doc], [Feature]])
- [ ] I've leverage the [tools](https://docs.google.com/document/d/1iHyj7zlmygKSk5gBPsqIqL5ASPzJSPREaNT_QdsiYA4/edit) to beautify the python and c++ code.
- [ ] The PR is complete and small, read the [Google eng practice (CL equals to PR)](https://google.github.io/eng-practices/review/developer/small-cls.html) to understand more about small PR. In DGL, we consider PRs with less than 200 lines of core code change are small (example, test and documentation could be exempted).
- [ ] All changes have test coverage
- [ ] Code is well-documented
- [ ] To the best of my knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change
- [ ] Related issue is referred in this PR
- [ ] If the PR is for a new model/paper, I've updated the example index [here](../examples/README.md).

## Changes
<!-- You could use following template
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)
-->
