### PR TITLE
[GraphBolt][CUDA] Pipelined sampling accuracy fix

### DIFF
--- a/python/dgl/graphbolt/impl/neighbor_sampler.py
+++ b/python/dgl/graphbolt/impl/neighbor_sampler.py
@@ -59,13 +59,18 @@ class FetchInsubgraphData(Mapper):
                     tensor.record_stream(stream)
                 return tensor
 
-            index, original_positions = index.sort()
-            if (original_positions.diff() == 1).all().item():  # is_sorted
+            if self.graph.node_type_offset is None:
+                # sorting not needed.
                 minibatch._subgraph_seed_nodes = None
             else:
-                minibatch._subgraph_seed_nodes = record_stream(
-                    original_positions.sort()[1]
-                )
+                index, original_positions = index.sort()
+                if (original_positions.diff() == 1).all().item():
+                    # already sorted.
+                    minibatch._subgraph_seed_nodes = None
+                else:
+                    minibatch._subgraph_seed_nodes = record_stream(
+                        original_positions.sort()[1]
+                    )
             index_select_csc_with_indptr = partial(
                 torch.ops.graphbolt.index_select_csc, self.graph.csc_indptr
             )

--- a/tests/python/pytorch/graphbolt/impl/test_neighbor_sampler.py
+++ b/tests/python/pytorch/graphbolt/impl/test_neighbor_sampler.py
@@ -41,8 +41,12 @@ def get_hetero_graph():
 @unittest.skipIf(F._default_context_str != "gpu", reason="Enabled only on GPU.")
 @pytest.mark.parametrize("hetero", [False, True])
 @pytest.mark.parametrize("prob_name", [None, "weight", "mask"])
-def test_NeighborSampler_GraphFetch(hetero, prob_name):
-    items = torch.arange(3)
+@pytest.mark.parametrize("sorted", [False, True])
+def test_NeighborSampler_GraphFetch(hetero, prob_name, sorted):
+    if sorted:
+        items = torch.arange(3)
+    else:
+        items = torch.tensor([2, 0, 1])
     names = "seed_nodes"
     itemset = gb.ItemSet(items, names=names)
     graph = get_hetero_graph().to(F.ctx())


### PR DESCRIPTION
## Description
There was a bug related to the permutation of the vertices and recording the inputs to the graph fetching datapipe. This PR fixes these issues.

Now, enabling graph fetch in the dataloader or not enabling it gives the identical accuracies.

I would like to modify the node_classification example to add the overlap_graph_fetch option so that we can run the regression test for this case as well.

## Checklist
Please feel free to remove inapplicable items for your PR.
- [ ] The PR title starts with [$CATEGORY] (such as [NN], [Model], [Doc], [Feature]])
- [ ] I've leverage the [tools](https://docs.google.com/document/d/1iHyj7zlmygKSk5gBPsqIqL5ASPzJSPREaNT_QdsiYA4/edit) to beautify the python and c++ code.
- [ ] The PR is complete and small, read the [Google eng practice (CL equals to PR)](https://google.github.io/eng-practices/review/developer/small-cls.html) to understand more about small PR. In DGL, we consider PRs with less than 200 lines of core code change are small (example, test and documentation could be exempted).
- [ ] All changes have test coverage
- [ ] Code is well-documented
- [ ] To the best of my knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change
- [ ] Related issue is referred in this PR
- [ ] If the PR is for a new model/paper, I've updated the example index [here](../examples/README.md).

## Changes
<!-- You could use following template
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)
-->
