### PR TITLE
[GraphBolt] Correct `to_pyg_data`

### DIFF
--- a/python/dgl/graphbolt/minibatch.py
+++ b/python/dgl/graphbolt/minibatch.py
@@ -500,7 +500,7 @@ class MiniBatch:
             col_nodes = torch.cat(col_nodes)
             row_nodes = torch.cat(row_nodes)
             edge_index = torch.unique(
-                torch.stack((col_nodes, row_nodes)), dim=1
+                torch.stack((row_nodes, col_nodes)), dim=1
             )
 
         if self.node_features is None:

--- a/tests/python/pytorch/graphbolt/test_minibatch.py
+++ b/tests/python/pytorch/graphbolt/test_minibatch.py
@@ -881,7 +881,7 @@ def test_to_pyg_data():
         original_column_node_ids=torch.tensor([10, 11]),
     )
     expected_edge_index = torch.tensor(
-        [[0, 0, 1, 1, 1, 2, 2, 3], [0, 1, 0, 1, 2, 1, 2, 2]]
+        [[0, 0, 1, 1, 1, 2, 2, 2], [0, 1, 0, 1, 2, 1, 2, 3]]
     )
     expected_node_features = torch.tensor([[1], [2], [3], [4]])
     expected_labels = torch.tensor([0, 1])


### PR DESCRIPTION
## Description
Correct a mistake in the `to_pyg_data`.

## Checklist
Please feel free to remove inapplicable items for your PR.
- [ ] The PR title starts with [$CATEGORY] (such as [NN], [Model], [Doc], [Feature]])
- [ ] I've leverage the [tools](https://docs.google.com/document/d/1iHyj7zlmygKSk5gBPsqIqL5ASPzJSPREaNT_QdsiYA4/edit) to beautify the python and c++ code.
- [ ] The PR is complete and small, read the [Google eng practice (CL equals to PR)](https://google.github.io/eng-practices/review/developer/small-cls.html) to understand more about small PR. In DGL, we consider PRs with less than 200 lines of core code change are small (example, test and documentation could be exempted).
- [ ] All changes have test coverage
- [ ] Code is well-documented
- [ ] To the best of my knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change
- [ ] Related issue is referred in this PR
- [ ] If the PR is for a new model/paper, I've updated the example index [here](../examples/README.md).

## Changes
<!-- You could use following template
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)
-->
