### PR TITLE
[GraphBolt] Update `__repr__` of `TorchBasedFeature` and `TorchBasedFeatureStore`

### DIFF
--- a/python/dgl/graphbolt/impl/torch_based_feature_store.py
+++ b/python/dgl/graphbolt/impl/torch_based_feature_store.py
@@ -1,4 +1,6 @@
 """Torch-based feature store for GraphBolt."""
+
+import textwrap
 from typing import Dict, List
 
 import numpy as np
@@ -169,7 +171,37 @@ class TorchBasedFeature(Feature):
         self._tensor = self._tensor.pin_memory()
 
     def __repr__(self) -> str:
-        return _torch_based_feature_str(self)
+        ret = (
+            "TorchBasedFeature(\n"
+            "    feature={feature},\n"
+            "    metadata={metadata},\n"
+            ")"
+        )
+
+        feature_str = str(self._tensor)
+        feature_str_lines = feature_str.splitlines()
+        if len(feature_str_lines) > 1:
+            feature_str = (
+                feature_str_lines[0]
+                + "\n"
+                + textwrap.indent(
+                    "\n".join(feature_str_lines[1:]), " " * len("    feature=")
+                )
+            )
+
+        metadata_str = str(self.metadata())
+        metadata_str_lines = metadata_str.splitlines()
+        if len(metadata_str_lines) > 1:
+            metadata_str = (
+                metadata_str_lines[0]
+                + "\n"
+                + textwrap.indent(
+                    "\n".join(metadata_str_lines[1:]),
+                    " " * len("    metadata="),
+                )
+            )
+
+        return ret.format(feature=feature_str, metadata=metadata_str)
 
 
 class TorchBasedFeatureStore(BasicFeatureStore):
@@ -236,40 +268,17 @@ class TorchBasedFeatureStore(BasicFeatureStore):
             feature.pin_memory_()
 
     def __repr__(self) -> str:
-        return _torch_based_feature_store_str(self._features)
+        ret = "TorchBasedFeatureStore(\n" + "    {features}\n" + ")"
 
+        features_str = str(self._features)
+        features_str_lines = features_str.splitlines()
+        if len(features_str_lines) > 1:
+            features_str = (
+                features_str_lines[0]
+                + "\n"
+                + textwrap.indent(
+                    "\n".join(features_str_lines[1:]), " " * len("    ")
+                )
+            )
 
-def _torch_based_feature_str(feature: TorchBasedFeature) -> str:
-    final_str = "TorchBasedFeature("
-    indent_len = len(final_str)
-
-    def _add_indent(_str, indent):
-        lines = _str.split("\n")
-        lines = [lines[0]] + [" " * indent + line for line in lines[1:]]
-        return "\n".join(lines)
-
-    feature_str = "feature=" + _add_indent(
-        str(feature._tensor), indent_len + len("feature=")
-    )
-    final_str += feature_str + ",\n" + " " * indent_len
-    metadata_str = "metadata=" + _add_indent(
-        str(feature.metadata()), indent_len + len("metadata=")
-    )
-    final_str += metadata_str + ",\n)"
-    return final_str
-
-
-def _torch_based_feature_store_str(
-    features: Dict[str, TorchBasedFeature]
-) -> str:
-    final_str = "TorchBasedFeatureStore"
-    indent_len = len(final_str)
-
-    def _add_indent(_str, indent):
-        lines = _str.split("\n")
-        lines = [lines[0]] + [" " * indent + line for line in lines[1:]]
-        return "\n".join(lines)
-
-    features_str = _add_indent(str(features), indent_len)
-    final_str += features_str
-    return final_str
+        return ret.format(features=features_str)

--- a/tests/python/pytorch/graphbolt/impl/test_torch_based_feature_store.py
+++ b/tests/python/pytorch/graphbolt/impl/test_torch_based_feature_store.py
@@ -296,23 +296,27 @@ def test_torch_based_feature_repr(in_memory):
         feature_a = gb.TorchBasedFeature(a, metadata=metadata)
         feature_b = gb.TorchBasedFeature(b)
 
