### PR TITLE
[Graphbolt] Implement Temporal Neighbor Sampling.

### DIFF
--- a/graphbolt/include/graphbolt/fused_csc_sampling_graph.h
+++ b/graphbolt/include/graphbolt/fused_csc_sampling_graph.h
@@ -508,11 +508,27 @@ int64_t NumPick(
     const torch::optional<torch::Tensor>& probs_or_mask, int64_t offset,
     int64_t num_neighbors);
 
+int64_t TemporalNumPick(
+    torch::Tensor seed_timestamp, torch::Tensor csc_indics, int64_t fanout,
+    bool replace, const torch::optional<torch::Tensor>& probs_or_mask,
+    const torch::optional<torch::Tensor>& node_timestamp,
+    const torch::optional<torch::Tensor>& edge_timestamp, int64_t seed_offset,
+    int64_t offset, int64_t num_neighbors);
+
 int64_t NumPickByEtype(
     const std::vector<int64_t>& fanouts, bool replace,
     const torch::Tensor& type_per_edge,
     const torch::optional<torch::Tensor>& probs_or_mask, int64_t offset,
     int64_t num_neighbors);
+
+int64_t TemporalNumPickByEtype(
+    torch::Tensor seed_timestamp, torch::Tensor csc_indices,
+    const std::vector<int64_t>& fanouts, bool replace,
+    const torch::Tensor& type_per_edge,
+    const torch::optional<torch::Tensor>& probs_or_mask,
+    const torch::optional<torch::Tensor>& node_timestamp,
+    const torch::optional<torch::Tensor>& edge_timestamp, int64_t seed_offset,
+    int64_t offset, int64_t num_neighbors);
 
 /**
  * @brief Picks a specified number of neighbors for a node, starting from the
@@ -562,6 +578,16 @@ int64_t Pick(
     const torch::optional<torch::Tensor>& probs_or_mask,
     SamplerArgs<SamplerType::LABOR> args, PickedType* picked_data_ptr);
 
+template <typename PickedType>
+int64_t TemporalPick(
+    torch::Tensor seed_timestamp, torch::Tensor csc_indices,
+    int64_t seed_offset, int64_t offset, int64_t num_neighbors, int64_t fanout,
+    bool replace, const torch::TensorOptions& options,
+    const torch::optional<torch::Tensor>& probs_or_mask,
+    const torch::optional<torch::Tensor>& node_timestamp,
+    const torch::optional<torch::Tensor>& edge_timestamp,
+    PickedType* picked_data_ptr);
+
 /**
  * @brief Picks a specified number of neighbors for a node per edge type,
  * starting from the given offset and having the specified number of neighbors.
@@ -595,6 +621,17 @@ int64_t PickByEtype(
     bool replace, const torch::TensorOptions& options,
     const torch::Tensor& type_per_edge,
     const torch::optional<torch::Tensor>& probs_or_mask, SamplerArgs<S> args,
+    PickedType* picked_data_ptr);
+
+template <typename PickedType>
+int64_t TemporalPickByEtype(
+    torch::Tensor seed_timestamp, torch::Tensor csc_indices,
+    int64_t seed_offset, int64_t offset, int64_t num_neighbors,
+    const std::vector<int64_t>& fanouts, bool replace,
+    const torch::TensorOptions& options, const torch::Tensor& type_per_edge,
+    const torch::optional<torch::Tensor>& probs_or_mask,
+    const torch::optional<torch::Tensor>& node_timestamp,
+    const torch::optional<torch::Tensor>& edge_timestamp,
     PickedType* picked_data_ptr);
 
 template <

--- a/graphbolt/src/utils.h
+++ b/graphbolt/src/utils.h
@@ -19,6 +19,29 @@ inline bool is_accessible_from_gpu(torch::Tensor tensor) {
   return tensor.is_pinned() || tensor.device().type() == c10::DeviceType::CUDA;
 }
 
+/**
+ * @brief Retrieves the value of the tensor at the given index.
+ *
+ * @note If the tensor is not contiguous, it will be copied to a contiguous
+ * tensor.
+ *
+ * @tparam T The type of the tensor.
+ * @param tensor The tensor.
+ * @param index The index.
+ *
+ * @return T The value of the tensor at the given index.
+ */
+template <typename T>
+T GetValueByIndex(const torch::Tensor& tensor, int64_t index) {
+  TORCH_CHECK(
+      index >= 0 && index < tensor.numel(),
+      "The index should be within the range of the tensor, but got index ",
+      index, " and tensor size ", tensor.numel());
+  auto contiguous_tensor = tensor.contiguous();
+  auto data_ptr = contiguous_tensor.data_ptr<T>();
+  return data_ptr[index];
+}
+
 }  // namespace utils
 }  // namespace graphbolt
 

