### PR TITLE
[GraphBolt] Refactor `NegativeSampler`.

### DIFF
--- a/python/dgl/graphbolt/impl/fused_csc_sampling_graph.py
+++ b/python/dgl/graphbolt/impl/fused_csc_sampling_graph.py
@@ -935,7 +935,7 @@ class FusedCSCSamplingGraph(SamplingGraph):
             ),
         )
 
-    def sample_negative_seeds_uniform(
+    def sample_negative_edges_uniform_2(
         self, edge_type, node_pairs, negative_ratio
     ):
         """
@@ -943,8 +943,9 @@ class FusedCSCSamplingGraph(SamplingGraph):
         edges according to a uniform distribution. For each edge ``(u, v)``,
         it is supposed to generate `negative_ratio` pairs of negative edges
         ``(u, v')``, where ``v'`` is chosen uniformly from all the nodes in
-        the graph. As ``u`` is exactly same as the corresponding positive edges,
-        it returns None for negative sources.
+        the graph. ``u`` is exactly same as the corresponding positive edges.
+        It returns negative sources constructed from the corresponding positive
+        edges.
 
         Parameters
         ----------
@@ -952,12 +953,12 @@ class FusedCSCSamplingGraph(SamplingGraph):
             The type of edges in the provided node_pairs. Any negative edges
             sampled will also have the same type. If set to None, it will be
             considered as a homogeneous graph.
-        node_pairs : Tuple[Tensor, Tensor]
-            A tuple of two 1D tensors that represent the source and destination
-            of positive edges, with 'positive' indicating that these edges are
-            present in the graph. It's important to note that within the
-            context of a heterogeneous graph, the ids in these tensors signify
-            heterogeneous ids.
+        node_pairs : torch.Tensor
+            A 2D tensors that represent the N pairs of positive edges in
+            source-destination format, with 'positive' indicating that these
+            edges are present in the graph. It's important to note that within
+            the context of a heterogeneous graph, the ids in these tensors
+            signify heterogeneous ids.
         negative_ratio: int
             The ratio of the number of negative samples to positive samples.
 

--- a/python/dgl/graphbolt/impl/fused_csc_sampling_graph.py
+++ b/python/dgl/graphbolt/impl/fused_csc_sampling_graph.py
@@ -978,12 +978,16 @@ class FusedCSCSamplingGraph(SamplingGraph):
             max_node_id = self.total_num_nodes
         pos_src = node_pairs[:, 0]
         num_negative = node_pairs.shape[0] * negative_ratio
-        negative_seeds = torch.cat(
-            (
-                pos_src.repeat_interleave(negative_ratio),
-                torch.randint(0, max_node_id, (num_negative,)),
-            ),
-        ).view(2, num_negative).T
+        negative_seeds = (
+            torch.cat(
+                (
+                    pos_src.repeat_interleave(negative_ratio),
+                    torch.randint(0, max_node_id, (num_negative,)),
+                ),
+            )
+            .view(2, num_negative)
+            .T
+        )
         return negative_seeds
 
     def copy_to_shared_memory(self, shared_memory_name: str):

--- a/python/dgl/graphbolt/impl/fused_csc_sampling_graph.py
+++ b/python/dgl/graphbolt/impl/fused_csc_sampling_graph.py
@@ -935,6 +935,57 @@ class FusedCSCSamplingGraph(SamplingGraph):
             ),
         )
 
+    def sample_negative_seeds_uniform(
+        self, edge_type, node_pairs, negative_ratio
+    ):
+        """
+        Sample negative edges by randomly choosing negative source-destination
+        edges according to a uniform distribution. For each edge ``(u, v)``,
+        it is supposed to generate `negative_ratio` pairs of negative edges
+        ``(u, v')``, where ``v'`` is chosen uniformly from all the nodes in
+        the graph. As ``u`` is exactly same as the corresponding positive edges,
+        it returns None for negative sources.
+
+        Parameters
+        ----------
+        edge_type: str
+            The type of edges in the provided node_pairs. Any negative edges
+            sampled will also have the same type. If set to None, it will be
+            considered as a homogeneous graph.
+        node_pairs : Tuple[Tensor, Tensor]
+            A tuple of two 1D tensors that represent the source and destination
+            of positive edges, with 'positive' indicating that these edges are
+            present in the graph. It's important to note that within the
+            context of a heterogeneous graph, the ids in these tensors signify
+            heterogeneous ids.
+        negative_ratio: int
+            The ratio of the number of negative samples to positive samples.
+
+        Returns
+        -------
+        torch.Tensor
+            A 2D tensors represents the N pairs of negative source-destination
+            node pairs. In the context of a heterogeneous graph, both the
+            input nodes and the selected nodes are represented by heterogeneous
+            IDs, and the formed edges are of the input type `edge_type`. Note
+            that negative refers to false negatives, which means the edge
+            could be present or not present in the graph.
+        """
+        if edge_type:
+            _, _, dst_ntype = etype_str_to_tuple(edge_type)
+            max_node_id = self.num_nodes[dst_ntype]
+        else:
+            max_node_id = self.total_num_nodes
+        pos_src = node_pairs[:, 0]
+        num_negative = node_pairs.shape[0] * negative_ratio
+        negative_seeds = torch.cat(
+            (
+                pos_src.repeat_interleave(negative_ratio),
+                torch.randint(0, max_node_id, (num_negative,)),
+            ),
+        ).view(2, num_negative).T
+        return negative_seeds
+
     def copy_to_shared_memory(self, shared_memory_name: str):
         """Copy the graph to shared memory.
 

--- a/python/dgl/graphbolt/impl/fused_csc_sampling_graph.py
+++ b/python/dgl/graphbolt/impl/fused_csc_sampling_graph.py
@@ -944,8 +944,9 @@ class FusedCSCSamplingGraph(SamplingGraph):
         it is supposed to generate `negative_ratio` pairs of negative edges
         ``(u, v')``, where ``v'`` is chosen uniformly from all the nodes in
         the graph. ``u`` is exactly same as the corresponding positive edges.
-        It returns negative sources constructed from the corresponding positive
-        edges.
+        It returns positive edges concatenated with negative edges. In
+        negative edges, negative sources are constructed from the
+        corresponding positive edges.
 
         Parameters
         ----------
@@ -989,7 +990,8 @@ class FusedCSCSamplingGraph(SamplingGraph):
             .view(2, num_negative)
             .T
         )
-        return negative_seeds
+        seeds = torch.cat((node_pairs, negative_seeds))
+        return seeds
 
     def copy_to_shared_memory(self, shared_memory_name: str):
         """Copy the graph to shared memory.

--- a/python/dgl/graphbolt/impl/fused_csc_sampling_graph.py
+++ b/python/dgl/graphbolt/impl/fused_csc_sampling_graph.py
@@ -966,12 +966,12 @@ class FusedCSCSamplingGraph(SamplingGraph):
         Returns
         -------
         torch.Tensor
-            A 2D tensors represents the N pairs of negative source-destination
-            node pairs. In the context of a heterogeneous graph, both the
-            input nodes and the selected nodes are represented by heterogeneous
-            IDs, and the formed edges are of the input type `edge_type`. Note
-            that negative refers to false negatives, which means the edge
-            could be present or not present in the graph.
+            A 2D tensors represents the N pairs of positive and negative
+            source-destination node pairs. In the context of a heterogeneous
+            graph, both the input nodes and the selected nodes are represented
+            by heterogeneous IDs, and the formed edges are of the input type
+            `edge_type`. Note that negative refers to false negatives, which
+            means the edge could be present or not present in the graph.
         """
         if edge_type:
             _, _, dst_ntype = etype_str_to_tuple(edge_type)

--- a/python/dgl/graphbolt/impl/uniform_negative_sampler.py
+++ b/python/dgl/graphbolt/impl/uniform_negative_sampler.py
@@ -69,15 +69,20 @@ class UniformNegativeSampler(NegativeSampler):
                 self.negative_ratio,
             )
         else:
-            return self.graph.sample_negative_seeds_uniform(
+            assert node_pairs.ndim == 2 and node_pairs.shape[1] == 2, (
+                "Only tensor with shape N*2 is supported for negative"
+                + f" sampling, but got {node_pairs.shape}."
+            )
+            # Construct negative node pairs.
+            neg_node_pairs = self.graph.sample_negative_edges_uniform_2(
                 etype,
                 node_pairs,
                 self.negative_ratio,
             )
-
-    def _construct_indexes(self, node_pairs):
-        num_pos_node_pairs = node_pairs.shape[0]
-        negative_ratio = self.negative_ratio
-        pos_indexes = torch.arange(0, num_pos_node_pairs)
-        neg_indexes = pos_indexes.repeat_interleave(negative_ratio)
-        return torch.cat((pos_indexes, neg_indexes))
+            # Construct indexes for all node pairs.
+            num_pos_node_pairs = node_pairs.shape[0]
+            negative_ratio = self.negative_ratio
+            pos_indexes = torch.arange(0, num_pos_node_pairs)
+            neg_indexes = pos_indexes.repeat_interleave(negative_ratio)
+            indexes = torch.cat((pos_indexes, neg_indexes))
+            return neg_node_pairs, indexes

--- a/python/dgl/graphbolt/impl/uniform_negative_sampler.py
+++ b/python/dgl/graphbolt/impl/uniform_negative_sampler.py
@@ -68,4 +68,8 @@ class UniformNegativeSampler(NegativeSampler):
                 self.negative_ratio,
             )
         else:
-            raise NotImplementedError("Not implemented yet.")
+            return self.graph.sample_negative_seeds_uniform(
+                etype,
+                node_pairs,
+                self.negative_ratio,
+            )

--- a/python/dgl/graphbolt/impl/uniform_negative_sampler.py
+++ b/python/dgl/graphbolt/impl/uniform_negative_sampler.py
@@ -1,5 +1,6 @@
 """Uniform negative sampler for GraphBolt."""
 
+import torch
 from torch.utils.data import functional_datapipe
 
 from ..negative_sampler import NegativeSampler
@@ -73,3 +74,10 @@ class UniformNegativeSampler(NegativeSampler):
                 node_pairs,
                 self.negative_ratio,
             )
