### PR TITLE
[GraphBolt][CUDA] Add a `node_type_offset_list` property.

### DIFF
--- a/python/dgl/graphbolt/impl/fused_csc_sampling_graph.py
+++ b/python/dgl/graphbolt/impl/fused_csc_sampling_graph.py
@@ -197,7 +197,9 @@ class FusedCSCSamplingGraph(SamplingGraph):
 
     @property
     def node_type_offset(self) -> Optional[torch.Tensor]:
-        """Returns the node type offset tensor if present.
+        """Returns the node type offset tensor if present. Do not modify the
+        returned tensor in place so that self.node_type_offset_list stays in
+        sync.
 
         Returns
         -------

--- a/python/dgl/graphbolt/impl/fused_csc_sampling_graph.py
+++ b/python/dgl/graphbolt/impl/fused_csc_sampling_graph.py
@@ -920,6 +920,7 @@ class FusedCSCSamplingGraph(SamplingGraph):
         """Apply passed fn to all members of `FusedCSCSamplingGraph`."""
         self.csc_indptr = recursive_apply(self.csc_indptr, fn)
         self.indices = recursive_apply(self.indices, fn)
+        self.node_type_offset = recursive_apply(self.node_type_offset, fn)
         self.type_per_edge = recursive_apply(self.type_per_edge, fn)
         self.node_attributes = recursive_apply(self.node_attributes, fn)
         self.edge_attributes = recursive_apply(self.edge_attributes, fn)

--- a/python/dgl/graphbolt/impl/fused_csc_sampling_graph.py
+++ b/python/dgl/graphbolt/impl/fused_csc_sampling_graph.py
@@ -1039,7 +1039,7 @@ def fused_csc_sampling_graph(
         torch.ops.graphbolt.fused_csc_sampling_graph(
             csc_indptr,
             indices,
-            node_type_offset,
+            node_type_offset.cpu(),
             type_per_edge,
             node_type_to_id,
             edge_type_to_id,
@@ -1160,7 +1160,7 @@ def from_dglgraph(
         torch.ops.graphbolt.fused_csc_sampling_graph(
             indptr,
             indices,
-            node_type_offset,
+            node_type_offset.cpu(),
             type_per_edge,
             node_type_to_id,
             edge_type_to_id,

--- a/python/dgl/graphbolt/impl/fused_csc_sampling_graph.py
+++ b/python/dgl/graphbolt/impl/fused_csc_sampling_graph.py
@@ -414,9 +414,10 @@ class FusedCSCSamplingGraph(SamplingGraph):
     def _convert_to_homogeneous_nodes(self, nodes, timestamps=None):
         homogeneous_nodes = []
         homogeneous_timestamps = []
+        offset = self.node_type_offset_list
         for ntype, ids in nodes.items():
             ntype_id = self.node_type_to_id[ntype]
-            homogeneous_nodes.append(ids + self.node_type_offset_list[ntype_id])
+            homogeneous_nodes.append(ids + offset[ntype_id])
             if timestamps is not None:
                 homogeneous_timestamps.append(timestamps[ntype])
         if timestamps is not None:
@@ -462,6 +463,7 @@ class FusedCSCSamplingGraph(SamplingGraph):
             original_hetero_edge_ids = {}
             sub_indices = {}
             sub_indptr = {}
+            offset = self.node_type_offset_list
             # 2. For loop each node type.
             for ntype, ntype_id in self.node_type_to_id.items():
                 # Get all nodes of a specific node type in column.
@@ -474,9 +476,7 @@ class FusedCSCSamplingGraph(SamplingGraph):
                     # Get all edge ids of a specific edge type.
                     eids = torch.nonzero(type_per_edge == etype_id).view(-1)
                     src_ntype_id = self.node_type_to_id[src_ntype]
-                    sub_indices[etype] = (
-                        indices[eids] - self.node_type_offset_list[src_ntype_id]
-                    )
+                    sub_indices[etype] = indices[eids] - offset[src_ntype_id]
                     cum_edges = torch.searchsorted(
                         eids, nids_original_indptr, right=False
                     )
@@ -910,9 +910,9 @@ class FusedCSCSamplingGraph(SamplingGraph):
                 negative sampling by edge type."
             _, _, dst_node_type = etype_str_to_tuple(edge_type)
             dst_node_type_id = self.node_type_to_id[dst_node_type]
+            offset = self.node_type_offset_list
             max_node_id = (
-                self.node_type_offset_list[dst_node_type_id + 1]
-                - self.node_type_offset_list[dst_node_type_id]
+                offset[dst_node_type_id + 1] - offset[dst_node_type_id]
             )
         else:
             max_node_id = self.total_num_nodes

--- a/python/dgl/graphbolt/impl/fused_csc_sampling_graph.py
+++ b/python/dgl/graphbolt/impl/fused_csc_sampling_graph.py
@@ -222,7 +222,7 @@ class FusedCSCSamplingGraph(SamplingGraph):
         """Sets the node type offset tensor if present."""
         self._c_csc_graph.set_node_type_offset(node_type_offset)
         self._node_type_offset = None
-        if node_type_offset:
+        if node_type_offset is not None:
             self._node_type_offset = node_type_offset.tolist()
 
     @property

--- a/python/dgl/graphbolt/impl/fused_csc_sampling_graph.py
+++ b/python/dgl/graphbolt/impl/fused_csc_sampling_graph.py
@@ -35,7 +35,7 @@ class FusedCSCSamplingGraph(SamplingGraph):
         super().__init__()
         self._c_csc_graph = c_csc_graph
         self._node_type_offset = self.node_type_offset
-        if self._node_type_offset:
+        if self._node_type_offset is not None:
             self._node_type_offset = self._node_type_offset.tolist()
 
     @property

--- a/python/dgl/graphbolt/impl/fused_csc_sampling_graph.py
+++ b/python/dgl/graphbolt/impl/fused_csc_sampling_graph.py
@@ -34,7 +34,9 @@ class FusedCSCSamplingGraph(SamplingGraph):
     ):
         super().__init__()
         self._c_csc_graph = c_csc_graph
-        self._node_type_offset = self.node_type_offset.tolist()
+        self._node_type_offset = self.node_type_offset
+        if self._node_type_offset:
+            self._node_type_offset = self._node_type_offset.tolist()
 
     @property
     def total_num_nodes(self) -> int:
@@ -219,7 +221,9 @@ class FusedCSCSamplingGraph(SamplingGraph):
     ) -> None:
         """Sets the node type offset tensor if present."""
         self._c_csc_graph.set_node_type_offset(node_type_offset)
-        self._node_type_offset = node_type_offset.tolist()
+        self._node_type_offset = None
+        if node_type_offset:
+            self._node_type_offset = node_type_offset.tolist()
 
     @property
     def type_per_edge(self) -> Optional[torch.Tensor]:


### PR DESCRIPTION
## Description
Adding a list version of `node_type_offset` that is called `node_type_offset_list`. Whenever we access it from the code with CPU indexes one-by-one, we should make sure to use `node_type_offset_list` so that there is no unnecessary CPU GPU transfer and synchronization as lists are guaranteed to be stored on the CPU and are fast to access element-wise. Should fix #6885.