### PR TITLE
[Misc] Turn off `fused` in DGL rgcn example

### DIFF
--- a/examples/core/rgcn/hetero_rgcn.py
+++ b/examples/core/rgcn/hetero_rgcn.py
@@ -116,7 +116,7 @@ def prepare_data(args, device):
     # Initialize a train sampler that samples neighbors for multi-layer graph
     # convolution. It samples 25 and 10 neighbors for the first and second
     # layers respectively.
-    sampler = dgl.dataloading.MultiLayerNeighborSampler([25, 10])
+    sampler = dgl.dataloading.MultiLayerNeighborSampler([25, 10], fused=False)
     num_workers = args.num_workers
     train_loader = dgl.dataloading.DataLoader(
         g,
@@ -488,7 +488,7 @@ def evaluate(
     else:
         evaluator = MAG240MEvaluator()
 
-    sampler = dgl.dataloading.MultiLayerNeighborSampler([25, 10])
+    sampler = dgl.dataloading.MultiLayerNeighborSampler([25, 10], fused=False)
     dataloader = dgl.dataloading.DataLoader(
         g,
         idx,


### PR DESCRIPTION
## Description
Temporarily turn off `fused` option of the sampler in DGL rgcn example to compare with GB.

## Checklist
Please feel free to remove inapplicable items for your PR.
- [ ] The PR title starts with [$CATEGORY] (such as [NN], [Model], [Doc], [Feature]])
- [ ] I've leverage the [tools](https://docs.google.com/document/d/1iHyj7zlmygKSk5gBPsqIqL5ASPzJSPREaNT_QdsiYA4/edit) to beautify the python and c++ code.
- [ ] The PR is complete and small, read the [Google eng practice (CL equals to PR)](https://google.github.io/eng-practices/review/developer/small-cls.html) to understand more about small PR. In DGL, we consider PRs with less than 200 lines of core code change are small (example, test and documentation could be exempted).
- [ ] All changes have test coverage
- [ ] Code is well-documented
- [ ] To the best of my knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change
- [ ] Related issue is referred in this PR
- [ ] If the PR is for a new model/paper, I've updated the example index [here](../examples/README.md).

## Changes
<!-- You could use following template
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)
-->