+
+    def _construct_indexes(self, node_pairs):
+        num_pos_node_pairs = node_pairs.shape[0]
+        negative_ratio = self.negative_ratio
+        pos_indexes = torch.arange(0, num_pos_node_pairs)
+        neg_indexes = pos_indexes.repeat_interleave(negative_ratio)
+        return torch.cat((pos_indexes, neg_indexes))

--- a/python/dgl/graphbolt/negative_sampler.py
+++ b/python/dgl/graphbolt/negative_sampler.py
@@ -2,8 +2,6 @@
 
 from _collections_abc import Mapping
 
-import torch
-
 from torch.utils.data import functional_datapipe
 
 from .minibatch_transformer import MiniBatchTransformer

--- a/python/dgl/graphbolt/negative_sampler.py
+++ b/python/dgl/graphbolt/negative_sampler.py
@@ -84,10 +84,14 @@ class NegativeSampler(MiniBatchTransformer):
                         ),
                         etype,
                     )
+                    minibatch.indexes[etype] = self._construct_indexes(
+                        pos_pairs
+                    )
             else:
                 self._collate(
                     minibatch, self._sample_with_etype(seeds, use_seeds=True)
                 )
+                minibatch.indexes = self._construct_indexes(seeds)
         return minibatch
 
     def _sample_with_etype(self, node_pairs, etype=None, use_seeds=False):
