### PR TITLE
[GraphBolt][CUDA] Fix cudart destructor race in unpinning.

### DIFF
--- a/python/dgl/graphbolt/impl/fused_csc_sampling_graph.py
+++ b/python/dgl/graphbolt/impl/fused_csc_sampling_graph.py
@@ -76,10 +76,7 @@ class FusedCSCSamplingGraph(SamplingGraph):
         # https://github.com/pytorch/pytorch/issues/32167#issuecomment-753551842
         if hasattr(self, "_is_inplace_pinned"):
             for tensor in self._is_inplace_pinned:
-                assert (
-                    torch.cuda.cudart().cudaHostUnregister(tensor.data_ptr())
-                    == 0
-                )
+                assert self._inplace_unpinner(tensor.data_ptr()) == 0
 
     @property
     def total_num_nodes(self) -> int:
@@ -1121,6 +1118,7 @@ class FusedCSCSamplingGraph(SamplingGraph):
                 )
 
                 self._is_inplace_pinned.add(x)
+                self._inplace_unpinner = cudart.cudaHostUnregister
 
             return x
 


### PR DESCRIPTION
## Description
When we are at the end of the program, the cudart can not be found as it get unloaded before unpinning happens. Saving a reference to the unpinner function resolves the issue and warnings at the end of some examples.

## Checklist
Please feel free to remove inapplicable items for your PR.
- [ ] The PR title starts with [$CATEGORY] (such as [NN], [Model], [Doc], [Feature]])
- [ ] I've leverage the [tools](https://docs.google.com/document/d/1iHyj7zlmygKSk5gBPsqIqL5ASPzJSPREaNT_QdsiYA4/edit) to beautify the python and c++ code.
- [ ] The PR is complete and small, read the [Google eng practice (CL equals to PR)](https://google.github.io/eng-practices/review/developer/small-cls.html) to understand more about small PR. In DGL, we consider PRs with less than 200 lines of core code change are small (example, test and documentation could be exempted).
- [ ] All changes have test coverage
- [ ] Code is well-documented
- [ ] To the best of my knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change
- [ ] Related issue is referred in this PR
- [ ] If the PR is for a new model/paper, I've updated the example index [here](../examples/README.md).

## Changes
<!-- You could use following template
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)
-->
