### PR TITLE
[GraphBolt] Update `__len__()` and `__getitem__()` of `ItemSet`

### DIFF
--- a/python/dgl/graphbolt/itemset.py
+++ b/python/dgl/graphbolt/itemset.py
@@ -137,6 +137,12 @@ class ItemSet:
             )
         else:
             self._names = None
+        if is_scalar(self._items):
+            self._length = int(self._items)
+        elif isinstance(self._items[0], Sized):
+            self._length = len(self._items[0])
+        else:
+            self._length = None
 
     def __iter__(self) -> Iterator:
         if is_scalar(self._items):
@@ -165,19 +171,8 @@ class ItemSet:
             for item in zip_items:
                 yield tuple(item)
 
-    def __len__(self) -> int:
-        if is_scalar(self._items):
-            return int(self._items)
-        if isinstance(self._items[0], Sized):
-            return len(self._items[0])
-        raise TypeError(
-            f"{type(self).__name__} instance doesn't have valid length."
-        )
-
     def __getitem__(self, idx: Union[int, slice, Iterable]) -> Tuple:
-        try:
-            len(self)
-        except TypeError:
+        if self._length is None:
             raise TypeError(
                 f"{type(self).__name__} instance doesn't support indexing."
             )
@@ -209,6 +204,13 @@ class ItemSet:
     def names(self) -> Tuple[str]:
         """Return the names of the items."""
         return self._names
+
+    def __len__(self):
+        if self._length is None:
+            raise TypeError(
+                f"{type(self).__name__} instance doesn't have valid length."
+            )
+        return self._length
 
     def __repr__(self) -> str:
         ret = (

--- a/python/dgl/graphbolt/itemset.py
+++ b/python/dgl/graphbolt/itemset.py
@@ -1,7 +1,7 @@
 """GraphBolt Itemset."""
 
 import textwrap
-from typing import Dict, Iterable, Iterator, Sized, Tuple, Union
+from typing import Dict, Iterable, Iterator, Tuple, Union
 
 import torch
 

--- a/tests/python/pytorch/graphbolt/test_subgraph_sampler.py
+++ b/tests/python/pytorch/graphbolt/test_subgraph_sampler.py
@@ -529,7 +529,7 @@ def test_SubgraphSampler_Random_Hetero_Graph_seed_ndoes(sampler_type, replace):
     "sampler_type",
     [SamplerType.Normal, SamplerType.Layer, SamplerType.Temporal],
 )
-def test_SubgraphSampler_without_dedpulication_Homo_seed_nodes(sampler_type):
+def test_SubgraphSampler_without_deduplication_Homo_seed_nodes(sampler_type):
     _check_sampler_type(sampler_type)
     graph = dgl.graph(
         ([5, 0, 1, 5, 6, 7, 2, 2, 4], [0, 1, 2, 2, 2, 2, 3, 4, 4])
@@ -643,7 +643,7 @@ def _assert_homo_values(
     "sampler_type",
     [SamplerType.Normal, SamplerType.Layer, SamplerType.Temporal],
 )
-def test_SubgraphSampler_without_dedpulication_Hetero_seed_nodes(sampler_type):
+def test_SubgraphSampler_without_deduplication_Hetero_seed_nodes(sampler_type):
     _check_sampler_type(sampler_type)
     graph = get_hetero_graph().to(F.ctx())
     items = torch.arange(2)
@@ -1409,7 +1409,7 @@ def test_SubgraphSampler_Random_Hetero_Graph(sampler_type, replace):
     "sampler_type",
     [SamplerType.Normal, SamplerType.Layer, SamplerType.Temporal],
 )
-def test_SubgraphSampler_without_dedpulication_Homo_Node(sampler_type):
+def test_SubgraphSampler_without_deduplication_Homo_Node(sampler_type):
     _check_sampler_type(sampler_type)
     graph = dgl.graph(
         ([5, 0, 1, 5, 6, 7, 2, 2, 4], [0, 1, 2, 2, 2, 2, 3, 4, 4])
@@ -1473,7 +1473,7 @@ def test_SubgraphSampler_without_dedpulication_Homo_Node(sampler_type):
     "sampler_type",
     [SamplerType.Normal, SamplerType.Layer, SamplerType.Temporal],
 )