@@ -107,6 +111,22 @@ class NegativeSampler(MiniBatchTransformer):
         -------
         Tuple[Tensor, Tensor]
             A collection of negative node pairs.
+        """
+        raise NotImplementedError
+
+    def _construct_indexes(self, node_pairs):
+        """Generate indexes for postive and negative edges. Positve edge and
+        the negative edges sampled from it will have same query.
+
+        Parameters
+        ----------
+        node_pairs: torch.Tensor
+            A N*2 tensor representing N positive edges.
+
+        Returns
+        -------
+        torch.Tensor
+            The indexes indicate to which query the edge belongs.
         """
         raise NotImplementedError
 

--- a/python/dgl/graphbolt/negative_sampler.py
+++ b/python/dgl/graphbolt/negative_sampler.py
@@ -72,11 +72,17 @@ class NegativeSampler(MiniBatchTransformer):
                 self._collate(minibatch, self._sample_with_etype(node_pairs))
         else:
             seeds = minibatch.seeds
-            assert (
-                len(seeds.shape) == 2 and seeds.shape[1] == 2
-            ), "Only 2-D tensor representing node paris is supported for negative sampling."
+
             if isinstance(seeds, Mapping):
+                if minibatch.indexes is None:
+                    minibatch.indexes = {}
                 for etype, pos_pairs in seeds.items():
+                    assert (
+                        len(pos_pairs.shape) == 2 and pos_pairs.shape[1] == 2
+                    ), (
+                        "Only tensor with shape N*2 is supported for negative"
+                        + f" sampling, but got {pos_pairs.shape}."
+                    )
                     self._collate(
                         minibatch,
                         self._sample_with_etype(
@@ -88,6 +94,10 @@ class NegativeSampler(MiniBatchTransformer):
                         pos_pairs
                     )
             else:
+                assert len(seeds.shape) == 2 and seeds.shape[1] == 2, (
+                    "Only tensor with shape N*2 is supported for negative"
+                    + f" sampling, but got {seeds.shape}."
+                )
                 self._collate(
                     minibatch, self._sample_with_etype(seeds, use_seeds=True)
                 )
@@ -158,14 +168,16 @@ class NegativeSampler(MiniBatchTransformer):
                 minibatch.negative_srcs = neg_src
                 minibatch.negative_dsts = neg_dst
         else:
-            neg_labels = torch.zeros(neg_pairs.shape[0])
+            neg_labels = torch.zeros(neg_pairs.shape[0]).bool()
             if etype is None:
                 if minibatch.labels is None:
                     minibatch.labels = torch.ones(minibatch.seeds.shape[0])
                 minibatch.labels = torch.cat((minibatch.labels, neg_labels))
                 minibatch.seeds = torch.cat((minibatch.seeds, neg_pairs))
             else:
-                if minibatch.labels[etype] is None:
+                if minibatch.labels is None:
+                    minibatch.labels = {}
+                if minibatch.labels.get(etype, None) is None:
                     minibatch.labels[etype] = torch.ones(
                         minibatch.seeds[etype].shape[0]
                     )

--- a/python/dgl/graphbolt/negative_sampler.py
+++ b/python/dgl/graphbolt/negative_sampler.py
@@ -108,8 +108,14 @@ class NegativeSampler(MiniBatchTransformer):
 
         Returns
         -------
-        Tuple[Tensor, Tensor]
+        Tuple[Tensor, Tensor] or Tensor
             A collection of negative node pairs.
+        Tensor or None
+            Corresponding labels. If label is True, corresponding edge is
+            positive. If label is False, corresponding edge is negative.
+        Tensor or None
+            Corresponding indexes, indicates to which query an edge belongs.
+
         """
         raise NotImplementedError
 

