### PR TITLE
[GraphBolt][CUDA] Add `.to()` method to Graph and FeatureStore.

### DIFF
--- a/python/dgl/graphbolt/impl/fused_csc_sampling_graph.py
+++ b/python/dgl/graphbolt/impl/fused_csc_sampling_graph.py
@@ -961,7 +961,17 @@ class FusedCSCSamplingGraph(SamplingGraph):
         def _pin(x):
             return x.pin_memory() if hasattr(x, "pin_memory") else x
 
-        self2 = copy.deepcopy(self)
+        # Create a copy of self.
+        self2 = fused_csc_sampling_graph(
+            self.csc_indptr,
+            self.indices,
+            self.node_type_offset,
+            self.type_per_edge,
+            self.node_type_to_id,
+            self.edge_type_to_id,
+            self.node_attributes,
+            self.edge_attributes,
+        )
         return self2._apply_to_members(_pin if device == "pinned" else _to)
 
     def pin_memory_(self):

--- a/python/dgl/graphbolt/impl/fused_csc_sampling_graph.py
+++ b/python/dgl/graphbolt/impl/fused_csc_sampling_graph.py
@@ -1,5 +1,4 @@
 """CSC format sampling graph."""
-import copy
 
 # pylint: disable= invalid-name
 from typing import Dict, Optional, Union

--- a/python/dgl/graphbolt/impl/fused_csc_sampling_graph.py
+++ b/python/dgl/graphbolt/impl/fused_csc_sampling_graph.py
@@ -1,4 +1,6 @@
 """CSC format sampling graph."""
+import copy
+
 # pylint: disable= invalid-name
 from typing import Dict, Optional, Union
 
@@ -956,7 +958,11 @@ class FusedCSCSamplingGraph(SamplingGraph):
         def _to(x):
             return x.to(device) if hasattr(x, "to") else x
 
-        return self._apply_to_members(_to)
+        def _pin(x):
+            return x.pin_memory() if hasattr(x, "pin_memory") else x
+
+        self2 = copy.deepcopy(self)
+        return self2._apply_to_members(_pin if device == "pinned" else _to)
 
     def pin_memory_(self):
         """Copy `FusedCSCSamplingGraph` to the pinned memory in-place."""

--- a/python/dgl/graphbolt/impl/fused_csc_sampling_graph.py
+++ b/python/dgl/graphbolt/impl/fused_csc_sampling_graph.py
@@ -1,5 +1,4 @@
 """CSC format sampling graph."""
-
 # pylint: disable= invalid-name
 from typing import Dict, Optional, Union
 

--- a/python/dgl/graphbolt/impl/torch_based_feature_store.py
+++ b/python/dgl/graphbolt/impl/torch_based_feature_store.py
@@ -1,5 +1,6 @@
 """Torch-based feature store for GraphBolt."""
 
+import copy
 import textwrap
 from typing import Dict, List
 
@@ -170,6 +171,15 @@ class TorchBasedFeature(Feature):
         """In-place operation to copy the feature to pinned memory."""
         self._tensor = self._tensor.pin_memory()
 
