### PR TITLE
[GraphBolt][CUDA] Better `TORCH_CUDA_ARCH_LIST` initialization.

### DIFF
--- a/graphbolt/build.sh
+++ b/graphbolt/build.sh
@@ -16,7 +16,19 @@ fi
 # TORCH_CUDA_ARCH_LIST and we need to at least compile for Volta. Until
 # https://github.com/NVIDIA/cccl/issues/1083 is resolved, we need to compile the
 # cuda/extension folder with Volta+ CUDA architectures.
-CMAKE_FLAGS="-DCUDA_TOOLKIT_ROOT_DIR=$CUDA_TOOLKIT_ROOT_DIR -DUSE_CUDA=$USE_CUDA -DGPU_CACHE_BUILD_DIR=$BINDIR -DTORCH_CUDA_ARCH_LIST=Volta"
+TORCH_CUDA_ARCH_LIST="Volta"
+if ! [[ -z "${CUDAARCHS}" ]]; then
+  # The architecture list is passed as an environment variable, we set
+  # TORCH_CUDA_ARCH_LIST to the latest architecture.
+  CUDAARCHSARR=(${CUDAARCHS//;/ })
+  LAST_ARCHITECTURE=${CUDAARCHSARR[-1]}
+  # TORCH_CUDA_ARCH_LIST has to be at least 70 to override Volta default.
+  if (( $LAST_ARCHITECTURE >= 70 )); then
+    # Convert "75" to "7.5".
+    TORCH_CUDA_ARCH_LIST=${LAST_ARCHITECTURE:0:-1}'.'${LAST_ARCHITECTURE: -1}
+  fi
+fi
+CMAKE_FLAGS="-DCUDA_TOOLKIT_ROOT_DIR=$CUDA_TOOLKIT_ROOT_DIR -DUSE_CUDA=$USE_CUDA -DGPU_CACHE_BUILD_DIR=$BINDIR -DTORCH_CUDA_ARCH_LIST=$TORCH_CUDA_ARCH_LIST"
 echo $CMAKE_FLAGS
 
 if [ $# -eq 0 ]; then


### PR DESCRIPTION
## Description
Instead of always compiling GraphBolt for Volta, we compile for the given latest architecture if it is greater than Volta. This way, if the user compiles for only a single architecture different from Volta (such as 80 (Ampere)), they won't have to compile for Volta unnecessarily.

## Checklist
Please feel free to remove inapplicable items for your PR.
- [ ] The PR title starts with [$CATEGORY] (such as [NN], [Model], [Doc], [Feature]])
- [ ] I've leverage the [tools](https://docs.google.com/document/d/1iHyj7zlmygKSk5gBPsqIqL5ASPzJSPREaNT_QdsiYA4/edit) to beautify the python and c++ code.
- [ ] The PR is complete and small, read the [Google eng practice (CL equals to PR)](https://google.github.io/eng-practices/review/developer/small-cls.html) to understand more about small PR. In DGL, we consider PRs with less than 200 lines of core code change are small (example, test and documentation could be exempted).
- [ ] All changes have test coverage
- [ ] Code is well-documented
- [ ] To the best of my knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change
- [ ] Related issue is referred in this PR
- [ ] If the PR is for a new model/paper, I've updated the example index [here](../examples/README.md).

## Changes
<!-- You could use following template
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)
-->