--- a/python/dgl/graphbolt/negative_sampler.py
+++ b/python/dgl/graphbolt/negative_sampler.py
@@ -72,14 +72,11 @@ class NegativeSampler(MiniBatchTransformer):
                 self._collate(minibatch, self._sample_with_etype(node_pairs))
         else:
             seeds = minibatch.seeds
-
             if isinstance(seeds, Mapping):
                 if minibatch.indexes is None:
                     minibatch.indexes = {}
                 for etype, pos_pairs in seeds.items():
-                    assert (
-                        len(pos_pairs.shape) == 2 and pos_pairs.shape[1] == 2
-                    ), (
+                    assert pos_pairs.ndim == 2 and pos_pairs.shape[1] == 2, (
                         "Only tensor with shape N*2 is supported for negative"
                         + f" sampling, but got {pos_pairs.shape}."
                     )
@@ -94,7 +91,7 @@ class NegativeSampler(MiniBatchTransformer):
                         pos_pairs
                     )
             else:
-                assert len(seeds.shape) == 2 and seeds.shape[1] == 2, (
+                assert seeds.ndim == 2 and seeds.shape[1] == 2, (
                     "Only tensor with shape N*2 is supported for negative"
                     + f" sampling, but got {seeds.shape}."
                 )

--- a/tests/python/pytorch/graphbolt/impl/test_negative_sampler.py
+++ b/tests/python/pytorch/graphbolt/impl/test_negative_sampler.py
@@ -1,3 +1,5 @@
+import re
+
 import dgl.graphbolt as gb
 import pytest
 import torch
@@ -31,7 +33,7 @@ def test_NegativeSampler_invoke():
         next(iter(negative_sampler))
 
 
-def test_UniformNegativeSampler_seeds_invoke():
+def test_UniformNegativeSampler_invoke():
     # Instantiate graph and required datapipes.
     graph = gb_test_utils.rand_csc_graph(100, 0.05, bidirection_edge=True)
     num_seeds = 30
@@ -41,24 +43,32 @@ def test_UniformNegativeSampler_seeds_invoke():
     batch_size = 10
     item_sampler = gb.ItemSampler(item_set, batch_size=batch_size)
     negative_ratio = 2
+
+    def _verify(negative_sampler):
+        for data in negative_sampler:
+            # Assertation
+            seeds_len = batch_size + batch_size * negative_ratio
+            assert data.seeds.size(0) == seeds_len
+            assert data.labels.size(0) == seeds_len
+            assert data.indexes.size(0) == seeds_len
+
     # Invoke UniformNegativeSampler via class constructor.
     negative_sampler = gb.UniformNegativeSampler(
         item_sampler,
         graph,
         negative_ratio,
     )
-    with pytest.raises(NotImplementedError):
-        next(iter(negative_sampler))
+    _verify(negative_sampler)
+
     # Invoke UniformNegativeSampler via functional form.
     negative_sampler = item_sampler.sample_uniform_negative(
         graph,
         negative_ratio,
     )
-    with pytest.raises(NotImplementedError):
-        next(iter(negative_sampler))
+    _verify(negative_sampler)
 
 
-def test_UniformNegativeSampler_invoke():
+def test_UniformNegativeSampler_node_pairs_invoke():
     # Instantiate graph and required datapipes.
     graph = gb_test_utils.rand_csc_graph(100, 0.05, bidirection_edge=True)
     num_seeds = 30
@@ -94,7 +104,7 @@ def test_UniformNegativeSampler_invoke():
 
 
 @pytest.mark.parametrize("negative_ratio", [1, 5, 10, 20])
-def test_Uniform_NegativeSampler(negative_ratio):
+def test_Uniform_NegativeSampler_node_pairs(negative_ratio):
     # Construct FusedCSCSamplingGraph.
     graph = gb_test_utils.rand_csc_graph(100, 0.05, bidirection_edge=True)
     num_seeds = 30
@@ -121,6 +131,112 @@ def test_Uniform_NegativeSampler(negative_ratio):
         assert neg_dst.numel() == batch_size * negative_ratio
 
 
+@pytest.mark.parametrize("negative_ratio", [1, 5, 10, 20])
+def test_Uniform_NegativeSampler(negative_ratio):
+    # Construct FusedCSCSamplingGraph.
+    graph = gb_test_utils.rand_csc_graph(100, 0.05, bidirection_edge=True)
+    num_seeds = 30
+    item_set = gb.ItemSet(
+        torch.arange(0, num_seeds * 2).reshape(-1, 2), names="seeds"
+    )
+    batch_size = 10
+    item_sampler = gb.ItemSampler(item_set, batch_size=batch_size)
+    # Construct NegativeSampler.
+    negative_sampler = gb.UniformNegativeSampler(
+        item_sampler,
+        graph,
+        negative_ratio,
+    )
+    # Perform Negative sampling.
+    for data in negative_sampler:
+        seeds_len = batch_size + batch_size * negative_ratio
+        # Assertation
+        assert data.seeds.size(0) == seeds_len
+        assert data.labels.size(0) == seeds_len
+        assert data.indexes.size(0) == seeds_len
+        # Check negative seeds value.
+        pos_src = data.seeds[:batch_size, 0]
+        neg_src = data.seeds[batch_size:, 0]
+        assert torch.equal(pos_src.repeat_interleave(negative_ratio), neg_src)
+        # Check labels.
+        assert torch.equal(data.labels[:batch_size], torch.ones(batch_size))
+        assert torch.equal(
+            data.labels[batch_size:], torch.zeros(batch_size * negative_ratio)
+        )
+        # Check indexes.
+        pos_indexes = torch.arange(0, batch_size)
+        neg_indexes = pos_indexes.repeat_interleave(negative_ratio)
+        expected_indexes = torch.cat((pos_indexes, neg_indexes))
+        assert torch.equal(data.indexes, expected_indexes)
+
+
+def test_Uniform_NegativeSampler_error_shape():
+    # 1. seeds with shape N*3.
+    # Construct FusedCSCSamplingGraph.
+    graph = gb_test_utils.rand_csc_graph(100, 0.05, bidirection_edge=True)
+    num_seeds = 30
+    item_set = gb.ItemSet(
+        torch.arange(0, num_seeds * 3).reshape(-1, 3), names="seeds"
+    )
+    batch_size = 10
+    item_sampler = gb.ItemSampler(item_set, batch_size=batch_size)
+    negative_ratio = 2
+    # Construct NegativeSampler.
+    negative_sampler = gb.UniformNegativeSampler(
+        item_sampler,
+        graph,
+        negative_ratio,
+    )
+    with pytest.raises(
+        AssertionError,
+        match=re.escape(
+            "Only tensor with shape N*2 is "
+            + "supported for negative sampling, but got torch.Size([10, 3])."
+        ),
+    ):
+        next(iter(negative_sampler))
+
+    # 2. seeds with shape N*2*1.
+    # Construct FusedCSCSamplingGraph.
+    item_set = gb.ItemSet(
+        torch.arange(0, num_seeds * 2).reshape(-1, 2, 1), names="seeds"
+    )
+    item_sampler = gb.ItemSampler(item_set, batch_size=batch_size)
+    # Construct NegativeSampler.
+    negative_sampler = gb.UniformNegativeSampler(
+        item_sampler,
+        graph,
+        negative_ratio,
+    )
+    with pytest.raises(
+        AssertionError,
+        match=re.escape(
+            "Only tensor with shape N*2 is "
+            + "supported for negative sampling, but got torch.Size([10, 2, 1])."
+        ),
+    ):
+        next(iter(negative_sampler))
+
+    # 3. seeds with shape N.
+    # Construct FusedCSCSamplingGraph.
+    item_set = gb.ItemSet(torch.arange(0, num_seeds), names="seeds")
+    item_sampler = gb.ItemSampler(item_set, batch_size=batch_size)
+    # Construct NegativeSampler.
+    negative_sampler = gb.UniformNegativeSampler(
+        item_sampler,
+        graph,
+        negative_ratio,
+    )
+    with pytest.raises(
+        AssertionError,
+        match=re.escape(
+            "Only tensor with shape N*2 is "
+            + "supported for negative sampling, but got torch.Size([10])."
+        ),
+    ):
+        next(iter(negative_sampler))
+
+
 def get_hetero_graph():
     # COO graph:
     # [0, 0, 1, 1, 2, 2, 3, 3, 4, 4]
@@ -143,7 +259,7 @@ def get_hetero_graph():
     )
 
 
