### PR TITLE
[GraphBolt] Fix gpu `NegativeSampler` for seeds.

### DIFF
--- a/python/dgl/graphbolt/impl/fused_csc_sampling_graph.py
+++ b/python/dgl/graphbolt/impl/fused_csc_sampling_graph.py
@@ -1018,7 +1018,13 @@ class FusedCSCSamplingGraph(SamplingGraph):
             torch.cat(
                 (
                     pos_src.repeat_interleave(negative_ratio),
-                    torch.randint(0, max_node_id, (num_negative,)),
+                    torch.randint(
+                        0,
+                        max_node_id,
+                        (num_negative,),
+                        dtype=node_pairs.dtype,
+                        device=node_pairs.device,
+                    ),
                 ),
             )
             .view(2, num_negative)

--- a/python/dgl/graphbolt/impl/uniform_negative_sampler.py
+++ b/python/dgl/graphbolt/impl/uniform_negative_sampler.py
@@ -76,14 +76,30 @@ class UniformNegativeSampler(NegativeSampler):
             # Construct indexes for all node pairs.
             num_pos_node_pairs = node_pairs.shape[0]
             negative_ratio = self.negative_ratio
-            pos_indexes = torch.arange(0, num_pos_node_pairs)
+            pos_indexes = torch.arange(
+                0,
+                num_pos_node_pairs,
+                dtype=seeds.dtype,
+                device=seeds.device,
+            )
             neg_indexes = pos_indexes.repeat_interleave(negative_ratio)
             indexes = torch.cat((pos_indexes, neg_indexes))
             # Construct labels for all node pairs.
             pos_num = node_pairs.shape[0]
             neg_num = seeds.shape[0] - pos_num
             labels = torch.cat(
-                (torch.ones(pos_num), torch.zeros(neg_num))
+                (
+                    torch.ones(
+                        pos_num,
+                        dtype=seeds.dtype,
+                        device=seeds.device,
+                    ),
+                    torch.zeros(
+                        neg_num,
+                        dtype=seeds.dtype,
+                        device=seeds.device,
+                    ),
+                ),
             ).bool()
             return seeds, labels, indexes
         else:

--- a/python/dgl/graphbolt/impl/uniform_negative_sampler.py
+++ b/python/dgl/graphbolt/impl/uniform_negative_sampler.py
@@ -79,7 +79,6 @@ class UniformNegativeSampler(NegativeSampler):
             pos_indexes = torch.arange(
                 0,
                 num_pos_node_pairs,
-                dtype=seeds.dtype,
                 device=seeds.device,
             )
             neg_indexes = pos_indexes.repeat_interleave(negative_ratio)
@@ -91,12 +90,10 @@ class UniformNegativeSampler(NegativeSampler):
                 (
                     torch.ones(
                         pos_num,
-                        dtype=seeds.dtype,
                         device=seeds.device,
                     ),
                     torch.zeros(
                         neg_num,
-                        dtype=seeds.dtype,
                         device=seeds.device,
                     ),
                 ),

--- a/python/dgl/graphbolt/impl/uniform_negative_sampler.py
+++ b/python/dgl/graphbolt/impl/uniform_negative_sampler.py
@@ -90,14 +90,16 @@ class UniformNegativeSampler(NegativeSampler):
                 (
                     torch.ones(
                         pos_num,
+                        dtype=torch.bool,
                         device=seeds.device,
                     ),
                     torch.zeros(
                         neg_num,
+                        dtype=torch.bool,
                         device=seeds.device,
                     ),
                 ),
-            ).bool()
+            )
             return seeds, labels, indexes
         else:
             return self.graph.sample_negative_edges_uniform(


### PR DESCRIPTION
## Description
<!-- Brief description. Refer to the related issues if existed.
It'll be great if relevant reviewers can be assigned as well.-->

1. move `seeds`, `indexes`, `labels` to GPU when sampling on GPU.
2. Add tests for `NegativeSampler` on GPU.

## Checklist
Please feel free to remove inapplicable items for your PR.
- [ ] The PR title starts with [$CATEGORY] (such as [NN], [Model], [Doc], [Feature]])
- [ ] I've leverage the [tools](https://docs.google.com/document/d/1iHyj7zlmygKSk5gBPsqIqL5ASPzJSPREaNT_QdsiYA4/edit) to beautify the python and c++ code.
- [ ] The PR is complete and small, read the [Google eng practice (CL equals to PR)](https://google.github.io/eng-practices/review/developer/small-cls.html) to understand more about small PR. In DGL, we consider PRs with less than 200 lines of core code change are small (example, test and documentation could be exempted).
- [ ] All changes have test coverage
- [ ] Code is well-documented
- [ ] To the best of my knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change
- [ ] Related issue is referred in this PR
- [ ] If the PR is for a new model/paper, I've updated the example index [here](../examples/README.md).

## Changes
<!-- You could use following template
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)
-->
