### PR TITLE
[Doc]fix ondisk_dataset_homograph.ipynb

### DIFF
--- a/notebooks/stochastic_training/ondisk_dataset_homograph.ipynb
+++ b/notebooks/stochastic_training/ondisk_dataset_homograph.ipynb
@@ -291,7 +291,7 @@
         "print(f\"LP val negative dsts are saved to {lp_val_neg_dsts_path}\\n\")\n",
         "\n",
         "lp_test_node_pairs_path = os.path.join(base_dir, \"lp-test-node-pairs.npy\")\n",
-        "lp_test_node_pairs = edges[-num_tests, :]\n",
+        "lp_test_node_pairs = edges[-num_tests:, :]\n",
         "print(f\"Part of test node pairs for link prediction: {lp_test_node_pairs[:3]}\")\n",
         "np.save(lp_test_node_pairs_path, lp_test_node_pairs)\n",
         "print(f\"LP test node pairs are saved to {lp_test_node_pairs_path}\\n\")\n",


### PR DESCRIPTION
## Description
When I was learning(https://docs.dgl.ai/stochastic_training/ondisk_dataset_homograph.html) to build the Graphbolt local data set, the data built according to the document tutorial code had an error when calculating the AUC in the link prediction task.
Fix data generation for lp_test_dode_pairs
"lp_test_node_pairs = edges[-num_tests, :] to lp_test_node_pairs = edges[-num_tests:, :] "
Refer to https://github.com/dmlc/dgl/pull/7252
## Checklist
Please feel free to remove inapplicable items for your PR.
- [x] The PR title starts with [$CATEGORY] (such as [NN], [Model], [Doc], [Feature]])
- [x] The PR is complete and small, read the [Google eng practice (CL equals to PR)](https://google.github.io/eng-practices/review/developer/small-cls.html) to understand more about small PR. In DGL, we consider PRs with less than 200 lines of core code change are small (example, test and documentation could be exempted).
