### PR TITLE
[GraphBolt] fix random generator for shuffle among all workers

### DIFF
--- a/python/dgl/graphbolt/item_sampler.py
+++ b/python/dgl/graphbolt/item_sampler.py
@@ -115,6 +115,8 @@ class ItemShufflerAndBatcher:
     rank : int
         The rank of the current replica. Applies only when `distributed` is
         True.
+    rng : np.random.Generator
+        The random number generator to use for shuffling.
     """
 
     def __init__(
@@ -128,6 +130,7 @@ class ItemShufflerAndBatcher:
         drop_uneven_inputs: Optional[bool] = False,
         world_size: Optional[int] = 1,
         rank: Optional[int] = 0,
+        rng: Optional[np.random.Generator] = None,
     ):
         self._item_set = item_set
         self._shuffle = shuffle
@@ -142,6 +145,7 @@ class ItemShufflerAndBatcher:
         self._drop_uneven_inputs = drop_uneven_inputs
         self._num_replicas = world_size
         self._rank = rank
+        self._rng = rng
 
     def _collate_batch(self, buffer, indices, offsets=None):
         """Collate a batch from the buffer. For internal use only."""
@@ -216,7 +220,7 @@ class ItemShufflerAndBatcher:
             buffer = self._item_set[start_offset + start : start_offset + end]
             indices = torch.arange(end - start)
             if self._shuffle:
-                np.random.shuffle(indices.numpy())
+                self._rng.shuffle(indices.numpy())
             offsets = self._calculate_offsets(buffer)
             for i in range(0, len(indices), self._batch_size):
                 if output_count <= 0:
@@ -494,6 +498,7 @@ class ItemSampler(IterDataPipe):
         self._drop_uneven_inputs = False
         self._world_size = None
         self._rank = None
+        self._rng = np.random.default_rng()
 
     def _organize_items(self, data_pipe) -> None:
         # Shuffle before batch.
@@ -529,6 +534,7 @@ class ItemSampler(IterDataPipe):
 
     def __iter__(self) -> Iterator:
         if self._use_indexing:
+            seed = self._rng.integers(0, np.iinfo(np.int32).max)
             data_pipe = IterableWrapper(
                 ItemShufflerAndBatcher(
                     self._item_set,
@@ -540,6 +546,7 @@ class ItemSampler(IterDataPipe):
                     drop_uneven_inputs=self._drop_uneven_inputs,
                     world_size=self._world_size,
                     rank=self._rank,
+                    rng=np.random.default_rng(seed),
                 )
             )
         else:


### PR DESCRIPTION
## Description
<!-- Brief description. Refer to the related issues if existed.
It'll be great if relevant reviewers can be assigned as well.-->
![image](https://github.com/dmlc/dgl/assets/85214957/e727cc20-72df-4a4c-8a1e-21fda91f7c35)

```
Test accuracy 45.8261

Epoch: 01, Loss: 2.3362, Valid accuracy: 48.41%, Time 68.9185
Training~Epoch 02: 0it [00:00, ?it/s]rank None shuffled indices: tensor([404999, 305221, 507294,  ..., 354460, 285126, 516371])
rank None shuffled indices: tensor([404999, 305221, 507294,  ..., 354460, 285126, 516371])
rank None shuffled indices: tensor([404999, 305221, 507294,  ..., 354460, 285126, 516371])
rank None shuffled indices: tensor([404999, 305221, 507294,  ..., 354460, 285126, 516371])
rank None shuffled indices: tensor([404999, 305221, 507294,  ..., 354460, 285126, 516371])
rank None shuffled indices: tensor([404999, 305221, 507294,  ..., 354460, 285126, 516371])
rank None shuffled indices: tensor([404999, 305221, 507294,  ..., 354460, 285126, 516371])
rank None shuffled indices: tensor([404999, 305221, 507294,  ..., 354460, 285126, 516371])
rank None shuffled indices: tensor([404999, 305221, 507294,  ..., 354460, 285126, 516371])
rank None shuffled indices: tensor([404999, 305221, 507294,  ..., 354460, 285126, 516371])
rank None shuffled indices: tensor([404999, 305221, 507294,  ..., 354460, 285126, 516371])
rank None shuffled indices: tensor([404999, 305221, 507294,  ..., 354460, 285126, 516371])
rank None shuffled indices: tensor([404999, 305221, 507294,  ..., 354460, 285126, 516371])
rank None shuffled indices: tensor([404999, 305221, 507294,  ..., 354460, 285126, 516371])
rank None shuffled indices: tensor([404999, 305221, 507294,  ..., 354460, 285126, 516371])
rank None shuffled indices: tensor([404999, 305221, 507294,  ..., 354460, 285126, 516371])
Training~Epoch 02: 615it [02:25,  4.23it/s]
Evaluating the model on the validation set.
Inference: 16it [00:03,  4.22it/s]
Finish evaluating on validation set.
Epoch: 02, Loss: 1.5541, Valid accuracy: 48.49%, Time 145.3738
Training~Epoch 03: 0it [00:00, ?it/s]rank None shuffled indices: tensor([ 87977, 530066, 189900,  ..., 302993,  15348, 600035])
rank None shuffled indices: tensor([ 87977, 530066, 189900,  ..., 302993,  15348, 600035])
rank None shuffled indices: tensor([ 87977, 530066, 189900,  ..., 302993,  15348, 600035])
rank None shuffled indices: tensor([ 87977, 530066, 189900,  ..., 302993,  15348, 600035])
rank None shuffled indices: tensor([ 87977, 530066, 189900,  ..., 302993,  15348, 600035])
rank None shuffled indices: tensor([ 87977, 530066, 189900,  ..., 302993,  15348, 600035])
rank None shuffled indices: tensor([ 87977, 530066, 189900,  ..., 302993,  15348, 600035])
```
## Checklist
Please feel free to remove inapplicable items for your PR.
- [ ] The PR title starts with [$CATEGORY] (such as [NN], [Model], [Doc], [Feature]])
- [ ] I've leverage the [tools](https://docs.google.com/document/d/1iHyj7zlmygKSk5gBPsqIqL5ASPzJSPREaNT_QdsiYA4/edit) to beautify the python and c++ code.
- [ ] The PR is complete and small, read the [Google eng practice (CL equals to PR)](https://google.github.io/eng-practices/review/developer/small-cls.html) to understand more about small PR. In DGL, we consider PRs with less than 200 lines of core code change are small (example, test and documentation could be exempted).
- [ ] All changes have test coverage
- [ ] Code is well-documented
- [ ] To the best of my knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change
- [ ] Related issue is referred in this PR
- [ ] If the PR is for a new model/paper, I've updated the example index [here](../examples/README.md).

## Changes
<!-- You could use following template
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)
-->
