### PR TITLE
[GraphBolt][PyG] Add more attributes in `to_pyg_data`

### DIFF
--- a/examples/sampling/pyg/node_classification.py
+++ b/examples/sampling/pyg/node_classification.py
@@ -95,8 +95,8 @@ class GraphSAGE(torch.nn.Module):
             for minibatch in dataloader:
                 # Call `to_pyg_data` to convert GB Minibatch to PyG Data.
                 pyg_data = minibatch.to_pyg_data()
-                n_ids = pyg_data.n_ids.to("cpu")
-                x = x_all[n_ids].to(device)
+                n_id = pyg_data.n_id.to("cpu")
+                x = x_all[n_id].to(device)
                 edge_index = pyg_data.edge_index
                 x = layer(x, edge_index)
                 x = x[: pyg_data.batch_size]

--- a/examples/sampling/pyg/node_classification.py
+++ b/examples/sampling/pyg/node_classification.py
@@ -88,18 +88,18 @@ class GraphSAGE(torch.nn.Module):
                 x = F.dropout(x, p=0.5, training=self.training)
         return x
 
-    def inference(self, args, dataloader, x_all, device):
+    def inference(self, dataloader, x_all, device):
         """Conduct layer-wise inference to get all the node embeddings."""
         for i, layer in tqdm(enumerate(self.layers), "inference"):
             xs = []
             for minibatch in dataloader:
                 # Call `to_pyg_data` to convert GB Minibatch to PyG Data.
                 pyg_data = minibatch.to_pyg_data()
-                n_ids = minibatch.node_ids().to("cpu")
+                n_ids = pyg_data.n_ids.to("cpu")
                 x = x_all[n_ids].to(device)
                 edge_index = pyg_data.edge_index
                 x = layer(x, edge_index)
-                x = x[: 4 * args.batch_size]
+                x = x[: pyg_data.batch_size]
                 if i != len(self.layers) - 1:
                     x = x.relu()
                 xs.append(x.cpu())
@@ -185,11 +185,11 @@ def evaluate(model, dataloader, num_classes):
 
 @torch.no_grad()
 def layerwise_infer(
-    model, args, infer_dataloader, test_set, feature, num_classes, device
+    model, infer_dataloader, test_set, feature, num_classes, device
 ):
     model.eval()
     features = feature.read("node", None, "feat")
-    pred = model.inference(args, infer_dataloader, features, device)
+    pred = model.inference(infer_dataloader, features, device)
     pred = pred[test_set._items[0]]
     label = test_set._items[1].to(pred.device)
 
@@ -271,7 +271,7 @@ def main():
             f"Valid Accuracy: {valid_accuracy:.4f}"
         )
     test_accuracy = layerwise_infer(
-        model, args, infer_dataloader, test_set, feature, num_classes, device
+        model, infer_dataloader, test_set, feature, num_classes, device
     )
     print(f"Test Accuracy: {test_accuracy:.4f}")
 

--- a/python/dgl/graphbolt/minibatch.py
+++ b/python/dgl/graphbolt/minibatch.py
@@ -543,7 +543,7 @@ class MiniBatch:
             edge_index=edge_index,
             y=self.labels,
             batch_size=batch_size,
-            n_ids=self.node_ids(),
+            n_id=self.node_ids(),
         )
         return pyg_data
 

--- a/python/dgl/graphbolt/minibatch.py
+++ b/python/dgl/graphbolt/minibatch.py
@@ -526,10 +526,24 @@ class MiniBatch:
             ), "`to_pyg_data` only supports single feature homogeneous graph."
             node_features = next(iter(self.node_features.values()))
 
+        if self.seed_nodes is not None:
+            if isinstance(self.seed_nodes, Dict):
+                batch_size = len(next(iter(self.seed_nodes.values())))
+            else:
+                batch_size = len(self.seed_nodes)
+        elif self.node_pairs is not None:
+            if isinstance(self.node_pairs, Dict):
+                batch_size = len(next(iter(self.node_pairs.values()))[0])
+            else:
+                batch_size = len(self.node_pairs[0])
+        else:
+            batch_size = None
         pyg_data = Data(
             x=node_features,
             edge_index=edge_index,
             y=self.labels,
+            batch_size=batch_size,
+            n_ids=self.node_ids(),
         )
         return pyg_data
 

--- a/tests/python/pytorch/graphbolt/test_minibatch.py
+++ b/tests/python/pytorch/graphbolt/test_minibatch.py
@@ -879,7 +879,7 @@ def test_to_pyg_data():
     expected_node_features = next(iter(test_minibatch.node_features.values()))
     expected_labels = torch.tensor([7, 8])
     expected_batch_size = 2
-    expected_n_ids = torch.tensor([10, 11, 12, 13])
+    expected_n_id = torch.tensor([10, 11, 12, 13])
 
     pyg_data = test_minibatch.to_pyg_data()
     pyg_data.validate()
@@ -887,7 +887,7 @@ def test_to_pyg_data():
     assert torch.equal(pyg_data.x, expected_node_features)
     assert torch.equal(pyg_data.y, expected_labels)
     assert pyg_data.batch_size == expected_batch_size
-    assert torch.equal(pyg_data.n_ids, expected_n_ids)
+    assert torch.equal(pyg_data.n_id, expected_n_id)
 
     subgraph = test_minibatch.sampled_subgraphs[0]
     # Test with sampled_csc as None.


### PR DESCRIPTION
## Description
Add `batch_size` and `n_id` in the `to_pyg_data` to reduce the modification to the PyG inference function when migrating.
So it'll be more seamless.

## Checklist
Please feel free to remove inapplicable items for your PR.
- [ ] The PR title starts with [$CATEGORY] (such as [NN], [Model], [Doc], [Feature]])
- [ ] I've leverage the [tools](https://docs.google.com/document/d/1iHyj7zlmygKSk5gBPsqIqL5ASPzJSPREaNT_QdsiYA4/edit) to beautify the python and c++ code.
- [ ] The PR is complete and small, read the [Google eng practice (CL equals to PR)](https://google.github.io/eng-practices/review/developer/small-cls.html) to understand more about small PR. In DGL, we consider PRs with less than 200 lines of core code change are small (example, test and documentation could be exempted).
- [ ] All changes have test coverage
- [ ] Code is well-documented
- [ ] To the best of my knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change
- [ ] Related issue is referred in this PR
- [ ] If the PR is for a new model/paper, I've updated the example index [here](../examples/README.md).

## Changes
<!-- You could use following template
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)
-->