-def test_NegativeSampler_Hetero_Data():
+def test_NegativeSampler_Hetero_node_pairs_Data():
     graph = get_hetero_graph()
     itemset = gb.ItemSetDict(
         {
@@ -154,6 +270,26 @@ def test_NegativeSampler_Hetero_Data():
             "n2:e2:n1": gb.ItemSet(
                 torch.LongTensor([[0, 0, 1, 1, 2, 2], [0, 1, 1, 0, 0, 1]]).T,
                 names="node_pairs",
+            ),
+        }
+    )
+
+    item_sampler = gb.ItemSampler(itemset, batch_size=2)
+    negative_dp = gb.UniformNegativeSampler(item_sampler, graph, 1)
+    assert len(list(negative_dp)) == 5
+
+
+def test_NegativeSampler_Hetero_Data():
+    graph = get_hetero_graph()
+    itemset = gb.ItemSetDict(
+        {
+            "n1:e1:n2": gb.ItemSet(
+                torch.LongTensor([[0, 0, 1, 1], [0, 2, 0, 1]]).T,
+                names="seeds",
+            ),
+            "n2:e2:n1": gb.ItemSet(
+                torch.LongTensor([[0, 0, 1, 1, 2, 2], [0, 1, 1, 0, 0, 1]]).T,
+                names="seeds",
             ),
         }
     )


