### PR TITLE
[Doc] The len(data) of TUDataset('DD') must be 1178.

### DIFF
--- a/python/dgl/data/tu.py
+++ b/python/dgl/data/tu.py
@@ -349,7 +349,7 @@ class TUDataset(DGLBuiltinDataset):
     The dataset instance is an iterable
 
     >>> len(data)
-    188
+    1178
     >>> g, label = data[1024]
     >>> g
     Graph(num_nodes=88, num_edges=410,


### PR DESCRIPTION
## Description
The len(data) of TUDataset('DD') must be 1178.

## Checklist
Please feel free to remove inapplicable items for your PR.
- [ ] The PR title starts with [$CATEGORY] (such as [NN], [Model], [Doc], [Feature]])
- [ ] I've leverage the [tools](https://docs.google.com/document/d/1iHyj7zlmygKSk5gBPsqIqL5ASPzJSPREaNT_QdsiYA4/edit) to beautify the python and c++ code.
- [ ] The PR is complete and small, read the [Google eng practice (CL equals to PR)](https://google.github.io/eng-practices/review/developer/small-cls.html) to understand more about small PR. In DGL, we consider PRs with less than 200 lines of core code change are small (example, test and documentation could be exempted).
- [ ] All changes have test coverage
- [ ] Code is well-documented
- [ ] To the best of my knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change
- [ ] Related issue is referred in this PR
- [ ] If the PR is for a new model/paper, I've updated the example index [here](../examples/README.md).

## Changes

