### PR TITLE
[GraphBolt] Add `__repr__`  to ItemSet.

### DIFF
--- a/python/dgl/graphbolt/itemset.py
+++ b/python/dgl/graphbolt/itemset.py
@@ -174,6 +174,9 @@ class ItemSet:
         """Return the names of the items."""
         return self._names
 
+    def __repr__(self) -> str:
+        return _itemset_str(self, "ItemSet")
+
 
 class ItemSetDict:
     r"""Dictionary wrapper of **ItemSet**.
@@ -325,3 +328,30 @@ class ItemSetDict:
     def names(self) -> Tuple[str]:
         """Return the names of the items."""
         return self._names
+    
+    def __repr__(self) -> str:
+        return _itemset_str(self, "ItemSetDict")
+
+
+def _itemset_str(itemset: Union[ItemSet, ItemSetDict], name) -> str:
+    final_str = f"{name}("
+    indent_len = len(final_str)
+
+    def _add_indent(_str, indent):
+        lines = _str.split("\n")
+        lines = [lines[0]] + [" " * indent + line for line in lines[1:]]
+        return "\n".join(lines)
+
+    item_str = (
+        "items="
+        + _add_indent(str(list(itemset)), indent_len + len("items="))
+        + ",\n"
+        + " " * indent_len
+    )
+    name_str = (
+        "names="
+        + _add_indent(str(itemset.names), indent_len + len("items="))
+        + ",\n)"
+    )
+    final_str += item_str + name_str
+    return final_str

--- a/python/dgl/graphbolt/itemset.py
+++ b/python/dgl/graphbolt/itemset.py
@@ -342,15 +342,18 @@ def _itemset_str(itemset: Union[ItemSet, ItemSetDict], name) -> str:
         lines = [lines[0]] + [" " * indent + line for line in lines[1:]]
         return "\n".join(lines)
 
+    items = (
+        itemset._items if isinstance(itemset, ItemSet) else itemset._itemsets
+    )
     item_str = (
         "items="
-        + _add_indent(str(list(itemset)), indent_len + len("items="))
+        + _add_indent(str(items), indent_len + len("items="))
         + ",\n"
         + " " * indent_len
     )
     name_str = (
         "names="
-        + _add_indent(str(itemset.names), indent_len + len("items="))
+        + _add_indent(str(itemset._names), indent_len + len("items="))
         + ",\n)"
     )
     final_str += item_str + name_str

--- a/python/dgl/graphbolt/itemset.py
+++ b/python/dgl/graphbolt/itemset.py
@@ -328,7 +328,7 @@ class ItemSetDict:
     def names(self) -> Tuple[str]:
         """Return the names of the items."""
         return self._names
-    
+
     def __repr__(self) -> str:
         return _itemset_str(self, "ItemSetDict")
 

--- a/tests/python/pytorch/graphbolt/test_itemset.py
+++ b/tests/python/pytorch/graphbolt/test_itemset.py
@@ -524,3 +524,62 @@ def test_ItemSetDict_iteration_node_pairs_neg_dsts():
     assert torch.equal(item_set[:]["user:like:item"][1], neg_dsts)
     assert torch.equal(item_set[:]["user:follow:user"][0], node_pairs)
     assert torch.equal(item_set[:]["user:follow:user"][1], neg_dsts)
+
+
+def test_ItemSet_repr():
+    # ItemSet with single name.
+    item_set = gb.ItemSet(torch.arange(0, 5), names="seed_nodes")
+    expected_str = str(
+        """ItemSet(items=[tensor(0), tensor(1), tensor(2), tensor(3), tensor(4)],
+        names=('seed_nodes',),
+)"""
+    )
+    assert str(item_set) == expected_str
+
+    # ItemSet with multiple names.
+    item_set = gb.ItemSet(
+        (torch.arange(0, 5), torch.arange(5, 10)),
+        names=("seed_nodes", "labels"),
+    )
+    expected_str = str(
+        """ItemSet(items=[(tensor(0), tensor(5)), (tensor(1), tensor(6)), (tensor(2), tensor(7)), (tensor(3), tensor(8)), (tensor(4), tensor(9))],
+        names=('seed_nodes', 'labels'),
+)"""
+    )
+    assert str(item_set) == expected_str
+
+
+def test_ItemSetDict_repr():
+    # ItemSetDict with single name.
+    item_set = gb.ItemSetDict(
+        {
+            "user": gb.ItemSet(torch.arange(0, 5), names="seed_nodes"),
+            "item": gb.ItemSet(torch.arange(5, 10), names="seed_nodes"),
+        }
+    )
+    expected_str = str(
+        """ItemSetDict(items=[{'user': tensor(0)}, {'user': tensor(1)}, {'user': tensor(2)}, {'user': tensor(3)}, {'user': tensor(4)}, {'item': tensor(5)}, {'item': tensor(6)}, {'item': tensor(7)}, {'item': tensor(8)}, {'item': tensor(9)}],
+            names=('seed_nodes',),
+)"""
+    )
+    assert str(item_set) == expected_str
+
+    # ItemSetDict with multiple names.
+    item_set = gb.ItemSetDict(
+        {
+            "user": gb.ItemSet(
+                (torch.arange(0, 5), torch.arange(5, 10)),
+                names=("seed_nodes", "labels"),
+            ),
+            "item": gb.ItemSet(
+                (torch.arange(5, 10), torch.arange(10, 15)),
+                names=("seed_nodes", "labels"),
+            ),
+        }
+    )
+    expected_str = str(
+        """ItemSetDict(items=[{'user': (tensor(0), tensor(5))}, {'user': (tensor(1), tensor(6))}, {'user': (tensor(2), tensor(7))}, {'user': (tensor(3), tensor(8))}, {'user': (tensor(4), tensor(9))}, {'item': (tensor(5), tensor(10))}, {'item': (tensor(6), tensor(11))}, {'item': (tensor(7), tensor(12))}, {'item': (tensor(8), tensor(13))}, {'item': (tensor(9), tensor(14))}],
+            names=('seed_nodes', 'labels'),
+)"""
+    )
+    assert str(item_set) == expected_str

--- a/tests/python/pytorch/graphbolt/test_itemset.py
+++ b/tests/python/pytorch/graphbolt/test_itemset.py
@@ -530,11 +530,11 @@ def test_ItemSet_repr():
     # ItemSet with single name.
     item_set = gb.ItemSet(torch.arange(0, 5), names="seed_nodes")
     expected_str = str(
-        """ItemSet(items=[tensor(0), tensor(1), tensor(2), tensor(3), tensor(4)],
+        """ItemSet(items=(tensor([0, 1, 2, 3, 4]),),
         names=('seed_nodes',),
 )"""
     )
