### PR TITLE
[GraphBolt] Add more detail to CopyTo docstring

### DIFF
--- a/python/dgl/graphbolt/base.py
+++ b/python/dgl/graphbolt/base.py
@@ -115,21 +115,27 @@ class CopyTo(IterDataPipe):
        for data in datapipe:
            yield data.to(device)
 
-    For `gb.MiniBatch`, only a part of attributes will be transferred to
-    accelerate the process:
+    For :class:~dgl.graphbolt.MiniBatch, only a part of attributes will be
+    transferred to accelerate the process by default:
 
-    - When `seed_nodes` is not None and `node_pairs` is None, node related
-    task is inferred. Only `labels`, `sampled_subgraphs`, `node_features`
-    and `edge_features` will be transferred.
+    - When "seed_nodes" is not None and "node_pairs" is None, node related
+    task is inferred. Only "labels", "sampled_subgraphs", "node_features"
+    and "edge_features" will be transferred.
 
-    - When `node_pairs` is not None and `seed_nodes` is None, edge/link
-    related task is inferred. Only `labels`, `compacted_node_pairs`,
-    `compacted_negative_srcs`, `compacted_negative_dsts`, `sampled_subgraphs`,
-    `node_features` and `edge_features` will be transferred.
+    - When "node_pairs" is not None and "seed_nodes" is None, edge/link
+    related task is inferred. Only "labels", "compacted_node_pairs",
+    "compacted_negative_srcs", "compacted_negative_dsts", "sampled_subgraphs",
+    "node_features" and "edge_features" will be transferred.
 
-    - Otherwise, all attributes will be transferred. If you want some other
-    attributes to be transferred as well, please indicate the name in the
-    `extra_attrs`.
+    - Otherwise, all attributes will be transferred.
+
+    - If you want some other attributes to be transferred as well, please
+    indicate the name in the `extra_attrs`. For instance, the following code
+    will copy "seed_nodes" to the GPU as well:
+
+    .. code:: python
+
+       datapipe = datapipe.copy_to(device="cuda", extra_attrs=["seed_nodes"])
 
     Parameters
     ----------
@@ -139,7 +145,9 @@ class CopyTo(IterDataPipe):
         The PyTorch CUDA device.
     extra_attrs: List[string]
         The extra attributes of the data in the DataPipe you want to be carried
-        to the specific device.
+        to the specific device. The attributes indicated in the `extra_attrs`
+        will be transferred regardless of the task inferred. It could also be
+        applied to classes other than :class:~dgl.graphbolt.MiniBatch.
     """
 
     def __init__(self, datapipe, device, extra_attrs=None):

--- a/python/dgl/graphbolt/base.py
+++ b/python/dgl/graphbolt/base.py
@@ -108,12 +108,28 @@ class CopyTo(IterDataPipe):
 
     Functional name: :obj:`copy_to`.
 
-    This is equivalent to
+    When `data` has `to` method implemented, `CopyTo` will be equivalent to
 
     .. code:: python
 
        for data in datapipe:
            yield data.to(device)
+
+    For `gb.MiniBatch`, only a part of attributes will be transferred to
+    accelerate the process:
+
+    - When `seed_nodes` is not None and `node_pairs` is None, node related
+    task is inferred. Only `labels`, `sampled_subgraphs`, `node_features`
+    and `edge_features` will be transferred.
+
+    - When `node_pairs` is not None and `seed_nodes` is None, edge/link
+    related task is inferred. Only `labels`, `compacted_node_pairs`,
+    `compacted_negative_srcs`, `compacted_negative_dsts`, `sampled_subgraphs`,
+    `node_features` and `edge_features` will be transferred.
+
+    - Otherwise, all attributes will be transferred. If you want some other
+    attributes to be transferred as well, please indicate the name in the
+    `extra_attrs`.
 
     Parameters
     ----------
@@ -122,8 +138,8 @@ class CopyTo(IterDataPipe):
     device : torch.device
         The PyTorch CUDA device.
     extra_attrs: List[string]
-        The extra attributes in the MiniBatch you want to be carried to the
-        specific device.
+        The extra attributes of the data in the DataPipe you want to be carried
+        to the specific device.
     """
 
     def __init__(self, datapipe, device, extra_attrs=None):

