### PR TITLE
[CUDA][Bug] CSR transpose bug in CUDA 12

### DIFF
--- a/src/array/cuda/csr_transpose.cc
+++ b/src/array/cuda/csr_transpose.cc
@@ -22,7 +22,64 @@ CSRMatrix CSRTranspose(CSRMatrix csr) {
 
 template <>
 CSRMatrix CSRTranspose<kDGLCUDA, int32_t>(CSRMatrix csr) {
+#if CUDART_VERSION < 12000
+  auto* thr_entry = runtime::CUDAThreadEntry::ThreadLocal();
+  cudaStream_t stream = runtime::getCurrentCUDAStream();
+  // allocate cusparse handle if needed
+  if (!thr_entry->cusparse_handle) {
+    CUSPARSE_CALL(cusparseCreate(&(thr_entry->cusparse_handle)));
+  }
+  CUSPARSE_CALL(cusparseSetStream(thr_entry->cusparse_handle, stream));
+
+  NDArray indptr = csr.indptr, indices = csr.indices, data = csr.data;
+  const int64_t nnz = indices->shape[0];
+  const auto& ctx = indptr->ctx;
+  const auto bits = indptr->dtype.bits;
+  if (aten::IsNullArray(data)) data = aten::Range(0, nnz, bits, ctx);
+  const int32_t* indptr_ptr = static_cast<int32_t*>(indptr->data);
+  const int32_t* indices_ptr = static_cast<int32_t*>(indices->data);
+  const void* data_ptr = data->data;
+
+  // (BarclayII) csr2csc doesn't seem to clear the content of cscColPtr if nnz
+  // == 0. We need to do it ourselves.
+  NDArray t_indptr = aten::Full(0, csr.num_cols + 1, bits, ctx);
+  NDArray t_indices = aten::NewIdArray(nnz, ctx, bits);
+  NDArray t_data = aten::NewIdArray(nnz, ctx, bits);
+  int32_t* t_indptr_ptr = static_cast<int32_t*>(t_indptr->data);
+  int32_t* t_indices_ptr = static_cast<int32_t*>(t_indices->data);
+  void* t_data_ptr = t_data->data;
+
+#if CUDART_VERSION >= 10010
+  auto device = runtime::DeviceAPI::Get(csr.indptr->ctx);
+  // workspace
+  size_t workspace_size;
+  CUSPARSE_CALL(cusparseCsr2cscEx2_bufferSize(
+      thr_entry->cusparse_handle, csr.num_rows, csr.num_cols, nnz, data_ptr,
+      indptr_ptr, indices_ptr, t_data_ptr, t_indptr_ptr, t_indices_ptr,
+      CUDA_R_32F, CUSPARSE_ACTION_NUMERIC, CUSPARSE_INDEX_BASE_ZERO,
+      CUSPARSE_CSR2CSC_ALG1,  // see cusparse doc for reference
+      &workspace_size));
+  void* workspace = device->AllocWorkspace(ctx, workspace_size);
+  CUSPARSE_CALL(cusparseCsr2cscEx2(
+      thr_entry->cusparse_handle, csr.num_rows, csr.num_cols, nnz, data_ptr,
+      indptr_ptr, indices_ptr, t_data_ptr, t_indptr_ptr, t_indices_ptr,
+      CUDA_R_32F, CUSPARSE_ACTION_NUMERIC, CUSPARSE_INDEX_BASE_ZERO,
+      CUSPARSE_CSR2CSC_ALG1,  // see cusparse doc for reference
+      workspace));
+  device->FreeWorkspace(ctx, workspace);
+#else
+  CUSPARSE_CALL(cusparseScsr2csc(
+      thr_entry->cusparse_handle, csr.num_rows, csr.num_cols, nnz,
+      static_cast<const float*>(data_ptr), indptr_ptr, indices_ptr,
+      static_cast<float*>(t_data_ptr), t_indices_ptr, t_indptr_ptr,
+      CUSPARSE_ACTION_NUMERIC, CUSPARSE_INDEX_BASE_ZERO));
+#endif
+
+  return CSRMatrix(
+      csr.num_cols, csr.num_rows, t_indptr, t_indices, t_data, false);
+#else
   return COOToCSR(COOTranspose(CSRToCOO(csr, false)));
+#endif
 }
 
 template <>

--- a/src/array/cuda/csr_transpose.cc
+++ b/src/array/cuda/csr_transpose.cc
@@ -23,60 +23,6 @@ CSRMatrix CSRTranspose(CSRMatrix csr) {
 template <>
 CSRMatrix CSRTranspose<kDGLCUDA, int32_t>(CSRMatrix csr) {
   return COOToCSR(COOTranspose(CSRToCOO(csr, false)));
-  auto* thr_entry = runtime::CUDAThreadEntry::ThreadLocal();
-  cudaStream_t stream = runtime::getCurrentCUDAStream();
-  // allocate cusparse handle if needed
-  if (!thr_entry->cusparse_handle) {
-    CUSPARSE_CALL(cusparseCreate(&(thr_entry->cusparse_handle)));
-  }
-  CUSPARSE_CALL(cusparseSetStream(thr_entry->cusparse_handle, stream));
-
-  NDArray indptr = csr.indptr, indices = csr.indices, data = csr.data;
-  const int64_t nnz = indices->shape[0];
-  const auto& ctx = indptr->ctx;
-  const auto bits = indptr->dtype.bits;
-  if (aten::IsNullArray(data)) data = aten::Range(0, nnz, bits, ctx);
-  const int32_t* indptr_ptr = static_cast<int32_t*>(indptr->data);
-  const int32_t* indices_ptr = static_cast<int32_t*>(indices->data);
-  const void* data_ptr = data->data;
-
-  // (BarclayII) csr2csc doesn't seem to clear the content of cscColPtr if nnz
-  // == 0. We need to do it ourselves.
-  NDArray t_indptr = aten::Full(0, csr.num_cols + 1, bits, ctx);
-  NDArray t_indices = aten::NewIdArray(nnz, ctx, bits);
-  NDArray t_data = aten::NewIdArray(nnz, ctx, bits);
-  int32_t* t_indptr_ptr = static_cast<int32_t*>(t_indptr->data);
-  int32_t* t_indices_ptr = static_cast<int32_t*>(t_indices->data);
-  void* t_data_ptr = t_data->data;
-
-#if CUDART_VERSION >= 10010
-  auto device = runtime::DeviceAPI::Get(csr.indptr->ctx);
-  // workspace
-  size_t workspace_size;
-  CUSPARSE_CALL(cusparseCsr2cscEx2_bufferSize(
-      thr_entry->cusparse_handle, csr.num_rows, csr.num_cols, nnz, data_ptr,
-      indptr_ptr, indices_ptr, t_data_ptr, t_indptr_ptr, t_indices_ptr,
-      CUDA_R_32F, CUSPARSE_ACTION_NUMERIC, CUSPARSE_INDEX_BASE_ZERO,
-      CUSPARSE_CSR2CSC_ALG1,  // see cusparse doc for reference
-      &workspace_size));
-  void* workspace = device->AllocWorkspace(ctx, workspace_size);
-  CUSPARSE_CALL(cusparseCsr2cscEx2(
-      thr_entry->cusparse_handle, csr.num_rows, csr.num_cols, nnz, data_ptr,
-      indptr_ptr, indices_ptr, t_data_ptr, t_indptr_ptr, t_indices_ptr,
-      CUDA_R_32F, CUSPARSE_ACTION_NUMERIC, CUSPARSE_INDEX_BASE_ZERO,
-      CUSPARSE_CSR2CSC_ALG1,  // see cusparse doc for reference
-      workspace));
-  device->FreeWorkspace(ctx, workspace);
-#else
-  CUSPARSE_CALL(cusparseScsr2csc(
-      thr_entry->cusparse_handle, csr.num_rows, csr.num_cols, nnz,
-      static_cast<const float*>(data_ptr), indptr_ptr, indices_ptr,
-      static_cast<float*>(t_data_ptr), t_indices_ptr, t_indptr_ptr,
-      CUSPARSE_ACTION_NUMERIC, CUSPARSE_INDEX_BASE_ZERO));
-#endif
-
-  return CSRMatrix(
-      csr.num_cols, csr.num_rows, t_indptr, t_indices, t_data, false);
 }
 
 template <>

--- a/src/array/cuda/csr_transpose.cc
+++ b/src/array/cuda/csr_transpose.cc
@@ -22,6 +22,7 @@ CSRMatrix CSRTranspose(CSRMatrix csr) {
 
 template <>
 CSRMatrix CSRTranspose<kDGLCUDA, int32_t>(CSRMatrix csr) {
+  return COOToCSR(COOTranspose(CSRToCOO(csr, false)));
   auto* thr_entry = runtime::CUDAThreadEntry::ThreadLocal();
   cudaStream_t stream = runtime::getCurrentCUDAStream();
   // allocate cusparse handle if needed


### PR DESCRIPTION
## Description
Running the hetero_rgcn example of graphbolt crashes on NVIDIA 4090 (CUDA 12.4) and A100 (CUDA 12.3). With this PR, it runs successfully. Another place where there may be a bug is the #7239, however #7297 strongly supports that there is no bug there. Before merging this, we want to ensure that the bug is here, I don't know how to do that. Compute sanitizer does not complain at all with this PR. Without this PR, compute sanitizer output below:

```
mfbalin@BALIN-PC:~/dgl-1/examples/sampling/graphbolt/lightning$ CUDA_LAUNCH_BLOCKING=1 compute-sanitizer --tool memcheck python ../rgcn/hetero_rgcn.py
========= COMPUTE-SANITIZER
The dataset is already preprocessed.
Loaded dataset: node_classification
node_num for rel_graph_embed: {'author': tensor(1134649, device='cuda:0', dtype=torch.int32), 'field_of_study': tensor(59965, device='cuda:0', dtype=torch.int32), 'institution': tensor(8740, device='cuda:0', dtype=torch.int32)}
Number of embedding parameters: 154029312
Number of model parameters: 337460
Start to train...
Training~Epoch 01: 375it [04:27,  1.36it/s]========= Invalid __shared__ read of size 4 bytes
=========     at void cusparse::csr2csc_rows_expansion_kernel<(int)128, (int)8, int>(const T3 *, int, T3, const T3 *, T3 *)+0x20e0
=========     by thread (99,0,0) in block (78,0,0)
=========     Address 0x1400 is out of bounds
=========     Saved host backtrace up to driver entry point at kernel launch time
=========     Host Frame: [0x252ff7]
=========                in /usr/lib/wsl/drivers/nv_dispi.inf_amd64_268e85175aa9e991/libcuda.so.1.1
=========     Host Frame: [0x93c3fa]
=========                in /home/mfbalin/.local/lib/python3.10/site-packages/torch/lib/../../nvidia/cusparse/lib/libcusparse.so.12
=========     Host Frame: [0x99859a]
=========                in /home/mfbalin/.local/lib/python3.10/site-packages/torch/lib/../../nvidia/cusparse/lib/libcusparse.so.12
=========     Host Frame: [0x79b7db]
=========                in /home/mfbalin/.local/lib/python3.10/site-packages/torch/lib/../../nvidia/cusparse/lib/libcusparse.so.12
=========     Host Frame: [0x79965f]
=========                in /home/mfbalin/.local/lib/python3.10/site-packages/torch/lib/../../nvidia/cusparse/lib/libcusparse.so.12
=========     Host Frame: [0x799bec]
=========                in /home/mfbalin/.local/lib/python3.10/site-packages/torch/lib/../../nvidia/cusparse/lib/libcusparse.so.12
=========     Host Frame:cusparseCsr2cscEx2 [0xf0b22]
=========                in /home/mfbalin/.local/lib/python3.10/site-packages/torch/lib/../../nvidia/cusparse/lib/libcusparse.so.12
=========     Host Frame:dgl::aten::CSRMatrix dgl::aten::impl::CSRTranspose<(DGLDeviceType)2, int>(dgl::aten::CSRMatrix) [0x9c93a0]
=========                in /home/mfbalin/dgl-1/build/libdgl.so
=========     Host Frame:dgl::aten::CSRTranspose(dgl::aten::CSRMatrix) [0x32a0b5]
=========                in /home/mfbalin/dgl-1/build/libdgl.so
=========     Host Frame:dgl::UnitGraph::GetInCSR(bool) const [0x9937d2]
=========                in /home/mfbalin/dgl-1/build/libdgl.so
=========     Host Frame:dgl::UnitGraph::GetCSCMatrix(unsigned long) const [0x993d79]
=========                in /home/mfbalin/dgl-1/build/libdgl.so
=========     Host Frame:dgl::HeteroGraph::GetCSCMatrix(unsigned long) const [0x8a9b46]
=========                in /home/mfbalin/dgl-1/build/libdgl.so
=========     Host Frame:dgl::aten::SpMM(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, std::shared_ptr<dgl::BaseHeteroGraph>, dgl::runtime::NDArray, dgl::runtime::NDArray, dgl::runtime::NDArray, std::vector<dgl::runtime::NDArray, std::allocator<dgl::runtime::NDArray> >) [0x7ea870]
=========                in /home/mfbalin/dgl-1/build/libdgl.so
=========     Host Frame:dgl::aten::__mk_DGL0::{lambda(dgl::runtime::DGLArgs, dgl::aten::__mk_DGL0::DGLRetValue*)#1}::operator()(dgl::runtime, dgl::aten::__mk_DGL0::DGLRetValue) const [clone .constprop.0] [0x80c3ee]
=========                in /home/mfbalin/dgl-1/build/libdgl.so
=========     Host Frame:std::_Function_handler<void (dgl::runtime::DGLArgs, dgl::runtime::DGLRetValue*), dgl::aten::__mk_DGL0::{lambda(dgl::runtime::DGLArgs, dgl::runtime::DGLRetValue*)#1}>::_M_invoke(std::_Any_data const&, dgl::runtime::DGLArgs&&, dgl::runtime::DGLRetValue*&&) [0x80ca7d]
=========                in /home/mfbalin/dgl-1/build/libdgl.so
=========     Host Frame:DGLFuncCall [0x84a168]
=========                in /home/mfbalin/dgl-1/build/libdgl.so
=========     Host Frame:__pyx_f_3dgl_4_ffi_4_cy3_4core_FuncCall(void*, _object*, DGLValue*, int*) in dgl/_ffi/_cython/core.cpp:6805 [0x18ef7]
=========                in /home/mfbalin/dgl-1/python/dgl/_ffi/_cy3/core.cpython-310-x86_64-linux-gnu.so
=========     Host Frame:__pyx_pw_3dgl_4_ffi_4_cy3_4core_12FunctionBase_5__call__(_object*, _object*, _object*) in dgl/_ffi/_cython/core.cpp:7629 [0x197cf]
=========                in /home/mfbalin/dgl-1/python/dgl/_ffi/_cy3/core.cpython-310-x86_64-linux-gnu.so
=========     Host Frame:_PyObject_MakeTpCall [0x150a7a]
=========                in /usr/bin/python
=========     Host Frame:_PyEval_EvalFrameDefault [0x149095]
=========                in /usr/bin/python
=========     Host Frame:_PyFunction_Vectorcall [0x15a9fb]
=========                in /usr/bin/python
=========     Host Frame:_PyEval_EvalFrameDefault [0x14326c]
=========                in /usr/bin/python
=========     Host Frame:_PyFunction_Vectorcall [0x15a9fb]
=========                in /usr/bin/python
=========     Host Frame:THPFunction_apply(_object*, _object*) [0x7e7d30]
=========                in /home/mfbalin/.local/lib/python3.10/site-packages/torch/lib/libtorch_python.so
=========     Host Frame: [0x15a137]
=========                in /usr/bin/python
=========     Host Frame:PyObject_Call [0x16942a]
=========                in /usr/bin/python
=========     Host Frame:_PyEval_EvalFrameDefault [0x1455d6]
=========                in /usr/bin/python
=========     Host Frame: [0x16893d]
=========                in /usr/bin/python
=========     Host Frame:_PyEval_EvalFrameDefault [0x1455d6]
=========                in /usr/bin/python
=========     Host Frame:_PyFunction_Vectorcall [0x15a9fb]
=========                in /usr/bin/python
=========     Host Frame:_PyEval_EvalFrameDefault [0x14326c]
=========                in /usr/bin/python
=========     Host Frame:_PyFunction_Vectorcall [0x15a9fb]
=========                in /usr/bin/python
=========     Host Frame:_PyEval_EvalFrameDefault [0x1455d6]
=========                in /usr/bin/python
=========     Host Frame: [0x16893d]
=========                in /usr/bin/python
=========     Host Frame:torch::autograd::PyNode::apply(std::vector<at::Tensor, std::allocator<at::Tensor> >&&) [0x7e0002]
=========                in /home/mfbalin/.local/lib/python3.10/site-packages/torch/lib/libtorch_python.so
=========     Host Frame:torch::autograd::Node::operator()(std::vector<at::Tensor, std::allocator<at::Tensor> >&&) [0x4ea4d3a]
=========                in /home/mfbalin/.local/lib/python3.10/site-packages/torch/lib/libtorch_cpu.so
=========     Host Frame:torch::autograd::Engine::evaluate_function(std::shared_ptr<torch::autograd::GraphTask>&, torch::autograd::Node*, torch::autograd::InputBuffer&, std::shared_ptr<torch::autograd::ReadyQueue> const&) [0x4e9e815]
=========                in /home/mfbalin/.local/lib/python3.10/site-packages/torch/lib/libtorch_cpu.so
=========     Host Frame:torch::autograd::Engine::thread_main(std::shared_ptr<torch::autograd::GraphTask> const&) [0x4e9f467]
=========                in /home/mfbalin/.local/lib/python3.10/site-packages/torch/lib/libtorch_cpu.so
=========     Host Frame:torch::autograd::Engine::thread_init(int, std::shared_ptr<torch::autograd::ReadyQueue> const&, bool) [0x4e96b75]
=========                in /home/mfbalin/.local/lib/python3.10/site-packages/torch/lib/libtorch_cpu.so
=========     Host Frame:torch::autograd::python::PythonEngine::thread_init(int, std::shared_ptr<torch::autograd::ReadyQueue> const&, bool) [0x7dc04b]
=========                in /home/mfbalin/.local/lib/python3.10/site-packages/torch/lib/libtorch_python.so
=========     Host Frame: [0xe62b2]
=========                in /lib/x86_64-linux-gnu/libstdc++.so.6
=========     Host Frame:start_thread in ./nptl/pthread_create.c:442 [0x94ac2]
=========                in /lib/x86_64-linux-gnu/libc.so.6
=========     Host Frame: [0x12684f]
=========                in /lib/x86_64-linux-gnu/libc.so.6
========= 
========= Program hit cudaErrorUnknown (error 999) due to "unknown error" on CUDA API call to cudaLaunchKernel.
=========     Saved host backtrace up to driver entry point at error
=========     Host Frame: [0x34d0a2]
=========                in /usr/lib/wsl/drivers/nv_dispi.inf_amd64_268e85175aa9e991/libcuda.so.1.1
=========     Host Frame: [0x9985da]
=========                in /home/mfbalin/.local/lib/python3.10/site-packages/torch/lib/../../nvidia/cusparse/lib/libcusparse.so.12
=========     Host Frame: [0x79b7db]
=========                in /home/mfbalin/.local/lib/python3.10/site-packages/torch/lib/../../nvidia/cusparse/lib/libcusparse.so.12
=========     Host Frame: [0x79965f]
=========                in /home/mfbalin/.local/lib/python3.10/site-packages/torch/lib/../../nvidia/cusparse/lib/libcusparse.so.12
=========     Host Frame: [0x799bec]
=========                in /home/mfbalin/.local/lib/python3.10/site-packages/torch/lib/../../nvidia/cusparse/lib/libcusparse.so.12
=========     Host Frame:cusparseCsr2cscEx2 [0xf0b22]
=========                in /home/mfbalin/.local/lib/python3.10/site-packages/torch/lib/../../nvidia/cusparse/lib/libcusparse.so.12
=========     Host Frame:dgl::aten::CSRMatrix dgl::aten::impl::CSRTranspose<(DGLDeviceType)2, int>(dgl::aten::CSRMatrix) [0x9c93a0]
=========                in /home/mfbalin/dgl-1/build/libdgl.so
=========     Host Frame:dgl::aten::CSRTranspose(dgl::aten::CSRMatrix) [0x32a0b5]
=========                in /home/mfbalin/dgl-1/build/libdgl.so
=========     Host Frame:dgl::UnitGraph::GetInCSR(bool) const [0x9937d2]
=========                in /home/mfbalin/dgl-1/build/libdgl.so
=========     Host Frame:dgl::UnitGraph::GetCSCMatrix(unsigned long) const [0x993d79]
=========                in /home/mfbalin/dgl-1/build/libdgl.so
=========     Host Frame:dgl::HeteroGraph::GetCSCMatrix(unsigned long) const [0x8a9b46]
=========                in /home/mfbalin/dgl-1/build/libdgl.so
=========     Host Frame:dgl::aten::SpMM(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, std::shared_ptr<dgl::BaseHeteroGraph>, dgl::runtime::NDArray, dgl::runtime::NDArray, dgl::runtime::NDArray, std::vector<dgl::runtime::NDArray, std::allocator<dgl::runtime::NDArray> >) [0x7ea870]
=========                in /home/mfbalin/dgl-1/build/libdgl.so
=========     Host Frame:dgl::aten::__mk_DGL0::{lambda(dgl::runtime::DGLArgs, dgl::aten::__mk_DGL0::DGLRetValue*)#1}::operator()(dgl::runtime, dgl::aten::__mk_DGL0::DGLRetValue) const [clone .constprop.0] [0x80c3ee]
=========                in /home/mfbalin/dgl-1/build/libdgl.so
=========     Host Frame:std::_Function_handler<void (dgl::runtime::DGLArgs, dgl::runtime::DGLRetValue*), dgl::aten::__mk_DGL0::{lambda(dgl::runtime::DGLArgs, dgl::runtime::DGLRetValue*)#1}>::_M_invoke(std::_Any_data const&, dgl::runtime::DGLArgs&&, dgl::runtime::DGLRetValue*&&) [0x80ca7d]
=========                in /home/mfbalin/dgl-1/build/libdgl.so
=========     Host Frame:DGLFuncCall [0x84a168]
=========                in /home/mfbalin/dgl-1/build/libdgl.so
=========     Host Frame:__pyx_f_3dgl_4_ffi_4_cy3_4core_FuncCall(void*, _object*, DGLValue*, int*) in dgl/_ffi/_cython/core.cpp:6805 [0x18ef7]
=========                in /home/mfbalin/dgl-1/python/dgl/_ffi/_cy3/core.cpython-310-x86_64-linux-gnu.so
=========     Host Frame:__pyx_pw_3dgl_4_ffi_4_cy3_4core_12FunctionBase_5__call__(_object*, _object*, _object*) in dgl/_ffi/_cython/core.cpp:7629 [0x197cf]
=========                in /home/mfbalin/dgl-1/python/dgl/_ffi/_cy3/core.cpython-310-x86_64-linux-gnu.so
=========     Host Frame:_PyObject_MakeTpCall [0x150a7a]
=========                in /usr/bin/python
=========     Host Frame:_PyEval_EvalFrameDefault [0x149095]
=========                in /usr/bin/python
=========     Host Frame:_PyFunction_Vectorcall [0x15a9fb]
=========                in /usr/bin/python
=========     Host Frame:_PyEval_EvalFrameDefault [0x14326c]
=========                in /usr/bin/python
=========     Host Frame:_PyFunction_Vectorcall [0x15a9fb]
=========                in /usr/bin/python
=========     Host Frame:THPFunction_apply(_object*, _object*) [0x7e7d30]
=========                in /home/mfbalin/.local/lib/python3.10/site-packages/torch/lib/libtorch_python.so
=========     Host Frame: [0x15a137]
=========                in /usr/bin/python
=========     Host Frame:PyObject_Call [0x16942a]
=========                in /usr/bin/python
=========     Host Frame:_PyEval_EvalFrameDefault [0x1455d6]
=========                in /usr/bin/python
=========     Host Frame: [0x16893d]
=========                in /usr/bin/python
=========     Host Frame:_PyEval_EvalFrameDefault [0x1455d6]
=========                in /usr/bin/python
=========     Host Frame:_PyFunction_Vectorcall [0x15a9fb]
=========                in /usr/bin/python
=========     Host Frame:_PyEval_EvalFrameDefault [0x14326c]
=========                in /usr/bin/python
=========     Host Frame:_PyFunction_Vectorcall [0x15a9fb]
=========                in /usr/bin/python
=========     Host Frame:_PyEval_EvalFrameDefault [0x1455d6]
=========                in /usr/bin/python
=========     Host Frame: [0x16893d]
=========                in /usr/bin/python
=========     Host Frame:torch::autograd::PyNode::apply(std::vector<at::Tensor, std::allocator<at::Tensor> >&&) [0x7e0002]
=========                in /home/mfbalin/.local/lib/python3.10/site-packages/torch/lib/libtorch_python.so
=========     Host Frame:torch::autograd::Node::operator()(std::vector<at::Tensor, std::allocator<at::Tensor> >&&) [0x4ea4d3a]
=========                in /home/mfbalin/.local/lib/python3.10/site-packages/torch/lib/libtorch_cpu.so
=========     Host Frame:torch::autograd::Engine::evaluate_function(std::shared_ptr<torch::autograd::GraphTask>&, torch::autograd::Node*, torch::autograd::InputBuffer&, std::shared_ptr<torch::autograd::ReadyQueue> const&) [0x4e9e815]
=========                in /home/mfbalin/.local/lib/python3.10/site-packages/torch/lib/libtorch_cpu.so
=========     Host Frame:torch::autograd::Engine::thread_main(std::shared_ptr<torch::autograd::GraphTask> const&) [0x4e9f467]
=========                in /home/mfbalin/.local/lib/python3.10/site-packages/torch/lib/libtorch_cpu.so
=========     Host Frame:torch::autograd::Engine::thread_init(int, std::shared_ptr<torch::autograd::ReadyQueue> const&, bool) [0x4e96b75]
=========                in /home/mfbalin/.local/lib/python3.10/site-packages/torch/lib/libtorch_cpu.so
=========     Host Frame:torch::autograd::python::PythonEngine::thread_init(int, std::shared_ptr<torch::autograd::ReadyQueue> const&, bool) [0x7dc04b]
=========                in /home/mfbalin/.local/lib/python3.10/site-packages/torch/lib/libtorch_python.so
=========     Host Frame: [0xe62b2]
=========                in /lib/x86_64-linux-gnu/libstdc++.so.6
=========     Host Frame:start_thread in ./nptl/pthread_create.c:442 [0x94ac2]
=========                in /lib/x86_64-linux-gnu/libc.so.6
=========     Host Frame: [0x12684f]
=========                in /lib/x86_64-linux-gnu/libc.so.6
========= 
```

## Checklist
Please feel free to remove inapplicable items for your PR.
- [ ] The PR title starts with [$CATEGORY] (such as [NN], [Model], [Doc], [Feature]])
- [ ] I've leverage the [tools](https://docs.google.com/document/d/1iHyj7zlmygKSk5gBPsqIqL5ASPzJSPREaNT_QdsiYA4/edit) to beautify the python and c++ code.
- [ ] The PR is complete and small, read the [Google eng practice (CL equals to PR)](https://google.github.io/eng-practices/review/developer/small-cls.html) to understand more about small PR. In DGL, we consider PRs with less than 200 lines of core code change are small (example, test and documentation could be exempted).
- [ ] All changes have test coverage
- [ ] Code is well-documented
- [ ] To the best of my knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change
- [ ] Related issue is referred in this PR
- [ ] If the PR is for a new model/paper, I've updated the example index [here](../examples/README.md).

## Changes
<!-- You could use following template
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)
-->
