### PR TITLE
[GraphBolt][CUDA] Add `gb.index_select` and fix example inferencing.

### DIFF
--- a/docs/source/api/python/dgl.graphbolt.rst
+++ b/docs/source/api/python/dgl.graphbolt.rst
@@ -187,6 +187,7 @@ Utilities
     etype_tuple_to_str
     isin
     seed
+    index_select
     expand_indptr
     add_reverse_edges
     exclude_seed_edges

--- a/examples/sampling/graphbolt/link_prediction.py
+++ b/examples/sampling/graphbolt/link_prediction.py
@@ -84,12 +84,6 @@ class SAGE(nn.Module):
         pin_memory = storage_device == "pinned"
         buffer_device = torch.device("cpu" if pin_memory else storage_device)
 
-        def move_to_storage_device(tensor):
-            if pin_memory:
-                return tensor.pin_memory()
-            else:
-                return tensor.to(buffer_device)
-
         print("Start node embedding inference.")
         for layer_idx, layer in enumerate(self.layers):
             is_last_layer = layer_idx == len(self.layers) - 1
@@ -99,6 +93,7 @@ class SAGE(nn.Module):
                 self.hidden_size,
                 dtype=torch.float32,
                 device=buffer_device,
+                pin_memory=pin_memory,
             )
             for data in tqdm.tqdm(dataloader):
                 # len(blocks) = 1
@@ -110,7 +105,7 @@ class SAGE(nn.Module):
                     buffer_device, non_blocking=True
                 )
             if not is_last_layer:
-                features.update("node", None, "feat", move_to_storage_device(y))
+                features.update("node", None, "feat", y)
 
         return y
 

--- a/examples/sampling/graphbolt/link_prediction.py
+++ b/examples/sampling/graphbolt/link_prediction.py
@@ -186,7 +186,9 @@ def create_dataloader(args, graph, features, itemset, is_train=True):
     # [Role]:
     # Initialize a neighbor sampler for sampling the neighborhoods of nodes.
     ############################################################################
-    datapipe = datapipe.sample_neighbor(graph, args.fanout)
+    datapipe = datapipe.sample_neighbor(
+        graph, args.fanout if is_train else [-1]
+    )
 
     ############################################################################
     # [Input]:
@@ -284,9 +286,6 @@ def evaluate(args, model, graph, features, all_nodes_set, valid_set, test_set):
     model.eval()
     evaluator = Evaluator(name="ogbl-citation2")
 
-    # Since we need to use all neghborhoods for evaluation, we set the fanout
-    # to -1.
-    args.fanout = [-1]
     dataloader = create_dataloader(
         args, graph, features, all_nodes_set, is_train=False
     )

--- a/examples/sampling/graphbolt/node_classification.py
+++ b/examples/sampling/graphbolt/node_classification.py
@@ -197,12 +197,6 @@ class SAGE(nn.Module):
         pin_memory = storage_device == "pinned"
         buffer_device = torch.device("cpu" if pin_memory else storage_device)
 
-        def move_to_storage_device(tensor):
-            if pin_memory:
-                return tensor.pin_memory()
-            else:
-                return tensor.to(buffer_device)
-
         for layer_idx, layer in enumerate(self.layers):
             is_last_layer = layer_idx == len(self.layers) - 1
 
@@ -211,6 +205,7 @@ class SAGE(nn.Module):
                 self.out_size if is_last_layer else self.hidden_size,
                 dtype=torch.float32,
                 device=buffer_device,
+                pin_memory=pin_memory,
             )
             for data in tqdm(dataloader):
                 # len(blocks) = 1
@@ -223,7 +218,7 @@ class SAGE(nn.Module):
                     buffer_device
                 )
             if not is_last_layer:
-                features.update("node", None, "feat", move_to_storage_device(y))
+                features.update("node", None, "feat", y)
 
         return y
 

--- a/examples/sampling/graphbolt/node_classification.py
+++ b/examples/sampling/graphbolt/node_classification.py
@@ -192,7 +192,6 @@ class SAGE(nn.Module):
                 hidden_x = self.dropout(hidden_x)
         return hidden_x
 
-    @torch.no_grad()
     def inference(self, graph, features, dataloader, storage_device):
         """Conduct layer-wise inference to get all the node embeddings."""
         pin_memory = storage_device == "pinned"

--- a/python/dgl/graphbolt/base.py
+++ b/python/dgl/graphbolt/base.py
@@ -15,6 +15,7 @@ __all__ = [
     "etype_tuple_to_str",
     "CopyTo",
     "isin",
+    "index_select",
     "expand_indptr",
     "CSCFormatBase",
     "seed",
@@ -100,6 +101,33 @@ def expand_indptr(indptr, dtype=None, node_ids=None, output_size=None):
     return torch.ops.graphbolt.expand_indptr(
         indptr, dtype, node_ids, output_size
     )
+
+
+def index_select(input, index):
+    """Returns a new tensor which indexes the input tensor along dimension dim
+    using the entries in index.
+
+    The returned tensor has the same number of dimensions as the original tensor
+    (input). The first dimension has the same size as the length of index; other
+    dimensions have the same size as in the original tensor.
+
+    When input is a pinned tensor and index.is_cuda is True, the operation runs
+    on the CUDA device and the returned tensor will also be on CUDA.
+
+    Parameters
+    ----------
+    input : torch.Tensor
+        The input tensor.
+    index : torch.Tensor
+        The 1-D tensor containing the indices to index.
+
+    Returns
+        -------
+        torch.Tensor
+            The indexed input tensor, equivalent to input[index].
+    """
+    assert index.dim() == 1, "Index should be 1D tensor."
+    return torch.ops.graphbolt.index_select(input, index)
 
 
 def etype_tuple_to_str(c_etype):

--- a/python/dgl/graphbolt/base.py
+++ b/python/dgl/graphbolt/base.py
@@ -103,20 +103,20 @@ def expand_indptr(indptr, dtype=None, node_ids=None, output_size=None):
     )
 
 
