### PR TITLE
[Graphbolt] Add an EdgeAttribute function in FusedCSCSamplingGraph to access an edge attribute by name.

### DIFF
--- a/graphbolt/include/graphbolt/fused_csc_sampling_graph.h
+++ b/graphbolt/include/graphbolt/fused_csc_sampling_graph.h
@@ -155,6 +155,25 @@ class FusedCSCSamplingGraph : public torch::CustomClassHolder {
   }
 
   /**
+   * @brief Get the node attribute tensor by name.
+   *
+   * If the input name is empty, return nullopt. Otherwise, return the node
+   * attribute tensor by name.
+   */
+  inline torch::optional<torch::Tensor> NodeAttribute(
+      torch::optional<std::string> name) const {
+    if (!name.has_value()) {
+      return torch::nullopt;
+    }
+    TORCH_CHECK(
+        node_attributes_.has_value() &&
+            node_attributes_.value().contains(name.value()),
+        "Node attribute ", name.value(), " does not exist.");
+    return torch::optional<torch::Tensor>(
+        node_attributes_.value().at(name.value()));
+  }
+
+  /**
    * @brief Get the edge attribute tensor by name.
    *
    * If the input name is empty, return nullopt. Otherwise, return the edge

--- a/graphbolt/include/graphbolt/fused_csc_sampling_graph.h
+++ b/graphbolt/include/graphbolt/fused_csc_sampling_graph.h
@@ -154,6 +154,25 @@ class FusedCSCSamplingGraph : public torch::CustomClassHolder {
     return edge_attributes_;
   }
 
+  /**
+   * @brief Get the edge attribute tensor by name.
+   *
+   * If the input name is empty, return nullopt. Otherwise, return the edge
+   * attribute tensor by name.
+   */
+  inline torch::optional<torch::Tensor> EdgeAttribute(
+      torch::optional<std::string> name) const {
+    if (!name.has_value()) {
+      return torch::nullopt;
+    }
+    TORCH_CHECK(
+        edge_attributes_.has_value() &&
+            edge_attributes_.value().contains(name.value()),
+        "Edge attribute ", name.value(), " does not exist.");
+    return torch::optional<torch::Tensor>(
+        edge_attributes_.value().at(name.value()));
+  }
+
   /** @brief Set the csc index pointer tensor. */
   inline void SetCSCIndptr(const torch::Tensor& indptr) { indptr_ = indptr; }
 

--- a/graphbolt/src/fused_csc_sampling_graph.cc
+++ b/graphbolt/src/fused_csc_sampling_graph.cc
@@ -582,9 +582,8 @@ c10::intrusive_ptr<FusedSampledSubgraph> FusedCSCSamplingGraph::SampleNeighbors(
     const torch::Tensor& nodes, const std::vector<int64_t>& fanouts,
     bool replace, bool layer, bool return_eids,
     torch::optional<std::string> probs_name) const {
-  torch::optional<torch::Tensor> probs_or_mask = torch::nullopt;
-  if (probs_name.has_value() && !probs_name.value().empty()) {
-    probs_or_mask = edge_attributes_.value().at(probs_name.value());
+  auto probs_or_mask = this->EdgeAttribute(probs_name);
+  if (probs_name.has_value()) {
     // Note probs will be passed as input for 'torch.multinomial' in deeper
     // stack, which doesn't support 'torch.half' and 'torch.bool' data types. To
     // avoid crashes, convert 'probs_or_mask' to 'float32' data type.


### PR DESCRIPTION
## Description

For the easy access of temporal attributes later.

## Checklist
Please feel free to remove inapplicable items for your PR.
- [ ] The PR title starts with [$CATEGORY] (such as [NN], [Model], [Doc], [Feature]])
- [ ] I've leverage the [tools](https://docs.google.com/document/d/1iHyj7zlmygKSk5gBPsqIqL5ASPzJSPREaNT_QdsiYA4/edit) to beautify the python and c++ code.
- [ ] The PR is complete and small, read the [Google eng practice (CL equals to PR)](https://google.github.io/eng-practices/review/developer/small-cls.html) to understand more about small PR. In DGL, we consider PRs with less than 200 lines of core code change are small (example, test and documentation could be exempted).
- [ ] All changes have test coverage
- [ ] Code is well-documented
- [ ] To the best of my knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change
- [ ] Related issue is referred in this PR
- [ ] If the PR is for a new model/paper, I've updated the example index [here](../examples/README.md).

## Changes
<!-- You could use following template
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)
-->
