### PR TITLE
[GraphBolt] Add `__repr__` to feature store.

### DIFF
--- a/python/dgl/graphbolt/impl/torch_based_feature_store.py
+++ b/python/dgl/graphbolt/impl/torch_based_feature_store.py
@@ -248,9 +248,7 @@ def _torch_based_feature_str(feature: TorchBasedFeature) -> str:
         lines = [lines[0]] + [" " * indent + line for line in lines[1:]]
         return "\n".join(lines)
 
-    feature_str = (
-        f"feature={_add_indent(str(feature._tensor), indent_len + 8)}"
-    )
+    feature_str = f"feature={_add_indent(str(feature._tensor), indent_len + 8)}"
     final_str += feature_str + ",\n" + " " * indent_len
     metadata_str = (
         f"metadata={_add_indent(str(feature.metadata()), indent_len + 9)}"
@@ -259,7 +257,9 @@ def _torch_based_feature_str(feature: TorchBasedFeature) -> str:
     return final_str
 
 
-def _torch_based_feature_store_str(features: Dict[str, TorchBasedFeature]) -> str:
+def _torch_based_feature_store_str(
+    features: Dict[str, TorchBasedFeature]
+) -> str:
     final_str = "TorchBasedFeatureStore"
     indent_len = len(final_str)
 

--- a/python/dgl/graphbolt/impl/torch_based_feature_store.py
+++ b/python/dgl/graphbolt/impl/torch_based_feature_store.py
@@ -168,6 +168,25 @@ class TorchBasedFeature(Feature):
         """In-place operation to copy the feature to pinned memory."""
         self._tensor = self._tensor.pin_memory()
 
+    def __repr__(self) -> str:
+        final_str = "TorchBasedFeature("
+        indent_len = len(final_str)
+
+        def _add_indent(_str, indent):
+            lines = _str.split("\n")
+            lines = [lines[0]] + [" " * indent + line for line in lines[1:]]
+            return "\n".join(lines)
+
+        feature_str = (
+            f"feature={_add_indent(str(self._tensor), indent_len + 8)}"
+        )
+        final_str += feature_str + ",\n" + " " * indent_len
+        metadata_str = (
+            f"metadata={_add_indent(str(self.metadata()), indent_len + 9)}"
+        )
+        final_str += metadata_str + ",\n)"
+        return final_str
+
 
 class TorchBasedFeatureStore(BasicFeatureStore):
     r"""A store to manage multiple pytorch based feature for access.
@@ -231,3 +250,16 @@ class TorchBasedFeatureStore(BasicFeatureStore):
         """In-place operation to copy the feature store to pinned memory."""
         for feature in self._features.values():
             feature.pin_memory_()
+
+    def __repr__(self) -> str:
+        final_str = "TorchBasedFeatureStore"
+        indent_len = len(final_str)
+
+        def _add_indent(_str, indent):
+            lines = _str.split("\n")
+            lines = [lines[0]] + [" " * indent + line for line in lines[1:]]
+            return "\n".join(lines)
+
+        features_str = f"{_add_indent(str(self._features), indent_len+9)}"
+        final_str += features_str
+        return final_str

--- a/python/dgl/graphbolt/impl/torch_based_feature_store.py
+++ b/python/dgl/graphbolt/impl/torch_based_feature_store.py
@@ -169,23 +169,7 @@ class TorchBasedFeature(Feature):
         self._tensor = self._tensor.pin_memory()
 
     def __repr__(self) -> str:
-        final_str = "TorchBasedFeature("
-        indent_len = len(final_str)
-
-        def _add_indent(_str, indent):
-            lines = _str.split("\n")
-            lines = [lines[0]] + [" " * indent + line for line in lines[1:]]
-            return "\n".join(lines)
-
-        feature_str = (
-            f"feature={_add_indent(str(self._tensor), indent_len + 8)}"
-        )
-        final_str += feature_str + ",\n" + " " * indent_len
-        metadata_str = (
-            f"metadata={_add_indent(str(self.metadata()), indent_len + 9)}"
-        )
-        final_str += metadata_str + ",\n)"
-        return final_str
+        return _torch_based_feature_str(self)
 
 
 class TorchBasedFeatureStore(BasicFeatureStore):
@@ -252,14 +236,38 @@ class TorchBasedFeatureStore(BasicFeatureStore):
             feature.pin_memory_()
 
     def __repr__(self) -> str:
-        final_str = "TorchBasedFeatureStore"
-        indent_len = len(final_str)
+        return _torch_based_feature_store_str(self._features)
 
-        def _add_indent(_str, indent):
-            lines = _str.split("\n")
-            lines = [lines[0]] + [" " * indent + line for line in lines[1:]]
-            return "\n".join(lines)
 
-        features_str = f"{_add_indent(str(self._features), indent_len+9)}"
-        final_str += features_str
-        return final_str
+def _torch_based_feature_str(feature: TorchBasedFeature) -> str:
+    final_str = "TorchBasedFeature("
+    indent_len = len(final_str)
+
+    def _add_indent(_str, indent):
+        lines = _str.split("\n")
+        lines = [lines[0]] + [" " * indent + line for line in lines[1:]]
+        return "\n".join(lines)
+
+    feature_str = (
+        f"feature={_add_indent(str(feature._tensor), indent_len + 8)}"
+    )
+    final_str += feature_str + ",\n" + " " * indent_len
+    metadata_str = (
+        f"metadata={_add_indent(str(feature.metadata()), indent_len + 9)}"
+    )
+    final_str += metadata_str + ",\n)"
+    return final_str
+
+
+def _torch_based_feature_store_str(features: Dict[str, TorchBasedFeature]) -> str:
+    final_str = "TorchBasedFeatureStore"
+    indent_len = len(final_str)
+
+    def _add_indent(_str, indent):
+        lines = _str.split("\n")
+        lines = [lines[0]] + [" " * indent + line for line in lines[1:]]
+        return "\n".join(lines)
+
+    features_str = f"{_add_indent(str(features), indent_len+9)}"
+    final_str += features_str
+    return final_str

--- a/python/dgl/graphbolt/impl/torch_based_feature_store.py
+++ b/python/dgl/graphbolt/impl/torch_based_feature_store.py
@@ -248,10 +248,12 @@ def _torch_based_feature_str(feature: TorchBasedFeature) -> str:
         lines = [lines[0]] + [" " * indent + line for line in lines[1:]]
         return "\n".join(lines)
 
-    feature_str = f"feature={_add_indent(str(feature._tensor), indent_len + 8)}"
+    feature_str = "feature=" + _add_indent(
+        str(feature._tensor), indent_len + len("feature=")
+    )
     final_str += feature_str + ",\n" + " " * indent_len
-    metadata_str = (
-        f"metadata={_add_indent(str(feature.metadata()), indent_len + 9)}"
+    metadata_str = "metadata=" + _add_indent(
+        str(feature.metadata()), indent_len + len("metadata=")
     )
     final_str += metadata_str + ",\n)"
     return final_str
@@ -268,6 +270,6 @@ def _torch_based_feature_store_str(
         lines = [lines[0]] + [" " * indent + line for line in lines[1:]]
         return "\n".join(lines)
 
-    features_str = f"{_add_indent(str(features), indent_len+9)}"
+    features_str = _add_indent(str(features), indent_len)
     final_str += features_str
     return final_str

--- a/tests/python/pytorch/graphbolt/impl/test_torch_based_feature_store.py
+++ b/tests/python/pytorch/graphbolt/impl/test_torch_based_feature_store.py
@@ -339,17 +339,19 @@ def test_torch_based_feature_store_repr(in_memory):
 
         expected_feature_store_str = str(
             """TorchBasedFeatureStore{(<OnDiskFeatureDataDomain.NODE: 'node'>, 'paper', 'a'): TorchBasedFeature(feature=tensor([[1, 2, 4],
-                                                                 [2, 5, 3]]),
-                                                 metadata={},
-                               ), (<OnDiskFeatureDataDomain.EDGE: 'edge'>, 'paper:cites:paper', 'b'): TorchBasedFeature(feature=tensor([[[1, 2],
-                                                                  [3, 4]],
-                                                         
-                                                                 [[2, 5],
-                                                                  [3, 4]]]),
-                                                 metadata={},
-                               )}"""
+                                                        [2, 5, 3]]),
+                                        metadata={},
+                      ), (<OnDiskFeatureDataDomain.EDGE: 'edge'>, 'paper:cites:paper', 'b'): TorchBasedFeature(feature=tensor([[[1, 2],
+                                                         [3, 4]],
+                                                
+                                                        [[2, 5],
+                                                         [3, 4]]]),
+                                        metadata={},
+                      )}"""
         )
