### PR TITLE
[GraphBolt] Remove opt `output_cscformat` from examples.

### DIFF
--- a/examples/sampling/graphbolt/link_prediction.py
+++ b/examples/sampling/graphbolt/link_prediction.py
@@ -175,11 +175,7 @@ def create_dataloader(args, graph, features, itemset, is_train=True):
     # [Role]:
     # Initialize a neighbor sampler for sampling the neighborhoods of nodes.
     ############################################################################
-    datapipe = datapipe.sample_neighbor(
-        graph,
-        args.fanout,
-        output_cscformat=(args.output_cscformat == "True"),
-    )
+    datapipe = datapipe.sample_neighbor(graph, args.fanout)
 
     ############################################################################
     # [Input]:
@@ -374,12 +370,6 @@ def parse_args():
         default="cpu",
         choices=["cpu", "cuda"],
         help="Train device: 'cpu' for CPU, 'cuda' for GPU.",
-    )
-    parser.add_argument(
-        "--output_cscformat",
-        default="False",
-        choices=["False", "True"],
-        help="Output type of SampledSubgraph. True for csc_formats, False for node_pairs.",
     )
     return parser.parse_args()
 

--- a/examples/sampling/graphbolt/node_classification.py
+++ b/examples/sampling/graphbolt/node_classification.py
@@ -50,15 +50,7 @@ from tqdm import tqdm
 
 
 def create_dataloader(
-    graph,
-    features,
-    itemset,
-    batch_size,
-    fanout,
-    device,
-    num_workers,
-    job,
-    output_cscformat,
+    graph, features, itemset, batch_size, fanout, device, num_workers, job
 ):
     """
     [HIGHLIGHT]
@@ -113,9 +105,7 @@ def create_dataloader(
     # Initialize a neighbor sampler for sampling the neighborhoods of nodes.
     ############################################################################
     datapipe = datapipe.sample_neighbor(
-        graph,
-        fanout if job != "infer" else [-1],
-        output_cscformat=(output_cscformat == "True"),
+        graph, fanout if job != "infer" else [-1]
     )
 
     ############################################################################
@@ -240,7 +230,6 @@ def layerwise_infer(
         device=args.device,
         num_workers=args.num_workers,
         job="infer",
-        output_cscformat=args.output_cscformat,
     )
     pred = model.inference(graph, features, dataloader, args.device)
     pred = pred[test_set._items[0]]
@@ -268,7 +257,6 @@ def evaluate(args, model, graph, features, itemset, num_classes):
         device=args.device,
         num_workers=args.num_workers,
         job="evaluate",
-        output_cscformat=args.output_cscformat,
     )
 
     for step, data in tqdm(enumerate(dataloader)):
@@ -295,7 +283,6 @@ def train(args, graph, features, train_set, valid_set, num_classes, model):
         device=args.device,
         num_workers=args.num_workers,
         job="train",
-        output_cscformat=args.output_cscformat,
     )
 
     for epoch in range(args.epochs):
@@ -366,12 +353,6 @@ def parse_args():
         default="cpu",
         choices=["cpu", "cuda"],
         help="Train device: 'cpu' for CPU, 'cuda' for GPU.",
-    )
-    parser.add_argument(
-        "--output_cscformat",
-        default="False",
-        choices=["False", "True"],
-        help="Output type of SampledSubgraph. True for csc_formats, False for node_pairs.",
     )
     return parser.parse_args()
 


### PR DESCRIPTION
## Description
<!-- Brief description. Refer to the related issues if existed.
It'll be great if relevant reviewers can be assigned as well.-->
Reverts dmlc/dgl#6773, so that examples can sample in csc format.

## Checklist
Please feel free to remove inapplicable items for your PR.
- [ ] The PR title starts with [$CATEGORY] (such as [NN], [Model], [Doc], [Feature]])
- [ ] I've leverage the [tools](https://docs.google.com/document/d/1iHyj7zlmygKSk5gBPsqIqL5ASPzJSPREaNT_QdsiYA4/edit) to beautify the python and c++ code.
- [ ] The PR is complete and small, read the [Google eng practice (CL equals to PR)](https://google.github.io/eng-practices/review/developer/small-cls.html) to understand more about small PR. In DGL, we consider PRs with less than 200 lines of core code change are small (example, test and documentation could be exempted).
- [ ] All changes have test coverage
- [ ] Code is well-documented
- [ ] To the best of my knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change
- [ ] Related issue is referred in this PR
- [ ] If the PR is for a new model/paper, I've updated the example index [here](../examples/README.md).

## Changes
<!-- You could use following template
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)
-->
