### PR TITLE
[GraphBolt] Fix the exclude edge functions when int32 is used.

### DIFF
--- a/python/dgl/graphbolt/sampled_subgraph.py
+++ b/python/dgl/graphbolt/sampled_subgraph.py
@@ -292,8 +292,10 @@ def _exclude_homo_edges(
 ):
     """Return the indices of edges to be included."""
     if assume_num_node_within_int32:
-        val = edges[0] << 32 | edges[1]
-        val_to_exclude = edges_to_exclude[0] << 32 | edges_to_exclude[1]
+        val = edges[0].long() << 32 | edges[1].long()
+        val_to_exclude = (
+            edges_to_exclude[0].long() << 32 | edges_to_exclude[1].long()
+        )
     else:
         # TODO: Add support for value > int32.
         raise NotImplementedError(
@@ -310,10 +312,11 @@ def _exclude_homo_edges_2(
 ):
     """Return the indices of edges to be included."""
     if assume_num_node_within_int32:
-        val = edges[0] << 32 | edges[1]
+        val = edges[0].long() << 32 | edges[1].long()
         edges_to_exclude_trans = edges_to_exclude.T
         val_to_exclude = (
-            edges_to_exclude_trans[0] << 32 | edges_to_exclude_trans[1]
+            edges_to_exclude_trans[0].long() << 32
+            | edges_to_exclude_trans[1].long()
         )
     else:
         # TODO: Add support for value > int32.


### PR DESCRIPTION
## Description
The code modified here assumes that int64 is used and shifts by 32 bits. But when we change the dtype of graph and int32 is used, the code fails silently. This PR ensures we use int64 here.

## Checklist
Please feel free to remove inapplicable items for your PR.
- [ ] The PR title starts with [$CATEGORY] (such as [NN], [Model], [Doc], [Feature]])
- [ ] I've leverage the [tools](https://docs.google.com/document/d/1iHyj7zlmygKSk5gBPsqIqL5ASPzJSPREaNT_QdsiYA4/edit) to beautify the python and c++ code.
- [ ] The PR is complete and small, read the [Google eng practice (CL equals to PR)](https://google.github.io/eng-practices/review/developer/small-cls.html) to understand more about small PR. In DGL, we consider PRs with less than 200 lines of core code change are small (example, test and documentation could be exempted).
- [ ] All changes have test coverage
- [ ] Code is well-documented
- [ ] To the best of my knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change
- [ ] Related issue is referred in this PR
- [ ] If the PR is for a new model/paper, I've updated the example index [here](../examples/README.md).

## Changes
<!-- You could use following template
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)
-->