-        assert str(feature_store) == expected_feature_store_str
+        assert str(feature_store) == expected_feature_store_str, print(
+            feature_store
+        )
 
         a = b = None
         feature_store = None

--- a/tests/python/pytorch/graphbolt/impl/test_torch_based_feature_store.py
+++ b/tests/python/pytorch/graphbolt/impl/test_torch_based_feature_store.py
@@ -275,3 +275,81 @@ def test_torch_based_feature_store(in_memory):
         assert feature_store.size("node", None, "a") == torch.Size([3])
 
         feature_store = None
+
+
+@pytest.mark.parametrize("in_memory", [True, False])
+def test_torch_based_feature_repr(in_memory):
+    with tempfile.TemporaryDirectory() as test_dir:
+        a = torch.tensor([[1, 2, 3], [4, 5, 6]])
+        b = torch.tensor([[[1, 2], [3, 4]], [[4, 5], [6, 7]]])
+        metadata = {"max_value": 3}
+        if not in_memory:
+            a = to_on_disk_tensor(test_dir, "a", a)
+            b = to_on_disk_tensor(test_dir, "b", b)
+
+        feature_a = gb.TorchBasedFeature(a, metadata=metadata)
+        feature_b = gb.TorchBasedFeature(b)
+
+        expected_str_feature_a = str(
+            """TorchBasedFeature(feature=tensor([[1, 2, 3],
+                                  [4, 5, 6]]),
+                  metadata={'max_value': 3},
+)"""
+        )
+        expected_str_feature_b = str(
+            """TorchBasedFeature(feature=tensor([[[1, 2],
+                                   [3, 4]],
+                          
+                                  [[4, 5],
+                                   [6, 7]]]),
+                  metadata={},
+)"""
+        )
+        assert str(feature_a) == expected_str_feature_a
+        assert str(feature_b) == expected_str_feature_b
+        feature_a = feature_b = None
+
+
+@pytest.mark.parametrize("in_memory", [True, False])
+def test_torch_based_feature_store_repr(in_memory):
+    with tempfile.TemporaryDirectory() as test_dir:
+        a = torch.tensor([[1, 2, 4], [2, 5, 3]])
+        b = torch.tensor([[[1, 2], [3, 4]], [[2, 5], [3, 4]]])
+        write_tensor_to_disk(test_dir, "a", a, fmt="torch")
+        write_tensor_to_disk(test_dir, "b", b, fmt="numpy")
+        feature_data = [
+            gb.OnDiskFeatureData(
+                domain="node",
+                type="paper",
+                name="a",
+                format="torch",
+                path=os.path.join(test_dir, "a.pt"),
+                in_memory=True,
+            ),
+            gb.OnDiskFeatureData(
+                domain="edge",
+                type="paper:cites:paper",
+                name="b",
+                format="numpy",
+                path=os.path.join(test_dir, "b.npy"),
+                in_memory=in_memory,
+            ),
+        ]
+        feature_store = gb.TorchBasedFeatureStore(feature_data)
+
+        expected_feature_store_str = str(
+            """TorchBasedFeatureStore{(<OnDiskFeatureDataDomain.NODE: 'node'>, 'paper', 'a'): TorchBasedFeature(feature=tensor([[1, 2, 4],
+                                                                 [2, 5, 3]]),
+                                                 metadata={},
+                               ), (<OnDiskFeatureDataDomain.EDGE: 'edge'>, 'paper:cites:paper', 'b'): TorchBasedFeature(feature=tensor([[[1, 2],
+                                                                  [3, 4]],
+                                                         
+                                                                 [[2, 5],
+                                                                  [3, 4]]]),
+                                                 metadata={},
+                               )}"""
+        )
+        assert str(feature_store) == expected_feature_store_str
+
+        a = b = None
+        feature_store = None

