### PR TITLE
[GraphBolt][CUDA] Hot fix after inplace pinning PR

### DIFF
--- a/python/dgl/graphbolt/impl/fused_csc_sampling_graph.py
+++ b/python/dgl/graphbolt/impl/fused_csc_sampling_graph.py
@@ -34,7 +34,6 @@ class FusedCSCSamplingGraph(SamplingGraph):
     ):
         super().__init__()
         self._c_csc_graph = c_csc_graph
-        self._is_inplace_pinned = set()
 
     def __del__(self):
         # torch.Tensor.pin_memory() is not an inplace operation. To make it
@@ -992,6 +991,8 @@ class FusedCSCSamplingGraph(SamplingGraph):
         # cudaHostUnregister to unpin the tensor in the destructor.
         # https://github.com/pytorch/pytorch/issues/32167#issuecomment-753551842
         cudart = torch.cuda.cudart()
+        if not hasattr(self, "_is_inplace_pinned"):
+            self._is_inplace_pinned = set()
 
         def _pin(x):
             if hasattr(x, "pin_memory_"):

--- a/python/dgl/graphbolt/impl/fused_csc_sampling_graph.py
+++ b/python/dgl/graphbolt/impl/fused_csc_sampling_graph.py
@@ -41,10 +41,12 @@ class FusedCSCSamplingGraph(SamplingGraph):
         # truly in-place, we need to use cudaHostRegister. Then, we need to use
         # cudaHostUnregister to unpin the tensor in the destructor.
         # https://github.com/pytorch/pytorch/issues/32167#issuecomment-753551842
-        for tensor in self._is_inplace_pinned:
-            assert (
-                torch.cuda.cudart().cudaHostUnregister(tensor.data_ptr()) == 0
-            )
+        if hasattr(self, "_is_inplace_pinned"):
+            for tensor in self._is_inplace_pinned:
+                assert (
+                    torch.cuda.cudart().cudaHostUnregister(tensor.data_ptr())
+                    == 0
+                )
 
     @property
     def total_num_nodes(self) -> int:


### PR DESCRIPTION
## Description
I think that FusedCSCSamplingGraph is not always created through its `__init__` method. That is why, we need to add this patch so that it is guaranteed to not crash. Running `node_classification.py` showed a warning at the program termination.

## Checklist
Please feel free to remove inapplicable items for your PR.
- [ ] The PR title starts with [$CATEGORY] (such as [NN], [Model], [Doc], [Feature]])
- [ ] I've leverage the [tools](https://docs.google.com/document/d/1iHyj7zlmygKSk5gBPsqIqL5ASPzJSPREaNT_QdsiYA4/edit) to beautify the python and c++ code.
- [ ] The PR is complete and small, read the [Google eng practice (CL equals to PR)](https://google.github.io/eng-practices/review/developer/small-cls.html) to understand more about small PR. In DGL, we consider PRs with less than 200 lines of core code change are small (example, test and documentation could be exempted).
- [ ] All changes have test coverage
- [ ] Code is well-documented
- [ ] To the best of my knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change
- [ ] Related issue is referred in this PR
- [ ] If the PR is for a new model/paper, I've updated the example index [here](../examples/README.md).

## Changes
<!-- You could use following template
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)
-->
