### PR TITLE
[DistGB] restrict NID/EID as int64_t

### DIFF
--- a/python/dgl/distributed/partition.py
+++ b/python/dgl/distributed/partition.py
@@ -1346,10 +1346,12 @@ def partition_graph(
         return orig_nids, orig_eids
 
 
+# [TODO][Rui] Due to int64_t is expected in RPC, we have to limit the data type
+# of node/edge IDs to int64_t. See more details in #7175.
 DTYPES_TO_CHECK = {
     "default": [torch.int32, torch.int64],
-    NID: [torch.int32, torch.int64],
-    EID: [torch.int32, torch.int64],
+    NID: [torch.int64],
+    EID: [torch.int64],
     NTYPE: [torch.int8, torch.int16, torch.int32, torch.int64],
     ETYPE: [torch.int8, torch.int16, torch.int32, torch.int64],
     "inner_node": [torch.uint8],
@@ -1537,16 +1539,10 @@ def dgl_partition_to_graphbolt(
         ] = os.path.relpath(csc_graph_path, os.path.dirname(part_config))
 
     # Save dtype info into partition config.
-    new_part_meta["node_map_dtype"] = (
-        "int32"
-        if part_meta["num_nodes"] <= torch.iinfo(torch.int32).max
-        else "int64"
-    )
-    new_part_meta["edge_map_dtype"] = (
-        "int32"
-        if part_meta["num_edges"] <= torch.iinfo(torch.int32).max
-        else "int64"
-    )
+    # [TODO][Rui] Always use int64_t for node/edge IDs in GraphBolt. See more
+    # details in #7175.
+    new_part_meta["node_map_dtype"] = "int64"
+    new_part_meta["edge_map_dtype"] = "int64"
 
     _dump_part_config(part_config, new_part_meta)
     print(f"Converted partitions to GraphBolt format into {part_config}")

--- a/tests/distributed/test_distributed_sampling.py
+++ b/tests/distributed/test_distributed_sampling.py
@@ -96,12 +96,7 @@ def start_sample_client_shuffle(
         use_graphbolt=use_graphbolt,
     )
     assert sampled_graph.idtype == dist_graph.idtype
-    if use_graphbolt:
-        # dtype conversion is applied for GraphBolt partitions.
-        assert sampled_graph.idtype == torch.int32
-    else:
-        # dtype conversion is not applied for non-GraphBolt partitions.
-        assert sampled_graph.idtype == torch.int64
+    assert sampled_graph.idtype == torch.int64
 
     assert (
         dgl.ETYPE not in sampled_graph.edata
@@ -1251,7 +1246,7 @@ def check_rpc_bipartite_etype_sampling_shuffle(
 @pytest.mark.parametrize("num_server", [1])
 @pytest.mark.parametrize("use_graphbolt", [False, True])
 @pytest.mark.parametrize("return_eids", [False, True])
-@pytest.mark.parametrize("node_id_dtype", [torch.int32, torch.int64])
+@pytest.mark.parametrize("node_id_dtype", [torch.int64])
 def test_rpc_sampling_shuffle(
     num_server, use_graphbolt, return_eids, node_id_dtype
 ):

--- a/tests/distributed/test_partition.py
+++ b/tests/distributed/test_partition.py
@@ -779,7 +779,7 @@ def test_dgl_partition_to_graphbolt_homo(
             assert th.equal(orig_indices, new_g.indices)
             assert new_g.node_type_offset is None
             assert orig_g.ndata[dgl.NID].dtype == th.int64
-            assert new_g.node_attributes[dgl.NID].dtype == th.int32
+            assert new_g.node_attributes[dgl.NID].dtype == th.int64
             assert th.equal(
                 orig_g.ndata[dgl.NID], new_g.node_attributes[dgl.NID]
             )
@@ -792,7 +792,7 @@ def test_dgl_partition_to_graphbolt_homo(
                 assert "inner_node" not in new_g.node_attributes
             if store_eids or debug_mode:
                 assert orig_g.edata[dgl.EID].dtype == th.int64
-                assert new_g.edge_attributes[dgl.EID].dtype == th.int32
+                assert new_g.edge_attributes[dgl.EID].dtype == th.int64
                 assert th.equal(
                     orig_g.edata[dgl.EID][orig_eids],
                     new_g.edge_attributes[dgl.EID],
@@ -861,7 +861,7 @@ def test_dgl_partition_to_graphbolt_hetero(
             assert th.equal(orig_indptr, new_g.csc_indptr)
             assert th.equal(orig_indices, new_g.indices)
             assert orig_g.ndata[dgl.NID].dtype == th.int64
-            assert new_g.node_attributes[dgl.NID].dtype == th.int32
+            assert new_g.node_attributes[dgl.NID].dtype == th.int64
             assert th.equal(
                 orig_g.ndata[dgl.NID], new_g.node_attributes[dgl.NID]
             )
@@ -882,7 +882,7 @@ def test_dgl_partition_to_graphbolt_hetero(
                 assert dgl.NTYPE not in new_g.node_attributes
             if store_eids or debug_mode:
                 assert orig_g.edata[dgl.EID].dtype == th.int64
-                assert new_g.edge_attributes[dgl.EID].dtype == th.int32
+                assert new_g.edge_attributes[dgl.EID].dtype == th.int64
                 assert th.equal(
                     orig_g.edata[dgl.EID][orig_eids],
                     new_g.edge_attributes[dgl.EID],


### PR DESCRIPTION
## Description
<!-- Brief description. Refer to the related issues if existed.
It'll be great if relevant reviewers can be assigned as well.-->
Due to #7175 , I'd like to restrict NID/EID as **int64** for now. And the additional memory consumption( **int32** -> **int64**) is usually relatively small(node/edge feature always takes the major parts).

Below are diff for `ogbn-products` and `ogbn-papers100M`.
```
-rw-rw-r-- 1 ubuntu ubuntu 252M Feb 28 07:29 ogbn_products/part0/fused_csc_sampling_graph.pt
-rw-rw-r-- 1 ubuntu ubuntu 262M Feb 28 07:29 ogbn_products/part1/fused_csc_sampling_graph.pt

VS

-rw-rw-r-- 1 ubuntu ubuntu 255M Feb 29 06:39 new_ogbn_products/part0/fused_csc_sampling_graph.pt
-rw-rw-r-- 1 ubuntu ubuntu 265M Feb 29 06:39 new_ogbn_products/part1/fused_csc_sampling_graph.pt
```
```
-rw-rw-r-- 1 ubuntu ubuntu 4.1G Feb 28 11:24 ogbn_papers100M/part0/fused_csc_sampling_graph.pt
-rw-rw-r-- 1 ubuntu ubuntu 3.8G Feb 28 11:24 ogbn_papers100M/part1/fused_csc_sampling_graph.pt

VS

-rw-rw-r-- 1 ubuntu ubuntu 4.4G Feb 29 07:37 new_ogbn_papers100M/part0/fused_csc_sampling_graph.pt
-rw-rw-r-- 1 ubuntu ubuntu 4.1G Feb 29 07:37 new_ogbn_papers100M/part1/fused_csc_sampling_graph.pt
```
## Checklist
Please feel free to remove inapplicable items for your PR.
- [ ] The PR title starts with [$CATEGORY] (such as [NN], [Model], [Doc], [Feature]])
- [ ] I've leverage the [tools](https://docs.google.com/document/d/1iHyj7zlmygKSk5gBPsqIqL5ASPzJSPREaNT_QdsiYA4/edit) to beautify the python and c++ code.
- [ ] The PR is complete and small, read the [Google eng practice (CL equals to PR)](https://google.github.io/eng-practices/review/developer/small-cls.html) to understand more about small PR. In DGL, we consider PRs with less than 200 lines of core code change are small (example, test and documentation could be exempted).
- [ ] All changes have test coverage
- [ ] Code is well-documented
- [ ] To the best of my knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change
- [ ] Related issue is referred in this PR
- [ ] If the PR is for a new model/paper, I've updated the example index [here](../examples/README.md).

## Changes
<!-- You could use following template
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)
-->
