### PR TITLE
[GraphBolt][CUDA] puregpu option for the multiGPU example.

### DIFF
--- a/examples/multigpu/graphbolt/node_classification.py
+++ b/examples/multigpu/graphbolt/node_classification.py
@@ -151,9 +151,7 @@ def evaluate(rank, model, dataloader, num_classes, device):
     y = []
     y_hats = []
 
-    for step, data in (
-        tqdm.tqdm(enumerate(dataloader)) if rank == 0 else enumerate(dataloader)
-    ):
+    for data in (tqdm.tqdm(dataloader) if rank == 0 else dataloader):
         blocks = data.blocks
         x = data.node_features["feat"]
         y.append(data.labels)

--- a/examples/multigpu/graphbolt/node_classification.py
+++ b/examples/multigpu/graphbolt/node_classification.py
@@ -151,7 +151,7 @@ def evaluate(rank, model, dataloader, num_classes, device):
     y = []
     y_hats = []
 
-    for data in (tqdm.tqdm(dataloader) if rank == 0 else dataloader):
+    for data in tqdm.tqdm(dataloader) if rank == 0 else dataloader:
         blocks = data.blocks
         x = data.node_features["feat"]
         y.append(data.labels)

--- a/python/dgl/graphbolt/impl/fused_csc_sampling_graph.py
+++ b/python/dgl/graphbolt/impl/fused_csc_sampling_graph.py
@@ -1092,7 +1092,8 @@ class FusedCSCSamplingGraph(SamplingGraph):
         return self2._apply_to_members(_pin if device == "pinned" else _to)
 
     def pin_memory_(self):
-        """Copy `FusedCSCSamplingGraph` to the pinned memory in-place."""
+        """Copy `FusedCSCSamplingGraph` to the pinned memory in-place. Returns
+        the same object modified in-place."""
         # torch.Tensor.pin_memory() is not an inplace operation. To make it
         # truly in-place, we need to use cudaHostRegister. Then, we need to use
         # cudaHostUnregister to unpin the tensor in the destructor.
@@ -1123,7 +1124,7 @@ class FusedCSCSamplingGraph(SamplingGraph):
 
             return x
 
-        self._apply_to_members(_pin)
+        return self._apply_to_members(_pin)
 
 
 def fused_csc_sampling_graph(

--- a/python/dgl/graphbolt/impl/torch_based_feature_store.py
+++ b/python/dgl/graphbolt/impl/torch_based_feature_store.py
@@ -175,7 +175,8 @@ class TorchBasedFeature(Feature):
         )
 
     def pin_memory_(self):
-        """In-place operation to copy the feature to pinned memory."""
+        """In-place operation to copy the feature to pinned memory. Returns the
+        same object modified in-place."""
         # torch.Tensor.pin_memory() is not an inplace operation. To make it
         # truly in-place, we need to use cudaHostRegister. Then, we need to use
         # cudaHostUnregister to unpin the tensor in the destructor.
@@ -193,6 +194,8 @@ class TorchBasedFeature(Feature):
             )
 
             self._is_inplace_pinned.add(x)
+
+        return self
 
     def is_pinned(self):
         """Returns True if the stored feature is pinned."""
@@ -289,9 +292,12 @@ class TorchBasedFeatureStore(BasicFeatureStore):
         super().__init__(features)
 
     def pin_memory_(self):
-        """In-place operation to copy the feature store to pinned memory."""
+        """In-place operation to copy the feature store to pinned memory.
+        Returns the same object modified in-place."""
         for feature in self._features.values():
             feature.pin_memory_()
+
+        return self
 
     def is_pinned(self):
         """Returns True if all the stored features are pinned."""


### PR DESCRIPTION
## Description
Added `cuda-cuda` option for the multiGPU example. Since the `OndiskDataset` can not be modified, I thought that if pin_memory_ method returns a reference to self, the code will be simpler at the end. Otherwise, extra two lines to separately assign `graph = dataset.graph` and `feature = dataset.feature` is needed.

