### PR TITLE
[GCMC] Fixing a parser warning appearing in one of the `gcmc` examples.

### DIFF
--- a/examples/pytorch/gcmc/data.py
+++ b/examples/pytorch/gcmc/data.py
@@ -689,7 +689,7 @@ class MovieLens(object):
                 header=None,
                 names=["id", "title", "genres"],
                 encoding="iso-8859-1",
-                engine='python',
+                engine="python",
             )
             genre_map = {ele: i for i, ele in enumerate(GENRES)}
             genre_map["Children's"] = genre_map["Children"]

--- a/examples/pytorch/gcmc/data.py
+++ b/examples/pytorch/gcmc/data.py
@@ -689,6 +689,7 @@ class MovieLens(object):
                 header=None,
                 names=["id", "title", "genres"],
                 encoding="iso-8859-1",
+                engine='python',
             )
             genre_map = {ele: i for i, ele in enumerate(GENRES)}
             genre_map["Children's"] = genre_map["Children"]


### PR DESCRIPTION
## Description
<!-- Brief description. Refer to the related issues if existed.
It'll be great if relevant reviewers can be assigned as well.-->
The following `ParserWarning`
```
/opt/dgl/dgl-source/examples/pytorch/gcmc/data.py:686: ParserWarning: Falling back to the 'python' engine because the 'c' engine does not support regex separators (separators > 1 char and different from '\s+' are interpreted as regex); you can avoid this warning by specifying engine='python'.
```
has been fixed exactly as suggested.

## Checklist
Please feel free to remove inapplicable items for your PR.
- [x] The PR title starts with [$CATEGORY] (such as [NN], [Model], [Doc], [Feature]])
- [x] I've leverage the [tools](https://docs.google.com/document/d/1iHyj7zlmygKSk5gBPsqIqL5ASPzJSPREaNT_QdsiYA4/edit) to beautify the python and c++ code.
- [x] The PR is complete and small, read the [Google eng practice (CL equals to PR)](https://google.github.io/eng-practices/review/developer/small-cls.html) to understand more about small PR. In DGL, we consider PRs with less than 200 lines of core code change are small (example, test and documentation could be exempted).
- [x] To the best of my knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

## Changes
<!-- You could use following template
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)
-->
