### PR TITLE
[Misc] Fix validation dataset's usage in RGCN link example

### DIFF
--- a/examples/pytorch/rgcn/README.md
+++ b/examples/pytorch/rgcn/README.md
@@ -58,4 +58,4 @@ Summary
 ### Link Prediction
 | Dataset       | Best MRR
 | ------------- | -------
-| FB15k-237     | ~0.2439
+| FB15k-237     | ~0.2397


### PR DESCRIPTION
## Description
<!-- Brief description. Refer to the related issues if existed.
It'll be great if relevant reviewers can be assigned as well.-->
The RGCN link example uses test dataset when training and get the test result using the same test dataset, the final result may not be accurate enough.
As the FB15k237Dataset dataset also has a validation dataset, so using it when training.
<img width="850" alt="f1" src="https://github.com/dmlc/dgl/assets/9260628/789ebe6e-4f1a-47dd-b2f8-dc60c3f6e07f">


## Checklist
Please feel free to remove inapplicable items for your PR.
- [ ] The PR title starts with [$CATEGORY] (such as [NN], [Model], [Doc], [Feature]])
- [ ] I've leverage the [tools](https://docs.google.com/document/d/1iHyj7zlmygKSk5gBPsqIqL5ASPzJSPREaNT_QdsiYA4/edit) to beautify the python and c++ code.
- [ ] The PR is complete and small, read the [Google eng practice (CL equals to PR)](https://google.github.io/eng-practices/review/developer/small-cls.html) to understand more about small PR. In DGL, we consider PRs with less than 200 lines of core code change are small (example, test and documentation could be exempted).
- [ ] All changes have test coverage
- [ ] Code is well-documented
- [ ] To the best of my knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change
- [ ] Related issue is referred in this PR
- [ ] If the PR is for a new model/paper, I've updated the example index [here](../examples/README.md).

## Changes
<!-- You could use following template
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)
-->
