### PR TITLE
[GraphBolt][CUDA] GPUCache performance fix.

### DIFF
--- a/examples/multigpu/graphbolt/node_classification.py
+++ b/examples/multigpu/graphbolt/node_classification.py
@@ -284,6 +284,10 @@ def run(rank, world_size, args, devices, dataset):
     hidden_size = 256
     out_size = num_classes
 
+    if args.gpu_cache_size > 0:
+        input_feature = dataset.feature._features[("node", None, "feat")]
+        dataset.feature._features[("node", None, "feat")] = gb.GPUCachedFeature(input_feature)
+
     # Create GraphSAGE model. It should be copied onto a GPU as a replica.
     model = SAGE(in_size, hidden_size, out_size).to(device)
     model = DDP(model)
@@ -380,6 +384,9 @@ def parse_args():
     )
     parser.add_argument(
         "--num-workers", type=int, default=0, help="The number of processes."
+    )
+    parser.add_argument(
+        "--gpu-cache-size", type=int, default=0, help="The GPU cache size for input features."
     )
     parser.add_argument(
         "--mode",

--- a/examples/multigpu/graphbolt/node_classification.py
+++ b/examples/multigpu/graphbolt/node_classification.py
@@ -284,12 +284,6 @@ def run(rank, world_size, args, devices, dataset):
     hidden_size = 256
     out_size = num_classes
 
-    if args.gpu_cache_size > 0:
-        dataset.feature._features[("node", None, "feat")] = gb.GPUCachedFeature(
-            dataset.feature._features[("node", None, "feat")],
-            args.gpu_cache_size,
-        )
-
     # Create GraphSAGE model. It should be copied onto a GPU as a replica.
     model = SAGE(in_size, hidden_size, out_size).to(device)
     model = DDP(model)
@@ -386,12 +380,6 @@ def parse_args():
     )
     parser.add_argument(
         "--num-workers", type=int, default=0, help="The number of processes."
-    )
-    parser.add_argument(
-        "--gpu-cache-size",
-        type=int,
-        default=0,
-        help="The GPU cache size for input features.",
     )
     parser.add_argument(
         "--mode",

--- a/examples/multigpu/graphbolt/node_classification.py
+++ b/examples/multigpu/graphbolt/node_classification.py
@@ -285,8 +285,10 @@ def run(rank, world_size, args, devices, dataset):
     out_size = num_classes
 
     if args.gpu_cache_size > 0:
-        input_feature = dataset.feature._features[("node", None, "feat")]
-        dataset.feature._features[("node", None, "feat")] = gb.GPUCachedFeature(input_feature)
+        dataset.feature._features[("node", None, "feat")] = gb.GPUCachedFeature(
+            dataset.feature._features[("node", None, "feat")],
+            args.gpu_cache_size,
+        )
 
     # Create GraphSAGE model. It should be copied onto a GPU as a replica.
     model = SAGE(in_size, hidden_size, out_size).to(device)
@@ -386,7 +388,10 @@ def parse_args():
         "--num-workers", type=int, default=0, help="The number of processes."
     )
     parser.add_argument(
-        "--gpu-cache-size", type=int, default=0, help="The GPU cache size for input features."
+        "--gpu-cache-size",
+        type=int,
+        default=0,
+        help="The GPU cache size for input features.",
     )
     parser.add_argument(
         "--mode",

--- a/graphbolt/src/cuda/gpu_cache.cu
+++ b/graphbolt/src/cuda/gpu_cache.cu
@@ -43,20 +43,19 @@ std::tuple<torch::Tensor, torch::Tensor, torch::Tensor> GpuCache::Query(
       torch::empty(keys.size(0), keys.options().dtype(torch::kLong));
   auto missing_keys =
       torch::empty(keys.size(0), keys.options().dtype(torch::kLong));
-  cuda::CopyScalar<size_t> missing_len;
-  auto stream = cuda::GetCurrentStream();
+  auto allocator = cuda::GetAllocator();
+  auto missing_len_device = allocator.AllocateStorage<size_t>(1);
   cache_->Query(
       reinterpret_cast<const key_t *>(keys.data_ptr()), keys.size(0),
       values.data_ptr<float>(),
       reinterpret_cast<uint64_t *>(missing_index.data_ptr()),
-      reinterpret_cast<key_t *>(missing_keys.data_ptr()), missing_len.get(),
-      stream);
+      reinterpret_cast<key_t *>(missing_keys.data_ptr()),
+      missing_len_device.get(), cuda::GetCurrentStream());
   values = values.view(torch::kByte)
                .slice(1, 0, num_bytes_)
                .view(dtype_)
                .view(shape_);
-  // To safely read missing_len, we synchronize
-  stream.synchronize();
+  cuda::CopyScalar<size_t> missing_len(missing_len_device.get());
   missing_index = missing_index.slice(0, 0, static_cast<size_t>(missing_len));
   missing_keys = missing_keys.slice(0, 0, static_cast<size_t>(missing_len));
   return std::make_tuple(values, missing_index, missing_keys);


### PR DESCRIPTION
## Description
The missing_len argument to the GPU cache needs to be on the GPU because the cache performs atomic operations on it. Results in a 1000x performance improvement. Before this change, it turns out that the GPUCache was practically not usable at all.

Testable with #7074, @TristonC could you test it on multiGPU machines with `--gpu-cache-size=1000000`, either before or after this PR is merged?

When the GPUCachedFeature is used, the feature fetching operation has a GPU synchronization. We might want to run the feature fetching operation in another thread. Hoping that the main thread will make progress while the feature fetching thread is waiting for synchronization. However, if the GIL is not released while waiting, then it may not do what we expect, which will pose a problem, and the overlap optimization might not work as expected.

## Checklist
Please feel free to remove inapplicable items for your PR.
- [ ] The PR title starts with [$CATEGORY] (such as [NN], [Model], [Doc], [Feature]])
- [ ] I've leverage the [tools](https://docs.google.com/document/d/1iHyj7zlmygKSk5gBPsqIqL5ASPzJSPREaNT_QdsiYA4/edit) to beautify the python and c++ code.
- [ ] The PR is complete and small, read the [Google eng practice (CL equals to PR)](https://google.github.io/eng-practices/review/developer/small-cls.html) to understand more about small PR. In DGL, we consider PRs with less than 200 lines of core code change are small (example, test and documentation could be exempted).
- [ ] All changes have test coverage
- [ ] Code is well-documented
- [ ] To the best of my knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change
- [ ] Related issue is referred in this PR
- [ ] If the PR is for a new model/paper, I've updated the example index [here](../examples/README.md).

## Changes
<!-- You could use following template
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)
-->