--- a/tests/python/pytorch/graphbolt/impl/test_torch_based_feature_store.py
+++ b/tests/python/pytorch/graphbolt/impl/test_torch_based_feature_store.py
@@ -307,7 +307,9 @@ def test_torch_based_feature_repr(in_memory):
         )
         assert str(feature_a) == expected_str_feature_a
         assert str(feature_b) == expected_str_feature_b
+        a = b = metadata = None
         feature_a = feature_b = None
+        expected_str_feature_a = expected_str_feature_b = None
 
 
 @pytest.mark.parametrize("in_memory", [True, False])
@@ -353,5 +355,5 @@ def test_torch_based_feature_store_repr(in_memory):
             feature_store
         )
 
-        a = b = None
-        feature_store = None
+        a = b = feature_data = None
+        feature_store = expected_feature_store_str = None


### PR DESCRIPTION
## Description
<!-- Brief description. Refer to the related issues if existed.
It'll be great if relevant reviewers can be assigned as well.-->
Add `__repr__` to feature store.

### TorchBasedFeature
```
TorchBasedFeature(feature=tensor([[[1, 2],
                                   [3, 4]],
                          
                                  [[4, 5],
                                   [6, 7]]]),
                  metadata={'max_value': 3},
)
```

### TorchBasedFeatureStore
```
TorchBasedFeatureStore{(<OnDiskFeatureDataDomain.NODE: 'node'>, 'paper', 'a'): TorchBasedFeature(feature=tensor([[1, 2, 4],
                                                                 [2, 5, 3]]),
                                                 metadata={},
                               ), (<OnDiskFeatureDataDomain.EDGE: 'edge'>, 'paper:cites:paper', 'b'): TorchBasedFeature(feature=tensor([[[1, 2],
                                                                  [3, 4]],
                                                         
                                                                 [[2, 5],
                                                                  [3, 4]]]),
                                                 metadata={},
                               )}
```

## Checklist
Please feel free to remove inapplicable items for your PR.
- [ ] The PR title starts with [$CATEGORY] (such as [NN], [Model], [Doc], [Feature]])
- [ ] I've leverage the [tools](https://docs.google.com/document/d/1iHyj7zlmygKSk5gBPsqIqL5ASPzJSPREaNT_QdsiYA4/edit) to beautify the python and c++ code.
- [ ] The PR is complete and small, read the [Google eng practice (CL equals to PR)](https://google.github.io/eng-practices/review/developer/small-cls.html) to understand more about small PR. In DGL, we consider PRs with less than 200 lines of core code change are small (example, test and documentation could be exempted).
- [ ] All changes have test coverage
- [ ] Code is well-documented
- [ ] To the best of my knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change
- [ ] Related issue is referred in this PR
- [ ] If the PR is for a new model/paper, I've updated the example index [here](../examples/README.md).

## Changes
<!-- You could use following template
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)
-->