-    assert str(item_set) == expected_str
+    assert str(item_set) == expected_str, print(item_set)
 
     # ItemSet with multiple names.
     item_set = gb.ItemSet(
@@ -542,11 +542,11 @@ def test_ItemSet_repr():
         names=("seed_nodes", "labels"),
     )
     expected_str = str(
-        """ItemSet(items=[(tensor(0), tensor(5)), (tensor(1), tensor(6)), (tensor(2), tensor(7)), (tensor(3), tensor(8)), (tensor(4), tensor(9))],
+        """ItemSet(items=(tensor([0, 1, 2, 3, 4]), tensor([5, 6, 7, 8, 9])),
         names=('seed_nodes', 'labels'),
 )"""
     )
-    assert str(item_set) == expected_str
+    assert str(item_set) == expected_str, print(item_set)
 
 
 def test_ItemSetDict_repr():
@@ -558,11 +558,15 @@ def test_ItemSetDict_repr():
         }
     )
     expected_str = str(
-        """ItemSetDict(items=[{'user': tensor(0)}, {'user': tensor(1)}, {'user': tensor(2)}, {'user': tensor(3)}, {'user': tensor(4)}, {'item': tensor(5)}, {'item': tensor(6)}, {'item': tensor(7)}, {'item': tensor(8)}, {'item': tensor(9)}],
+        """ItemSetDict(items={'user': ItemSet(items=(tensor([0, 1, 2, 3, 4]),),
+                          names=('seed_nodes',),
+                  ), 'item': ItemSet(items=(tensor([5, 6, 7, 8, 9]),),
+                          names=('seed_nodes',),
+                  )},
             names=('seed_nodes',),
 )"""
     )
-    assert str(item_set) == expected_str
+    assert str(item_set) == expected_str, print(item_set)
 
     # ItemSetDict with multiple names.
     item_set = gb.ItemSetDict(
@@ -578,8 +582,12 @@ def test_ItemSetDict_repr():
         }
     )
     expected_str = str(
-        """ItemSetDict(items=[{'user': (tensor(0), tensor(5))}, {'user': (tensor(1), tensor(6))}, {'user': (tensor(2), tensor(7))}, {'user': (tensor(3), tensor(8))}, {'user': (tensor(4), tensor(9))}, {'item': (tensor(5), tensor(10))}, {'item': (tensor(6), tensor(11))}, {'item': (tensor(7), tensor(12))}, {'item': (tensor(8), tensor(13))}, {'item': (tensor(9), tensor(14))}],
+        """ItemSetDict(items={'user': ItemSet(items=(tensor([0, 1, 2, 3, 4]), tensor([5, 6, 7, 8, 9])),
+                          names=('seed_nodes', 'labels'),
+                  ), 'item': ItemSet(items=(tensor([5, 6, 7, 8, 9]), tensor([10, 11, 12, 13, 14])),
+                          names=('seed_nodes', 'labels'),
+                  )},
             names=('seed_nodes', 'labels'),
 )"""
     )
-    assert str(item_set) == expected_str
+    assert str(item_set) == expected_str, print(item_set)


### PR DESCRIPTION
## Description
<!-- Brief description. Refer to the related issues if existed.
It'll be great if relevant reviewers can be assigned as well.-->
Add `__repr__`  to ItemSet. 

### ItemSet
```
ItemSet(items=(tensor([0, 1, 2, 3, 4]), tensor([5, 6, 7, 8, 9])),
        names=('seed_nodes', 'labels'),
)
```

### ItemSetDict
```
ItemSetDict(items={'user': ItemSet(items=(tensor([0, 1, 2, 3, 4]), tensor([5, 6, 7, 8, 9])),
                          names=('seed_nodes', 'labels'),
                  ), 'item': ItemSet(items=(tensor([5, 6, 7, 8, 9]), tensor([10, 11, 12, 13, 14])),
                          names=('seed_nodes', 'labels'),
                  )},
            names=('seed_nodes', 'labels'),
)
```

## Checklist
Please feel free to remove inapplicable items for your PR.
- [ ] The PR title starts with [$CATEGORY] (such as [NN], [Model], [Doc], [Feature]])
- [ ] I've leverage the [tools](https://docs.google.com/document/d/1iHyj7zlmygKSk5gBPsqIqL5ASPzJSPREaNT_QdsiYA4/edit) to beautify the python and c++ code.
- [ ] The PR is complete and small, read the [Google eng practice (CL equals to PR)](https://google.github.io/eng-practices/review/developer/small-cls.html) to understand more about small PR. In DGL, we consider PRs with less than 200 lines of core code change are small (example, test and documentation could be exempted).
- [ ] All changes have test coverage
- [ ] Code is well-documented
- [ ] To the best of my knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change
- [ ] Related issue is referred in this PR
- [ ] If the PR is for a new model/paper, I've updated the example index [here](../examples/README.md).

## Changes
<!-- You could use following template
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)
-->
