### PR TITLE
[GraphBolt] Fix acc drop due to unique seed nodes.

### DIFF
--- a/python/dgl/graphbolt/subgraph_sampler.py
+++ b/python/dgl/graphbolt/subgraph_sampler.py
@@ -264,6 +264,7 @@ class SubgraphSampler(MiniBatchTransformer):
             # Collect nodes from all types of input.
             nodes = defaultdict(list)
             nodes_timestamp = None
+            is_nodes = False
             if use_timestamp:
                 nodes_timestamp = defaultdict(list)
             for etype, pair in seeds.items():
@@ -273,6 +274,8 @@ class SubgraphSampler(MiniBatchTransformer):
                     "Only tensor with shape 1*N and N*2 is "
                     + f"supported now, but got {pair.shape}."
                 )
+                if pair.ndim == 1:
+                    is_nodes = True
                 ntypes = etype[:].split(":")[::2]
                 pair = pair.view(pair.shape[0], -1)
                 if use_timestamp:
@@ -309,6 +312,8 @@ class SubgraphSampler(MiniBatchTransformer):
                     src = compacted[src_type].pop(0)
                     dst = compacted[dst_type].pop(0)
                     compacted_seeds[etype] = torch.cat((src, dst)).view(2, -1).T
+            if is_nodes:
+                unique_seeds = seeds
         else:
             # Collect nodes from all types of input.
             nodes = [seeds.view(-1)]
@@ -337,6 +342,8 @@ class SubgraphSampler(MiniBatchTransformer):
                 nodes_timestamp = None
             # Map back in same order as collect.
             compacted_seeds = compacted[0].view(seeds.shape)
+            if seeds.ndim == 1:
+                unique_seeds = seeds
         return (
             unique_seeds,
             nodes_timestamp,


### PR DESCRIPTION
## Description
<!-- Brief description. Refer to the related issues if existed.
It'll be great if relevant reviewers can be assigned as well.-->
When running benchmark for hetero rgcn and node classification examples based on `seeds`, I found a drop of accuracy. So, I compared the differences between original code and new one. I found that for 1*N `seeds`, representing `seed_nodes`, does not need unique operation, so I add checks to code and remain compact parts.

## Checklist
Please feel free to remove inapplicable items for your PR.
- [ ] The PR title starts with [$CATEGORY] (such as [NN], [Model], [Doc], [Feature]])
- [ ] I've leverage the [tools](https://docs.google.com/document/d/1iHyj7zlmygKSk5gBPsqIqL5ASPzJSPREaNT_QdsiYA4/edit) to beautify the python and c++ code.
- [ ] The PR is complete and small, read the [Google eng practice (CL equals to PR)](https://google.github.io/eng-practices/review/developer/small-cls.html) to understand more about small PR. In DGL, we consider PRs with less than 200 lines of core code change are small (example, test and documentation could be exempted).
- [ ] All changes have test coverage
- [ ] Code is well-documented
- [ ] To the best of my knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change
- [ ] Related issue is referred in this PR
- [ ] If the PR is for a new model/paper, I've updated the example index [here](../examples/README.md).

## Changes
<!-- You could use following template
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)
-->
