### PR TITLE
[GraphBolt] Modify multigpu example arguments

### DIFF
--- a/examples/multigpu/graphbolt/node_classification.py
+++ b/examples/multigpu/graphbolt/node_classification.py
@@ -408,8 +408,7 @@ if __name__ == "__main__":
     if not torch.cuda.is_available():
         print(f"Multi-gpu training needs to be in gpu mode.")
         exit(0)
-    args.storage_device, args.device = args.mode.split("-")
-    args.device = torch.device(args.device)
+    args.storage_device, _ = args.mode.split("-")
 
     devices = list(map(int, args.gpu.split(",")))
     world_size = len(devices)

--- a/examples/multigpu/graphbolt/node_classification.py
+++ b/examples/multigpu/graphbolt/node_classification.py
@@ -134,11 +134,11 @@ def create_dataloader(
     # [Output]:
     # A CopyTo object copying data in the datapipe to a specified device.\
     ############################################################################
-    if not args.cpu_sampling:
+    if args.storage_device != "cpu":
         datapipe = datapipe.copy_to(device, extra_attrs=["seed_nodes"])
     datapipe = datapipe.sample_neighbor(graph, args.fanout)
     datapipe = datapipe.fetch_feature(features, node_feature_keys=["feat"])
-    if args.cpu_sampling:
+    if args.storage_device == "cpu":
         datapipe = datapipe.copy_to(device)
 
     dataloader = gb.DataLoader(datapipe, args.num_workers)
@@ -276,7 +276,7 @@ def run(rank, world_size, args, devices, dataset):
     )
 
     # Pin the graph and features to enable GPU access.
-    if not args.cpu_sampling:
+    if args.storage_device == "pinned":
         dataset.graph.pin_memory_()
         dataset.feature.pin_memory_()
 
@@ -388,15 +388,17 @@ def parse_args():
         type=str,
         default="10,10,10",
         help="Fan-out of neighbor sampling. It is IMPORTANT to keep len(fanout)"
-        " identical with the number of layers in your model. Default: 15,10,5",
+        " identical with the number of layers in your model. Default: 10,10,10",
     )
     parser.add_argument(
         "--num-workers", type=int, default=0, help="The number of processes."
     )
     parser.add_argument(
-        "--cpu-sampling",
-        action="store_true",
-        help="Disables GPU sampling and utilizes the CPU for dataloading.",
+        "--mode",
+        default="pinned-cuda",
+        choices=["cpu-cuda", "pinned-cuda"],
+        help="Dataset storage placement and Train device: 'cpu' for CPU and RAM,"
+        " 'pinned' for pinned memory in RAM, 'cuda' for GPU and GPU memory.",
     )
     return parser.parse_args()
 
@@ -406,6 +408,8 @@ if __name__ == "__main__":
     if not torch.cuda.is_available():
         print(f"Multi-gpu training needs to be in gpu mode.")
         exit(0)
+    args.storage_device, args.device = args.mode.split("-")
+    args.device = torch.device(args.device)
 
     devices = list(map(int, args.gpu.split(",")))
     world_size = len(devices)


### PR DESCRIPTION
## Description
Add `mode` arg which can be set to `cpu-cuda` or `pinned-cuda`.

## Checklist
Please feel free to remove inapplicable items for your PR.
- [ ] The PR title starts with [$CATEGORY] (such as [NN], [Model], [Doc], [Feature]])
- [ ] I've leverage the [tools](https://docs.google.com/document/d/1iHyj7zlmygKSk5gBPsqIqL5ASPzJSPREaNT_QdsiYA4/edit) to beautify the python and c++ code.
- [ ] The PR is complete and small, read the [Google eng practice (CL equals to PR)](https://google.github.io/eng-practices/review/developer/small-cls.html) to understand more about small PR. In DGL, we consider PRs with less than 200 lines of core code change are small (example, test and documentation could be exempted).
- [ ] All changes have test coverage
- [ ] Code is well-documented
- [ ] To the best of my knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change
- [ ] Related issue is referred in this PR
- [ ] If the PR is for a new model/paper, I've updated the example index [here](../examples/README.md).

## Changes
<!-- You could use following template
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)
-->
