### PR TITLE
[GraphBolt] Fix `to` when using `seeds`.

### DIFF
--- a/python/dgl/graphbolt/minibatch.py
+++ b/python/dgl/graphbolt/minibatch.py
@@ -591,15 +591,10 @@ class MiniBatch:
                 "sampled_subgraphs",
                 "node_features",
                 "edge_features",
+                "compacted_seeds",
+                "indexes",
+                "seeds",
             ]
-            # Link/edge related tasks.
-            if self.compacted_seeds is not None:
-                transfer_attrs.append("compacted_seeds")
-            if self.indexes is not None:
-                transfer_attrs.append("indexes")
-            if self.labels is None:
-                # Layerwise inference
-                transfer_attrs.append("seeds")
         else:
             # Otherwise copy all the attributes to the device.
             transfer_attrs = get_attributes(self)

--- a/tests/python/pytorch/graphbolt/test_base.py
+++ b/tests/python/pytorch/graphbolt/test_base.py
@@ -252,7 +252,7 @@ def test_CopyToWithMiniBatches(task):
             "node_features",
             "edge_features",
             "blocks",
-            "seeds"
+            "seeds",
         ]
     elif task == "extra_attrs":
         copied_attrs = [
@@ -262,7 +262,7 @@ def test_CopyToWithMiniBatches(task):
             "labels",
             "blocks",
             "seed_nodes",
-            "seeds"
+            "seeds",
         ]
 
     def test_data_device(datapipe):

--- a/tests/python/pytorch/graphbolt/test_base.py
+++ b/tests/python/pytorch/graphbolt/test_base.py
@@ -234,6 +234,7 @@ def test_CopyToWithMiniBatches(task):
             "sampled_subgraphs",
             "labels",
             "blocks",
+            "seeds",
         ]
     elif task == "node_inference":
         copied_attrs = [
@@ -251,6 +252,7 @@ def test_CopyToWithMiniBatches(task):
             "node_features",
             "edge_features",
             "blocks",
+            "seeds"
         ]
     elif task == "extra_attrs":
         copied_attrs = [
@@ -260,6 +262,7 @@ def test_CopyToWithMiniBatches(task):
             "labels",
             "blocks",
             "seed_nodes",
+            "seeds"
         ]
 
     def test_data_device(datapipe):


### PR DESCRIPTION
## Description
<!-- Brief description. Refer to the related issues if existed.
It'll be great if relevant reviewers can be assigned as well.-->
In examples, we will use `copy_to` after `ItemSampler` and `fetch_feature`.
When using `copy_to` after `ItemSampler`, we will copy all attributes because at this time, only `seed_nodes`, `node_pairs` and `labels` have value in minibatch.
When using `copy_to` after `fetch_feature`, we will only copy attributes we need.
These two situations are selected by checking `seed_nodes` and `compacted_pairs` to determine the current stage and the task. However, when using `seeds`, it is difficult to determine these through `seeds` and `compacted_seeds`. For example, when running evaluation in quickstart/link_prediction, `seeds` will not be transfered due to existing `labels`, which may cause error. So, I have changed the `transfer_attr` to confirm `seeds` will be transfered every situation to avoid such error.

## Checklist
Please feel free to remove inapplicable items for your PR.
- [ ] The PR title starts with [$CATEGORY] (such as [NN], [Model], [Doc], [Feature]])
- [ ] I've leverage the [tools](https://docs.google.com/document/d/1iHyj7zlmygKSk5gBPsqIqL5ASPzJSPREaNT_QdsiYA4/edit) to beautify the python and c++ code.
- [ ] The PR is complete and small, read the [Google eng practice (CL equals to PR)](https://google.github.io/eng-practices/review/developer/small-cls.html) to understand more about small PR. In DGL, we consider PRs with less than 200 lines of core code change are small (example, test and documentation could be exempted).
- [ ] All changes have test coverage
- [ ] Code is well-documented
- [ ] To the best of my knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change
- [ ] Related issue is referred in this PR
- [ ] If the PR is for a new model/paper, I've updated the example index [here](../examples/README.md).

## Changes
<!-- You could use following template
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)
-->
