### PR TITLE
[GraphBolt] Fix scalar itemset dtype issue

### DIFF
--- a/python/dgl/graphbolt/itemset.py
+++ b/python/dgl/graphbolt/itemset.py
@@ -52,7 +52,22 @@ class ItemSet:
     >>> item_set.names
     ('seed_nodes',)
 
-    2. Single iterable: seed nodes.
+    2. Torch scalar: number of nodes. Customizable dtype compared to Integer.
+
+    >>> num = torch.tensor(10, dtype=torch.int32)
+    >>> item_set = gb.ItemSet(num, names="seed_nodes")
+    >>> list(item_set)
+    [tensor(0, dtype=torch.int32), tensor(1, dtype=torch.int32),
+     tensor(2, dtype=torch.int32), tensor(3, dtype=torch.int32),
+     tensor(4, dtype=torch.int32), tensor(5, dtype=torch.int32),
+     tensor(6, dtype=torch.int32), tensor(7, dtype=torch.int32),
+     tensor(8, dtype=torch.int32), tensor(9, dtype=torch.int32)]
+    >>> item_set[:]
+    tensor([0, 1, 2, 3, 4, 5, 6, 7, 8, 9], dtype=torch.int32)
+    >>> item_set.names
+    ('seed_nodes',)
+
+    3. Single iterable: seed nodes.
 
     >>> node_ids = torch.arange(0, 5)
     >>> item_set = gb.ItemSet(node_ids, names="seed_nodes")
@@ -63,7 +78,7 @@ class ItemSet:
     >>> item_set.names
     ('seed_nodes',)
 
-    3. Tuple of iterables with same shape: seed nodes and labels.
+    4. Tuple of iterables with same shape: seed nodes and labels.
 
     >>> node_ids = torch.arange(0, 5)
     >>> labels = torch.arange(5, 10)
@@ -77,7 +92,7 @@ class ItemSet:
     >>> item_set.names
     ('seed_nodes', 'labels')
 
-    4. Tuple of iterables with different shape: node pairs and negative dsts.
+    5. Tuple of iterables with different shape: node pairs and negative dsts.
 
     >>> node_pairs = torch.arange(0, 10).reshape(-1, 2)
     >>> neg_dsts = torch.arange(10, 25).reshape(-1, 3)

--- a/python/dgl/graphbolt/itemset.py
+++ b/python/dgl/graphbolt/itemset.py
@@ -9,6 +9,7 @@ __all__ = ["ItemSet", "ItemSetDict"]
 
 
 def is_torch_scalar(x):
+    """Checks if the input is a torch.Tensor with 0 dimensions; a scalar."""
     return isinstance(x, torch.Tensor) and len(x.shape) == 0
 
 

--- a/python/dgl/graphbolt/itemset.py
+++ b/python/dgl/graphbolt/itemset.py
@@ -10,8 +10,8 @@ __all__ = ["ItemSet", "ItemSetDict"]
 
 def is_scalar(x):
     """Checks if the input is a scalar."""
-    return (isinstance(x, torch.Tensor) and len(x.shape) == 0) or isinstance(
-        x, int
+    return (
+        len(x.shape) == 0 if isinstance(x, torch.Tensor) else isinstance(x, int)
     )
 
 

--- a/python/dgl/graphbolt/minibatch.py
+++ b/python/dgl/graphbolt/minibatch.py
@@ -231,7 +231,7 @@ class MiniBatch:
             self.sampled_subgraphs[0].sampled_csc, Dict
         )
 
-        # casts to minimum dtype in-place and returns self.
+        # Casts to minimum dtype in-place and returns self.
         def cast_to_minimum_dtype(v: CSCFormatBase):
             # Checks if number of vertices and edges fit into an int32.
             dtype = (

--- a/tests/python/pytorch/graphbolt/test_itemset.py
+++ b/tests/python/pytorch/graphbolt/test_itemset.py
@@ -4,7 +4,6 @@ import dgl
 import pytest
 import torch
 from dgl import graphbolt as gb
-from torch.testing import assert_close
 
 
 def test_ItemSet_names():
@@ -36,6 +35,18 @@ def test_ItemSet_names():
         match=re.escape("Number of items (1) and names (2) must match."),
     ):
         _ = gb.ItemSet(torch.arange(0, 5), names=("seed_nodes", "labels"))
+
+
+@pytest.mark.parametrize("dtype", [torch.int32, torch.int64])
+def test_ItemSet_scalar_dtype(dtype):
+    item_set = gb.ItemSet(torch.tensor(5, dtype=dtype), names="seed_nodes")
+    for i, item in enumerate(item_set):
+        assert i == item
+        assert item.dtype == dtype
+    assert item_set[2] == torch.tensor(2, dtype=dtype)
+    assert torch.equal(
+        item_set[slice(1, 4, 2)], torch.arange(1, 4, 2, dtype=dtype)
+    )
 
 
 def test_ItemSet_length():


### PR DESCRIPTION
## Description
Scalar torch tensor option is added to ItemSet so that we can generate `all_nodes_set` with a specific dtype.

Should help #7127 CI tests to pass.

Also related to #7130.

Now, we will need to modify all the itemsets in our BuiltinDatasets that are simple integers and wrap them into a `torch.tensor(N, dtype=dtype)`.

## Checklist
Please feel free to remove inapplicable items for your PR.
- [ ] The PR title starts with [$CATEGORY] (such as [NN], [Model], [Doc], [Feature]])
- [ ] I've leverage the [tools](https://docs.google.com/document/d/1iHyj7zlmygKSk5gBPsqIqL5ASPzJSPREaNT_QdsiYA4/edit) to beautify the python and c++ code.
- [ ] The PR is complete and small, read the [Google eng practice (CL equals to PR)](https://google.github.io/eng-practices/review/developer/small-cls.html) to understand more about small PR. In DGL, we consider PRs with less than 200 lines of core code change are small (example, test and documentation could be exempted).
- [ ] All changes have test coverage
- [ ] Code is well-documented
- [ ] To the best of my knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change
- [ ] Related issue is referred in this PR
- [ ] If the PR is for a new model/paper, I've updated the example index [here](../examples/README.md).

## Changes
<!-- You could use following template
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)
-->
