### PR TITLE
[GraphBolt] `CopyTo` node classification fix

### DIFF
--- a/python/dgl/graphbolt/minibatch.py
+++ b/python/dgl/graphbolt/minibatch.py
@@ -445,6 +445,7 @@ class MiniBatch:
         if self.seed_nodes is not None and self.compacted_node_pairs is None:
             # Node related tasks.
             transfer_attrs = [
+                "seed_nodes",
                 "labels",
                 "sampled_subgraphs",
                 "node_features",

--- a/tests/python/pytorch/graphbolt/test_base.py
+++ b/tests/python/pytorch/graphbolt/test_base.py
@@ -87,6 +87,7 @@ def test_CopyToWithMiniBatches(task):
 
     if task == "node_classification":
         copied_attrs = [
+            "seed_nodes",
             "node_features",
             "edge_features",
             "sampled_subgraphs",


### PR DESCRIPTION
## Description
When running GPU sampling with #6770, I got an error saying that `seed_nodes` are not on the CUDA device. Thus, this should fix the issue.