### PR TITLE
[GraphBolt] `torch.compile()` support for `gb.expand_indptr`.

### DIFF
--- a/graphbolt/src/expand_indptr.cc
+++ b/graphbolt/src/expand_indptr.cc
@@ -5,6 +5,7 @@
  * @brief ExpandIndptr operators.
  */
 #include <graphbolt/cuda_ops.h>
+#include <torch/autograd.h>
 
 #include "./macro.h"
 #include "./utils.h"
@@ -27,6 +28,18 @@ torch::Tensor ExpandIndptr(
   }
   return node_ids.value().to(dtype).repeat_interleave(
       indptr.diff(), 0, output_size);
+}
+
+TORCH_LIBRARY_IMPL(graphbolt, CPU, m) {
+  m.impl("expand_indptr", &ExpandIndptr);
+}
+
+TORCH_LIBRARY_IMPL(graphbolt, CUDA, m) {
+  m.impl("expand_indptr", &ExpandIndptrImpl);
+}
+
+TORCH_LIBRARY_IMPL(graphbolt, Autograd, m) {
+  m.impl("expand_indptr", torch::autograd::autogradNotImplementedFallback());
 }
 
 }  // namespace ops

--- a/graphbolt/src/expand_indptr.cc
+++ b/graphbolt/src/expand_indptr.cc
@@ -34,9 +34,11 @@ TORCH_LIBRARY_IMPL(graphbolt, CPU, m) {
   m.impl("expand_indptr", &ExpandIndptr);
 }
 
+#ifdef GRAPHBOLT_USE_CUDA
 TORCH_LIBRARY_IMPL(graphbolt, CUDA, m) {
   m.impl("expand_indptr", &ExpandIndptrImpl);
 }
