### PR TITLE
[GraphBolt][CUDA] GraphBolt compiles for only newer architectures by default.

### DIFF
--- a/graphbolt/CMakeLists.txt
+++ b/graphbolt/CMakeLists.txt
@@ -58,16 +58,18 @@ if(USE_CUDA)
   if(DEFINED ENV{CUDAARCHS})
     set(CMAKE_CUDA_ARCHITECTURES $ENV{CUDAARCHS})
   endif()
+  set(CMAKE_CUDA_ARCHITECTURES_UNFILTERED ${CMAKE_CUDA_ARCHITECTURES})
+  if(MSVC)
+    # Windows supports only sm_70 and up (Volta+).
+    list(FILTER CMAKE_CUDA_ARCHITECTURES EXCLUDE REGEX "[2-6][0-9]")
+  else(MSVC)
+    # Unix supports only sm_60 and up (Pascal+).
+    list(FILTER CMAKE_CUDA_ARCHITECTURES EXCLUDE REGEX "[2-5][0-9]")
+  endif(MSVC)
   list(LENGTH CMAKE_CUDA_ARCHITECTURES CMAKE_CUDA_ARCHITECTURES_LEN)
-  # Can build for a single older architecture.
-  if(CMAKE_CUDA_ARCHITECTURES_LEN GREATER 1)
-    if(MSVC)
-      # Windows supports only sm_70 and up (Volta+).
-      list(FILTER CMAKE_CUDA_ARCHITECTURES EXCLUDE REGEX "[2-6][0-9]")
-    else(MSVC)
-      # Unix supports only sm_60 and up (Pascal+).
-      list(FILTER CMAKE_CUDA_ARCHITECTURES EXCLUDE REGEX "[2-5][0-9]")
-    endif(MSVC)
+  # If no architectures are left due to filtering, use unfiltered list.
+  if(CMAKE_CUDA_ARCHITECTURES_LEN EQUAL 0)
+    set(CMAKE_CUDA_ARCHITECTURES ${CMAKE_CUDA_ARCHITECTURES_UNFILTERED})
   endif()
 endif()
 

--- a/graphbolt/CMakeLists.txt
+++ b/graphbolt/CMakeLists.txt
@@ -58,13 +58,17 @@ if(USE_CUDA)
   if(DEFINED ENV{CUDAARCHS})
     set(CMAKE_CUDA_ARCHITECTURES $ENV{CUDAARCHS})
   endif()
-  if(MSVC)
-    # Windows supports only sm_70 and up (Volta+).
-    list(FILTER CMAKE_CUDA_ARCHITECTURES EXCLUDE REGEX "[2-6][0-9]")
-  else(MSVC)
-    # Unix supports only sm_60 and up (Pascal+).
-    list(FILTER CMAKE_CUDA_ARCHITECTURES EXCLUDE REGEX "[2-5][0-9]")
-  endif(MSVC)
+  list(LENGTH CMAKE_CUDA_ARCHITECTURES CMAKE_CUDA_ARCHITECTURES_LEN)
+  # Can build for a single older architecture.
+  if(CMAKE_CUDA_ARCHITECTURES_LEN GREATER 1)
+    if(MSVC)
+      # Windows supports only sm_70 and up (Volta+).
+      list(FILTER CMAKE_CUDA_ARCHITECTURES EXCLUDE REGEX "[2-6][0-9]")
+    else(MSVC)
+      # Unix supports only sm_60 and up (Pascal+).
+      list(FILTER CMAKE_CUDA_ARCHITECTURES EXCLUDE REGEX "[2-5][0-9]")
+    endif(MSVC)
+  endif()
 endif()
 
 add_library(${LIB_GRAPHBOLT_NAME} SHARED ${BOLT_SRC} ${BOLT_HEADERS})

--- a/graphbolt/CMakeLists.txt
+++ b/graphbolt/CMakeLists.txt
@@ -58,6 +58,13 @@ if(USE_CUDA)
   if(DEFINED ENV{CUDAARCHS})
     set(CMAKE_CUDA_ARCHITECTURES $ENV{CUDAARCHS})
   endif()
+  if(MSVC)
+    # Windows supports only sm_70 and up (Volta+).
+    list(FILTER CMAKE_CUDA_ARCHITECTURES EXCLUDE REGEX "[2-6][0-9]")
+  else(MSVC)
+    # Unix supports only sm_60 and up (Pascal+).
+    list(FILTER CMAKE_CUDA_ARCHITECTURES EXCLUDE REGEX "[2-5][0-9]")
+  endif(MSVC)
 endif()
 
 add_library(${LIB_GRAPHBOLT_NAME} SHARED ${BOLT_SRC} ${BOLT_HEADERS})


### PR DESCRIPTION
## Description
Needed in #7239. Users can comment out the added lines in this PR to build GraphBolt for older CUDA architectures (35, 50 etc.).

## Checklist
Please feel free to remove inapplicable items for your PR.
- [ ] The PR title starts with [$CATEGORY] (such as [NN], [Model], [Doc], [Feature]])
- [ ] I've leverage the [tools](https://docs.google.com/document/d/1iHyj7zlmygKSk5gBPsqIqL5ASPzJSPREaNT_QdsiYA4/edit) to beautify the python and c++ code.
- [ ] The PR is complete and small, read the [Google eng practice (CL equals to PR)](https://google.github.io/eng-practices/review/developer/small-cls.html) to understand more about small PR. In DGL, we consider PRs with less than 200 lines of core code change are small (example, test and documentation could be exempted).
- [ ] All changes have test coverage
- [ ] Code is well-documented
- [ ] To the best of my knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change
- [ ] Related issue is referred in this PR
- [ ] If the PR is for a new model/paper, I've updated the example index [here](../examples/README.md).

## Changes
<!-- You could use following template
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)
-->
