### PR TITLE
[GraphBolt] Eliminate test warning

### DIFF
--- a/python/dgl/graphbolt/impl/torch_based_feature_store.py
+++ b/python/dgl/graphbolt/impl/torch_based_feature_store.py
@@ -72,6 +72,7 @@ class TorchBasedFeature(Feature):
 
     def __init__(self, torch_feature: torch.Tensor, metadata: Dict = None):
         super().__init__()
+        self._is_inplace_pinned = set()
         assert isinstance(torch_feature, torch.Tensor), (
             f"torch_feature in TorchBasedFeature must be torch.Tensor, "
             f"but got {type(torch_feature)}."
@@ -83,7 +84,6 @@ class TorchBasedFeature(Feature):
         # Make sure the tensor is contiguous.
         self._tensor = torch_feature.contiguous()
         self._metadata = metadata
-        self._is_inplace_pinned = set()
 
     def __del__(self):
         # torch.Tensor.pin_memory() is not an inplace operation. To make it


### PR DESCRIPTION
## Description
Eliminates the following warning:

```
tests/python/pytorch/graphbolt/impl/test_basic_feature_store.py::test_basic_feature_store_errors
  /usr/local/lib/python3.10/dist-packages/_pytest/unraisableexception.py:78: PytestUnraisableExceptionWarning: Exception ignored in: <function TorchBasedFeature.__del__ at 0x7f6150076ef0>
  
  Traceback (most recent call last):
    File "/localscratch/dgl-3/python/dgl/graphbolt/impl/torch_based_feature_store.py", line 93, in __del__
      for tensor in self._is_inplace_pinned:
  AttributeError: 'TorchBasedFeature' object has no attribute '_is_inplace_pinned'
  
    warnings.warn(pytest.PytestUnraisableExceptionWarning(msg))
```

## Checklist
Please feel free to remove inapplicable items for your PR.
- [ ] The PR title starts with [$CATEGORY] (such as [NN], [Model], [Doc], [Feature]])
- [ ] I've leverage the [tools](https://docs.google.com/document/d/1iHyj7zlmygKSk5gBPsqIqL5ASPzJSPREaNT_QdsiYA4/edit) to beautify the python and c++ code.
- [ ] The PR is complete and small, read the [Google eng practice (CL equals to PR)](https://google.github.io/eng-practices/review/developer/small-cls.html) to understand more about small PR. In DGL, we consider PRs with less than 200 lines of core code change are small (example, test and documentation could be exempted).
- [ ] All changes have test coverage
- [ ] Code is well-documented
- [ ] To the best of my knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change
- [ ] Related issue is referred in this PR
- [ ] If the PR is for a new model/paper, I've updated the example index [here](../examples/README.md).

## Changes
<!-- You could use following template
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)
-->
