### PR TITLE
[DistGB] return eids together with etype_ids in sampling

### DIFF
--- a/python/dgl/distributed/graph_services.py
+++ b/python/dgl/distributed/graph_services.py
@@ -625,7 +625,7 @@ def merge_graphs(res_list, num_nodes):
 LocalSampledGraph = namedtuple(
     "LocalSampledGraph",
     "global_src global_dst global_eids etype_ids",
-    defaults=(None, None, None, None), # pylint: unexpected-keyword-arg
+    defaults=(None, None, None, None), # pylint: disable=unexpected-keyword-arg
 )
 
 

--- a/python/dgl/distributed/graph_services.py
+++ b/python/dgl/distributed/graph_services.py
@@ -625,8 +625,8 @@ def merge_graphs(res_list, num_nodes):
 LocalSampledGraph = namedtuple(
     "LocalSampledGraph",
     "global_src global_dst global_eids etype_ids",
-    defaults=(None, None, None, None), # pylint: disable=unexpected-keyword-arg
-)
+    defaults=(None, None, None, None),
+) # pylint: disable=unexpected-keyword-arg
 
 
 def _distributed_access(g, nodes, issue_remote_req, local_access):

--- a/python/dgl/distributed/graph_services.py
+++ b/python/dgl/distributed/graph_services.py
@@ -625,7 +625,7 @@ def merge_graphs(res_list, num_nodes):
 LocalSampledGraph = namedtuple(
     "LocalSampledGraph",
     "global_src global_dst global_eids etype_ids",
-    defaults=(None, None, None, None),
+    defaults=(None, None, None, None), # pylint: unexpected-keyword-arg
 )
 
 

--- a/python/dgl/distributed/graph_services.py
+++ b/python/dgl/distributed/graph_services.py
@@ -622,11 +622,11 @@ def merge_graphs(res_list, num_nodes):
     return g
 
 
-LocalSampledGraph = namedtuple(
+LocalSampledGraph = namedtuple( # pylint: disable=unexpected-keyword-arg
     "LocalSampledGraph",
     "global_src global_dst global_eids etype_ids",
     defaults=(None, None, None, None),
-) # pylint: disable=unexpected-keyword-arg
+)
 
 
 def _distributed_access(g, nodes, issue_remote_req, local_access):

--- a/python/dgl/distributed/graph_services.py
+++ b/python/dgl/distributed/graph_services.py
@@ -622,7 +622,7 @@ def merge_graphs(res_list, num_nodes):
     return g
 
 
