### PR TITLE
[GraphBolt] Add a check assertion for data type of nodes

### DIFF
--- a/python/dgl/graphbolt/impl/fused_csc_sampling_graph.py
+++ b/python/dgl/graphbolt/impl/fused_csc_sampling_graph.py
@@ -629,6 +629,9 @@ class FusedCSCSamplingGraph(SamplingGraph):
 
     def _check_sampler_arguments(self, nodes, fanouts, probs_name):
         assert nodes.dim() == 1, "Nodes should be 1-D tensor."
+        assert (
+            nodes.dtype == self.indices.dtype
+        ), f"Data type of nodes must be consistent with indices.dtype({self.indices.dtype}), but got {nodes.dtype}."
         assert fanouts.dim() == 1, "Fanouts should be 1-D tensor."
         expected_fanout_len = 1
         if self.edge_type_to_id:

--- a/tests/python/pytorch/graphbolt/impl/test_fused_csc_sampling_graph.py
+++ b/tests/python/pytorch/graphbolt/impl/test_fused_csc_sampling_graph.py
@@ -1051,7 +1051,7 @@ def test_sample_neighbors_hetero(labor, indptr_dtype, indices_dtype):
     assert subgraph.original_edge_ids is None
 
     # Sample on single node type.
-    nodes = {"n1": torch.LongTensor([0])}
+    nodes = {"n1": torch.tensor([0], dtype=indices_dtype)}
     fanouts = torch.tensor([-1, -1])
     sampler = graph.sample_layer_neighbors if labor else graph.sample_neighbors
     subgraph = sampler(nodes, fanouts)
@@ -1059,12 +1059,12 @@ def test_sample_neighbors_hetero(labor, indptr_dtype, indices_dtype):
     # Verify in subgraph.
     expected_node_pairs = {
         "n2:e2:n1": (
-            torch.LongTensor([0, 2]),
-            torch.LongTensor([0, 0]),
+            torch.tensor([0, 2], dtype=indices_dtype),
+            torch.tensor([0, 0], dtype=indices_dtype),
         ),
         "n1:e1:n2": (
-            torch.LongTensor([]),
-            torch.LongTensor([]),
+            torch.tensor([], dtype=indices_dtype),
+            torch.tensor([], dtype=indices_dtype),
         ),
     }
     assert len(subgraph.node_pairs) == 2


### PR DESCRIPTION
## Description
<!-- Brief description. Refer to the related issues if existed.
It'll be great if relevant reviewers can be assigned as well.-->
Add a check assertion for data type of nodes in `python/dgl/graphbolt/impl/fused_csc_sampling_graph.py::_check_sampler_arguments()`

## Checklist
Please feel free to remove inapplicable items for your PR.
- [ ] The PR title starts with [$CATEGORY] (such as [NN], [Model], [Doc], [Feature]])
- [ ] I've leverage the [tools](https://docs.google.com/document/d/1iHyj7zlmygKSk5gBPsqIqL5ASPzJSPREaNT_QdsiYA4/edit) to beautify the python and c++ code.
- [ ] The PR is complete and small, read the [Google eng practice (CL equals to PR)](https://google.github.io/eng-practices/review/developer/small-cls.html) to understand more about small PR. In DGL, we consider PRs with less than 200 lines of core code change are small (example, test and documentation could be exempted).
- [ ] All changes have test coverage
- [ ] Code is well-documented
- [ ] To the best of my knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change
- [ ] Related issue is referred in this PR
- [ ] If the PR is for a new model/paper, I've updated the example index [here](../examples/README.md).

## Changes
<!-- You could use following template
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)
-->