+    def to(self, device):  # pylint: disable=invalid-name
+        """Copy `TorchBasedFeature` to the specified device."""
+        self2 = copy.deepcopy(self)
+        if device == "pinned":
+            self2.pin_memory_()
+        else:
+            self2._tensor = self2._tensor.to(device)
+        return self2
+
     def __repr__(self) -> str:
         ret = (
             "TorchBasedFeature(\n"
@@ -266,6 +276,12 @@ class TorchBasedFeatureStore(BasicFeatureStore):
         """In-place operation to copy the feature store to pinned memory."""
         for feature in self._features.values():
             feature.pin_memory_()
+
+    def to(self, device):  # pylint: disable=invalid-name
+        """Copy `TorchBasedFeatureStore` to the specified device."""
+        self2 = copy.deepcopy(self)
+        self2._features = {k: v.to(device) for k, v in self2._features.items()}
+        return self2
 
     def __repr__(self) -> str:
         ret = "TorchBasedFeatureStore(\n" + "    {features}\n" + ")"

--- a/python/dgl/graphbolt/impl/torch_based_feature_store.py
+++ b/python/dgl/graphbolt/impl/torch_based_feature_store.py
@@ -173,6 +173,7 @@ class TorchBasedFeature(Feature):
 
     def to(self, device):  # pylint: disable=invalid-name
         """Copy `TorchBasedFeature` to the specified device."""
+        # copy.copy is a shallow copy so it does not copy tensor memory.
         self2 = copy.copy(self)
         if device == "pinned":
             self2.pin_memory_()
@@ -267,6 +268,7 @@ class TorchBasedFeatureStore(BasicFeatureStore):
 
     def to(self, device):  # pylint: disable=invalid-name
         """Copy `TorchBasedFeatureStore` to the specified device."""
+        # copy.copy is a shallow copy so it does not copy tensor memory.
         self2 = copy.copy(self)
         self2._features = {k: v.to(device) for k, v in self2._features.items()}
         return self2

--- a/python/dgl/graphbolt/impl/torch_based_feature_store.py
+++ b/python/dgl/graphbolt/impl/torch_based_feature_store.py
@@ -173,7 +173,7 @@ class TorchBasedFeature(Feature):
 
     def to(self, device):  # pylint: disable=invalid-name
         """Copy `TorchBasedFeature` to the specified device."""
-        self2 = copy.deepcopy(self)
+        self2 = copy.copy(self)
         if device == "pinned":
             self2.pin_memory_()
         else:
@@ -267,7 +267,7 @@ class TorchBasedFeatureStore(BasicFeatureStore):
 
     def to(self, device):  # pylint: disable=invalid-name
         """Copy `TorchBasedFeatureStore` to the specified device."""
-        self2 = copy.deepcopy(self)
+        self2 = copy.copy(self)
         self2._features = {k: v.to(device) for k, v in self2._features.items()}
         return self2
 

--- a/tests/python/pytorch/graphbolt/impl/test_fused_csc_sampling_graph.py
+++ b/tests/python/pytorch/graphbolt/impl/test_fused_csc_sampling_graph.py
@@ -1553,7 +1553,6 @@ def create_fused_csc_sampling_graph():
 
 
 def is_graph_on_device_type(graph, device_type):
-    # Check.
     assert graph.csc_indptr.device.type == device_type
     assert graph.indices.device.type == device_type
     assert graph.node_type_offset.device.type == device_type
@@ -1564,7 +1563,6 @@ def is_graph_on_device_type(graph, device_type):
 
 
 def is_graph_pinned(graph):
-    # Check.
     assert graph.csc_indptr.is_pinned()
     assert graph.indices.is_pinned()
     assert graph.node_type_offset.is_pinned()

--- a/tests/python/pytorch/graphbolt/impl/test_fused_csc_sampling_graph.py
+++ b/tests/python/pytorch/graphbolt/impl/test_fused_csc_sampling_graph.py
@@ -1552,25 +1552,48 @@ def create_fused_csc_sampling_graph():
     )
 
 
+def is_graph_on_device_type(graph, device_type):
+    # Check.
+    assert graph.csc_indptr.device.type == device_type
+    assert graph.indices.device.type == device_type
+    assert graph.node_type_offset.device.type == device_type
+    assert graph.type_per_edge.device.type == device_type
+    assert graph.csc_indptr.device.type == device_type
+    for key in graph.edge_attributes:
+        assert graph.edge_attributes[key].device.type == device_type
+
+
+def is_graph_pinned(graph):
+    # Check.
+    assert graph.csc_indptr.is_pinned()
+    assert graph.indices.is_pinned()
+    assert graph.node_type_offset.is_pinned()
+    assert graph.type_per_edge.is_pinned()
+    assert graph.csc_indptr.is_pinned()
+    for key in graph.edge_attributes:
+        assert graph.edge_attributes[key].is_pinned()
+
+
 @unittest.skipIf(
     F._default_context_str == "cpu",
     reason="`to` function needs GPU to test.",
 )
-def test_csc_sampling_graph_to_device():
+@pytest.mark.parametrize("device", ["pinned", "cuda"])
+def test_csc_sampling_graph_to_device(device):
     # Construct FusedCSCSamplingGraph.
     graph = create_fused_csc_sampling_graph()
 
     # Copy to device.
-    graph = graph.to("cuda")
+    graph2 = graph.to(device)
 