-LocalSampledGraph = namedtuple( # pylint: disable=unexpected-keyword-arg
+LocalSampledGraph = namedtuple(  # pylint: disable=unexpected-keyword-arg
     "LocalSampledGraph",
     "global_src global_dst global_eids etype_ids",
     defaults=(None, None, None, None),

--- a/python/dgl/distributed/graph_services.py
+++ b/python/dgl/distributed/graph_services.py
@@ -100,6 +100,8 @@ def _sample_neighbors_graphbolt(
         The nodes to sample neighbors from.
     fanout : tensor or int
         The number of edges to be sampled for each node.
+    edge_dir : str, optional
+        Determines whether to sample inbound or outbound edges.
     prob : tensor, optional
         The probability associated with each neighboring edge of a node.
     replace : bool, optional

--- a/tests/distributed/test_distributed_sampling.py
+++ b/tests/distributed/test_distributed_sampling.py
@@ -1,7 +1,7 @@
 import multiprocessing as mp
 import os
 import random
-import sys
+import tempfile
 import time
 import traceback
 import unittest
@@ -1013,47 +1013,85 @@ def check_rpc_bipartite_etype_sampling_shuffle(tmpdir, num_server):
         assert np.all(F.asnumpy(orig_dst1) == orig_dst)
 
 
-# Wait non shared memory graph store
-@unittest.skipIf(os.name == "nt", reason="Do not support windows yet")
-@unittest.skipIf(
-    dgl.backend.backend_name == "tensorflow",
-    reason="Not support tensorflow for now",
-)
-@unittest.skipIf(
-    dgl.backend.backend_name == "mxnet", reason="Turn off Mxnet support"
-)
 @pytest.mark.parametrize("num_server", [1])
-def test_rpc_sampling_shuffle(num_server):
+@pytest.mark.parametrize("use_graphbolt", [False, True])
+def test_rpc_sampling_shuffle(num_server, use_graphbolt):
     reset_envs()
-    import tempfile
-
     os.environ["DGL_DIST_MODE"] = "distributed"
     with tempfile.TemporaryDirectory() as tmpdirname:
         check_rpc_sampling_shuffle(
-            Path(tmpdirname), num_server, use_graphbolt=True
+            Path(tmpdirname), num_server, use_graphbolt=use_graphbolt
         )
-        check_rpc_sampling_shuffle(Path(tmpdirname), num_server)
-        # [TODO][Rhett] Tests for multiple groups may fail sometimes and
-        # root cause is unknown. Let's disable them for now.
-        # check_rpc_sampling_shuffle(Path(tmpdirname), num_server, num_groups=2)
+
+
+@pytest.mark.parametrize("num_server", [1])
+def test_rpc_hetero_sampling_shuffle(num_server):
+    reset_envs()
+    os.environ["DGL_DIST_MODE"] = "distributed"
+    with tempfile.TemporaryDirectory() as tmpdirname:
         check_rpc_hetero_sampling_shuffle(Path(tmpdirname), num_server)
+
+
+@pytest.mark.parametrize("num_server", [1])
+def test_rpc_hetero_sampling_empty_shuffle(num_server):
+    reset_envs()
+    os.environ["DGL_DIST_MODE"] = "distributed"
+    with tempfile.TemporaryDirectory() as tmpdirname:
         check_rpc_hetero_sampling_empty_shuffle(Path(tmpdirname), num_server)
-        check_rpc_hetero_etype_sampling_shuffle(Path(tmpdirname), num_server)
+
+
+@pytest.mark.parametrize("num_server", [1])
+@pytest.mark.parametrize(
+    "graph_formats", [None, ["csc"], ["csr"], ["csc", "coo"]]
+)
+def test_rpc_hetero_etype_sampling_shuffle(num_server, graph_formats):
+    reset_envs()
+    os.environ["DGL_DIST_MODE"] = "distributed"
+    with tempfile.TemporaryDirectory() as tmpdirname:
         check_rpc_hetero_etype_sampling_shuffle(
-            Path(tmpdirname), num_server, ["csc"]
+            Path(tmpdirname), num_server, graph_formats=graph_formats
         )
-        check_rpc_hetero_etype_sampling_shuffle(
-            Path(tmpdirname), num_server, ["csr"]
-        )
-        check_rpc_hetero_etype_sampling_shuffle(
-            Path(tmpdirname), num_server, ["csc", "coo"]
-        )
+
+
+@pytest.mark.parametrize("num_server", [1])
+def test_rpc_hetero_etype_sampling_empty_shuffle(num_server):
+    reset_envs()
+    os.environ["DGL_DIST_MODE"] = "distributed"
+    with tempfile.TemporaryDirectory() as tmpdirname:
         check_rpc_hetero_etype_sampling_empty_shuffle(
             Path(tmpdirname), num_server
         )
+
+
+@pytest.mark.parametrize("num_server", [1])
+def test_rpc_bipartite_sampling_empty_shuffle(num_server):
+    reset_envs()
+    os.environ["DGL_DIST_MODE"] = "distributed"
+    with tempfile.TemporaryDirectory() as tmpdirname:
         check_rpc_bipartite_sampling_empty(Path(tmpdirname), num_server)
+
+
+@pytest.mark.parametrize("num_server", [1])
+def test_rpc_bipartite_sampling_shuffle(num_server):
+    reset_envs()
+    os.environ["DGL_DIST_MODE"] = "distributed"
+    with tempfile.TemporaryDirectory() as tmpdirname:
         check_rpc_bipartite_sampling_shuffle(Path(tmpdirname), num_server)
+
+
+@pytest.mark.parametrize("num_server", [1])
+def test_rpc_bipartite_etype_sampling_empty_shuffle(num_server):
+    reset_envs()
+    os.environ["DGL_DIST_MODE"] = "distributed"
+    with tempfile.TemporaryDirectory() as tmpdirname:
         check_rpc_bipartite_etype_sampling_empty(Path(tmpdirname), num_server)
+
+
+@pytest.mark.parametrize("num_server", [1])
+def test_rpc_bipartite_etype_sampling_shuffle(num_server):
+    reset_envs()
+    os.environ["DGL_DIST_MODE"] = "distributed"
+    with tempfile.TemporaryDirectory() as tmpdirname:
         check_rpc_bipartite_etype_sampling_shuffle(Path(tmpdirname), num_server)
 
 


### PR DESCRIPTION
## Description
<!-- Brief description. Refer to the related issues if existed.
It'll be great if relevant reviewers can be assigned as well.-->
1. unify `sample_neighbors()` to return `global_src, global_dst, global_eids, etype_ids`.
2. split testcases into separate ones to be clearer.
## Checklist
Please feel free to remove inapplicable items for your PR.
- [ ] The PR title starts with [$CATEGORY] (such as [NN], [Model], [Doc], [Feature]])
- [ ] I've leverage the [tools](https://docs.google.com/document/d/1iHyj7zlmygKSk5gBPsqIqL5ASPzJSPREaNT_QdsiYA4/edit) to beautify the python and c++ code.
- [ ] The PR is complete and small, read the [Google eng practice (CL equals to PR)](https://google.github.io/eng-practices/review/developer/small-cls.html) to understand more about small PR. In DGL, we consider PRs with less than 200 lines of core code change are small (example, test and documentation could be exempted).
- [ ] All changes have test coverage
- [ ] Code is well-documented
- [ ] To the best of my knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change
- [ ] Related issue is referred in this PR
- [ ] If the PR is for a new model/paper, I've updated the example index [here](../examples/README.md).

## Changes
<!-- You could use following template
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)
-->
