### PR TITLE
[GraphBolt] Automatically force preprocess on-disk dataset.

### DIFF
--- a/python/dgl/graphbolt/impl/ondisk_dataset.py
+++ b/python/dgl/graphbolt/impl/ondisk_dataset.py
@@ -270,9 +270,12 @@ def preprocess_ondisk_dataset(
     print("Finish preprocessing the on-disk dataset.")
 
     # 10. Calculate and save the hash value of the dataset directory.
-    dir_hash = calculate_dir_hash(dataset_dir)
     hash_value_file = "dataset_hash_value.txt"
-    with open(os.path.join(dataset_dir, hash_value_file), "w") as f:
+    hash_value_file_path = os.path.join(dataset_dir, hash_value_file)
+    if os.path.exists(hash_value_file_path):
+        os.remove(hash_value_file_path)
+    dir_hash = calculate_dir_hash(dataset_dir)
+    with open(hash_value_file_path, "w") as f:
         f.write(json.dumps(dir_hash, indent=4))
 
     # 11. Return the absolute path of the preprocessing yaml file.

--- a/python/dgl/graphbolt/impl/ondisk_dataset.py
+++ b/python/dgl/graphbolt/impl/ondisk_dataset.py
@@ -93,7 +93,7 @@ def preprocess_ondisk_dataset(
                 "The on-disk dataset is re-preprocessing, so the existing "
                 + "preprocessed dataset has been removed."
             )
-        elif force_preprocess is False:
+        else:
             print("The dataset is already preprocessed.")
             return os.path.join(dataset_dir, preprocess_metadata_path)
 
@@ -747,7 +747,7 @@ class BuiltinDataset(OnDiskDataset):
             download(url, path=zip_file_path)
             extract_archive(zip_file_path, root, overwrite=True)
             os.remove(zip_file_path)
-        super().__init__(dataset_dir)
+        super().__init__(dataset_dir, force_preprocess=False)
 
 
 def _ondisk_task_str(task: OnDiskTask) -> str:

--- a/python/dgl/graphbolt/impl/ondisk_dataset.py
+++ b/python/dgl/graphbolt/impl/ondisk_dataset.py
@@ -84,7 +84,9 @@ def preprocess_ondisk_dataset(
                 preprocess_config.get("include_original_edge_id", None)
                 == include_original_edge_id
             ):
-                force_preprocess = check_dataset_change(dataset_dir)
+                force_preprocess = check_dataset_change(
+                    dataset_dir, processed_dir_prefix
+                )
             else:
                 force_preprocess = True
         if force_preprocess:
@@ -271,7 +273,9 @@ def preprocess_ondisk_dataset(
 
     # 10. Calculate and save the hash value of the dataset directory.
     hash_value_file = "dataset_hash_value.txt"
-    hash_value_file_path = os.path.join(dataset_dir, hash_value_file)
+    hash_value_file_path = os.path.join(
+        dataset_dir, processed_dir_prefix, hash_value_file
+    )
     if os.path.exists(hash_value_file_path):
         os.remove(hash_value_file_path)
     dir_hash = calculate_dir_hash(dataset_dir)

--- a/python/dgl/graphbolt/internal/utils.py
+++ b/python/dgl/graphbolt/internal/utils.py
@@ -4,7 +4,7 @@ import hashlib
 import json
 import os
 import shutil
-from typing import Dict, List, Union
+from typing import List, Union
 
 import numpy as np
 import pandas as pd

--- a/python/dgl/graphbolt/internal/utils.py
+++ b/python/dgl/graphbolt/internal/utils.py
@@ -183,12 +183,13 @@ def calculate_dir_hash(
 def check_dataset_change(dataset_dir):
     """Check whether dataset has been changed by checking its hash value."""
     hash_value_file = "dataset_hash_value.txt"
+    if not os.path.exists(os.path.join(dataset_dir, hash_value_file)):
+        return True
     with open(os.path.join(dataset_dir, hash_value_file), "r") as f:
         oringinal_hash_value = json.load(f)
     present_hash_value = calculate_dir_hash(dataset_dir, ignore=hash_value_file)
     if oringinal_hash_value == present_hash_value:
         force_preprocess = False
     else:
-        os.remove(os.path.join(dataset_dir, hash_value_file))
         force_preprocess = True
     return force_preprocess

--- a/python/dgl/graphbolt/internal/utils.py
+++ b/python/dgl/graphbolt/internal/utils.py
@@ -180,12 +180,15 @@ def calculate_dir_hash(
     return hashes
 
 
-def check_dataset_change(dataset_dir):
+def check_dataset_change(dataset_dir, processed_dir):
     """Check whether dataset has been changed by checking its hash value."""
     hash_value_file = "dataset_hash_value.txt"
-    if not os.path.exists(os.path.join(dataset_dir, hash_value_file)):
+    hash_value_file_path = os.path.join(
+        dataset_dir, processed_dir, hash_value_file
+    )
+    if not os.path.exists(hash_value_file_path):
         return True
-    with open(os.path.join(dataset_dir, hash_value_file), "r") as f:
+    with open(hash_value_file_path, "r") as f:
         oringinal_hash_value = json.load(f)
     present_hash_value = calculate_dir_hash(dataset_dir, ignore=hash_value_file)
     if oringinal_hash_value == present_hash_value:

--- a/tests/python/pytorch/graphbolt/impl/test_ondisk_dataset.py
+++ b/tests/python/pytorch/graphbolt/impl/test_ondisk_dataset.py
@@ -1650,7 +1650,7 @@ def test_OnDiskDataset_auto_force_preprocess(capsys):
             target_yaml_data = yaml.safe_load(f)
         assert target_yaml_data["tasks"][0]["name"] == "link_prediction"
 
-        # Change yaml_data, automatically force preprocess on-disk dataset.
+        # 1. Change yaml_data.
         with open(yaml_file, "r") as f:
             yaml_data = yaml.safe_load(f)
         yaml_data["tasks"][0]["name"] = "fake_name"
@@ -1673,7 +1673,7 @@ def test_OnDiskDataset_auto_force_preprocess(capsys):
             target_yaml_data = yaml.safe_load(f)
         assert target_yaml_data["tasks"][0]["name"] == "fake_name"
 
-        # Change edge feature, automatically force preprocess on-disk dataset.
+        # 2. Change edge feature.
         edge_feats = np.random.rand(num_edges, num_classes)
         edge_feat_path = os.path.join("data", "edge-feat.npy")
         np.save(os.path.join(test_dir, edge_feat_path), edge_feats)
@@ -1699,7 +1699,7 @@ def test_OnDiskDataset_auto_force_preprocess(capsys):
             target_yaml_data = yaml.safe_load(f)
         assert target_yaml_data["include_original_edge_id"] == False
 
-        # Change include_original_edge_id, automatically force preprocess on-disk dataset.
+        # 3. Change include_original_edge_id.
         preprocessed_metadata_path = (
             gb.ondisk_dataset.preprocess_ondisk_dataset(
                 test_dir, include_original_edge_id=True
@@ -2484,7 +2484,7 @@ def test_OnDiskDataset_auto_force_preprocess(capsys):
         tasks = dataset.tasks
         assert tasks[0].metadata["name"] == "link_prediction"
 
-        # Change yaml_data, automatically force preprocess on-disk dataset.
+        # 1. Change yaml_data.
         with open(yaml_file, "r") as f:
             yaml_data = yaml.safe_load(f)
         yaml_data["tasks"][0]["name"] = "fake_name"
@@ -2504,7 +2504,7 @@ def test_OnDiskDataset_auto_force_preprocess(capsys):
         tasks = dataset.tasks
         assert tasks[0].metadata["name"] == "fake_name"
 
-        # Change edge feature, automatically force preprocess on-disk dataset.
+        # 2. Change edge feature.
         edge_feats = np.random.rand(num_edges, num_classes)
         edge_feat_path = os.path.join("data", "edge-feat.npy")
         np.save(os.path.join(test_dir, edge_feat_path), edge_feats)
@@ -2526,7 +2526,7 @@ def test_OnDiskDataset_auto_force_preprocess(capsys):
         graph = dataset.graph
         assert gb.ORIGINAL_EDGE_ID not in graph.edge_attributes
 
-        # Change include_original_edge_id, automatically force preprocess on-disk dataset.
+        # 3. Change include_original_edge_id.
         dataset = gb.OnDiskDataset(
             test_dir, include_original_edge_id=True
         ).load()

--- a/tests/python/pytorch/graphbolt/utils/test_internal.py
+++ b/tests/python/pytorch/graphbolt/utils/test_internal.py
@@ -254,11 +254,15 @@ def test_check_dataset_change():
             file.write("test contents of directory")
         hash_value = internal.calculate_dir_hash(test_dir, hash_algo="md5")
         hash_value_file = "dataset_hash_value.txt"
-        with open(os.path.join(test_dir, hash_value_file), "w") as file:
+        hash_value_file_paht = os.path.join(
+            test_dir, "preprocessed", hash_value_file
+        )
+        os.makedirs(os.path.join(test_dir, "preprocessed"), exist_ok=True)
+        with open(hash_value_file_paht, "w") as file:
             file.write(json.dumps(hash_value, indent=4))
 
         # Modify the content of a file.
         with open(test_file_path_2, "w") as file:
             file.write("test contents of directory changed")
 
-        assert internal.check_dataset_change(test_dir)
+        assert internal.check_dataset_change(test_dir, "preprocessed")

--- a/tests/python/pytorch/graphbolt/utils/test_internal.py
+++ b/tests/python/pytorch/graphbolt/utils/test_internal.py
@@ -212,7 +212,7 @@ def test_calculate_file_hash():
             test_file_path, hash_algo="md5"
         )
         expected_hash_value = "9473fdd0d880a43c21b7778d34872157"
-        assert expected_hash_value == hash_value, print(hash_value)
+        assert expected_hash_value == hash_value
         with pytest.raises(
             ValueError,
             match=re.escape(

--- a/tests/python/pytorch/graphbolt/utils/test_internal.py
+++ b/tests/python/pytorch/graphbolt/utils/test_internal.py
@@ -1,3 +1,4 @@
+import json
 import os
 import re
 import tempfile
@@ -200,3 +201,64 @@ def test_read_edges_error():
             ),
         ):
             internal.read_edges(test_dir, "numpy", edge_path)
+
+
+def test_calculate_file_hash():
+    with tempfile.TemporaryDirectory() as test_dir:
+        test_file_path = os.path.join(test_dir, "test.txt")
+        with open(test_file_path, "w") as file:
+            file.write("test content")
+        hash_value = internal.calculate_file_hash(
+            test_file_path, hash_algo="md5"
+        )
+        expected_hash_value = "9473fdd0d880a43c21b7778d34872157"
+        assert expected_hash_value == hash_value, print(hash_value)
+        with pytest.raises(
+            ValueError,
+            match=re.escape(
+                "Hash algorithm must be one of: ['md5', 'sha1', 'sha224', "
+                + "'sha256', 'sha384', 'sha512'], but got `fake`."
+            ),
+        ):
+            hash_value = internal.calculate_file_hash(
+                test_file_path, hash_algo="fake"
+            )
+
+
+def test_calculate_dir_hash():
+    with tempfile.TemporaryDirectory() as test_dir:
+        test_file_path_1 = os.path.join(test_dir, "test_1.txt")
+        test_file_path_2 = os.path.join(test_dir, "test_2.txt")
+        with open(test_file_path_1, "w") as file:
+            file.write("test content")
+        with open(test_file_path_2, "w") as file:
+            file.write("test contents of directory")
+        hash_value = internal.calculate_dir_hash(test_dir, hash_algo="md5")
+        expected_hash_value = [
+            "56e708a2bdf92887d4a7f25cbc13c555",
+            "9473fdd0d880a43c21b7778d34872157",
+        ]
+        assert len(hash_value) == 2
+        for val in hash_value.values():
+            assert val in expected_hash_value
+
+
+def test_check_dataset_change():
+    with tempfile.TemporaryDirectory() as test_dir:
+        # Generate directory and record its hash value.
+        test_file_path_1 = os.path.join(test_dir, "test_1.txt")
+        test_file_path_2 = os.path.join(test_dir, "test_2.txt")
+        with open(test_file_path_1, "w") as file:
+            file.write("test content")
+        with open(test_file_path_2, "w") as file:
+            file.write("test contents of directory")
+        hash_value = internal.calculate_dir_hash(test_dir, hash_algo="md5")
+        hash_value_file = "dataset_hash_value.txt"
+        with open(os.path.join(test_dir, hash_value_file), "w") as file:
+            file.write(json.dumps(hash_value, indent=4))
+
+        # Modify the content of a file.
+        with open(test_file_path_2, "w") as file:
+            file.write("test contents of directory changed")
+
+        assert internal.check_dataset_change(test_dir)


### PR DESCRIPTION
## Description
<!-- Brief description. Refer to the related issues if existed.
It'll be great if relevant reviewers can be assigned as well.-->
Automatically force preprocess on-disk dataset in following situations.
- `include_original_eids` has been changed.
- Value in file has been changed, no matter data files or yaml file.


## Checklist
Please feel free to remove inapplicable items for your PR.
- [ ] The PR title starts with [$CATEGORY] (such as [NN], [Model], [Doc], [Feature]])
- [ ] I've leverage the [tools](https://docs.google.com/document/d/1iHyj7zlmygKSk5gBPsqIqL5ASPzJSPREaNT_QdsiYA4/edit) to beautify the python and c++ code.
- [ ] The PR is complete and small, read the [Google eng practice (CL equals to PR)](https://google.github.io/eng-practices/review/developer/small-cls.html) to understand more about small PR. In DGL, we consider PRs with less than 200 lines of core code change are small (example, test and documentation could be exempted).
- [ ] All changes have test coverage
- [ ] Code is well-documented
- [ ] To the best of my knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change
- [ ] Related issue is referred in this PR
- [ ] If the PR is for a new model/paper, I've updated the example index [here](../examples/README.md).

## Changes
<!-- You could use following template
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)
-->
