### PR TITLE
[GraphBolt][CUDA] Inplace pin memory for Graph and TorchFeatureStore

### DIFF
--- a/examples/sampling/graphbolt/node_classification.py
+++ b/examples/sampling/graphbolt/node_classification.py
@@ -384,10 +384,8 @@ def main(args):
     dataset = gb.BuiltinDataset("ogbn-products").load()
 
     # Move the dataset to the selected storage.
-    # graph = dataset.graph.to(args.storage_device)
+    graph = dataset.graph.to(args.storage_device)
     features = dataset.feature.to(args.storage_device)
-    dataset.graph.pin_memory_()
-    graph = dataset.graph
 
     train_set = dataset.tasks[0].train_set
     valid_set = dataset.tasks[0].validation_set

--- a/examples/sampling/graphbolt/node_classification.py
+++ b/examples/sampling/graphbolt/node_classification.py
@@ -384,8 +384,10 @@ def main(args):
     dataset = gb.BuiltinDataset("ogbn-products").load()
 
     # Move the dataset to the selected storage.
-    graph = dataset.graph.to(args.storage_device)
+    # graph = dataset.graph.to(args.storage_device)
     features = dataset.feature.to(args.storage_device)
+    dataset.graph.pin_memory_()
+    graph = dataset.graph
 
     train_set = dataset.tasks[0].train_set
     valid_set = dataset.tasks[0].validation_set

--- a/python/dgl/graphbolt/impl/fused_csc_sampling_graph.py
+++ b/python/dgl/graphbolt/impl/fused_csc_sampling_graph.py
@@ -36,6 +36,9 @@ class FusedCSCSamplingGraph(SamplingGraph):
         self._c_csc_graph = c_csc_graph
 
     def __del__(self):
+        # torch.Tensor.pin_memory() is not an inplace operation. To make it
+        # truly in-place, we need to use cudaHostRegister. Then, we need to use
+        # cudaHostUnregister to unpin the tensor in the destructor.
         # https://github.com/pytorch/pytorch/issues/32167#issuecomment-753551842
         if hasattr(self, "_is_inplace_pinned"):
             cudart = torch.cuda.cudart()
@@ -983,6 +986,9 @@ class FusedCSCSamplingGraph(SamplingGraph):
         """Copy `FusedCSCSamplingGraph` to the pinned memory in-place."""
         self._is_inplace_pinned = set()
 
+        # torch.Tensor.pin_memory() is not an inplace operation. To make it
+        # truly in-place, we need to use cudaHostRegister. Then, we need to use
+        # cudaHostUnregister to unpin the tensor in the destructor.
         # https://github.com/pytorch/pytorch/issues/32167#issuecomment-753551842
         cudart = torch.cuda.cudart()
 

--- a/python/dgl/graphbolt/impl/fused_csc_sampling_graph.py
+++ b/python/dgl/graphbolt/impl/fused_csc_sampling_graph.py
@@ -1006,7 +1006,7 @@ class FusedCSCSamplingGraph(SamplingGraph):
 
             return x
 
-        return self._apply_to_members(_pin)
+        self._apply_to_members(_pin)
 
 
 def fused_csc_sampling_graph(

--- a/python/dgl/graphbolt/impl/fused_csc_sampling_graph.py
+++ b/python/dgl/graphbolt/impl/fused_csc_sampling_graph.py
@@ -998,8 +998,10 @@ class FusedCSCSamplingGraph(SamplingGraph):
                 isinstance(x, torch.Tensor)
                 and not x.is_pinned()
                 and x.device.type == "cpu"
-                and x.is_contiguous()
             ):