<details><summary>Evaluating `cpu-cuda`, `pinned-cuda` and `cuda-cuda` on 2 A100 GPUs</summary>
<p>

root@a100cse:/localscratch/dgl-3/examples/sampling/graphbolt/lightning# python ../../../multigpu/graphbolt/node_classification.py --gpu=2,3 --mode=pinned-cuda
Training with 2 gpus.
The dataset is already preprocessed.
Training...
96it [00:05, 17.48it/s]
Validating...
20it [00:00, 30.66it/s]
Epoch 00000 | Average Loss 1.7811 | Accuracy 0.8321 | Time 6.1841
96it [00:02, 37.11it/s]
Validating...
20it [00:00, 50.69it/s]
Epoch 00001 | Average Loss 0.7472 | Accuracy 0.8623 | Time 3.0013
96it [00:02, 32.76it/s]
Validating...
20it [00:00, 47.64it/s]
Epoch 00002 | Average Loss 0.5928 | Accuracy 0.8759 | Time 3.3666
96it [00:02, 44.08it/s]
Validating...
20it [00:00, 48.99it/s]
Epoch 00003 | Average Loss 0.5219 | Accuracy 0.8816 | Time 2.5997
96it [00:02, 43.94it/s]
Validating...
20it [00:00, 48.49it/s]
Epoch 00004 | Average Loss 0.4816 | Accuracy 0.8855 | Time 2.6107
96it [00:02, 44.00it/s]
Validating...
20it [00:00, 48.26it/s]
Epoch 00005 | Average Loss 0.4515 | Accuracy 0.8892 | Time 2.6129
96it [00:02, 43.98it/s]
Validating...
20it [00:00, 47.38it/s]
Epoch 00006 | Average Loss 0.4306 | Accuracy 0.8939 | Time 2.6198
96it [00:02, 44.12it/s]
Validating...
20it [00:00, 47.76it/s]
Epoch 00007 | Average Loss 0.4127 | Accuracy 0.8962 | Time 2.6113
96it [00:03, 31.98it/s]
Validating...
20it [00:00, 45.73it/s]
Epoch 00008 | Average Loss 0.4007 | Accuracy 0.8973 | Time 3.6965
96it [00:02, 44.19it/s]
Validating...
20it [00:00, 48.43it/s]
Epoch 00009 | Average Loss 0.3869 | Accuracy 0.8976 | Time 2.6030
Testing...
1081it [00:38, 28.44it/s]
Test Accuracy 0.7600
root@a100cse:/localscratch/dgl-3/examples/sampling/graphbolt/lightning# python ../../../multigpu/graphbolt/node_classification.py --gpu=2,3 --mode=cuda-cuda
Training with 2 gpus.
The dataset is already preprocessed.
Training...
96it [00:03, 27.75it/s]
Validating...
20it [00:01, 16.96it/s]
Epoch 00000 | Average Loss 1.7608 | Accuracy 0.8303 | Time 4.7051
96it [00:01, 56.16it/s]
Validating...
20it [00:00, 107.00it/s]
Epoch 00001 | Average Loss 0.7387 | Accuracy 0.8627 | Time 1.9173
96it [00:01, 65.53it/s]
Validating...
20it [00:00, 105.78it/s]
Epoch 00002 | Average Loss 0.5890 | Accuracy 0.8762 | Time 1.6677
96it [00:01, 76.83it/s]
Validating...
20it [00:00, 104.87it/s]
Epoch 00003 | Average Loss 0.5205 | Accuracy 0.8830 | Time 1.4542
96it [00:01, 74.72it/s]
Validating...
20it [00:00, 106.14it/s]
Epoch 00004 | Average Loss 0.4791 | Accuracy 0.8879 | Time 1.4872
96it [00:01, 74.95it/s]
Validating...
20it [00:00, 105.89it/s]
Epoch 00005 | Average Loss 0.4486 | Accuracy 0.8909 | Time 1.4843
96it [00:01, 76.94it/s]
Validating...
20it [00:00, 106.96it/s]
Epoch 00006 | Average Loss 0.4263 | Accuracy 0.8930 | Time 1.4500
96it [00:01, 75.87it/s]
Validating...
20it [00:00, 103.08it/s]
Epoch 00007 | Average Loss 0.4109 | Accuracy 0.8968 | Time 1.4750
96it [00:01, 51.91it/s]
Validating...
20it [00:00, 98.53it/s] 
Epoch 00008 | Average Loss 0.3970 | Accuracy 0.8969 | Time 2.4360
96it [00:01, 56.90it/s]
Validating...
20it [00:00, 104.95it/s]
Epoch 00009 | Average Loss 0.3854 | Accuracy 0.9000 | Time 1.8945
Testing...
1081it [00:20, 51.92it/s]
Test Accuracy 0.7641
root@a100cse:/localscratch/dgl-3/examples/sampling/graphbolt/lightning# python ../../../multigpu/graphbolt/node_classification.py --gpu=2,3 --mode=cpu-cuda
Training with 2 gpus.
The dataset is already preprocessed.
Training...
96it [00:10,  9.20it/s]
Validating...
20it [00:01, 12.34it/s]
Epoch 00000 | Average Loss 1.7369 | Accuracy 0.8330 | Time 12.1240
96it [00:06, 14.58it/s]
Validating...
20it [00:01, 17.17it/s]
Epoch 00001 | Average Loss 0.7252 | Accuracy 0.8649 | Time 7.7691
96it [00:07, 13.04it/s]
Validating...
20it [00:01, 15.63it/s]
Epoch 00002 | Average Loss 0.5784 | Accuracy 0.8780 | Time 8.6619
96it [00:07, 13.64it/s]
Validating...
20it [00:01, 16.11it/s]
Epoch 00003 | Average Loss 0.5092 | Accuracy 0.8825 | Time 8.2973
96it [00:06, 14.45it/s]
Validating...
20it [00:01, 14.99it/s]
Epoch 00004 | Average Loss 0.4716 | Accuracy 0.8875 | Time 7.9967
96it [00:06, 14.96it/s]
Validating...
20it [00:01, 14.66it/s]
Epoch 00005 | Average Loss 0.4405 | Accuracy 0.8907 | Time 7.8170
96it [00:06, 14.89it/s]
Validating...
20it [00:01, 16.86it/s]
Epoch 00006 | Average Loss 0.4216 | Accuracy 0.8942 | Time 7.6524
96it [00:07, 13.48it/s]
Validating...
20it [00:01, 16.55it/s]
Epoch 00007 | Average Loss 0.4070 | Accuracy 0.8966 | Time 9.1566
96it [00:06, 14.51it/s]
Validating...
20it [00:01, 15.58it/s]
Epoch 00008 | Average Loss 0.3924 | Accuracy 0.8983 | Time 7.9233
96it [00:06, 14.43it/s]
Validating...
20it [00:01, 15.23it/s]
Epoch 00009 | Average Loss 0.3816 | Accuracy 0.8998 | Time 7.9852
Testing...
1081it [01:22, 13.05it/s]
Test Accuracy 0.7624

</p>
</details> 

## Checklist
Please feel free to remove inapplicable items for your PR.
- [ ] The PR title starts with [$CATEGORY] (such as [NN], [Model], [Doc], [Feature]])
- [ ] I've leverage the [tools](https://docs.google.com/document/d/1iHyj7zlmygKSk5gBPsqIqL5ASPzJSPREaNT_QdsiYA4/edit) to beautify the python and c++ code.
- [ ] The PR is complete and small, read the [Google eng practice (CL equals to PR)](https://google.github.io/eng-practices/review/developer/small-cls.html) to understand more about small PR. In DGL, we consider PRs with less than 200 lines of core code change are small (example, test and documentation could be exempted).
- [ ] All changes have test coverage
- [ ] Code is well-documented
- [ ] To the best of my knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change
- [ ] Related issue is referred in this PR
- [ ] If the PR is for a new model/paper, I've updated the example index [here](../examples/README.md).

## Changes
<!-- You could use following template
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)
-->