-def test_SubgraphSampler_without_dedpulication_Hetero_Node(sampler_type):
+def test_SubgraphSampler_without_deduplication_Hetero_Node(sampler_type):
     _check_sampler_type(sampler_type)
     graph = get_hetero_graph().to(F.ctx())
     items = torch.arange(2)
@@ -1829,7 +1829,7 @@ def test_SubgraphSampler_Hetero_multifanout_per_layer(sampler_type):
     "sampler_type",
     [SamplerType.Normal, SamplerType.Layer, SamplerType.Temporal],
 )
-def test_SubgraphSampler_without_dedpulication_Homo_Link(sampler_type):
+def test_SubgraphSampler_without_deduplication_Homo_Link(sampler_type):
     _check_sampler_type(sampler_type)
     graph = dgl.graph(
         ([5, 0, 1, 5, 6, 7, 2, 2, 4], [0, 1, 2, 2, 2, 2, 3, 4, 4])
@@ -1845,7 +1845,7 @@ def test_SubgraphSampler_without_dedpulication_Homo_Link(sampler_type):
         graph.edge_attributes = {
             "timestamp": torch.zeros(graph.indices.numel()).to(F.ctx())
         }
-        items = (items, torch.randint(1, 10, (3,)))
+        items = (items, torch.randint(1, 10, (2,)))
         names = (names, "timestamp")
 
     itemset = gb.ItemSet(items, names=names)
@@ -1891,7 +1891,7 @@ def test_SubgraphSampler_without_dedpulication_Homo_Link(sampler_type):
     "sampler_type",
     [SamplerType.Normal, SamplerType.Layer, SamplerType.Temporal],
 )
-def test_SubgraphSampler_without_dedpulication_Hetero_Link(sampler_type):
+def test_SubgraphSampler_without_deduplication_Hetero_Link(sampler_type):
     _check_sampler_type(sampler_type)
     graph = get_hetero_graph().to(F.ctx())
     items = torch.arange(2).view(1, 2)
@@ -1903,7 +1903,7 @@ def test_SubgraphSampler_without_dedpulication_Hetero_Link(sampler_type):
         graph.edge_attributes = {
             "timestamp": torch.zeros(graph.indices.numel()).to(F.ctx())
         }
-        items = (items, torch.randint(1, 10, (2,)))
+        items = (items, torch.randint(1, 10, (1,)))
         names = (names, "timestamp")
     itemset = gb.ItemSetDict({"n1:e1:n2": gb.ItemSet(items, names=names)})
     item_sampler = gb.ItemSampler(itemset, batch_size=2).copy_to(F.ctx())


### PR DESCRIPTION
## Description
<!-- Brief description. Refer to the related issues if existed.
It'll be great if relevant reviewers can be assigned as well.-->
Currently the time overhead of the `ItemSet`'s `__getitem__` method is high because each call to `__getitem__` requires the execution of `len(self)`. This PR intends to make `len(self)` a fixed value since `ItemSet` itself is immutable.

## Checklist
Please feel free to remove inapplicable items for your PR.
- [ ] The PR title starts with [$CATEGORY] (such as [NN], [Model], [Doc], [Feature]])
- [ ] I've leverage the [tools](https://docs.google.com/document/d/1iHyj7zlmygKSk5gBPsqIqL5ASPzJSPREaNT_QdsiYA4/edit) to beautify the python and c++ code.
- [ ] The PR is complete and small, read the [Google eng practice (CL equals to PR)](https://google.github.io/eng-practices/review/developer/small-cls.html) to understand more about small PR. In DGL, we consider PRs with less than 200 lines of core code change are small (example, test and documentation could be exempted).
- [ ] All changes have test coverage
- [ ] Code is well-documented
- [ ] To the best of my knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change
- [ ] Related issue is referred in this PR
- [ ] If the PR is for a new model/paper, I've updated the example index [here](../examples/README.md).

## Changes
<!-- You could use following template
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)
-->
