### PR TITLE
[GraphBolt] Modify docstring of `SampledSubgraph`.

### DIFF
--- a/python/dgl/graphbolt/sampled_subgraph.py
+++ b/python/dgl/graphbolt/sampled_subgraph.py
@@ -122,8 +122,8 @@ class SampledSubgraph:
         >>> node_pairs = {"A:relation:B": gb.CSCFormatBase(
         ...     indptr=torch.tensor([0, 1, 2, 3]),
         ...     indices=torch.tensor([0, 1, 2]))}
-        >>> original_column_node_ids = {'B': torch.tensor([10, 11, 12])}
-        >>> original_row_node_ids = {'A': torch.tensor([13, 14, 15])}
+        >>> original_column_node_ids = {"B": torch.tensor([10, 11, 12])}
+        >>> original_row_node_ids = {"A": torch.tensor([13, 14, 15])}
         >>> original_edge_ids = {"A:relation:B": torch.tensor([19, 20, 21])}
         >>> subgraph = gb.SampledSubgraphImpl(
         ...     node_pairs=node_pairs,


### PR DESCRIPTION
## Description
<!-- Brief description. Refer to the related issues if existed.
It'll be great if relevant reviewers can be assigned as well.-->
Modify docstring of `SampledSubgraph` from coo to csc.

## Checklist
Please feel free to remove inapplicable items for your PR.
- [ ] The PR title starts with [$CATEGORY] (such as [NN], [Model], [Doc], [Feature]])
- [ ] I've leverage the [tools](https://docs.google.com/document/d/1iHyj7zlmygKSk5gBPsqIqL5ASPzJSPREaNT_QdsiYA4/edit) to beautify the python and c++ code.
- [ ] The PR is complete and small, read the [Google eng practice (CL equals to PR)](https://google.github.io/eng-practices/review/developer/small-cls.html) to understand more about small PR. In DGL, we consider PRs with less than 200 lines of core code change are small (example, test and documentation could be exempted).
- [ ] All changes have test coverage
- [ ] Code is well-documented
- [ ] To the best of my knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change
- [ ] Related issue is referred in this PR
- [ ] If the PR is for a new model/paper, I've updated the example index [here](../examples/README.md).

## Changes
<!-- You could use following template
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)
-->
