### PR TITLE
Using `tensor.untyped_storage()` in `InvertibleCheckpoint` class methods.

### DIFF
--- a/python/dgl/nn/pytorch/conv/grouprevres.py
+++ b/python/dgl/nn/pytorch/conv/grouprevres.py
@@ -32,7 +32,7 @@ class InvertibleCheckpoint(torch.autograd.Function):
             outputs = ctx.fn(*x).detach_()
 
         # clear memory of input node features
-        inputs[1].storage().resize_(0)
+        inputs[1].untyped_storage().resize_(0)
 
         # store for backward pass
         ctx.inputs = [inputs]
@@ -63,10 +63,10 @@ class InvertibleCheckpoint(torch.autograd.Function):
                 *((inputs[0], outputs) + inputs[2:])
             )
             # clear memory of outputs
-            outputs.storage().resize_(0)
+            outputs.untyped_storage().resize_(0)
 
             x = inputs[1]
-            x.storage().resize_(int(np.prod(x.size())))
+            x.untyped_storage().resize_(int(np.prod(x.size())))
             x.set_(inputs_inverted)
 
         # compute gradients


### PR DESCRIPTION

## Description
<!-- Brief description. Refer to the related issues if existed.
It'll be great if relevant reviewers can be assigned as well.-->
 As suggested in the following warning:
```
tests/python/pytorch/nn/test_nn.py::test_group_rev_res[idtype0]
  /usr/local/lib/python3.10/dist-packages/dgl/nn/pytorch/conv/grouprevres.py:35: UserWarning: TypedStorage is deprecated. It will be removed in the future and UntypedStorage will be the only storage class. This should only matter to you if you are using storages directly.  To access UntypedStorage directly, use tensor.untyped_storage() instead of tensor.storage()
    inputs[1].storage().resize_(0)
```
the use `tensor.storage()` has been replaced by  `tensor.untyped_storage()`
## Checklist
Please feel free to remove inapplicable items for your PR.
- [x] I've leverage the [tools](https://docs.google.com/document/d/1iHyj7zlmygKSk5gBPsqIqL5ASPzJSPREaNT_QdsiYA4/edit) to beautify the python and c++ code.
- [x] The PR is complete and small, read the [Google eng practice (CL equals to PR)](https://google.github.io/eng-practices/review/developer/small-cls.html) to understand more about small PR. In DGL, we consider PRs with less than 200 lines of core code change are small (example, test and documentation could be exempted).
- [x] To the best of my knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

## Changes
<!-- You could use following template
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)
-->