-    # Check.
-    assert graph.csc_indptr.device.type == "cuda"
-    assert graph.indices.device.type == "cuda"
-    assert graph.node_type_offset.device.type == "cuda"
-    assert graph.type_per_edge.device.type == "cuda"
-    assert graph.csc_indptr.device.type == "cuda"
-    for key in graph.edge_attributes:
-        assert graph.edge_attributes[key].device.type == "cuda"
+    if device == "cuda":
+        is_graph_on_device_type(graph2, "cuda")
+    elif device == "pinned":
+        is_graph_on_device_type(graph2, "cpu")
+        is_graph_pinned(graph2)
+
+    # The original variable should be untouched.
+    is_graph_on_device_type(graph, "cpu")
 
 
 @unittest.skipIf(
@@ -1584,14 +1607,8 @@ def test_csc_sampling_graph_to_pinned_memory():
     # Copy to pinned_memory in-place.
     graph.pin_memory_()
 
-    # Check.
-    assert graph.csc_indptr.is_pinned()
-    assert graph.indices.is_pinned()
-    assert graph.node_type_offset.is_pinned()
-    assert graph.type_per_edge.is_pinned()
-    assert graph.csc_indptr.is_pinned()
-    for key in graph.edge_attributes:
-        assert graph.edge_attributes[key].is_pinned()
+    is_graph_on_device_type(graph, "cpu")
+    is_graph_pinned(graph)
 
 
 @pytest.mark.parametrize("labor", [False, True])

--- a/tests/python/pytorch/graphbolt/impl/test_torch_based_feature_store.py
+++ b/tests/python/pytorch/graphbolt/impl/test_torch_based_feature_store.py
@@ -136,6 +136,59 @@ def test_torch_based_feature(in_memory):
         feature_a = feature_b = None
 
 
+def is_feature_store_pinned(store):
+    for feature in store._features.values():
+        assert feature._tensor.is_pinned()
+
+
+def is_feature_store_on_cuda(store):
+    for feature in store._features.values():
+        assert feature._tensor.is_cuda
+
+
+def is_feature_store_on_cpu(store):
+    for feature in store._features.values():
+        assert not feature._tensor.is_cuda
+
+
+@unittest.skipIf(
+    F._default_context_str == "cpu",
+    reason="Tests for pinned memory are only meaningful on GPU.",
+)
+@pytest.mark.parametrize("device", ["pinned", "cuda"])
+def test_feature_store_to_device(device):
+    with tempfile.TemporaryDirectory() as test_dir:
+        a = torch.tensor([[1, 2, 4], [2, 5, 3]])
+        b = torch.tensor([[[1, 2], [3, 4]], [[2, 5], [3, 4]]])
+        write_tensor_to_disk(test_dir, "a", a, fmt="torch")
+        write_tensor_to_disk(test_dir, "b", b, fmt="numpy")
+        feature_data = [
+            gb.OnDiskFeatureData(
+                domain="node",
+                type="paper",
+                name="a",
+                format="torch",
+                path=os.path.join(test_dir, "a.pt"),
+            ),
+            gb.OnDiskFeatureData(
+                domain="edge",
+                type="paper:cites:paper",
+                name="b",
+                format="numpy",
+                path=os.path.join(test_dir, "b.npy"),
+            ),
+        ]
+        feature_store = gb.TorchBasedFeatureStore(feature_data)
+        feature_store2 = feature_store.to(device)
+        if device == "pinned":
+            is_feature_store_pinned(feature_store2)
+        elif device == "cuda":
+            is_feature_store_on_cuda(feature_store2)
+
+        # The original variable should be untouched.
+        is_feature_store_on_cpu(feature_store)
+
+
 @unittest.skipIf(
     F._default_context_str == "cpu",
     reason="Tests for pinned memory are only meaningful on GPU.",


### PR DESCRIPTION
## Description
<!-- Brief description. Refer to the related issues if existed.
It'll be great if relevant reviewers can be assigned as well.-->

## Checklist
Please feel free to remove inapplicable items for your PR.
- [ ] The PR title starts with [$CATEGORY] (such as [NN], [Model], [Doc], [Feature]])
- [ ] I've leverage the [tools](https://docs.google.com/document/d/1iHyj7zlmygKSk5gBPsqIqL5ASPzJSPREaNT_QdsiYA4/edit) to beautify the python and c++ code.
- [ ] The PR is complete and small, read the [Google eng practice (CL equals to PR)](https://google.github.io/eng-practices/review/developer/small-cls.html) to understand more about small PR. In DGL, we consider PRs with less than 200 lines of core code change are small (example, test and documentation could be exempted).
- [ ] All changes have test coverage
- [ ] Code is well-documented
- [ ] To the best of my knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change
- [ ] Related issue is referred in this PR
- [ ] If the PR is for a new model/paper, I've updated the example index [here](../examples/README.md).

## Changes
<!-- You could use following template
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)
-->