--- a/python/dgl/graphbolt/base.py
+++ b/python/dgl/graphbolt/base.py
@@ -104,34 +104,36 @@ class CopyTo(IterDataPipe):
     """DataPipe that transfers each element yielded from the previous DataPipe
     to the given device. For MiniBatch, only the related attributes
     (automatically inferred) will be transferred by default. If you want to
-    transfer any other attributes, indicate them in the `extra_attrs`.
+    transfer any other attributes, indicate them in the ``extra_attrs``.
 
     Functional name: :obj:`copy_to`.
 
-    When `data` has `to` method implemented, `CopyTo` will be equivalent to
+    When ``data`` has ``to`` method implemented, ``CopyTo`` will be equivalent
+    to
 
     .. code:: python
 
        for data in datapipe:
            yield data.to(device)
 
-    For :class:~dgl.graphbolt.MiniBatch, only a part of attributes will be
+    For :class:`~dgl.graphbolt.MiniBatch`, only a part of attributes will be
     transferred to accelerate the process by default:
 
-    - When "seed_nodes" is not None and "node_pairs" is None, node related
-    task is inferred. Only "labels", "sampled_subgraphs", "node_features"
-    and "edge_features" will be transferred.
+    - When ``seed_nodes`` is not None and ``node_pairs`` is None, node related
+    task is inferred. Only ``labels``, ``sampled_subgraphs``, ``node_features``
+    and ``edge_features`` will be transferred.
 
-    - When "node_pairs" is not None and "seed_nodes" is None, edge/link
-    related task is inferred. Only "labels", "compacted_node_pairs",
-    "compacted_negative_srcs", "compacted_negative_dsts", "sampled_subgraphs",
-    "node_features" and "edge_features" will be transferred.
+    - When ``node_pairs`` is not None and ``seed_nodes`` is None, edge/link
+    related task is inferred. Only ``labels``, ``compacted_node_pairs``,
+    ``compacted_negative_srcs``, ``compacted_negative_dsts``,
+    ``sampled_subgraphs``, ``node_features`` and ``edge_features`` will be
+    transferred.
 
     - Otherwise, all attributes will be transferred.
 
     - If you want some other attributes to be transferred as well, please
-    indicate the name in the `extra_attrs`. For instance, the following code
-    will copy "seed_nodes" to the GPU as well:
+    specify the name in the ``extra_attrs``. For instance, the following code
+    will copy ``seed_nodes`` to the GPU as well:
 
     .. code:: python
 
@@ -145,9 +147,9 @@ class CopyTo(IterDataPipe):
         The PyTorch CUDA device.
     extra_attrs: List[string]
         The extra attributes of the data in the DataPipe you want to be carried
-        to the specific device. The attributes indicated in the `extra_attrs`
+        to the specific device. The attributes specified in the ``extra_attrs``
         will be transferred regardless of the task inferred. It could also be
-        applied to classes other than :class:~dgl.graphbolt.MiniBatch.
+        applied to classes other than :class:`~dgl.graphbolt.MiniBatch`.
     """
 
     def __init__(self, datapipe, device, extra_attrs=None):


### PR DESCRIPTION
## Description
Clarify the attribute selection in CopyTo.

## Checklist
Please feel free to remove inapplicable items for your PR.
- [ ] The PR title starts with [$CATEGORY] (such as [NN], [Model], [Doc], [Feature]])
- [ ] I've leverage the [tools](https://docs.google.com/document/d/1iHyj7zlmygKSk5gBPsqIqL5ASPzJSPREaNT_QdsiYA4/edit) to beautify the python and c++ code.
- [ ] The PR is complete and small, read the [Google eng practice (CL equals to PR)](https://google.github.io/eng-practices/review/developer/small-cls.html) to understand more about small PR. In DGL, we consider PRs with less than 200 lines of core code change are small (example, test and documentation could be exempted).
- [ ] All changes have test coverage
- [ ] Code is well-documented
- [ ] To the best of my knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change
- [ ] Related issue is referred in this PR
- [ ] If the PR is for a new model/paper, I've updated the example index [here](../examples/README.md).

## Changes
<!-- You could use following template
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)
-->