### PR DESCRIPTION
## Description
<!-- Brief description. Refer to the related issues if existed.
It'll be great if relevant reviewers can be assigned as well.-->
`sample_negative_edges_uniform_2` in fused_csc_sampling_graph: the function to sample negative seeds uniformly and construct corresponding indexes. Return: N*2 tensor representing negative edges and 1D tensor representing indexes. The function name will be update later.
`_collate`: deal with the concatenation of pos_edges and neg_edges, also construct `labels`.

## Checklist
Please feel free to remove inapplicable items for your PR.
- [ ] The PR title starts with [$CATEGORY] (such as [NN], [Model], [Doc], [Feature]])
- [ ] I've leverage the [tools](https://docs.google.com/document/d/1iHyj7zlmygKSk5gBPsqIqL5ASPzJSPREaNT_QdsiYA4/edit) to beautify the python and c++ code.
- [ ] The PR is complete and small, read the [Google eng practice (CL equals to PR)](https://google.github.io/eng-practices/review/developer/small-cls.html) to understand more about small PR. In DGL, we consider PRs with less than 200 lines of core code change are small (example, test and documentation could be exempted).
- [ ] All changes have test coverage
- [ ] Code is well-documented
- [ ] To the best of my knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change
- [ ] Related issue is referred in this PR
- [ ] If the PR is for a new model/paper, I've updated the example index [here](../examples/README.md).

## Changes
<!-- You could use following template
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)
-->
