### PR TITLE
[GraphBolt][CUDA] Dataloader feature overlap fix

### DIFF
--- a/examples/multigpu/graphbolt/node_classification.py
+++ b/examples/multigpu/graphbolt/node_classification.py
@@ -139,10 +139,7 @@ def create_dataloader(
     if args.storage_device == "cpu":
         datapipe = datapipe.copy_to(device)
 
-    # Until https://github.com/dmlc/dgl/issues/7008, overlap should be False.
-    dataloader = gb.DataLoader(
-        datapipe, args.num_workers, overlap_feature_fetch=False
-    )
+    dataloader = gb.DataLoader(datapipe, args.num_workers)
 
     # Return the fully-initialized DataLoader object.
     return dataloader

--- a/python/dgl/graphbolt/dataloader.py
+++ b/python/dgl/graphbolt/dataloader.py
@@ -58,8 +58,8 @@ class Bufferer(dp.iter.IterDataPipe):
         The data pipeline.
     buffer_size : int, optional
         The size of the buffer which stores the fetched samples. If data coming
-        from datapipe has latency spikes, consider increasing passing a high
-        value. Default is 1.
+        from datapipe has latency spikes, consider setting to a higher value.
+        Default is 1.
     """
 
     def __init__(self, datapipe, buffer_size=1):

--- a/python/dgl/graphbolt/dataloader.py
+++ b/python/dgl/graphbolt/dataloader.py
@@ -222,15 +222,8 @@ class DataLoader(torch.utils.data.DataLoader):
                 datapipe_graph = dp_utils.replace_dp(
                     datapipe_graph,
                     feature_fetcher,
-                    Awaiter(feature_fetcher),
+                    Awaiter(Bufferer(feature_fetcher, buffer_size=1)),
                 )
-                # Now, we have FeatureFetcher -> Awaiter
-                datapipe_graph = dp_utils.replace_dp(
-                    datapipe_graph,
-                    feature_fetcher,
-                    Bufferer(feature_fetcher, buffer_size=1),
-                )
-                # Now, we have FeatureFetcher -> Bufferer -> Awaiter
 
         # (4) Cut datapipe at CopyTo and wrap with prefetcher. This enables the
         # data pipeline up to the CopyTo operation to run in a separate thread.

--- a/python/dgl/graphbolt/dataloader.py
+++ b/python/dgl/graphbolt/dataloader.py
@@ -16,6 +16,7 @@ from .item_sampler import ItemSampler
 
 __all__ = [
     "DataLoader",
+    "Awaiter",
 ]
 
 

--- a/python/dgl/graphbolt/dataloader.py
+++ b/python/dgl/graphbolt/dataloader.py
@@ -219,9 +219,6 @@ class DataLoader(torch.utils.data.DataLoader):
             )
             for feature_fetcher in feature_fetchers:
                 feature_fetcher.stream = _get_uva_stream()
-            # _find_and_wrap_parent does not work if we wrap the same datapipe
-            # more than once. So, we wrap it once by a single datapipe called
-            # BuffererAndAwaiter instead of Bufferer and Awaiter separately.
             if len(feature_fetchers) > 0:
                 datapipe_graph = _find_and_wrap_parent(
                     datapipe_graph,

--- a/python/dgl/graphbolt/dataloader.py
+++ b/python/dgl/graphbolt/dataloader.py
@@ -17,6 +17,7 @@ from .item_sampler import ItemSampler
 __all__ = [
     "DataLoader",
     "Awaiter",
+    "Bufferer",
 ]
 
 

--- a/python/dgl/graphbolt/dataloader.py
+++ b/python/dgl/graphbolt/dataloader.py
@@ -235,13 +235,14 @@ class DataLoader(torch.utils.data.DataLoader):
             # _find_and_wrap_parent does not work if we wrap the same datapipe
             # more than once. So, we wrap it once by a single datapipe called
             # BuffererAndAwaiter instead of Bufferer and Awaiter separately.
-            _find_and_wrap_parent(
-                datapipe_graph,
-                datapipe_adjlist,
-                EndMarker,
-                BuffererAndAwaiter,
-                buffer_size=1,
-            )
+            if len(feature_fetchers) > 0:
+                _find_and_wrap_parent(
+                    datapipe_graph,
+                    datapipe_adjlist,
+                    EndMarker,
+                    BuffererAndAwaiter,
+                    buffer_size=1,
+                )
 
         # (4) Cut datapipe at CopyTo and wrap with prefetcher. This enables the
         # data pipeline up to the CopyTo operation to run in a separate thread.

--- a/python/dgl/graphbolt/dataloader.py
+++ b/python/dgl/graphbolt/dataloader.py
@@ -59,10 +59,10 @@ class Bufferer(dp.iter.IterDataPipe):
     buffer_size : int, optional
         The size of the buffer which stores the fetched samples. If data coming
         from datapipe has latency spikes, consider increasing passing a high
-        value. Default is 2.
+        value. Default is 1.
     """
 
-    def __init__(self, datapipe, buffer_size):
+    def __init__(self, datapipe, buffer_size=1):
         self.datapipe = datapipe
         if buffer_size <= 0:
             raise ValueError(

--- a/tests/python/pytorch/graphbolt/test_dataloader.py
+++ b/tests/python/pytorch/graphbolt/test_dataloader.py
@@ -83,12 +83,17 @@ def test_gpu_sampling_DataLoader(overlap_feature_fetch, enable_feature_fetch):
     dataloader = dgl.graphbolt.DataLoader(
         datapipe, overlap_feature_fetch=overlap_feature_fetch
     )
-    if enable_feature_fetch and overlap_feature_fetch:
-        datapipe = dataloader.dataset
-        datapipe_graph = dp_utils.traverse_dps(datapipe)
-        awaiters = dp_utils.find_dps(
-            datapipe_graph,
-            dgl.graphbolt.Awaiter,
-        )
-        assert len(awaiters) == 1
+    bufferer_awaiter_cnt = int(enable_feature_fetch and overlap_feature_fetch)
+    datapipe = dataloader.dataset
+    datapipe_graph = dp_utils.traverse_dps(datapipe)
+    awaiters = dp_utils.find_dps(
+        datapipe_graph,
+        dgl.graphbolt.Awaiter,
+    )
+    assert len(awaiters) == bufferer_awaiter_cnt
+    bufferers = dp_utils.find_dps(
+        datapipe_graph,
+        dgl.graphbolt.Bufferer,
+    )
+    assert len(bufferers) == bufferer_awaiter_cnt
     assert len(list(dataloader)) == N // B

--- a/tests/python/pytorch/graphbolt/test_dataloader.py
+++ b/tests/python/pytorch/graphbolt/test_dataloader.py
@@ -7,6 +7,8 @@ import dgl.graphbolt
 import pytest
 import torch
 
+import torchdata.dataloader2.graph as dp_utils
+
 from . import gb_test_utils
 
 
@@ -81,4 +83,12 @@ def test_gpu_sampling_DataLoader(overlap_feature_fetch, enable_feature_fetch):
     dataloader = dgl.graphbolt.DataLoader(
         datapipe, overlap_feature_fetch=overlap_feature_fetch
     )
+    if enable_feature_fetch and overlap_feature_fetch:
+        datapipe = dataloader.dataset
+        datapipe_graph = dp_utils.traverse_dps(datapipe)
+        awaiters = dp_utils.find_dps(
+            datapipe_graph,
+            dgl.graphbolt.Awaiter,
+        )
+        assert len(awaiters) == 1
     assert len(list(dataloader)) == N // B

--- a/tests/python/pytorch/graphbolt/test_dataloader.py
+++ b/tests/python/pytorch/graphbolt/test_dataloader.py
@@ -46,7 +46,8 @@ def test_DataLoader():
     reason="This test requires the GPU.",
 )
 @pytest.mark.parametrize("overlap_feature_fetch", [True, False])
-def test_gpu_sampling_DataLoader(overlap_feature_fetch):
+@pytest.mark.parametrize("enable_feature_fetch", [True, False])
+def test_gpu_sampling_DataLoader(overlap_feature_fetch, enable_feature_fetch):
     N = 40
     B = 4
     itemset = dgl.graphbolt.ItemSet(torch.arange(N), names="seed_nodes")
@@ -70,11 +71,12 @@ def test_gpu_sampling_DataLoader(overlap_feature_fetch):
         graph,
         fanouts=[torch.LongTensor([2]) for _ in range(2)],
     )