+#endif
 
 TORCH_LIBRARY_IMPL(graphbolt, Autograd, m) {
   m.impl("expand_indptr", torch::autograd::autogradNotImplementedFallback());

--- a/graphbolt/src/python_binding.cc
+++ b/graphbolt/src/python_binding.cc
@@ -90,8 +90,8 @@ TORCH_LIBRARY(graphbolt, m) {
   m.def("index_select", &ops::IndexSelect);
   m.def("index_select_csc", &ops::IndexSelectCSC);
   m.def(
-      "expand_indptr(Tensor indptr, ScalarType dtype, Tensor? node_ids, int? "
-      "output_size) -> Tensor",
+      "expand_indptr(Tensor indptr, ScalarType dtype, Tensor? node_ids, "
+      "SymInt? output_size) -> Tensor",
       {at::Tag::pt2_compliant_tag});
   m.def("set_seed", &RandomEngine::SetManualSeed);
 #ifdef GRAPHBOLT_USE_CUDA

--- a/graphbolt/src/python_binding.cc
+++ b/graphbolt/src/python_binding.cc
@@ -24,6 +24,7 @@ namespace graphbolt {
 namespace sampling {
 
 TORCH_LIBRARY(graphbolt, m) {
+  m.impl_abstract_pystub("graphbolt", "//dgl.graphbolt");
   m.class_<FusedSampledSubgraph>("FusedSampledSubgraph")
       .def(torch::init<>())
       .def_readwrite("indptr", &FusedSampledSubgraph::indptr)
@@ -88,7 +89,10 @@ TORCH_LIBRARY(graphbolt, m) {
   m.def("isin", &IsIn);
   m.def("index_select", &ops::IndexSelect);
   m.def("index_select_csc", &ops::IndexSelectCSC);
-  m.def("expand_indptr", &ops::ExpandIndptr);
+  m.def(
+      "expand_indptr(Tensor indptr, ScalarType dtype, Tensor? node_ids, int? "
+      "output_size) -> Tensor",
+      {at::Tag::pt2_compliant_tag});
   m.def("set_seed", &RandomEngine::SetManualSeed);
 #ifdef GRAPHBOLT_USE_CUDA
   m.def("set_max_uva_threads", &cuda::set_max_uva_threads);

--- a/graphbolt/src/python_binding.cc
+++ b/graphbolt/src/python_binding.cc
@@ -24,9 +24,6 @@ namespace graphbolt {
 namespace sampling {
 
 TORCH_LIBRARY(graphbolt, m) {
-#ifdef HAS_IMPL_ABSTRACT_PYSTUB
-  m.impl_abstract_pystub("graphbolt", "//dgl.graphbolt");
-#endif
   m.class_<FusedSampledSubgraph>("FusedSampledSubgraph")
       .def(torch::init<>())
       .def_readwrite("indptr", &FusedSampledSubgraph::indptr)
@@ -91,6 +88,13 @@ TORCH_LIBRARY(graphbolt, m) {
   m.def("isin", &IsIn);
   m.def("index_select", &ops::IndexSelect);
   m.def("index_select_csc", &ops::IndexSelectCSC);
+  m.def("set_seed", &RandomEngine::SetManualSeed);
+#ifdef GRAPHBOLT_USE_CUDA
+  m.def("set_max_uva_threads", &cuda::set_max_uva_threads);
+#endif
+#ifdef HAS_IMPL_ABSTRACT_PYSTUB
+  m.impl_abstract_pystub("dgl.graphbolt.base", "//dgl.graphbolt.base");
+#endif
   m.def(
       "expand_indptr(Tensor indptr, ScalarType dtype, Tensor? node_ids, "
       "SymInt? output_size) -> Tensor"
@@ -99,10 +103,6 @@ TORCH_LIBRARY(graphbolt, m) {
       {at::Tag::pt2_compliant_tag}
 #endif
   );
-  m.def("set_seed", &RandomEngine::SetManualSeed);
-#ifdef GRAPHBOLT_USE_CUDA
-  m.def("set_max_uva_threads", &cuda::set_max_uva_threads);
-#endif
 }
 
 }  // namespace sampling

--- a/graphbolt/src/python_binding.cc
+++ b/graphbolt/src/python_binding.cc
@@ -24,7 +24,9 @@ namespace graphbolt {
 namespace sampling {
 
 TORCH_LIBRARY(graphbolt, m) {
+#ifdef HAS_IMPL_ABSTRACT_PYSTUB
   m.impl_abstract_pystub("graphbolt", "//dgl.graphbolt");
+#endif
   m.class_<FusedSampledSubgraph>("FusedSampledSubgraph")
       .def(torch::init<>())
       .def_readwrite("indptr", &FusedSampledSubgraph::indptr)
@@ -91,8 +93,12 @@ TORCH_LIBRARY(graphbolt, m) {
   m.def("index_select_csc", &ops::IndexSelectCSC);
   m.def(
       "expand_indptr(Tensor indptr, ScalarType dtype, Tensor? node_ids, "
-      "SymInt? output_size) -> Tensor",
-      {at::Tag::pt2_compliant_tag});
+      "SymInt? output_size) -> Tensor"
+#ifdef HAS_PT2_COMPLIANT_TAG
+      ,
+      {at::Tag::pt2_compliant_tag}
+#endif
+  );
   m.def("set_seed", &RandomEngine::SetManualSeed);
 #ifdef GRAPHBOLT_USE_CUDA
   m.def("set_max_uva_threads", &cuda::set_max_uva_threads);

--- a/python/dgl/graphbolt/__init__.py
+++ b/python/dgl/graphbolt/__init__.py
@@ -5,25 +5,6 @@ import sys
 import torch
 
 from .._ffi import libinfo
-from .base import *
-from .minibatch import *
-from .dataloader import *
-from .dataset import *
-from .feature_fetcher import *
-from .feature_store import *
-from .impl import *
-from .itemset import *
-from .item_sampler import *
-from .minibatch_transformer import *
-from .negative_sampler import *
-from .sampled_subgraph import *
-from .subgraph_sampler import *
-from .internal import (
-    compact_csc_format,
-    unique_and_compact,
-    unique_and_compact_csc_formats,
-)
-from .utils import add_reverse_edges, add_reverse_edges_2, exclude_seed_edges
 
 
 def load_graphbolt():
@@ -53,3 +34,23 @@ def load_graphbolt():
 
 
 load_graphbolt()
+
+from .base import *
+from .minibatch import *
+from .dataloader import *
+from .dataset import *
+from .feature_fetcher import *
+from .feature_store import *
+from .impl import *
+from .itemset import *
+from .item_sampler import *
+from .minibatch_transformer import *
+from .negative_sampler import *
+from .sampled_subgraph import *
+from .subgraph_sampler import *
+from .internal import (
+    compact_csc_format,
+    unique_and_compact,
+    unique_and_compact_csc_formats,
+)
+from .utils import add_reverse_edges, add_reverse_edges_2, exclude_seed_edges

--- a/python/dgl/graphbolt/__init__.py
+++ b/python/dgl/graphbolt/__init__.py
@@ -35,6 +35,7 @@ def load_graphbolt():
 
 load_graphbolt()
 
+# pylint: disable=wrong-import-position
 from .base import *
 from .minibatch import *
 from .dataloader import *

--- a/python/dgl/graphbolt/base.py
+++ b/python/dgl/graphbolt/base.py
@@ -63,6 +63,15 @@ def isin(elements, test_elements):
     return torch.ops.graphbolt.isin(elements, test_elements)
 
 
+@torch.library.impl_abstract("graphbolt::expand_indptr")
+def expand_indptr_abstract(indptr, dtype, node_ids, output_size):
+    if output_size is None:
+        output_size = torch.library.get_ctx().new_dynamic_size()
+    if dtype is None:
+        dtype = node_ids.dtype
+    return indptr.new_empty(output_size, dtype=dtype)
+
+
 def expand_indptr(indptr, dtype=None, node_ids=None, output_size=None):
     """Converts a given indptr offset tensor to a COO format tensor. If
     node_ids is not given, it is assumed to be equal to

--- a/python/dgl/graphbolt/base.py
+++ b/python/dgl/graphbolt/base.py
@@ -65,6 +65,7 @@ def isin(elements, test_elements):
 
 @torch.library.impl_abstract("graphbolt::expand_indptr")
 def expand_indptr_abstract(indptr, dtype, node_ids, output_size):
+    """Abstract implementation of expand_indptr for torch.compile() support."""
     if output_size is None:
         output_size = torch.library.get_ctx().new_dynamic_size()
     if dtype is None:

--- a/python/dgl/graphbolt/base.py
+++ b/python/dgl/graphbolt/base.py
@@ -4,6 +4,7 @@ from collections import deque
 from dataclasses import dataclass
 
 import torch
+from torch.torch_version import TorchVersion
 from torch.utils.data import functional_datapipe
 from torchdata.datapipes.iter import IterDataPipe
 
@@ -63,14 +64,16 @@ def isin(elements, test_elements):
     return torch.ops.graphbolt.isin(elements, test_elements)
 
 
-@torch.library.impl_abstract("graphbolt::expand_indptr")
-def expand_indptr_abstract(indptr, dtype, node_ids, output_size):
-    """Abstract implementation of expand_indptr for torch.compile() support."""
-    if output_size is None:
-        output_size = torch.library.get_ctx().new_dynamic_size()
-    if dtype is None:
-        dtype = node_ids.dtype
-    return indptr.new_empty(output_size, dtype=dtype)
+if TorchVersion(torch.__version__) >= TorchVersion("2.2.0a0"):
+
+    @torch.library.impl_abstract("graphbolt::expand_indptr")
+    def expand_indptr_abstract(indptr, dtype, node_ids, output_size):
+        """Abstract implementation of expand_indptr for torch.compile() support."""
+        if output_size is None:
+            output_size = torch.library.get_ctx().new_dynamic_size()
+        if dtype is None:
+            dtype = node_ids.dtype
+        return indptr.new_empty(output_size, dtype=dtype)
 
 
 def expand_indptr(indptr, dtype=None, node_ids=None, output_size=None):

--- a/tests/python/pytorch/graphbolt/test_base.py
+++ b/tests/python/pytorch/graphbolt/test_base.py
@@ -7,6 +7,7 @@ import backend as F
 import dgl.graphbolt as gb
 import pytest
 import torch
+from torch.torch_version import TorchVersion
 
 from . import gb_test_utils
 
@@ -299,27 +300,28 @@ def test_expand_indptr(nodes, dtype):
     import torch._dynamo as dynamo
     from torch.testing._internal.optests import opcheck
 
-    # Tests torch.compile compatibility
-    for output_size in [None, indptr[-1].item()]:
-        kwargs = {"node_ids": nodes, "output_size": output_size}
-        opcheck(
-            torch.ops.graphbolt.expand_indptr,
-            (indptr, dtype),
-            kwargs,
-            test_utils=[
-                "test_schema",
-                "test_autograd_registration",
-                "test_faketensor",
-                "test_aot_dispatch_dynamic",
-            ],
-            raise_exception=True,
-        )
+    if TorchVersion(torch.__version__) >= TorchVersion("2.2.0a0"):
+        # Tests torch.compile compatibility
+        for output_size in [None, indptr[-1].item()]:
+            kwargs = {"node_ids": nodes, "output_size": output_size}
+            opcheck(
+                torch.ops.graphbolt.expand_indptr,
+                (indptr, dtype),
+                kwargs,
+                test_utils=[
+                    "test_schema",
+                    "test_autograd_registration",
+                    "test_faketensor",
+                    "test_aot_dispatch_dynamic",
+                ],
+                raise_exception=True,
+            )
 
-        explanation = dynamo.explain(gb.expand_indptr)(
-            indptr, dtype, nodes, output_size
-        )
-        expected_breaks = -1 if output_size is None else 0
-        assert explanation.graph_break_count == expected_breaks
+            explanation = dynamo.explain(gb.expand_indptr)(
+                indptr, dtype, nodes, output_size
+            )
+            expected_breaks = -1 if output_size is None else 0
+            assert explanation.graph_break_count == expected_breaks
 
 
 def test_csc_format_base_representation():

--- a/tests/python/pytorch/graphbolt/test_base.py
+++ b/tests/python/pytorch/graphbolt/test_base.py
@@ -297,10 +297,10 @@ def test_expand_indptr(nodes, dtype):
     gb_result = gb.expand_indptr(indptr, dtype, nodes, indptr[-1].item())
     assert torch.equal(torch_result, gb_result)
 
-    import torch._dynamo as dynamo
-    from torch.testing._internal.optests import opcheck
-
     if TorchVersion(torch.__version__) >= TorchVersion("2.2.0a0"):
+        import torch._dynamo as dynamo
+        from torch.testing._internal.optests import opcheck
+
         # Tests torch.compile compatibility
         for output_size in [None, indptr[-1].item()]:
             kwargs = {"node_ids": nodes, "output_size": output_size}


### PR DESCRIPTION
## Description
Details in this document by PyTorch developers: https://docs.google.com/document/d/1W--T6wz8IY8fOI0Vm8BF44PdBgs283QvpelJZWieQWQ/edit?usp=sharing

This PR utilizes `torch>=2.2.0` features.

## Checklist
Please feel free to remove inapplicable items for your PR.
- [ ] The PR title starts with [$CATEGORY] (such as [NN], [Model], [Doc], [Feature]])
- [ ] I've leverage the [tools](https://docs.google.com/document/d/1iHyj7zlmygKSk5gBPsqIqL5ASPzJSPREaNT_QdsiYA4/edit) to beautify the python and c++ code.
- [ ] The PR is complete and small, read the [Google eng practice (CL equals to PR)](https://google.github.io/eng-practices/review/developer/small-cls.html) to understand more about small PR. In DGL, we consider PRs with less than 200 lines of core code change are small (example, test and documentation could be exempted).
- [ ] All changes have test coverage
- [ ] Code is well-documented
- [ ] To the best of my knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change
- [ ] Related issue is referred in this PR
- [ ] If the PR is for a new model/paper, I've updated the example index [here](../examples/README.md).

## Changes
<!-- You could use following template
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)
-->
