### PR TITLE
PyG's training  code

### DIFF
--- a/examples/sampling/pyg/pure_PyG.py
+++ b/examples/sampling/pyg/pure_PyG.py
@@ -166,8 +166,6 @@ def test():
     return train_acc, val_acc, test_acc
 
 
-start_time = time.time()
-
 test_accs = []
 for epoch in range(10):
     epoch_start_time = time.time()
@@ -180,6 +178,10 @@ for epoch in range(10):
     loss, acc = train(epoch)
     print(f"Epoch {epoch:02d}, Loss: {loss:.4f}, Approx. Train: {acc:.4f}")
 
+    epoch_end_time = time.time()
+    each_training_time = epoch_end_time - epoch_start_time
+    print(f"This epoch training time: {each_training_time:.2f} seconds")
+
     train_acc, val_acc, test_acc = test()
     print(
         f"Train: {train_acc:.4f}, Val: {val_acc:.4f}, " f"Test: {test_acc:.4f}"
@@ -189,13 +191,8 @@ for epoch in range(10):
         best_val_acc = val_acc
         final_test_acc = test_acc
     test_accs.append(final_test_acc)
-    epoch_end_time = time.time()
-    each_training_time = epoch_end_time - epoch_start_time
-    print(f"This epoch training time: {each_training_time:.2f} seconds")
+
 
 test_acc = torch.tensor(test_accs)
 print("================================")
 print(f"Test accuracy {test_acc.mean():.4f}")
-end_time = time.time()
-total_training_time = end_time - start_time
-print(f"Total training time: {total_training_time:.2f} seconds")

--- a/examples/sampling/pyg/pure_PyG.py
+++ b/examples/sampling/pyg/pure_PyG.py
@@ -195,7 +195,7 @@ for epoch in range(10):
 
 test_acc = torch.tensor(test_accs)
 print("================================")
-print(f"Final Test: {test_acc.mean():.4f} ± {test_acc.std():.4f}")
+print(f"Test accuracy: {test_acc.mean():.4f}")
 end_time = time.time()
 total_training_time = end_time - start_time
 print(f"Total training time: {total_training_time:.2f} seconds")

--- a/examples/sampling/pyg/pure_PyG.py
+++ b/examples/sampling/pyg/pure_PyG.py
@@ -195,7 +195,7 @@ for epoch in range(10):
 
 test_acc = torch.tensor(test_accs)
 print("================================")
-print(f"Test accuracy: {test_acc.mean():.4f}")
+print(f"Test accuracy {test_acc.mean():.4f}")
 end_time = time.time()
 total_training_time = end_time - start_time
 print(f"Total training time: {total_training_time:.2f} seconds")

--- a/examples/sampling/pyg/pure_PyG.py
+++ b/examples/sampling/pyg/pure_PyG.py
@@ -180,7 +180,7 @@ for epoch in range(10):
 
     epoch_end_time = time.time()
     each_training_time = epoch_end_time - epoch_start_time
-    print(f"This epoch training time: {each_training_time:.2f} seconds")
+    print(f"Time {each_training_time:.2f}")
 
     train_acc, val_acc, test_acc = test()
     print(

--- a/examples/sampling/pyg/pure_PyG.py
+++ b/examples/sampling/pyg/pure_PyG.py
@@ -1,0 +1,188 @@
+# Reaches around 0.7870 ± 0.0036 test accuracy.
+
+import os.path as osp
+import argparse
+import torch
+import torch.nn.functional as F
+from ogb.nodeproppred import Evaluator, PygNodePropPredDataset
+from tqdm import tqdm
+
+from torch_geometric.loader import NeighborLoader
+from torch_geometric.nn import SAGEConv
+import time
+
+
+parser = argparse.ArgumentParser(
+        description="Which dataset are you going to use?"
+    )
+
+parser.add_argument(
+        "--dataset",
+        type=str,
+        default="ogbn-arxiv",
+        help='Name of the dataset to use (e.g., "ogbn-products", "ogbn-arxiv")',
+)
+
+
+args = parser.parse_args()
+dataset_name = args.dataset
+device = torch.device('cuda' if torch.cuda.is_available() else 'cpu')
+dataset = PygNodePropPredDataset(name=args.dataset)
+split_idx = dataset.get_idx_split()
+evaluator = Evaluator(name=dataset_name)
+data = dataset[0].to(device, 'x', 'y')
+
+
+train_loader = NeighborLoader(
+    data,
+    input_nodes=split_idx['train'],
+    num_neighbors=[15, 10, 5],
+    batch_size=1024,
+    shuffle=True,
+    num_workers=12,
+    persistent_workers=True,
+)
+subgraph_loader = NeighborLoader(
+    data,
+    input_nodes=None,
+    num_neighbors=[-1],
+    batch_size=4096,
+    num_workers=12,
+    persistent_workers=True,
+)
+
+
+class SAGE(torch.nn.Module):
+    def __init__(self, in_channels, hidden_channels, out_channels, num_layers):
+        super().__init__()
+
+        self.num_layers = num_layers
+
+        self.convs = torch.nn.ModuleList()
+        self.convs.append(SAGEConv(in_channels, hidden_channels))
+        for _ in range(num_layers - 2):
+            self.convs.append(SAGEConv(hidden_channels, hidden_channels))
+        self.convs.append(SAGEConv(hidden_channels, out_channels))
+
+    def reset_parameters(self):
+        for conv in self.convs:
+            conv.reset_parameters()
+
+    def forward(self, x, edge_index):
+        for i, conv in enumerate(self.convs):
+            x = conv(x, edge_index)
+            if i != self.num_layers - 1:
+                x = x.relu()
+                x = F.dropout(x, p=0.5, training=self.training)
+        return x
+
+    def inference(self, x_all):
+        pbar = tqdm(total=x_all.size(0) * self.num_layers)
+        pbar.set_description('Evaluating')
+
+        # Compute representations of nodes layer by layer, using *all*
+        # available edges. This leads to faster computation in contrast to
+        # immediately computing the final representations of each batch.
+        for i in range(self.num_layers):
+            xs = []
+            for batch in subgraph_loader:
+                x = x_all[batch.n_id].to(device)
+                edge_index = batch.edge_index.to(device)
+                x = self.convs[i](x, edge_index)
+                x = x[:batch.batch_size]
+                if i != self.num_layers - 1:
+                    x = x.relu()
+                xs.append(x.cpu())
+
+                pbar.update(batch.batch_size)
+
+            x_all = torch.cat(xs, dim=0)
+
+        pbar.close()
+
+        return x_all
+
+
+model = SAGE(dataset.num_features, 256, dataset.num_classes, num_layers=3)
+model = model.to(device)
+
+
+def train(epoch):
+    model.train()
+
+    pbar = tqdm(total=split_idx['train'].size(0))
+    pbar.set_description(f'Epoch {epoch:02d}')
+
+    total_loss = total_correct = 0
+    for batch in train_loader:
+        optimizer.zero_grad()
+        out = model(batch.x, batch.edge_index.to(device))[:batch.batch_size]
+        y = batch.y[:batch.batch_size].squeeze()
+        loss = F.cross_entropy(out, y)
+        loss.backward()
+        optimizer.step()
+
+        total_loss += float(loss)
+        total_correct += int(out.argmax(dim=-1).eq(y).sum())
+        pbar.update(batch.batch_size)
+
+    pbar.close()
+
+    loss = total_loss / len(train_loader)
+    approx_acc = total_correct / split_idx['train'].size(0)
+
+    return loss, approx_acc
+
+
+@torch.no_grad()
+def test():
+    model.eval()
+
+    out = model.inference(data.x)
+
+    y_true = data.y.cpu()
+    y_pred = out.argmax(dim=-1, keepdim=True)
+
+    train_acc = evaluator.eval({
+        'y_true': y_true[split_idx['train']],
+        'y_pred': y_pred[split_idx['train']],
+    })['acc']
+    val_acc = evaluator.eval({
+        'y_true': y_true[split_idx['valid']],
+        'y_pred': y_pred[split_idx['valid']],
+    })['acc']
+    test_acc = evaluator.eval({
+        'y_true': y_true[split_idx['test']],
+        'y_pred': y_pred[split_idx['test']],
+    })['acc']
+
+    return train_acc, val_acc, test_acc
+
+start_time = time.time()
+
+test_accs = []
+for epoch in range(10):
+  
+
+    model.reset_parameters()
+    optimizer = torch.optim.Adam(model.parameters(), lr=0.003)
+
+    best_val_acc = final_test_acc = 0.0
+  
+    loss, acc = train(epoch)
+    print(f'Epoch {epoch:02d}, Loss: {loss:.4f}, Approx. Train: {acc:.4f}')
+
+    train_acc, val_acc, test_acc = test()
+    print(f'Train: {train_acc:.4f}, Val: {val_acc:.4f}, 'f'Test: {test_acc:.4f}')
+
+    if val_acc > best_val_acc:
+        best_val_acc = val_acc
+        final_test_acc = test_acc
+    test_accs.append(final_test_acc)
+
+test_acc = torch.tensor(test_accs)
+print('================================')
+print(f'Final Test: {test_acc.mean():.4f} ± {test_acc.std():.4f}')
+end_time = time.time()  
+total_training_time = end_time - start_time  
+print(f"Total training time: {total_training_time:.2f} seconds")

--- a/examples/sampling/pyg/pure_PyG.py
+++ b/examples/sampling/pyg/pure_PyG.py
@@ -170,6 +170,7 @@ start_time = time.time()
 
 test_accs = []
 for epoch in range(10):
+    epoch_start_time = time.time()
 
     model.reset_parameters()
     optimizer = torch.optim.Adam(model.parameters(), lr=0.003)
@@ -188,6 +189,9 @@ for epoch in range(10):
         best_val_acc = val_acc
         final_test_acc = test_acc
     test_accs.append(final_test_acc)
+    epoch_end_time = time.time()
+    each_training_time = epoch_end_time - epoch_start_time
+    print(f"This epoch training time: {each_training_time:.2f} seconds")
 
 test_acc = torch.tensor(test_accs)
 print("================================")


### PR DESCRIPTION
## Description

This is the code from pytorch_geometric/tree/master/examples/ogbn_products_sage.py. The result would show the total running time. It is used to compare with our Graphbolt + PyG.


Epoch 00: 100%|█████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 90941/90941 [00:02<00:00, 35622.37it/s]
Epoch 00, Loss: 2.1922, Approx. Train: 0.4017
Time 2.56
Evaluating: 100%|████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 508029/508029 [00:02<00:00, 239648.41it/s]
Train: 0.5455, Val: 0.5342, Test: 0.4670
Epoch 01: 100%|█████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 90941/90941 [00:01<00:00, 51098.59it/s]
Epoch 01, Loss: 2.2190, Approx. Train: 0.3943
Time 1.78
Evaluating: 100%|████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 508029/508029 [00:01<00:00, 271906.52it/s]
Train: 0.5429, Val: 0.5406, Test: 0.4877
Epoch 02: 100%|█████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 90941/90941 [00:01<00:00, 50560.25it/s]
Epoch 02, Loss: 2.1863, Approx. Train: 0.4050
Time 1.80
Evaluating: 100%|████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 508029/508029 [00:01<00:00, 271424.98it/s]
Train: 0.5426, Val: 0.5445, Test: 0.4952
Epoch 03: 100%|█████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 90941/90941 [00:01<00:00, 51083.91it/s]
Epoch 03, Loss: 2.1738, Approx. Train: 0.4073
Time 1.78
Evaluating: 100%|████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 508029/508029 [00:01<00:00, 280394.80it/s]
Train: 0.5487, Val: 0.5454, Test: 0.4832
Epoch 04: 100%|█████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 90941/90941 [00:01<00:00, 51113.39it/s]
Epoch 04, Loss: 2.1897, Approx. Train: 0.4027
Time 1.78
Evaluating: 100%|████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 508029/508029 [00:01<00:00, 284590.95it/s]
Train: 0.5461, Val: 0.5312, Test: 0.4611
Epoch 05: 100%|█████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 90941/90941 [00:01<00:00, 51279.40it/s]
Epoch 05, Loss: 2.1677, Approx. Train: 0.4083
Time 1.77
Evaluating: 100%|████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 508029/508029 [00:01<00:00, 282094.19it/s]
Train: 0.5514, Val: 0.5449, Test: 0.4913
Epoch 06: 100%|█████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 90941/90941 [00:01<00:00, 50564.79it/s]
Epoch 06, Loss: 2.1941, Approx. Train: 0.4019
Time 1.80
Evaluating: 100%|████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 508029/508029 [00:01<00:00, 277938.22it/s]
Train: 0.5452, Val: 0.5359, Test: 0.4810
Epoch 07: 100%|█████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 90941/90941 [00:01<00:00, 50874.68it/s]
Epoch 07, Loss: 2.1877, Approx. Train: 0.4024
Time 1.79
Evaluating: 100%|████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 508029/508029 [00:01<00:00, 282090.49it/s]
Train: 0.5487, Val: 0.5482, Test: 0.4939
Epoch 08: 100%|█████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 90941/90941 [00:01<00:00, 51179.46it/s]
Epoch 08, Loss: 2.1888, Approx. Train: 0.4004
Time 1.78
Evaluating: 100%|████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 508029/508029 [00:01<00:00, 288544.26it/s]
Train: 0.5467, Val: 0.5398, Test: 0.4834
Epoch 09: 100%|█████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 90941/90941 [00:01<00:00, 50541.80it/s]
Epoch 09, Loss: 2.1593, Approx. Train: 0.4096
Time 1.80
Evaluating: 100%|████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 508029/508029 [00:01<00:00, 280487.85it/s]
Train: 0.5537, Val: 0.5457, Test: 0.4876

Test accuracy 0.4832


<!-- Brief description. Refer to the related issues if existed.
It'll be great if relevant reviewers can be assigned as well.-->

## Checklist
Please feel free to remove inapplicable items for your PR.
- [ ] The PR title starts with [$CATEGORY] (such as [NN], [Model], [Doc], [Feature]])
- [ ] I've leverage the [tools](https://docs.google.com/document/d/1iHyj7zlmygKSk5gBPsqIqL5ASPzJSPREaNT_QdsiYA4/edit) to beautify the python and c++ code.
- [ ] The PR is complete and small, read the [Google eng practice (CL equals to PR)](https://google.github.io/eng-practices/review/developer/small-cls.html) to understand more about small PR. In DGL, we consider PRs with less than 200 lines of core code change are small (example, test and documentation could be exempted).
- [ ] All changes have test coverage
- [ ] Code is well-documented
- [ ] To the best of my knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change
- [ ] Related issue is referred in this PR
- [ ] If the PR is for a new model/paper, I've updated the example index [here](../examples/README.md).

## Changes
<!-- You could use following template
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)
-->
