### PR TITLE
[GraphBolt] Update `to_pyg_data()` to support get batch_size from `seeds`.

### DIFF
--- a/python/dgl/graphbolt/minibatch.py
+++ b/python/dgl/graphbolt/minibatch.py
@@ -536,6 +536,11 @@ class MiniBatch:
                 batch_size = len(next(iter(self.node_pairs.values()))[0])
             else:
                 batch_size = len(self.node_pairs[0])
+        elif self.seeds is not None:
+            if isinstance(self.seeds, Dict):
+                batch_size = len(next(iter(self.seeds.values())))
+            else:
+                batch_size = len(self.seeds)
         else:
             batch_size = None
         pyg_data = Data(

--- a/tests/python/pytorch/graphbolt/test_minibatch.py
+++ b/tests/python/pytorch/graphbolt/test_minibatch.py
@@ -888,6 +888,14 @@ def test_to_pyg_data():
     assert torch.equal(pyg_data.y, expected_labels)
     assert pyg_data.batch_size == expected_batch_size
     assert torch.equal(pyg_data.n_id, expected_n_id)
+    
+    # Test with seeds in minibatch.
+    test_minibatch.seed_nodes = None
+    test_minibatch.seeds = torch.tensor([0, 1])
+    assert pyg_data.batch_size == expected_batch_size
+
+    test_minibatch.seeds = torch.tensor([[0, 1], [2, 3]])
+    assert pyg_data.batch_size == expected_batch_size
 
     subgraph = test_minibatch.sampled_subgraphs[0]
     # Test with sampled_csc as None.

--- a/tests/python/pytorch/graphbolt/test_minibatch.py
+++ b/tests/python/pytorch/graphbolt/test_minibatch.py
@@ -868,7 +868,7 @@ def test_dgl_link_predication_hetero(mode):
             )
 
 
-def test_to_pyg_data():
+def test_to_pyg_data_original():
     test_minibatch = create_homo_minibatch()
     test_minibatch.seed_nodes = torch.tensor([0, 1])
     test_minibatch.labels = torch.tensor([7, 8])
@@ -889,12 +889,83 @@ def test_to_pyg_data():
     assert pyg_data.batch_size == expected_batch_size
     assert torch.equal(pyg_data.n_id, expected_n_id)
 
-    # Test with seeds in minibatch.
-    test_minibatch.seed_nodes = None
+    subgraph = test_minibatch.sampled_subgraphs[0]
+    # Test with sampled_csc as None.
+    test_minibatch = gb.MiniBatch(
+        sampled_subgraphs=None,
+        node_features={"feat": expected_node_features},
+        labels=expected_labels,
+    )
+    pyg_data = test_minibatch.to_pyg_data()
+    assert pyg_data.edge_index is None, "Edge index should be none."
+
+    # Test with node_features as None.
+    test_minibatch = gb.MiniBatch(
+        sampled_subgraphs=[subgraph],
+        node_features=None,
+        labels=expected_labels,
+    )
+    pyg_data = test_minibatch.to_pyg_data()
+    assert pyg_data.x is None, "Node features should be None."
+
+    # Test with labels as None.
+    test_minibatch = gb.MiniBatch(
+        sampled_subgraphs=[subgraph],
+        node_features={"feat": expected_node_features},
+        labels=None,
+    )
+    pyg_data = test_minibatch.to_pyg_data()
+    assert pyg_data.y is None, "Labels should be None."
+
+    # Test with multiple features.
+    test_minibatch = gb.MiniBatch(
+        sampled_subgraphs=[subgraph],
+        node_features={
+            "feat": expected_node_features,
+            "extra_feat": torch.tensor([[3], [4]]),
+        },
+        labels=expected_labels,
+    )
+    try:
+        pyg_data = test_minibatch.to_pyg_data()
+        assert (
+            pyg_data.x is None
+        ), "Multiple features case should raise an error."
+    except AssertionError as e:
+        assert (
+            str(e)
+            == "`to_pyg_data` only supports single feature homogeneous graph."
+        )
+
+
+def test_to_pyg_data():
+    test_minibatch = create_homo_minibatch()
     test_minibatch.seeds = torch.tensor([0, 1])
+    test_minibatch.labels = torch.tensor([7, 8])
+
+    expected_edge_index = torch.tensor(
+        [[0, 0, 1, 1, 1, 2, 2, 2, 2], [0, 1, 0, 1, 2, 0, 1, 2, 3]]
+    )
+    expected_node_features = next(iter(test_minibatch.node_features.values()))
+    expected_labels = torch.tensor([7, 8])
+    expected_batch_size = 2
+    expected_n_id = torch.tensor([10, 11, 12, 13])
+
+    pyg_data = test_minibatch.to_pyg_data()
+    pyg_data.validate()
+    assert torch.equal(pyg_data.edge_index, expected_edge_index)
+    assert torch.equal(pyg_data.x, expected_node_features)
+    assert torch.equal(pyg_data.y, expected_labels)
     assert pyg_data.batch_size == expected_batch_size
+    assert torch.equal(pyg_data.n_id, expected_n_id)
 
     test_minibatch.seeds = torch.tensor([[0, 1], [2, 3]])
+    assert pyg_data.batch_size == expected_batch_size
+
+    test_minibatch.seeds = {"A": torch.tensor([0, 1])}
+    assert pyg_data.batch_size == expected_batch_size
+
+    test_minibatch.seeds = {"A": torch.tensor([[0, 1], [2, 3]])}
     assert pyg_data.batch_size == expected_batch_size
 
     subgraph = test_minibatch.sampled_subgraphs[0]

--- a/tests/python/pytorch/graphbolt/test_minibatch.py
+++ b/tests/python/pytorch/graphbolt/test_minibatch.py
@@ -888,7 +888,7 @@ def test_to_pyg_data():
     assert torch.equal(pyg_data.y, expected_labels)
     assert pyg_data.batch_size == expected_batch_size
     assert torch.equal(pyg_data.n_id, expected_n_id)
-    
+
     # Test with seeds in minibatch.
     test_minibatch.seed_nodes = None
     test_minibatch.seeds = torch.tensor([0, 1])


### PR DESCRIPTION
## Description
<!-- Brief description. Refer to the related issues if existed.
It'll be great if relevant reviewers can be assigned as well.-->
 Update `to_pyg_data()` in `MiniBatch` to support get batch_size from `seeds`.

## Checklist
Please feel free to remove inapplicable items for your PR.
- [ ] The PR title starts with [$CATEGORY] (such as [NN], [Model], [Doc], [Feature]])
- [ ] I've leverage the [tools](https://docs.google.com/document/d/1iHyj7zlmygKSk5gBPsqIqL5ASPzJSPREaNT_QdsiYA4/edit) to beautify the python and c++ code.
- [ ] The PR is complete and small, read the [Google eng practice (CL equals to PR)](https://google.github.io/eng-practices/review/developer/small-cls.html) to understand more about small PR. In DGL, we consider PRs with less than 200 lines of core code change are small (example, test and documentation could be exempted).
- [ ] All changes have test coverage
- [ ] Code is well-documented
- [ ] To the best of my knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change
- [ ] Related issue is referred in this PR
- [ ] If the PR is for a new model/paper, I've updated the example index [here](../examples/README.md).

## Changes
<!-- You could use following template
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)
-->
