### PR TITLE
[GraphBolt] Fixing warning in `test_to_pyg_data`.

### DIFF
--- a/tests/python/pytorch/graphbolt/test_minibatch.py
+++ b/tests/python/pytorch/graphbolt/test_minibatch.py
@@ -929,7 +929,7 @@ def test_to_pyg_data():
     try:
         pyg_data = test_minibatch.to_pyg_data()
         assert (
-            pyg_data.x is None,
+            pyg_data.x is None
         ), "Multiple features case should raise an error."
     except AssertionError as e:
         assert (


### PR DESCRIPTION
## Description
<!-- Brief description. Refer to the related issues if existed.
It'll be great if relevant reviewers can be assigned as well.-->
The following warning
``` 
tests/python/pytorch/graphbolt/test_minibatch.py:944
  /opt/dgl/dgl-source/tests/python/pytorch/graphbolt/test_minibatch.py:944: PytestAssertRewriteWarning: assertion is always true, perhaps remove parentheses?
    assert (
```
is fixed in `graphbolt/test_minibatch.py::test_to_pyg_data` test.

## Checklist
Please feel free to remove inapplicable items for your PR.
- [x] The PR title starts with [$CATEGORY] (such as [NN], [Model], [Doc], [Feature]])
- [x] I've leverage the [tools](https://docs.google.com/document/d/1iHyj7zlmygKSk5gBPsqIqL5ASPzJSPREaNT_QdsiYA4/edit) to beautify the python and c++ code.
- [x] The PR is complete and small, read the [Google eng practice (CL equals to PR)](https://google.github.io/eng-practices/review/developer/small-cls.html) to understand more about small PR. In DGL, we consider PRs with less than 200 lines of core code change are small (example, test and documentation could be exempted).
- [x] To the best of my knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

## Changes
<!-- You could use following template
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)
-->