-    datapipe = dgl.graphbolt.FeatureFetcher(
-        datapipe,
-        feature_store,
-        ["a", "b"],
-    )
+    if enable_feature_fetch:
+        datapipe = dgl.graphbolt.FeatureFetcher(
+            datapipe,
+            feature_store,
+            ["a", "b"],
+        )
 
     dataloader = dgl.graphbolt.DataLoader(
         datapipe, overlap_feature_fetch=overlap_feature_fetch


### PR DESCRIPTION
## Description
See the picture in #6983. The Awaiter block is missing. This is due to a bug in the wrap parent usage. Fixes #7028 and #7008. This bug arised due to a buggy use of the _find_and_wrap_parent function. It needs to return the modified datapipe_graph to the user so that the user uses the updated version after modifications.

Below, you can see that both Bufferer and Awaiter is present after modification. Awaiter basically synchronizes the feature copy on the uva_stream with the main stream. When it is missing, the fetched features will be accessed when the copy operation has not finished yet.

![image](https://github.com/dmlc/dgl/assets/16190101/ca54d11b-316b-4162-9b93-66b4434b1dac)

## Checklist
Please feel free to remove inapplicable items for your PR.
- [ ] The PR title starts with [$CATEGORY] (such as [NN], [Model], [Doc], [Feature]])
- [ ] I've leverage the [tools](https://docs.google.com/document/d/1iHyj7zlmygKSk5gBPsqIqL5ASPzJSPREaNT_QdsiYA4/edit) to beautify the python and c++ code.
- [ ] The PR is complete and small, read the [Google eng practice (CL equals to PR)](https://google.github.io/eng-practices/review/developer/small-cls.html) to understand more about small PR. In DGL, we consider PRs with less than 200 lines of core code change are small (example, test and documentation could be exempted).
- [ ] All changes have test coverage
- [ ] Code is well-documented
- [ ] To the best of my knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change
- [ ] Related issue is referred in this PR
- [ ] If the PR is for a new model/paper, I've updated the example index [here](../examples/README.md).

## Changes
<!-- You could use following template
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)
-->
