### PR TITLE
[GraphBolt] set buffer_size as whole itemset in default

### DIFF
--- a/python/dgl/graphbolt/item_sampler.py
+++ b/python/dgl/graphbolt/item_sampler.py
@@ -100,7 +100,21 @@ class ItemShufflerAndBatcher:
     drop_last : bool
         Option to drop the last batch if it's not full.
     buffer_size : int
-        The size of the buffer to store items sliced from the :class:`ItemSet`.
+        The size of the buffer to store items sliced from the :class:`ItemSet`
+        or :class:`ItemSetDict`.
+    distributed : bool
+        Option to apply on :class:`DistributedItemSampler`.
+    drop_uneven_inputs : bool
+        Option to make sure the numbers of batches for each replica are the
+        same. Applies only when `distributed` is True.
+    world_size : int
+        The number of model replicas that will be created during Distributed
+        Data Parallel (DDP) training. It should be the same as the real world
+        size, otherwise it could cause errors. Applies only when `distributed`
+        is True.
+    rank : int
+        The rank of the current replica. Applies only when `distributed` is
+        True.
     """
 
     def __init__(
@@ -109,7 +123,7 @@ class ItemShufflerAndBatcher:
         shuffle: bool,
         batch_size: int,
         drop_last: bool,
-        buffer_size: Optional[int] = 10 * 1000,
+        buffer_size: int,
         distributed: Optional[bool] = False,
         drop_uneven_inputs: Optional[bool] = False,
         world_size: Optional[int] = 1,
@@ -119,7 +133,7 @@ class ItemShufflerAndBatcher:
         self._shuffle = shuffle
         self._batch_size = batch_size
         self._drop_last = drop_last
-        self._buffer_size = max(buffer_size, 20 * batch_size)
+        self._buffer_size = buffer_size
         # Round up the buffer size to the nearest multiple of batch size.
         self._buffer_size = (
             (self._buffer_size + batch_size - 1) // batch_size * batch_size
@@ -240,6 +254,23 @@ class ItemSampler(IterDataPipe):
         Option to drop the last batch if it's not full.
     shuffle : bool
         Option to shuffle before sample.
+    use_indexing : bool
+        Option to use indexing to slice items from the item set. This is an
+        optimization to avoid time-consuming iteration over the item set. If
+        the item set does not support indexing, this option will be disabled
+        automatically. If the item set supports indexing but the user wants to
+        disable it, this option can be set to False. By default, it is set to
+        True.
+    buffer_size : int
+        The size of the buffer to store items sliced from the :class:`ItemSet`
+        or :class:`ItemSetDict`. By default, it is set to -1, which means the
+        buffer size will be set as the total number of items in the item set.
+        If the item set is too large, it is recommended to set a smaller buffer
+        size to avoid out of memory error. As items are shuffled within each
+        buffer, a smaller buffer size may incur less randomness and such less
+        randomness can further affect the training performance such as
+        convergence speed and accuracy. Therefore, it is recommended to set a
+        larger buffer size if possible.
 
     Examples
     --------
@@ -429,6 +460,7 @@ class ItemSampler(IterDataPipe):
         # [TODO][Rui] For now, it's a temporary knob to disable indexing. In
         # the future, we will enable indexing for all the item sets.
         use_indexing: Optional[bool] = True,
+        buffer_size: Optional[int] = -1,
     ) -> None:
         super().__init__()
         self._names = item_set.names
@@ -441,11 +473,13 @@ class ItemSampler(IterDataPipe):
         self._item_set = (
             item_set if self._use_indexing else IterableWrapper(item_set)
         )
+        self._buffer_size = (
+            len(self._item_set) if buffer_size == -1 else buffer_size
+        )
         self._batch_size = batch_size
         self._minibatcher = minibatcher
         self._drop_last = drop_last
         self._shuffle = shuffle
-        self._use_indexing = use_indexing
         self._distributed = False
         self._drop_uneven_inputs = False
         self._world_size = None
@@ -454,11 +488,7 @@ class ItemSampler(IterDataPipe):
     def _organize_items(self, data_pipe) -> None:
         # Shuffle before batch.
         if self._shuffle:
-            # `torchdata.datapipes.iter.Shuffler` works with stream too.
-            # To ensure randomness, make sure the buffer size is at least 10
-            # times the batch size.
-            buffer_size = max(10000, 10 * self._batch_size)
-            data_pipe = data_pipe.shuffle(buffer_size=buffer_size)
+            data_pipe = data_pipe.shuffle(buffer_size=self._buffer_size)
 
         # Batch.
         data_pipe = data_pipe.batch(
@@ -495,6 +525,7 @@ class ItemSampler(IterDataPipe):
                     self._shuffle,
                     self._batch_size,
                     self._drop_last,
+                    self._buffer_size,
                     distributed=self._distributed,
                     drop_uneven_inputs=self._drop_uneven_inputs,
                     world_size=self._world_size,
@@ -563,6 +594,16 @@ class DistributedItemSampler(ItemSampler):
         https://pytorch.org/tutorials/advanced/generic_join.html. However, this
         option can be used if the Join Context Manager is not helpful for any
         reason.
+    buffer_size : int
+        The size of the buffer to store items sliced from the :class:`ItemSet`
+        or :class:`ItemSetDict`. By default, it is set to -1, which means the
+        buffer size will be set as the total number of items in the item set.
+        If the item set is too large, it is recommended to set a smaller buffer
+        size to avoid out of memory error. As items are shuffled within each
+        buffer, a smaller buffer size may incur less randomness and such less
+        randomness can further affect the training performance such as
+        convergence speed and accuracy. Therefore, it is recommended to set a
+        larger buffer size if possible.
 
     Examples
     --------
@@ -667,6 +708,7 @@ class DistributedItemSampler(ItemSampler):
         drop_last: Optional[bool] = False,
         shuffle: Optional[bool] = False,
         drop_uneven_inputs: Optional[bool] = False,
+        buffer_size: Optional[int] = -1,
     ) -> None:
         super().__init__(
             item_set,
@@ -675,6 +717,7 @@ class DistributedItemSampler(ItemSampler):
             drop_last,
             shuffle,
             use_indexing=True,
+            buffer_size=buffer_size,
         )
         self._distributed = True
         self._drop_uneven_inputs = drop_uneven_inputs


### PR DESCRIPTION
## Description
<!-- Brief description. Refer to the related issues if existed.
It'll be great if relevant reviewers can be assigned as well.-->
In principle, we should shuffle upon the whole item set to achieve good randomness.

For now, accuracy aligns with https://github.com/dmlc/dgl/blob/master/examples/sampling/graphbolt/rgcn/README.md#accuracies

**use_indexing=True, buffer_size=-1**
Training~Epoch 02: 615it [01:01,  9.92it/s]
Evaluating the model on the training set.
Inference: 154it [00:17,  8.61it/s]
Finish evaluating on training set.
Evaluating the model on the validation set.
Inference: 16it [00:01,  9.47it/s]
Finish evaluating on validation set.
Evaluating the model on the test set.
Inference: 11it [00:01,  8.93it/s]
Finish evaluating on test set.
Run: 01, Epoch: 03, Loss: 1.8374, Train: 65.51%, Valid: 41.73%, Test: 41.36%
Finish evaluating on test set.
Run 01:
Highest Train: 65.51
Highest Valid: 42.13
  Final Train: 59.28
   Final Test: 41.40

**use_indexing=False, BF=-1**
Run: 01, Epoch: 02, Loss: 2.0556, Train: 60.57%, Valid: 42.76%, Test: 42.09%
Finish evaluating on test set.
Training~Epoch 02: 615it [01:51,  5.51it/s]
Evaluating the model on the training set.
Inference: 154it [00:29,  5.19it/s]
Finish evaluating on training set.
Evaluating the model on the validation set.
Inference: 16it [00:03,  5.33it/s]
Finish evaluating on validation set.
Evaluating the model on the test set.
Inference: 11it [00:02,  5.12it/s]
Finish evaluating on test set.
Run: 01, Epoch: 03, Loss: 1.7843, Train: 66.54%, Valid: 42.68%, Test: 41.60%
Finish evaluating on test set.
Run 01:
Highest Train: 66.54
Highest Valid: 42.76
  Final Train: 60.57
   Final Test: 42.09


## Checklist
Please feel free to remove inapplicable items for your PR.
- [ ] The PR title starts with [$CATEGORY] (such as [NN], [Model], [Doc], [Feature]])
- [ ] I've leverage the [tools](https://docs.google.com/document/d/1iHyj7zlmygKSk5gBPsqIqL5ASPzJSPREaNT_QdsiYA4/edit) to beautify the python and c++ code.
- [ ] The PR is complete and small, read the [Google eng practice (CL equals to PR)](https://google.github.io/eng-practices/review/developer/small-cls.html) to understand more about small PR. In DGL, we consider PRs with less than 200 lines of core code change are small (example, test and documentation could be exempted).
- [ ] All changes have test coverage
- [ ] Code is well-documented
- [ ] To the best of my knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change
- [ ] Related issue is referred in this PR
- [ ] If the PR is for a new model/paper, I've updated the example index [here](../examples/README.md).

## Changes
<!-- You could use following template
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)
-->
