### PR TITLE
[GraphBolt] Use `diff()` to calculate the differences for simplicity

### DIFF
--- a/python/dgl/graphbolt/sampled_subgraph.py
+++ b/python/dgl/graphbolt/sampled_subgraph.py
@@ -227,13 +227,9 @@ def _to_reverse_ids(node_pair, original_row_node_ids, original_column_node_ids):
             original_row_node_ids, dim=0, index=indices
         )
     if original_column_node_ids is not None:
-        indptr = original_column_node_ids.repeat_interleave(
-            indptr[1:] - indptr[:-1]
-        )
+        indptr = original_column_node_ids.repeat_interleave(indptr.diff())
     else:
-        indptr = torch.arange(len(indptr) - 1).repeat_interleave(
-            indptr[1:] - indptr[:-1]
-        )
+        indptr = torch.arange(len(indptr) - 1).repeat_interleave(indptr.diff())
     return (indices, indptr)
 
 

--- a/tests/python/pytorch/graphbolt/impl/test_fused_csc_sampling_graph.py
+++ b/tests/python/pytorch/graphbolt/impl/test_fused_csc_sampling_graph.py
@@ -1402,7 +1402,7 @@ def test_from_dglgraph_homogeneous():
         dgl_g, is_homogeneous=True, include_original_edge_id=True
     )
     # Get the COO representation of the FusedCSCSamplingGraph.
-    num_columns = gb_g.csc_indptr[1:] - gb_g.csc_indptr[:-1]
+    num_columns = gb_g.csc_indptr.diff()
     rows = gb_g.indices
     columns = torch.arange(gb_g.total_num_nodes).repeat_interleave(num_columns)
 
@@ -1456,11 +1456,11 @@ def test_from_dglgraph_heterogeneous():
 
     # `reverse_node_id` is used to map the node id in FusedCSCSamplingGraph to the
     # node id in Hetero-DGLGraph.
-    num_ntypes = gb_g.node_type_offset[1:] - gb_g.node_type_offset[:-1]
+    num_ntypes = gb_g.node_type_offset.diff()
     reverse_node_id = torch.cat([torch.arange(num) for num in num_ntypes])
 
     # Get the COO representation of the FusedCSCSamplingGraph.
-    num_columns = gb_g.csc_indptr[1:] - gb_g.csc_indptr[:-1]
+    num_columns = gb_g.csc_indptr.diff()
     rows = reverse_node_id[gb_g.indices]
     columns = reverse_node_id[
         torch.arange(gb_g.total_num_nodes).repeat_interleave(num_columns)

--- a/tests/python/pytorch/graphbolt/impl/test_minibatch.py
+++ b/tests/python/pytorch/graphbolt/impl/test_minibatch.py
@@ -664,10 +664,7 @@ def check_dgl_blocks_hetero(minibatch, blocks):
         edges = block.edges(etype=etype)
         dst_ndoes = torch.arange(
             0, len(sampled_csc[i][relation].indptr) - 1
-        ).repeat_interleave(
-            sampled_csc[i][relation].indptr[1:]
-            - sampled_csc[i][relation].indptr[:-1]
-        )
+        ).repeat_interleave(sampled_csc[i][relation].indptr.diff())
         assert torch.equal(edges[0], sampled_csc[i][relation].indices)
         assert torch.equal(edges[1], dst_ndoes)
         assert torch.equal(
@@ -676,10 +673,7 @@ def check_dgl_blocks_hetero(minibatch, blocks):
     edges = blocks[0].edges(etype=gb.etype_str_to_tuple(reverse_relation))
     dst_ndoes = torch.arange(
         0, len(sampled_csc[0][reverse_relation].indptr) - 1
-    ).repeat_interleave(
-        sampled_csc[0][reverse_relation].indptr[1:]
-        - sampled_csc[0][reverse_relation].indptr[:-1]
-    )
+    ).repeat_interleave(sampled_csc[0][reverse_relation].indptr.diff())
     assert torch.equal(edges[0], sampled_csc[0][reverse_relation].indices)
     assert torch.equal(edges[1], dst_ndoes)
     assert torch.equal(
@@ -704,9 +698,7 @@ def check_dgl_blocks_homo(minibatch, blocks):
     for i, block in enumerate(blocks):
         dst_ndoes = torch.arange(
             0, len(sampled_csc[i].indptr) - 1
-        ).repeat_interleave(
-            sampled_csc[i].indptr[1:] - sampled_csc[i].indptr[:-1]
-        )
+        ).repeat_interleave(sampled_csc[i].indptr.diff())
         assert torch.equal(block.edges()[0], sampled_csc[i].indices), print(
             block.edges()
         )


