### PR TITLE
[GraphBolt] sample with unknown etype

### DIFF
--- a/tests/python/pytorch/graphbolt/test_subgraph_sampler.py
+++ b/tests/python/pytorch/graphbolt/test_subgraph_sampler.py
@@ -326,19 +326,37 @@ def test_SubgraphSampler_Link_Hetero_With_Negative(sampler_type):
     assert len(list(datapipe)) == 5
 
 
-@pytest.mark.parametrize("labor", [False, True])
-def test_SubgraphSampler_Link_Hetero_Unknown_Etype(labor):
+@pytest.mark.parametrize(
+    "sampler_type",
+    [SamplerType.Normal, SamplerType.Layer, SamplerType.Temporal],
+)
+def test_SubgraphSampler_Link_Hetero_Unknown_Etype(sampler_type):
     graph = get_hetero_graph().to(F.ctx())
+    first_items = torch.LongTensor([[0, 0, 1, 1], [0, 2, 0, 1]]).T
+    first_names = "node_pairs"
+    second_items = torch.LongTensor([[0, 0, 1, 1, 2, 2], [0, 1, 1, 0, 0, 1]]).T
+    second_names = "node_pairs"
+    if sampler_type == SamplerType.Temporal:
+        graph.node_attributes = {
+            "timestamp": torch.arange(graph.csc_indptr.numel() - 1).to(F.ctx())
+        }
+        graph.edge_attributes = {
+            "timestamp": torch.arange(graph.indices.numel()).to(F.ctx())
+        }
+        first_items = (first_items, torch.randint(0, 10, (4,)))
+        first_names = (first_names, "timestamp")
+        second_items = (second_items, torch.randint(0, 10, (6,)))
+        second_names = (second_names, "timestamp")
     # "e11" and "e22" are not valid edge types.
     itemset = gb.ItemSetDict(
         {
             "n1:e11:n2": gb.ItemSet(
-                torch.LongTensor([[0, 0, 1, 1], [0, 2, 0, 1]]).T,
-                names="node_pairs",
+                first_items,
+                names=first_names,
             ),
             "n2:e22:n1": gb.ItemSet(
-                torch.LongTensor([[0, 0, 1, 1, 2, 2], [0, 1, 1, 0, 0, 1]]).T,
-                names="node_pairs",
+                second_items,
+                names=second_names,
             ),
         }
     )
@@ -346,26 +364,43 @@ def test_SubgraphSampler_Link_Hetero_Unknown_Etype(labor):
     datapipe = gb.ItemSampler(itemset, batch_size=2).copy_to(F.ctx())
     num_layer = 2
     fanouts = [torch.LongTensor([2]) for _ in range(num_layer)]
-    Sampler = gb.LayerNeighborSampler if labor else gb.NeighborSampler
-    datapipe = Sampler(datapipe, graph, fanouts)
+    sampler = _get_sampler(sampler_type)
+    datapipe = sampler(datapipe, graph, fanouts)
     datapipe = datapipe.transform(partial(gb.exclude_seed_edges))
-    dataloader = gb.DataLoader(datapipe)
     assert len(list(datapipe)) == 5
 
 
-@pytest.mark.parametrize("labor", [False, True])
-def test_SubgraphSampler_Link_Hetero_With_Negative(labor):
+@pytest.mark.parametrize(
+    "sampler_type",
+    [SamplerType.Normal, SamplerType.Layer, SamplerType.Temporal],
+)
+def test_SubgraphSampler_Link_Hetero_With_Negative_Unknown_Etype(sampler_type):
     graph = get_hetero_graph().to(F.ctx())
+    first_items = torch.LongTensor([[0, 0, 1, 1], [0, 2, 0, 1]]).T
+    first_names = "node_pairs"
+    second_items = torch.LongTensor([[0, 0, 1, 1, 2, 2], [0, 1, 1, 0, 0, 1]]).T
+    second_names = "node_pairs"
+    if sampler_type == SamplerType.Temporal:
+        graph.node_attributes = {
+            "timestamp": torch.arange(graph.csc_indptr.numel() - 1).to(F.ctx())
+        }
+        graph.edge_attributes = {
+            "timestamp": torch.arange(graph.indices.numel()).to(F.ctx())
+        }
+        first_items = (first_items, torch.randint(0, 10, (4,)))
+        first_names = (first_names, "timestamp")
+        second_items = (second_items, torch.randint(0, 10, (6,)))
+        second_names = (second_names, "timestamp")
     # "e11" and "e22" are not valid edge types.
     itemset = gb.ItemSetDict(
         {
             "n1:e11:n2": gb.ItemSet(
-                torch.LongTensor([[0, 0, 1, 1], [0, 2, 0, 1]]).T,
-                names="node_pairs",
+                first_items,
+                names=first_names,
             ),
             "n2:e22:n1": gb.ItemSet(
-                torch.LongTensor([[0, 0, 1, 1, 2, 2], [0, 1, 1, 0, 0, 1]]).T,
-                names="node_pairs",
+                second_items,
+                names=second_names,
             ),
         }
     )
@@ -374,8 +409,8 @@ def test_SubgraphSampler_Link_Hetero_With_Negative(labor):
     num_layer = 2
     fanouts = [torch.LongTensor([2]) for _ in range(num_layer)]
     datapipe = gb.UniformNegativeSampler(datapipe, graph, 1)
-    Sampler = gb.LayerNeighborSampler if labor else gb.NeighborSampler
-    datapipe = Sampler(datapipe, graph, fanouts)
+    sampler = _get_sampler(sampler_type)
+    datapipe = sampler(datapipe, graph, fanouts)
     datapipe = datapipe.transform(partial(gb.exclude_seed_edges))
     assert len(list(datapipe)) == 5
 

