### PR TITLE
[Example] modify dgl rgcn example to make it consistent with graphbolt's

### DIFF
--- a/examples/core/rgcn/README.md
+++ b/examples/core/rgcn/README.md
@@ -25,12 +25,10 @@ Below results are roughly collected from an AWS EC2 **g4dn.metal**, 384GB RAM, 9
 
 ### Accuracies
 ```
-Final performance: 
-All runs:
-Highest Train: 83.22 ± 0.00
-Highest Valid: 48.25 ± 0.20
-  Final Train: 68.45 ± 9.81
-   Final Test: 47.51 ± 0.19
+Epoch: 01, Loss: 2.3625, Valid: 48.25%, Test: 47.91%, Time 86.0210
+Epoch: 02, Loss: 1.5852, Valid: 48.56%, Test: 46.98%, Time 84.2728
+Epoch: 03, Loss: 1.1974, Valid: 45.99%, Test: 44.05%, Time 85.7916
+Test accuracy 44.1165
 ```
 
 ## Run on `ogb-lsc-mag240m` dataset

--- a/examples/core/rgcn/hetero_rgcn.py
+++ b/examples/core/rgcn/hetero_rgcn.py
@@ -49,6 +49,7 @@ main
 import argparse
 import itertools
 import sys
+import time
 
 import dgl
 import dgl.nn as dglnn
@@ -714,7 +715,7 @@ if __name__ == "__main__":
     parser.add_argument(
         "--rootdir",
         type=str,
-        default="./",
+        default="./dataset/",
         help="Directory to download the OGB dataset.",
     )
     parser.add_argument(

--- a/examples/core/rgcn/hetero_rgcn.py
+++ b/examples/core/rgcn/hetero_rgcn.py
@@ -462,7 +462,7 @@ def train(
             f"Epoch: {epoch +1 :02d}, "
             f"Loss: {loss:.4f}, "
             f"Valid: {100 * valid_acc:.2f}%, "
-            f"Test: {100 * test_acc:.2f}%"
+            f"Test: {100 * test_acc:.2f}%, "
             f"Time {t1 - t0:.4f}"
         )
 
@@ -536,7 +536,6 @@ def main(args):
     device = (
         "cuda:0" if torch.cuda.is_available() and args.num_gpus > 0 else "cpu"
     )
-
 
     # Prepare the data.
     g, labels, num_classes, split_idx, train_loader, feats = prepare_data(
@@ -628,6 +627,7 @@ def main(args):
         save_test_submission=(args.dataset == "ogb-lsc-mag240m"),
     )
     print(f"Test accuracy {test_acc*100:.4f}")
+
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(description="RGCN")

--- a/examples/core/rgcn/hetero_rgcn.py
+++ b/examples/core/rgcn/hetero_rgcn.py
@@ -400,6 +400,7 @@ def train(
     # the 1st or 2nd epoch. This is why the max epoch is set to 3.
     for epoch in range(3):
         num_train = split_idx["train"][category].shape[0]
+        t0 = time.time()
         model.train()
 
         total_loss = 0
@@ -431,6 +432,7 @@ def train(
 
             total_loss += loss.item() * batch_size
 
+        t1 = time.time()
         loss = total_loss / num_train
 
         # Evaluate the model on the val/test set.
@@ -461,6 +463,7 @@ def train(
             f"Loss: {loss:.4f}, "
             f"Valid: {100 * valid_acc:.2f}%, "
             f"Test: {100 * test_acc:.2f}%"
+            f"Time {t1 - t0:.4f}"
         )
 
 

--- a/examples/core/rgcn/hetero_rgcn.py
+++ b/examples/core/rgcn/hetero_rgcn.py
@@ -46,6 +46,7 @@ main
                   │
                   └───> EntityClassify.evaluate
 """
+
 import argparse
 import itertools
 import sys


### PR DESCRIPTION
## Description
<!-- Brief description. Refer to the related issues if existed.
It'll be great if relevant reviewers can be assigned as well.-->
1. deleted `--runs` and `Logger`.
2. update the log format for benchmark.

stdout:
```shell
Start to transform graph. This may take a while...
Loaded graph: Graph(num_nodes={'author': 1134649, 'field_of_study': 59965, 'institution': 8740, 'paper': 736389},
      num_edges={('author', 'affiliated_with', 'institution'): 1043998, ('author', 'writes', 'paper'): 7145660, ('field_of_study', 'rev_has_topic', 'paper'): 7505078, ('institution', 'rev_affiliated_with', 'author'): 1043998, ('paper', 'cites', 'paper'): 10832542, ('paper', 'has_topic', 'field_of_study'): 7505078, ('paper', 'rev_writes', 'author'): 7145660},
      metagraph=[('author', 'institution', 'affiliated_with'), ('author', 'paper', 'writes'), ('institution', 'author', 'rev_affiliated_with'), ('paper', 'paper', 'cites'), ('paper', 'field_of_study', 'has_topic'), ('paper', 'author', 'rev_writes'), ('field_of_study', 'paper', 'rev_has_topic')])
Number of embedding parameters: 154029312
Number of model parameters: 337460
Start training...
Epoch: 01, Loss: 2.3625, Valid: 48.25%, Test: 47.91%, Time 86.0210
Epoch: 02, Loss: 1.5852, Valid: 48.56%, Test: 46.98%, Time 84.2728
Epoch: 03, Loss: 1.1974, Valid: 45.99%, Test: 44.05%, Time 85.7916
Testing...
Test accuracy 44.1165
```

## Checklist
Please feel free to remove inapplicable items for your PR.
- [ ] The PR title starts with [$CATEGORY] (such as [NN], [Model], [Doc], [Feature]])
- [ ] I've leverage the [tools](https://docs.google.com/document/d/1iHyj7zlmygKSk5gBPsqIqL5ASPzJSPREaNT_QdsiYA4/edit) to beautify the python and c++ code.
- [ ] The PR is complete and small, read the [Google eng practice (CL equals to PR)](https://google.github.io/eng-practices/review/developer/small-cls.html) to understand more about small PR. In DGL, we consider PRs with less than 200 lines of core code change are small (example, test and documentation could be exempted).
- [ ] All changes have test coverage
- [ ] Code is well-documented
- [ ] To the best of my knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change
- [ ] Related issue is referred in this PR
- [ ] If the PR is for a new model/paper, I've updated the example index [here](../examples/README.md).

## Changes
<!-- You could use following template
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)
-->
