### PR TITLE
[GraphBolt][CUDA] Handle edge case for fetch feature overlap

### DIFF
--- a/python/dgl/graphbolt/feature_fetcher.py
+++ b/python/dgl/graphbolt/feature_fetcher.py
@@ -171,7 +171,6 @@ class FeatureFetcher(MiniBatchTransformer):
         if self.stream is not None:
             current_stream = torch.cuda.current_stream()
             self.stream.wait_stream(current_stream)
-            self.feature_store.record_stream(self.stream)
         with torch.cuda.stream(self.stream):
             data = self._read_data(data, current_stream)
             if self.stream is not None:

--- a/python/dgl/graphbolt/feature_fetcher.py
+++ b/python/dgl/graphbolt/feature_fetcher.py
@@ -134,6 +134,8 @@ class FeatureFetcher(MiniBatchTransformer):
                         edges = original_edge_ids.get(type_name, None)
                         if edges is None:
                             continue
+                        if edges.is_cuda:
+                            edges.record_stream(torch.cuda.current_stream())
                         for feature_name in feature_names:
                             edge_features[i][
                                 (type_name, feature_name)
@@ -143,6 +145,10 @@ class FeatureFetcher(MiniBatchTransformer):
                                 )
                             )
                 else:
+                    if original_edge_ids.is_cuda:
+                        original_edge_ids.record_stream(
+                            torch.cuda.current_stream()
+                        )
                     for feature_name in self.edge_feature_keys:
                         edge_features[i][feature_name] = record_stream(
                             self.feature_store.read(

--- a/python/dgl/graphbolt/feature_fetcher.py
+++ b/python/dgl/graphbolt/feature_fetcher.py
@@ -92,6 +92,8 @@ class FeatureFetcher(MiniBatchTransformer):
                     nodes = input_nodes[type_name]
                     if nodes is None:
                         continue
+                    if nodes.is_cuda:
+                        nodes.record_stream(torch.cuda.current_stream())
                     for feature_name in feature_names:
                         node_features[
                             (type_name, feature_name)
@@ -104,6 +106,8 @@ class FeatureFetcher(MiniBatchTransformer):
                             )
                         )
             else:
+                if input_nodes.is_cuda:
+                    input_nodes.record_stream(torch.cuda.current_stream())
                 for feature_name in self.node_feature_keys:
                     node_features[feature_name] = record_stream(
                         self.feature_store.read(

--- a/python/dgl/graphbolt/feature_fetcher.py
+++ b/python/dgl/graphbolt/feature_fetcher.py
@@ -167,6 +167,7 @@ class FeatureFetcher(MiniBatchTransformer):
         if self.stream is not None:
             current_stream = torch.cuda.current_stream()
             self.stream.wait_stream(current_stream)
+            self.feature_store.record_stream(self.stream)
         with torch.cuda.stream(self.stream):
             data = self._read_data(data, current_stream)
             if self.stream is not None:

--- a/python/dgl/graphbolt/impl/torch_based_feature_store.py
+++ b/python/dgl/graphbolt/impl/torch_based_feature_store.py
@@ -208,6 +208,10 @@ class TorchBasedFeature(Feature):
             self2._tensor = self2._tensor.to(device)
         return self2
 
+    def record_stream(self, stream):
+        """Record the given stream in the Feature."""
+        self._tensor.record_stream(stream)
+
     def __repr__(self) -> str:
         ret = (
             "{Classname}(\n"
@@ -299,6 +303,11 @@ class TorchBasedFeatureStore(BasicFeatureStore):
         self2 = copy.copy(self)
         self2._features = {k: v.to(device) for k, v in self2._features.items()}
         return self2
+
+    def record_stream(self, stream):
+        """Record the given stream in all the stored Features."""
+        for feature in self._features.values():
+            feature.record_stream(stream)
 
     def __repr__(self) -> str:
         ret = "{Classname}(\n" + "    {features}\n" + ")"

--- a/python/dgl/graphbolt/impl/torch_based_feature_store.py
+++ b/python/dgl/graphbolt/impl/torch_based_feature_store.py
@@ -210,7 +210,8 @@ class TorchBasedFeature(Feature):
 
     def record_stream(self, stream):
         """Record the given stream in the Feature."""
-        self._tensor.record_stream(stream)
+        if self._tensor.is_cuda:
+            self._tensor.record_stream(stream)
 
     def __repr__(self) -> str:
         ret = (

--- a/python/dgl/graphbolt/impl/torch_based_feature_store.py
+++ b/python/dgl/graphbolt/impl/torch_based_feature_store.py
@@ -208,11 +208,6 @@ class TorchBasedFeature(Feature):
             self2._tensor = self2._tensor.to(device)
         return self2
 
-    def record_stream(self, stream):
-        """Record the given stream in the Feature."""
-        if self._tensor.is_cuda:
-            self._tensor.record_stream(stream)
-
     def __repr__(self) -> str:
         ret = (
             "{Classname}(\n"
@@ -304,11 +299,6 @@ class TorchBasedFeatureStore(BasicFeatureStore):
         self2 = copy.copy(self)
         self2._features = {k: v.to(device) for k, v in self2._features.items()}
         return self2
-
-    def record_stream(self, stream):
-        """Record the given stream in all the stored Features."""
-        for feature in self._features.values():
-            feature.record_stream(stream)
 
     def __repr__(self) -> str:
         ret = "{Classname}(\n" + "    {features}\n" + ")"


### PR DESCRIPTION
## Description
If the user runs the following:
```python
for data in dataloader:
    pass
```

Moreover, this PR fixes the multi-GPU example crash tracked by #6978. I believe the crash is due to dropping uneven inputs, basically meaning that we discard the last minibatch coming from the dataloader. It is like the case above but only just for the last minibatch.

Because the feature fetch operation doesn't synchronize, the edge id and vertex id tensors might get freed while the fetch operation is still ongoing. If there are forward/backward operations inside the loop, this doesn't happen because we make the current stream wait for the UVA stream via CUDA events.

https://github.com/dmlc/dgl/blob/f7e065f7672198f033bd50da8694a5ec20b4a160/python/dgl/graphbolt/dataloader.py#L85-L94
https://github.com/dmlc/dgl/blob/f7e065f7672198f033bd50da8694a5ec20b4a160/python/dgl/graphbolt/feature_fetcher.py#L165-L172

I reproduced a crash by replacing the training loop of the `graphbolt/node_classification.py` with a simple `pass` expression to simulate edge case above.

```
/localscratch/dgl-1/graphbolt/src/cuda/index_select_impl.cu:84: void graphbolt::ops::IndexSelectMultiKernelAligned(const DType *, signed long, signed long, const IdType *, signed long, DType *, const signed long *) [with DType = float4; IdType = signed long]: block: [6,0,0], thread: [26,12,0] Assertion `in_row >= 0 && in_row < input_len` failed.
/localscratch/dgl-1/graphbolt/src/cuda/index_select_impl.cu:84: void graphbolt::ops::IndexSelectMultiKernelAligned(const DType *, signed long, signed long, const IdType *, signed long, DType *, const signed long *) [with DType = float4; IdType = signed long]: block: [6,0,0], thread: [27,12,0] Assertion `in_row >= 0 && in_row < input_len` failed.
/localscratch/dgl-1/graphbolt/src/cuda/index_select_impl.cu:84: void graphbolt::ops::IndexSelectMultiKernelAligned(const DType *, signed long, signed long, const IdType *, signed long, DType *, const signed long *) [with DType = float4; IdType = signed long]: block: [6,0,0], thread: [28,12,0] Assertion `in_row >= 0 && in_row < input_len` failed.
/localscratch/dgl-1/graphbolt/src/cuda/index_select_impl.cu:84: void graphbolt::ops::IndexSelectMultiKernelAligned(const DType *, signed long, signed long, const IdType *, signed long, DType *, const signed long *) [with DType = float4; IdType = signed long]: block: [6,0,0], thread: [29,12,0] Assertion `in_row >= 0 && in_row < input_len` failed.
/localscratch/dgl-1/graphbolt/src/cuda/index_select_impl.cu:84: void graphbolt::ops::IndexSelectMultiKernelAligned(const DType *, signed long, signed long, const IdType *, signed long, DType *, const signed long *) [with DType = float4; IdType = signed long]: block: [6,0,0], thread: [30,12,0] Assertion `in_row >= 0 && in_row < input_len` failed.
/localscratch/dgl-1/graphbolt/src/cuda/index_select_impl.cu:84: void graphbolt::ops::IndexSelectMultiKernelAligned(const DType *, signed long, signed long, const IdType *, signed long, DType *, const signed long *) [with DType = float4; IdType = signed long]: block: [6,0,0], thread: [31,12,0] Assertion `in_row >= 0 && in_row < input_len` failed.
```

## Checklist
Please feel free to remove inapplicable items for your PR.
- [ ] The PR title starts with [$CATEGORY] (such as [NN], [Model], [Doc], [Feature]])
- [ ] I've leverage the [tools](https://docs.google.com/document/d/1iHyj7zlmygKSk5gBPsqIqL5ASPzJSPREaNT_QdsiYA4/edit) to beautify the python and c++ code.
- [ ] The PR is complete and small, read the [Google eng practice (CL equals to PR)](https://google.github.io/eng-practices/review/developer/small-cls.html) to understand more about small PR. In DGL, we consider PRs with less than 200 lines of core code change are small (example, test and documentation could be exempted).
- [ ] All changes have test coverage
- [ ] Code is well-documented
- [ ] To the best of my knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change
- [ ] Related issue is referred in this PR
- [ ] If the PR is for a new model/paper, I've updated the example index [here](../examples/README.md).

## Changes
<!-- You could use following template
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)
-->