### PR DESCRIPTION
## Description
<!-- Brief description. Refer to the related issues if existed.
It'll be great if relevant reviewers can be assigned as well.-->
Since PyTorch has provided `diff()` API, we can take advantage of it to avoid prolix code.

### Simple benchmarking

Only tested 1-D Tensor, as it is the only possible shape of `indptr`.

Code:
```python
def test(dtype, size, loops, device):
    t0 = time.time()
    for i in range(loops):
        x = torch.randint(low=0, high=1000000000, size=(size,), dtype=dtype, device=device)
        y = x[1:] - x[:-1]
        assert y.shape[0] == size - 1, y.shape
    t1 = time.time()
    print(f"primitive: {t1-t0}")

def test_diff(dtype, size, loops, device):
    t0 = time.time()
    for i in range(loops):
        x = torch.randint(low=0, high=1000000000, size=(size,), dtype=dtype, device=device)
        y = x.diff()
        assert y.shape[0] == size - 1, y.shape
    t1 = time.time()
    print(f"diff: {t1-t0}")
```
Result:
```
dtype: torch.int32      size: 100       loops: 10000    device: cpu
primitive: 0.12396717071533203
diff: 0.11626815795898438
--------------
dtype: torch.int32      size: 100       loops: 10000    device: cuda
primitive: 1.2713725566864014
diff: 0.21969366073608398
--------------
dtype: torch.int32      size: 1000      loops: 10000    device: cpu
primitive: 0.27355527877807617
diff: 0.2639734745025635
--------------
dtype: torch.int32      size: 1000      loops: 10000    device: cuda
primitive: 0.23079228401184082
diff: 0.2223656177520752
--------------
dtype: torch.int32      size: 10000     loops: 10000    device: cpu
primitive: 1.5612947940826416
diff: 1.5515084266662598
--------------
dtype: torch.int32      size: 10000     loops: 10000    device: cuda
primitive: 0.23158836364746094
diff: 0.2203676700592041
--------------
dtype: torch.int64      size: 100       loops: 10000    device: cpu
primitive: 0.12445807456970215
diff: 0.1165471076965332
--------------
dtype: torch.int64      size: 100       loops: 10000    device: cuda
primitive: 0.22972774505615234
diff: 0.21904563903808594
--------------
dtype: torch.int64      size: 1000      loops: 10000    device: cpu
primitive: 0.24886631965637207
diff: 0.24067211151123047
--------------
dtype: torch.int64      size: 1000      loops: 10000    device: cuda
primitive: 0.23061037063598633
diff: 0.22037243843078613
--------------
dtype: torch.int64      size: 10000     loops: 10000    device: cpu
primitive: 1.4729905128479004
diff: 1.4655311107635498
--------------
dtype: torch.int64      size: 10000     loops: 10000    device: cuda
primitive: 0.23140454292297363
diff: 0.2220616340637207
--------------
```

It is astonishing to notice the acceleration ratio when dtype=torch.int32, size=100, and device=cuda. Hoping someone can explain this.

## Checklist
Please feel free to remove inapplicable items for your PR.
- [x] The PR title starts with [$CATEGORY] (such as [NN], [Model], [Doc], [Feature]])
- [x] I've leverage the [tools](https://docs.google.com/document/d/1iHyj7zlmygKSk5gBPsqIqL5ASPzJSPREaNT_QdsiYA4/edit) to beautify the python and c++ code.
- [x] The PR is complete and small, read the [Google eng practice (CL equals to PR)](https://google.github.io/eng-practices/review/developer/small-cls.html) to understand more about small PR. In DGL, we consider PRs with less than 200 lines of core code change are small (example, test and documentation could be exempted).
- [x] All changes have test coverage
- [ ] Code is well-documented
- [x] To the best of my knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change
- [ ] Related issue is referred in this PR
- [ ] If the PR is for a new model/paper, I've updated the example index [here](../examples/README.md).

## Changes
<!-- You could use following template
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)
-->
