### PR TITLE
[GraphBolt] Labor dependent template specialization.

### DIFF
--- a/graphbolt/include/graphbolt/continuous_seed.h
+++ b/graphbolt/include/graphbolt/continuous_seed.h
@@ -93,23 +93,24 @@ class continuous_seed {
 };
 
 class single_seed {
-  uint64_t s;
+  uint64_t seed_;
 
  public:
-  /* implicit */ single_seed(const int64_t seed) : s(seed) {}  // NOLINT
+  /* implicit */ single_seed(const int64_t seed) : seed_(seed) {}  // NOLINT
 
-  single_seed(torch::Tensor seed_arr) : s(seed_arr.data_ptr<int64_t>()[0]) {}
+  single_seed(torch::Tensor seed_arr)
+      : seed_(seed_arr.data_ptr<int64_t>()[0]) {}
 
 #ifdef __CUDACC__
-  __device__ inline float uniform(const uint64_t t) const {
+  __device__ inline float uniform(const uint64_t id) const {
     const uint64_t kCurandSeed = 999961;  // Could be any random number.
     curandStatePhilox4_32_10_t rng;
-    curand_init(kCurandSeed, s, t, &rng);
+    curand_init(kCurandSeed, seed_, id, &rng);
     return curand_uniform(&rng);
   }
 #else
-  inline float uniform(const uint64_t t) const {
-    pcg32 ng0(s, t);
+  inline float uniform(const uint64_t id) const {
+    pcg32 ng0(seed_, id);
     std::uniform_real_distribution<float> uni;
     return uni(ng0);
   }


### PR DESCRIPTION
## Description
Should fix #7209. Need to watch regression tests and see if actually fixes the slow down.

## Checklist
Please feel free to remove inapplicable items for your PR.
- [ ] The PR title starts with [$CATEGORY] (such as [NN], [Model], [Doc], [Feature]])
- [ ] I've leverage the [tools](https://docs.google.com/document/d/1iHyj7zlmygKSk5gBPsqIqL5ASPzJSPREaNT_QdsiYA4/edit) to beautify the python and c++ code.
- [ ] The PR is complete and small, read the [Google eng practice (CL equals to PR)](https://google.github.io/eng-practices/review/developer/small-cls.html) to understand more about small PR. In DGL, we consider PRs with less than 200 lines of core code change are small (example, test and documentation could be exempted).
- [ ] All changes have test coverage
- [ ] Code is well-documented
- [ ] To the best of my knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change
- [ ] Related issue is referred in this PR
- [ ] If the PR is for a new model/paper, I've updated the example index [here](../examples/README.md).

## Changes
<!-- You could use following template
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)
-->