-def index_select(input, index):
+def index_select(tensor, index):
     """Returns a new tensor which indexes the input tensor along dimension dim
     using the entries in index.
 
     The returned tensor has the same number of dimensions as the original tensor
-    (input). The first dimension has the same size as the length of index; other
-    dimensions have the same size as in the original tensor.
+    (tensor). The first dimension has the same size as the length of index;
+    other dimensions have the same size as in the original tensor.
 
-    When input is a pinned tensor and index.is_cuda is True, the operation runs
+    When tensor is a pinned tensor and index.is_cuda is True, the operation runs
     on the CUDA device and the returned tensor will also be on CUDA.
 
     Parameters
     ----------
-    input : torch.Tensor
+    tensor : torch.Tensor
         The input tensor.
     index : torch.Tensor
         The 1-D tensor containing the indices to index.
@@ -124,10 +124,10 @@ def index_select(input, index):
     Returns
         -------
         torch.Tensor
-            The indexed input tensor, equivalent to input[index].
+            The indexed input tensor, equivalent to tensor[index].
     """
     assert index.dim() == 1, "Index should be 1D tensor."
-    return torch.ops.graphbolt.index_select(input, index)
+    return torch.ops.graphbolt.index_select(tensor, index)
 
 
 def etype_tuple_to_str(c_etype):

--- a/python/dgl/graphbolt/impl/torch_based_feature_store.py
+++ b/python/dgl/graphbolt/impl/torch_based_feature_store.py
@@ -98,9 +98,9 @@ class TorchBasedFeature(Feature):
     def read(self, ids: torch.Tensor = None):
         """Read the feature by index.
 
-        If the feature is on pinned CPU memory and `ids` is on GPU or pinned CPU
-        memory, it will be read by GPU and the returned tensor will be on GPU.
-        Otherwise, the returned tensor will be on CPU.
+        If the feature is on pinned CPU memory and `ids` is on GPU, it will be
+        read by the GPU and the returned tensor will be on GPU. Otherwise, the
+        returned tensor will be on the same device as the feature.
 
         Parameters
         ----------
@@ -114,8 +114,6 @@ class TorchBasedFeature(Feature):
             The read feature.
         """
         if ids is None:
-            if self._tensor.is_pinned():
-                return self._tensor.cuda()
             return self._tensor
         return torch.ops.graphbolt.index_select(self._tensor, ids)
 

--- a/python/dgl/graphbolt/impl/torch_based_feature_store.py
+++ b/python/dgl/graphbolt/impl/torch_based_feature_store.py
@@ -7,6 +7,7 @@ from typing import Dict, List
 import numpy as np
 import torch
 
+from ..base import index_select
 from ..feature_store import Feature
 from .basic_feature_store import BasicFeatureStore
 from .ondisk_metadata import OnDiskFeatureData
@@ -117,7 +118,7 @@ class TorchBasedFeature(Feature):
             if self._tensor.is_pinned():
                 return self._tensor.cuda()
             return self._tensor
-        return torch.ops.graphbolt.index_select(self._tensor, ids)
+        return index_select(self._tensor, ids)
 
     def size(self):
         """Get the size of the feature.


### PR DESCRIPTION
## Description
The existing example was moving the feature memory to the device memory. We change it to the storage_device instead.

When I started this PR, I thought I would use `gb.index_select` to load features for inferencing. Then I realized that I can just update the features and rely on the dataloader to fetch the features for inferencing. Otherwise, the copies for all the different modes become too complicated and ugly, which the dataloader automatically handles for us. However, I am sure that `gb.index_select` will be useful to us down the road, it is a very simple wrapper over `torch.ops.graphbolt.index_select`.

## Checklist
Please feel free to remove inapplicable items for your PR.
- [ ] The PR title starts with [$CATEGORY] (such as [NN], [Model], [Doc], [Feature]])
- [ ] I've leverage the [tools](https://docs.google.com/document/d/1iHyj7zlmygKSk5gBPsqIqL5ASPzJSPREaNT_QdsiYA4/edit) to beautify the python and c++ code.
- [ ] The PR is complete and small, read the [Google eng practice (CL equals to PR)](https://google.github.io/eng-practices/review/developer/small-cls.html) to understand more about small PR. In DGL, we consider PRs with less than 200 lines of core code change are small (example, test and documentation could be exempted).
- [ ] All changes have test coverage
- [ ] Code is well-documented
- [ ] To the best of my knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change
- [ ] Related issue is referred in this PR
- [ ] If the PR is for a new model/paper, I've updated the example index [here](../examples/README.md).

## Changes
<!-- You could use following template
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)
-->
