### PR TITLE
[Misc] Correct `test_OnDiskDataset_preprocess_homogeneous`

### DIFF
--- a/tests/python/pytorch/graphbolt/impl/test_ondisk_dataset.py
+++ b/tests/python/pytorch/graphbolt/impl/test_ondisk_dataset.py
@@ -1824,14 +1824,11 @@ def test_OnDiskDataset_load_tasks(edge_fmt):
         # the absolute path segment.
         dataset = gb.OnDiskDataset(test_dir).load()
         original_train_set = dataset.tasks[0].train_set._items
-        train_set_data_path = dataset.yaml_data["tasks"][0]["train_set"][0][
-            "data"
-        ][0]["path"]
-        dataset.yaml_data["tasks"][0]["train_set"][0]["data"][0]["path"] = (
-            os.path.join(
-                test_dir,
-                train_set_data_path,
-            )
+        dataset.yaml_data["tasks"][0]["train_set"][0]["data"][0][
+            "path"
+        ] = os.path.join(
+            test_dir,
+            dataset.yaml_data["tasks"][0]["train_set"][0]["data"][0]["path"],
         )
         dataset.load()
         modify_train_set = dataset.tasks[0].train_set._items

--- a/tests/python/pytorch/graphbolt/impl/test_ondisk_dataset.py
+++ b/tests/python/pytorch/graphbolt/impl/test_ondisk_dataset.py
@@ -1168,9 +1168,9 @@ def test_OnDiskDataset_preprocess_homogeneous(edge_fmt):
         yaml_file = os.path.join(test_dir, "metadata.yaml")
         with open(yaml_file, "w") as f:
             f.write(yaml_content)
-        # Test do not generate original_edge_id.
+        # Test generating original_edge_id.
         output_file = gb.ondisk_dataset.preprocess_ondisk_dataset(
-            test_dir, include_original_edge_id=False
+            test_dir, include_original_edge_id=True
         )
         with open(output_file, "rb") as f:
             processed_dataset = yaml.load(f, Loader=yaml.Loader)
@@ -1179,8 +1179,7 @@ def test_OnDiskDataset_preprocess_homogeneous(edge_fmt):
         )
         assert (
             fused_csc_sampling_graph.edge_attributes is not None
-            and gb.ORIGINAL_EDGE_ID
-            not in fused_csc_sampling_graph.edge_attributes
+            and gb.ORIGINAL_EDGE_ID in fused_csc_sampling_graph.edge_attributes
         )
         fused_csc_sampling_graph = None
 
@@ -1825,11 +1824,13 @@ def test_OnDiskDataset_load_tasks(edge_fmt):
         # the absolute path segment.
         dataset = gb.OnDiskDataset(test_dir).load()
         original_train_set = dataset.tasks[0].train_set._items
-        dataset.yaml_data["tasks"][0]["train_set"][0]["data"][0][
-            "path"
-        ] = os.path.join(
-            test_dir,
-            dataset.yaml_data["tasks"][0]["train_set"][0]["data"][0]["path"],
+        dataset.yaml_data["tasks"][0]["train_set"][0]["data"][0]["path"] = (
+            os.path.join(
+                test_dir,
+                dataset.yaml_data["tasks"][0]["train_set"][0]["data"][0][
+                    "path"
+                ],
+            )
         )
         dataset.load()
         modify_train_set = dataset.tasks[0].train_set._items

--- a/tests/python/pytorch/graphbolt/impl/test_ondisk_dataset.py
+++ b/tests/python/pytorch/graphbolt/impl/test_ondisk_dataset.py
@@ -1824,12 +1824,13 @@ def test_OnDiskDataset_load_tasks(edge_fmt):
         # the absolute path segment.
         dataset = gb.OnDiskDataset(test_dir).load()
         original_train_set = dataset.tasks[0].train_set._items
+        train_set_data_path = dataset.yaml_data["tasks"][0]["train_set"][0][
+            "data"
+        ][0]["path"]
         dataset.yaml_data["tasks"][0]["train_set"][0]["data"][0]["path"] = (
             os.path.join(
                 test_dir,
-                dataset.yaml_data["tasks"][0]["train_set"][0]["data"][0][
-                    "path"
-                ],
+                train_set_data_path,
             )
         )
         dataset.load()


### PR DESCRIPTION
## Description
<!-- Brief description. Refer to the related issues if existed.
It'll be great if relevant reviewers can be assigned as well.-->
Currently `dgl/tests/python/pytorch/graphbolt/impl/test_ondisk_dataset.py::test_OnDiskDataset_preprocess_homogeneous` tests `gb.ondisk_dataset.preprocess_ondisk_dataset` with `include_original_edge_id=False` twice, but should be `True` and `False` each once.
This PR intends to correct it.

## Checklist
Please feel free to remove inapplicable items for your PR.
- [ ] The PR title starts with [$CATEGORY] (such as [NN], [Model], [Doc], [Feature]])
- [ ] I've leverage the [tools](https://docs.google.com/document/d/1iHyj7zlmygKSk5gBPsqIqL5ASPzJSPREaNT_QdsiYA4/edit) to beautify the python and c++ code.
- [ ] The PR is complete and small, read the [Google eng practice (CL equals to PR)](https://google.github.io/eng-practices/review/developer/small-cls.html) to understand more about small PR. In DGL, we consider PRs with less than 200 lines of core code change are small (example, test and documentation could be exempted).
- [ ] All changes have test coverage
- [ ] Code is well-documented
- [ ] To the best of my knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change
- [ ] Related issue is referred in this PR
- [ ] If the PR is for a new model/paper, I've updated the example index [here](../examples/README.md).

## Changes
<!-- You could use following template
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)
-->