+                assert (
+                    x.is_contiguous()
+                ), "Tensor pinning is only supported for contiguous tensors."
                 assert (
                     cudart.cudaHostRegister(
                         x.data_ptr(), x.numel() * x.element_size(), 0

--- a/python/dgl/graphbolt/impl/fused_csc_sampling_graph.py
+++ b/python/dgl/graphbolt/impl/fused_csc_sampling_graph.py
@@ -990,7 +990,8 @@ class FusedCSCSamplingGraph(SamplingGraph):
             if hasattr(x, "pin_memory_"):
                 x.pin_memory_()
             elif (
-                not x.is_pinned()
+                isinstance(x, torch.Tensor)
+                and not x.is_pinned()
                 and x.device.type == "cpu"
                 and x.is_contiguous()
             ):

--- a/python/dgl/graphbolt/impl/fused_csc_sampling_graph.py
+++ b/python/dgl/graphbolt/impl/fused_csc_sampling_graph.py
@@ -990,8 +990,7 @@ class FusedCSCSamplingGraph(SamplingGraph):
             if hasattr(x, "pin_memory_"):
                 x.pin_memory_()
             elif (
-                isinstance(x, torch.Tensor)
-                and not x.is_pinned()
+                not x.is_pinned()
                 and x.device.type == "cpu"
                 and x.is_contiguous()
             ):

--- a/python/dgl/graphbolt/impl/fused_csc_sampling_graph.py
+++ b/python/dgl/graphbolt/impl/fused_csc_sampling_graph.py
@@ -1006,7 +1006,7 @@ class FusedCSCSamplingGraph(SamplingGraph):
 
             return x
 
-        self._apply_to_members(_pin)
+        return self._apply_to_members(_pin)
 
 
 def fused_csc_sampling_graph(

--- a/python/dgl/graphbolt/impl/torch_based_feature_store.py
+++ b/python/dgl/graphbolt/impl/torch_based_feature_store.py
@@ -188,7 +188,6 @@ class TorchBasedFeature(Feature):
             )
 
             self._is_inplace_pinned.add(x)
-        return self
 
     def to(self, device):  # pylint: disable=invalid-name
         """Copy `TorchBasedFeature` to the specified device."""
@@ -284,7 +283,6 @@ class TorchBasedFeatureStore(BasicFeatureStore):
         """In-place operation to copy the feature store to pinned memory."""
         for feature in self._features.values():
             feature.pin_memory_()
-        return self
 
     def to(self, device):  # pylint: disable=invalid-name
         """Copy `TorchBasedFeatureStore` to the specified device."""

--- a/python/dgl/graphbolt/impl/torch_based_feature_store.py
+++ b/python/dgl/graphbolt/impl/torch_based_feature_store.py
@@ -187,6 +187,7 @@ class TorchBasedFeature(Feature):
             )
 
             self._is_inplace_pinned.add(x)
+        return self
 
     def to(self, device):  # pylint: disable=invalid-name
         """Copy `TorchBasedFeature` to the specified device."""
@@ -282,6 +283,7 @@ class TorchBasedFeatureStore(BasicFeatureStore):
         """In-place operation to copy the feature store to pinned memory."""
         for feature in self._features.values():
             feature.pin_memory_()
+        return self
 
     def to(self, device):  # pylint: disable=invalid-name
         """Copy `TorchBasedFeatureStore` to the specified device."""

--- a/python/dgl/graphbolt/impl/torch_based_feature_store.py
+++ b/python/dgl/graphbolt/impl/torch_based_feature_store.py
@@ -195,7 +195,7 @@ class TorchBasedFeature(Feature):
         # copy.copy is a shallow copy so it does not copy tensor memory.
         self2 = copy.copy(self)
         if device == "pinned":
-            self2._tensor = self2.pin_memory()
+            self2._tensor = self2._tensor.pin_memory()
         else:
             self2._tensor = self2._tensor.to(device)
         return self2

--- a/python/dgl/graphbolt/impl/torch_based_feature_store.py
+++ b/python/dgl/graphbolt/impl/torch_based_feature_store.py
@@ -176,6 +176,7 @@ class TorchBasedFeature(Feature):
 
     def pin_memory_(self):
         """In-place operation to copy the feature to pinned memory."""
+        self._is_inplace_pinned = set()
         # https://github.com/pytorch/pytorch/issues/32167#issuecomment-753551842
         x = self._tensor
         if not x.is_pinned() and x.device.type == "cpu" and x.is_contiguous():

--- a/python/dgl/graphbolt/impl/torch_based_feature_store.py
+++ b/python/dgl/graphbolt/impl/torch_based_feature_store.py
@@ -185,7 +185,10 @@ class TorchBasedFeature(Feature):
         # cudaHostUnregister to unpin the tensor in the destructor.
         # https://github.com/pytorch/pytorch/issues/32167#issuecomment-753551842
         x = self._tensor
-        if not x.is_pinned() and x.device.type == "cpu" and x.is_contiguous():
+        if not x.is_pinned() and x.device.type == "cpu":
+            assert (
+                x.is_contiguous()
+            ), "Tensor pinning is only supported for contiguous tensors."
             assert (
                 torch.cuda.cudart().cudaHostRegister(
                     x.data_ptr(), x.numel() * x.element_size(), 0

--- a/tests/python/pytorch/graphbolt/impl/test_fused_csc_sampling_graph.py
+++ b/tests/python/pytorch/graphbolt/impl/test_fused_csc_sampling_graph.py
@@ -1601,9 +1601,13 @@ def test_csc_sampling_graph_to_device(device):
 def test_csc_sampling_graph_to_pinned_memory():
     # Construct FusedCSCSamplingGraph.
     graph = create_fused_csc_sampling_graph()
+    ptr = graph.csc_indptr.data_ptr()
 
     # Copy to pinned_memory in-place.
     graph.pin_memory_()
+
+    # Check if pinning is truly in-place.
+    assert graph.csc_indptr.data_ptr() == ptr
 
     is_graph_on_device_type(graph, "cpu")
     is_graph_pinned(graph)

--- a/tests/python/pytorch/graphbolt/impl/test_torch_based_feature_store.py
+++ b/tests/python/pytorch/graphbolt/impl/test_torch_based_feature_store.py
@@ -221,6 +221,9 @@ def test_torch_based_pinned_feature(dtype, idtype, shape):
     feature = gb.TorchBasedFeature(tensor)
     feature.pin_memory_()
 
+    # Check if pinning is truly in-place.
+    assert feature._tensor.data_ptr() == tensor.data_ptr()
+
     # Test read entire pinned feature, the result should be on cuda.
     assert torch.equal(feature.read(), test_tensor_cuda)
     assert feature.read().is_cuda


### PR DESCRIPTION
## Description
torch pin_memory method creates a copy of the tensor. When we work with large datasets or use multi-GPU training, we don't want copies to be made. So, this PR ensures that `pin_memory_()` method is in-place by using `cudaHostRegister`.

## Checklist
Please feel free to remove inapplicable items for your PR.
- [ ] The PR title starts with [$CATEGORY] (such as [NN], [Model], [Doc], [Feature]])
- [ ] I've leverage the [tools](https://docs.google.com/document/d/1iHyj7zlmygKSk5gBPsqIqL5ASPzJSPREaNT_QdsiYA4/edit) to beautify the python and c++ code.
- [ ] The PR is complete and small, read the [Google eng practice (CL equals to PR)](https://google.github.io/eng-practices/review/developer/small-cls.html) to understand more about small PR. In DGL, we consider PRs with less than 200 lines of core code change are small (example, test and documentation could be exempted).
- [ ] All changes have test coverage
- [ ] Code is well-documented
- [ ] To the best of my knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change
- [ ] Related issue is referred in this PR
- [ ] If the PR is for a new model/paper, I've updated the example index [here](../examples/README.md).

## Changes
<!-- You could use following template
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)
-->