-        expected_str_feature_a = str(
-            """TorchBasedFeature(feature=tensor([[1, 2, 3],
-                                  [4, 5, 6]]),
-                  metadata={'max_value': 3},
-)"""
+        expected_str_feature_a = (
+            "TorchBasedFeature(\n"
+            "    feature=tensor([[1, 2, 3],\n"
+            "                    [4, 5, 6]]),\n"
+            "    metadata={'max_value': 3},\n"
+            ")"
         )
-        expected_str_feature_b = str(
-            """TorchBasedFeature(feature=tensor([[[1, 2],
-                                   [3, 4]],
-                          
-                                  [[4, 5],
-                                   [6, 7]]]),
-                  metadata={},
-)"""
+        expected_str_feature_b = (
+            "TorchBasedFeature(\n"
+            "    feature=tensor([[[1, 2],\n"
+            "                     [3, 4]],\n"
+            "\n"
+            "                    [[4, 5],\n"
+            "                     [6, 7]]]),\n"
+            "    metadata={},\n"
+            ")"
         )
-        assert str(feature_a) == expected_str_feature_a
-        assert str(feature_b) == expected_str_feature_b
+
+        assert repr(feature_a) == expected_str_feature_a, feature_a
+        assert repr(feature_b) == expected_str_feature_b, feature_b
+
         a = b = metadata = None
         feature_a = feature_b = None
         expected_str_feature_a = expected_str_feature_b = None
@@ -345,21 +349,24 @@ def test_torch_based_feature_store_repr(in_memory):
         ]
         feature_store = gb.TorchBasedFeatureStore(feature_data)
 
-        expected_feature_store_str = str(
-            """TorchBasedFeatureStore{(<OnDiskFeatureDataDomain.NODE: 'node'>, 'paper', 'a'): TorchBasedFeature(feature=tensor([[1, 2, 4],
-                                                        [2, 5, 3]]),
-                                        metadata={},
-                      ), (<OnDiskFeatureDataDomain.EDGE: 'edge'>, 'paper:cites:paper', 'b'): TorchBasedFeature(feature=tensor([[[1, 2],
-                                                         [3, 4]],
-                                                
-                                                        [[2, 5],
-                                                         [3, 4]]]),
-                                        metadata={},
-                      )}"""
+        expected_feature_store_str = (
+            "TorchBasedFeatureStore(\n"
+            "    {(<OnDiskFeatureDataDomain.NODE: 'node'>, 'paper', 'a'): TorchBasedFeature(\n"
+            "        feature=tensor([[1, 2, 4],\n"
+            "                        [2, 5, 3]]),\n"
+            "        metadata={},\n"
+            "    ), (<OnDiskFeatureDataDomain.EDGE: 'edge'>, 'paper:cites:paper', 'b'): TorchBasedFeature(\n"
+            "        feature=tensor([[[1, 2],\n"
+            "                         [3, 4]],\n"
+            "\n"
+            "                        [[2, 5],\n"
+            "                         [3, 4]]]),\n"
+            "        metadata={},\n"
+            "    )}\n"
+            ")"
         )
-        assert str(feature_store) == expected_feature_store_str, print(
-            feature_store
-        )
+
+        assert repr(feature_store) == expected_feature_store_str, feature_store
 
         a = b = feature_data = None
         feature_store = expected_feature_store_str = None


### PR DESCRIPTION
## Description
<!-- Brief description. Refer to the related issues if existed.
It'll be great if relevant reviewers can be assigned as well.-->

### TorchBasedFeature
```
TorchBasedFeature(
    feature=tensor([[1, 2, 3],
                    [4, 5, 6]]),
    metadata={'max_value': 3},
)
```

### TorchBasedFeatureStore
```
TorchBasedFeatureStore(
    {(<OnDiskFeatureDataDomain.NODE: 'node'>, 'paper', 'a'): TorchBasedFeature(
        feature=tensor([[1, 2, 4],
                        [2, 5, 3]]),
        metadata={},
    ), (<OnDiskFeatureDataDomain.EDGE: 'edge'>, 'paper:cites:paper', 'b'): TorchBasedFeature(
        feature=tensor([[[1, 2],
                         [3, 4]],

                        [[2, 5],
                         [3, 4]]]),
        metadata={},
    )}
)
```

## Checklist
Please feel free to remove inapplicable items for your PR.
- [ ] The PR title starts with [$CATEGORY] (such as [NN], [Model], [Doc], [Feature]])
- [ ] I've leverage the [tools](https://docs.google.com/document/d/1iHyj7zlmygKSk5gBPsqIqL5ASPzJSPREaNT_QdsiYA4/edit) to beautify the python and c++ code.
- [ ] The PR is complete and small, read the [Google eng practice (CL equals to PR)](https://google.github.io/eng-practices/review/developer/small-cls.html) to understand more about small PR. In DGL, we consider PRs with less than 200 lines of core code change are small (example, test and documentation could be exempted).
- [ ] All changes have test coverage
- [ ] Code is well-documented
- [ ] To the best of my knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change
- [ ] Related issue is referred in this PR
- [ ] If the PR is for a new model/paper, I've updated the example index [here](../examples/README.md).

## Changes
<!-- You could use following template
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)
-->
