### PR TITLE
[GraphBolt] add exclude_seed_edges() for link prediction example

### DIFF
--- a/notebooks/stochastic_training/link_prediction.ipynb
+++ b/notebooks/stochastic_training/link_prediction.ipynb
@@ -137,9 +137,11 @@
     {
       "cell_type": "code",
       "source": [
+        "from functools import partial\n",
         "datapipe = gb.ItemSampler(train_set, batch_size=256, shuffle=True)\n",
         "datapipe = datapipe.sample_uniform_negative(graph, 5)\n",
         "datapipe = datapipe.sample_neighbor(graph, [5, 5, 5])\n",
+        "datapipe = datapipe.transform(partial(gb.exclude_seed_edges, include_reverse_edges=True))\n",
         "datapipe = datapipe.fetch_feature(feature, node_feature_keys=[\"feat\"])\n",
         "datapipe = datapipe.copy_to(device)\n",
         "train_dataloader = gb.DataLoader(datapipe, num_workers=0)"


### PR DESCRIPTION
## Description
<!-- Brief description. Refer to the related issues if existed.
It'll be great if relevant reviewers can be assigned as well.-->

## Checklist
Please feel free to remove inapplicable items for your PR.
- [ ] The PR title starts with [$CATEGORY] (such as [NN], [Model], [Doc], [Feature]])
- [ ] I've leverage the [tools](https://docs.google.com/document/d/1iHyj7zlmygKSk5gBPsqIqL5ASPzJSPREaNT_QdsiYA4/edit) to beautify the python and c++ code.
- [ ] The PR is complete and small, read the [Google eng practice (CL equals to PR)](https://google.github.io/eng-practices/review/developer/small-cls.html) to understand more about small PR. In DGL, we consider PRs with less than 200 lines of core code change are small (example, test and documentation could be exempted).
- [ ] All changes have test coverage
- [ ] Code is well-documented
- [ ] To the best of my knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change
- [ ] Related issue is referred in this PR
- [ ] If the PR is for a new model/paper, I've updated the example index [here](../examples/README.md).

## Changes
<!-- You could use following template
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)
-->
