### PR TITLE
[GraphBolt][CUDA] Add `is_pinned` method to `TorchBasedFeatureStore`.

### DIFF
--- a/python/dgl/graphbolt/impl/torch_based_feature_store.py
+++ b/python/dgl/graphbolt/impl/torch_based_feature_store.py
@@ -198,6 +198,10 @@ class TorchBasedFeature(Feature):
 
             self._is_inplace_pinned.add(x)
 
+    def is_pinned(self):
+        """Returns True if the stored feature is pinned."""
+        return self._tensor.is_pinned()
+
     def to(self, device):  # pylint: disable=invalid-name
         """Copy `TorchBasedFeature` to the specified device."""
         # copy.copy is a shallow copy so it does not copy tensor memory.
@@ -292,6 +296,10 @@ class TorchBasedFeatureStore(BasicFeatureStore):
         """In-place operation to copy the feature store to pinned memory."""
         for feature in self._features.values():
             feature.pin_memory_()
+
+    def is_pinned(self):
+        """Returns True if all the stored features are pinned."""
+        return all(feature.is_pinned() for feature in self._features.values())
 
     def to(self, device):  # pylint: disable=invalid-name
         """Copy `TorchBasedFeatureStore` to the specified device."""

--- a/tests/python/pytorch/graphbolt/impl/test_torch_based_feature_store.py
+++ b/tests/python/pytorch/graphbolt/impl/test_torch_based_feature_store.py
@@ -136,11 +136,6 @@ def test_torch_based_feature(in_memory):
         feature_a = feature_b = None
 
 
-def is_feature_store_pinned(store):
-    for feature in store._features.values():
-        assert feature._tensor.is_pinned()
-
-
 def is_feature_store_on_cuda(store):
     for feature in store._features.values():
         assert feature._tensor.is_cuda
@@ -181,7 +176,7 @@ def test_feature_store_to_device(device):
         feature_store = gb.TorchBasedFeatureStore(feature_data)
         feature_store2 = feature_store.to(device)
         if device == "pinned":
-            is_feature_store_pinned(feature_store2)
+            assert feature_store2.is_pinned()
         elif device == "cuda":
             is_feature_store_on_cuda(feature_store2)
 
@@ -227,6 +222,8 @@ def test_torch_based_pinned_feature(dtype, idtype, shape, in_place):
         assert feature._tensor.data_ptr() == tensor.data_ptr()
     else:
         feature = feature.to("pinned")
+
+    assert feature.is_pinned()
 
     # Test read entire pinned feature, the result should be on cuda.
     assert torch.equal(feature.read(), test_tensor_cuda)


### PR DESCRIPTION
## Description
Will use this function inside the dataloader for sanity checks to make it robust against erroneous use by the users.

## Checklist
Please feel free to remove inapplicable items for your PR.
- [ ] The PR title starts with [$CATEGORY] (such as [NN], [Model], [Doc], [Feature]])
- [ ] I've leverage the [tools](https://docs.google.com/document/d/1iHyj7zlmygKSk5gBPsqIqL5ASPzJSPREaNT_QdsiYA4/edit) to beautify the python and c++ code.
- [ ] The PR is complete and small, read the [Google eng practice (CL equals to PR)](https://google.github.io/eng-practices/review/developer/small-cls.html) to understand more about small PR. In DGL, we consider PRs with less than 200 lines of core code change are small (example, test and documentation could be exempted).
- [ ] All changes have test coverage
- [ ] Code is well-documented
- [ ] To the best of my knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change
- [ ] Related issue is referred in this PR
- [ ] If the PR is for a new model/paper, I've updated the example index [here](../examples/README.md).

## Changes
<!-- You could use following template
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)
-->