--- a/tests/python/pytorch/graphbolt/test_subgraph_sampler.py
+++ b/tests/python/pytorch/graphbolt/test_subgraph_sampler.py
@@ -326,6 +326,36 @@ def test_SubgraphSampler_Link_Hetero_With_Negative(sampler_type):
     assert len(list(datapipe)) == 5
 
 
+@pytest.mark.parametrize("labor", [False])
+def test_SubgraphSampler_Link_Hetero_Unknown_Etype(labor):
+    graph = get_hetero_graph().to(F.ctx())
+    # "e11" and "e22" are not valid edge types.
+    itemset = gb.ItemSetDict(
+        {
+            "n1:e11:n2": gb.ItemSet(
+                torch.LongTensor([[0, 0, 1, 1], [0, 2, 0, 1]]).T,
+                names="node_pairs",
+            ),
+            "n2:e22:n1": gb.ItemSet(
+                torch.LongTensor([[0, 0, 1, 1, 2, 2], [0, 1, 1, 0, 0, 1]]).T,
+                names="node_pairs",
+            ),
+        }
+    )
+
+    datapipe = gb.ItemSampler(itemset, batch_size=2).copy_to(F.ctx())
+    num_layer = 2
+    fanouts = [torch.LongTensor([2]) for _ in range(num_layer)]
+    Sampler = gb.LayerNeighborSampler if labor else gb.NeighborSampler
+    datapipe = Sampler(datapipe, graph, fanouts)
+    datapipe = datapipe.transform(partial(gb.exclude_seed_edges))
+    dataloader = gb.DataLoader(datapipe)
+    for data in dataloader:
+        print(data)
+    assert len(list(datapipe)) == 5
+
+
+
 @unittest.skipIf(
     F._default_context_str != "cpu",
     reason="Sampling with replacement not yet supported on GPU.",


### PR DESCRIPTION
## Description
<!-- Brief description. Refer to the related issues if existed.
It'll be great if relevant reviewers can be assigned as well.-->
```
MiniBatch(seed_nodes=None,
          sampled_subgraphs=[SampledSubgraphImpl(sampled_csc={'n1:e1:n2': CSCFormatBase(indptr=tensor([0, 2, 4]),
                                                                         indices=tensor([1, 0, 0, 1]),
                                                           ), 'n2:e2:n1': CSCFormatBase(indptr=tensor([0, 2, 4]),
                                                                         indices=tensor([0, 1, 0, 2]),
                                                           )},
                                               original_row_node_ids={'n1': tensor([1, 0]), 'n2': tensor([0, 1, 2])},
                                               original_edge_ids=None,
                                               original_column_node_ids={'n1': tensor([1, 0]), 'n2': tensor([0, 1])},
                            ),
                            SampledSubgraphImpl(sampled_csc={'n1:e1:n2': CSCFormatBase(indptr=tensor([0, 2, 4]),
                                                                         indices=tensor([1, 0, 0, 1]),
                                                           ), 'n2:e2:n1': CSCFormatBase(indptr=tensor([0, 2]),
                                                                         indices=tensor([0, 1]),
                                                           )},
                                               original_row_node_ids={'n1': tensor([1, 0]), 'n2': tensor([0, 1])},
                                               original_edge_ids=None,
                                               original_column_node_ids={'n1': tensor([1]), 'n2': tensor([0, 1])},
                            )],
          positive_node_pairs={'n1:e11:n2': (tensor([0, 0]), tensor([0, 1]))},
          node_pairs_with_labels=None,
          node_pairs={'n1:e11:n2': (tensor([1, 1]), tensor([0, 1]))},
          node_features=None,
          negative_srcs=None,
          negative_node_pairs=None,
          negative_dsts=None,
          labels=None,
          input_nodes={'n1': tensor([1, 0]), 'n2': tensor([0, 1, 2])},
          edge_features=None,
          compacted_node_pairs={'n1:e11:n2': (tensor([0, 0]), tensor([0, 1]))},
          compacted_negative_srcs=None,
          compacted_negative_dsts=None,
          blocks=[Block(num_src_nodes={'n1': 2, 'n2': 3},
                       num_dst_nodes={'n1': 2, 'n2': 2},
                       num_edges={('n1', 'e1', 'n2'): 4, ('n2', 'e2', 'n1'): 4},
                       metagraph=[('n1', 'n2', 'e1'), ('n2', 'n1', 'e2')]),
                 Block(num_src_nodes={'n1': 2, 'n2': 2},
                       num_dst_nodes={'n1': 1, 'n2': 2},
                       num_edges={('n1', 'e1', 'n2'): 4, ('n2', 'e2', 'n1'): 2},
                       metagraph=[('n1', 'n2', 'e1'), ('n2', 'n1', 'e2')])],
       )
```
## Checklist
Please feel free to remove inapplicable items for your PR.
- [ ] The PR title starts with [$CATEGORY] (such as [NN], [Model], [Doc], [Feature]])
- [ ] I've leverage the [tools](https://docs.google.com/document/d/1iHyj7zlmygKSk5gBPsqIqL5ASPzJSPREaNT_QdsiYA4/edit) to beautify the python and c++ code.
- [ ] The PR is complete and small, read the [Google eng practice (CL equals to PR)](https://google.github.io/eng-practices/review/developer/small-cls.html) to understand more about small PR. In DGL, we consider PRs with less than 200 lines of core code change are small (example, test and documentation could be exempted).
- [ ] All changes have test coverage
- [ ] Code is well-documented
- [ ] To the best of my knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change
- [ ] Related issue is referred in this PR
- [ ] If the PR is for a new model/paper, I've updated the example index [here](../examples/README.md).

## Changes
<!-- You could use following template
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)
-->