--- a/python/dgl/graphbolt/impl/fused_csc_sampling_graph.py
+++ b/python/dgl/graphbolt/impl/fused_csc_sampling_graph.py
@@ -439,11 +439,18 @@ class FusedCSCSamplingGraph(SamplingGraph):
             node_pairs=node_pairs, original_edge_ids=original_edge_ids
         )
 
-    def _convert_to_homogeneous_nodes(self, nodes):
+    def _convert_to_homogeneous_nodes(self, nodes, timestamps=None):
         homogeneous_nodes = []
+        homogeneous_timestamps = []
         for ntype, ids in nodes.items():
             ntype_id = self.node_type_to_id[ntype]
             homogeneous_nodes.append(ids + self.node_type_offset[ntype_id])
+            if timestamps is not None:
+                homogeneous_timestamps.append(timestamps[ntype])
+        if timestamps is not None:
+            return torch.cat(homogeneous_nodes), torch.cat(
+                homogeneous_timestamps
+            )
         return torch.cat(homogeneous_nodes)
 
     def _convert_to_sampled_subgraph(
@@ -830,7 +837,7 @@ class FusedCSCSamplingGraph(SamplingGraph):
         else:
             return self._convert_to_sampled_subgraph(C_sampled_subgraph)
 
-    def _temporal_sample_neighbors(
+    def temporal_sample_neighbors(
         self,
         nodes: torch.Tensor,
         input_nodes_timestamp: torch.Tensor,
@@ -887,25 +894,38 @@ class FusedCSCSamplingGraph(SamplingGraph):
 
         Returns
         -------
-        torch.classes.graphbolt.SampledSubgraph
-            The sampled C subgraph.
+        FusedSampledSubgraphImpl
+            The sampled subgraph.
         """
+        if isinstance(nodes, dict):
+            nodes, input_nodes_timestamp = self._convert_to_homogeneous_nodes(
+                nodes, input_nodes_timestamp
+            )
+
         # Ensure nodes is 1-D tensor.
         self._check_sampler_arguments(nodes, fanouts, probs_name)
         has_original_eids = (
             self.edge_attributes is not None
             and ORIGINAL_EDGE_ID in self.edge_attributes
         )
-        return self._c_csc_graph.temporal_sample_neighbors(
+        C_sampled_subgraph = self._c_csc_graph.temporal_sample_neighbors(
             nodes,
             input_nodes_timestamp,
             fanouts.tolist(),
             replace,
-            False,
             has_original_eids,
             probs_name,
             node_timestamp_attr_name,
             edge_timestamp_attr_name,
+        )
+        # Broadcast the input nodes' timestamp to the sampled neighbors.
+        sampled_count = torch.diff(C_sampled_subgraph.indptr)
+        neighbors_timestamp = input_nodes_timestamp.repeat_interleave(
+            sampled_count
+        )
+        return (
+            self._convert_to_sampled_subgraph(C_sampled_subgraph),
+            neighbors_timestamp,
         )
 
     def sample_negative_edges_uniform(


### PR DESCRIPTION
## Description
Implemented TemporalNeighborSampler.

Since there are more and more samplers in Graphbolt, we may need to refactor the sampling logic. The current PickFn and NumPickFn are lambdas, which are pretty tedious since they forward a lot of arguments multiple times during the sampling logic. And it is not straightforward to support template in lambda. I'd suggest to use a abstract class for various sampling methods, which offer NumPick and Pick functions but with private attributes to support different sampling logics.

## Checklist
Please feel free to remove inapplicable items for your PR.
- [ ] The PR title starts with [$CATEGORY] (such as [NN], [Model], [Doc], [Feature]])
- [ ] I've leverage the [tools](https://docs.google.com/document/d/1iHyj7zlmygKSk5gBPsqIqL5ASPzJSPREaNT_QdsiYA4/edit) to beautify the python and c++ code.
- [ ] The PR is complete and small, read the [Google eng practice (CL equals to PR)](https://google.github.io/eng-practices/review/developer/small-cls.html) to understand more about small PR. In DGL, we consider PRs with less than 200 lines of core code change are small (example, test and documentation could be exempted).
- [ ] All changes have test coverage
- [ ] Code is well-documented
- [ ] To the best of my knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change
- [ ] Related issue is referred in this PR
- [ ] If the PR is for a new model/paper, I've updated the example index [here](../examples/README.md).

## Changes
<!-- You could use following template
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)
-->
