### PR TITLE
[GraphBolt][CUDA] Don't link against `libcuda.so`.

### DIFF
--- a/graphbolt/src/cuda/common.h
+++ b/graphbolt/src/cuda/common.h
@@ -11,7 +11,6 @@
 #include <c10/cuda/CUDACachingAllocator.h>
 #include <c10/cuda/CUDAException.h>
 #include <c10/cuda/CUDAStream.h>
-#include <cuda.h>
 #include <cuda_runtime.h>
 #include <torch/script.h>
 
@@ -89,19 +88,13 @@ inline bool is_zero<dim3>(dim3 size) {
   return size.x == 0 || size.y == 0 || size.z == 0;
 }
 
-#define CUDA_DRIVER_CHECK(EXPR)                       \
-  do {                                                \
-    CUresult __err = EXPR;                            \
-    if (__err != CUDA_SUCCESS) {                      \
-      const char* err_str;                            \
-      CUresult get_error_str_err C10_UNUSED =         \
-          cuGetErrorString(__err, &err_str);          \
-      if (get_error_str_err != CUDA_SUCCESS) {        \
-        AT_ERROR("CUDA driver error: unknown error"); \
-      } else {                                        \
-        AT_ERROR("CUDA driver error: ", err_str);     \
-      }                                               \
-    }                                                 \
+#define CUDA_RUNTIME_CHECK(EXPR)                           \
+  do {                                                     \
+    cudaError_t __err = EXPR;                              \
+    if (__err != cudaSuccess) {                            \
+      auto get_error_str_err = cudaGetErrorString(__err);  \
+      AT_ERROR("CUDA runtime error: ", get_error_str_err); \
+    }                                                      \
   } while (0)
 
 #define CUDA_CALL(func) C10_CUDA_CHECK((func))

--- a/graphbolt/src/cuda/unique_and_compact_impl.cu
+++ b/graphbolt/src/cuda/unique_and_compact_impl.cu
@@ -274,8 +274,8 @@ UniqueAndCompactBatched(
       return it->second;
     } else {
       int major;
-      CUDA_DRIVER_CHECK(cuDeviceGetAttribute(
-          &major, CU_DEVICE_ATTRIBUTE_COMPUTE_CAPABILITY_MAJOR, dev_id));
+      CUDA_RUNTIME_CHECK(cudaDeviceGetAttribute(
+          &major, cudaDevAttrComputeCapabilityMajor, dev_id));
       return compute_capability_cache[dev_id] = major;
     }
   }();


### PR DESCRIPTION
## Description
With this PR:
```
root@a100cse:/localscratch/dgl-3/build# ldd graphbolt/libgraphbolt_pytorch_2.3.0a0.so 
        linux-vdso.so.1 (0x00007ffc5e5af000)
        libc10.so => /usr/local/lib/python3.10/dist-packages/torch/lib/libc10.so (0x00007fad7511e000)
        libcudart.so.12 => /usr/local/cuda/lib64/libcudart.so.12 (0x00007fad74e00000)
        libc10_cuda.so => /usr/local/lib/python3.10/dist-packages/torch/lib/libc10_cuda.so (0x00007fad74d76000)
        libtorch_cpu.so => /usr/local/lib/python3.10/dist-packages/torch/lib/libtorch_cpu.so (0x00007fad69d8f000)
        libtorch_cuda.so => /usr/local/lib/python3.10/dist-packages/torch/lib/libtorch_cuda.so (0x00007fad142b0000)
        libtorch.so => /usr/local/lib/python3.10/dist-packages/torch/lib/libtorch.so (0x00007fad75115000)
        libstdc++.so.6 => /usr/lib/x86_64-linux-gnu/libstdc++.so.6 (0x00007fad14084000)
        libm.so.6 => /usr/lib/x86_64-linux-gnu/libm.so.6 (0x00007fad13f9d000)
        libgomp.so.1 => /usr/lib/x86_64-linux-gnu/libgomp.so.1 (0x00007fad750be000)
        libgcc_s.so.1 => /usr/lib/x86_64-linux-gnu/libgcc_s.so.1 (0x00007fad13f7d000)
        libc.so.6 => /usr/lib/x86_64-linux-gnu/libc.so.6 (0x00007fad13d54000)
        /lib64/ld-linux-x86-64.so.2 (0x00007fad78131000)
        libpthread.so.0 => /usr/lib/x86_64-linux-gnu/libpthread.so.0 (0x00007fad750b7000)
        libdl.so.2 => /usr/lib/x86_64-linux-gnu/libdl.so.2 (0x00007fad750b2000)
        librt.so.1 => /usr/lib/x86_64-linux-gnu/librt.so.1 (0x00007fad13d4f000)
        libmkl_intel_lp64.so.1 => /usr/local/lib/libmkl_intel_lp64.so.1 (0x00007fad13000000)
        libmkl_gnu_thread.so.1 => /usr/local/lib/libmkl_gnu_thread.so.1 (0x00007fad11200000)
        libmkl_core.so.1 => /usr/local/lib/libmkl_core.so.1 (0x00007fad09200000)
        libcupti.so.12 => /usr/local/cuda/lib64/libcupti.so.12 (0x00007fad08800000)
        libmpi.so.40 => /opt/hpcx/ompi/lib/libmpi.so.40 (0x00007fad086e1000)
        libcusparse.so.12 => /usr/local/cuda/lib64/libcusparse.so.12 (0x00007facf8600000)
        libcufft.so.11 => /usr/local/cuda/lib64/libcufft.so.11 (0x00007faced800000)
        libnccl.so.2 => /usr/lib/x86_64-linux-gnu/libnccl.so.2 (0x00007face1050000)
        libucs.so.0 => /opt/hpcx/ucx/lib/libucs.so.0 (0x00007face0ec9000)
        libucp.so.0 => /opt/hpcx/ucx/lib/libucp.so.0 (0x00007facf8520000)
        libucc.so.1 => /opt/hpcx/ucc/lib/libucc.so.1 (0x00007fad12fc8000)
        libnvToolsExt.so.1 => /usr/local/cuda/lib64/libnvToolsExt.so.1 (0x00007face0c00000)
        libcurand.so.10 => /usr/local/cuda/lib64/libcurand.so.10 (0x00007facda600000)
        libcublas.so.12 => /usr/local/cuda/lib64/libcublas.so.12 (0x00007facd3e00000)
        libcublasLt.so.12 => /usr/local/cuda/lib64/libcublasLt.so.12 (0x00007facb1400000)
        libcudnn.so.9 => /usr/lib/x86_64-linux-gnu/libcudnn.so.9 (0x00007facb1000000)
        libutil.so.1 => /usr/lib/x86_64-linux-gnu/libutil.so.1 (0x00007fad13d48000)
        libopen-rte.so.40 => /opt/hpcx/ompi/lib/libopen-rte.so.40 (0x00007face0e0a000)
        libopen-pal.so.40 => /opt/hpcx/ompi/lib/libopen-pal.so.40 (0x00007face0ae9000)
        libnvJitLink.so.12 => /usr/local/cuda/lib64/libnvJitLink.so.12 (0x00007facada00000)
        libucm.so.0 => /opt/hpcx/ucx/lib/libucm.so.0 (0x00007fad12fab000)
        libz.so.1 => /usr/lib/x86_64-linux-gnu/libz.so.1 (0x00007fad12f8f000)
        libuct.so.0 => /opt/hpcx/ucx/lib/libuct.so.0 (0x00007fad12f50000)
```

## Checklist
Please feel free to remove inapplicable items for your PR.
- [ ] The PR title starts with [$CATEGORY] (such as [NN], [Model], [Doc], [Feature]])
- [ ] I've leverage the [tools](https://docs.google.com/document/d/1iHyj7zlmygKSk5gBPsqIqL5ASPzJSPREaNT_QdsiYA4/edit) to beautify the python and c++ code.
- [ ] The PR is complete and small, read the [Google eng practice (CL equals to PR)](https://google.github.io/eng-practices/review/developer/small-cls.html) to understand more about small PR. In DGL, we consider PRs with less than 200 lines of core code change are small (example, test and documentation could be exempted).
- [ ] All changes have test coverage
- [ ] Code is well-documented
- [ ] To the best of my knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change
- [ ] Related issue is referred in this PR
- [ ] If the PR is for a new model/paper, I've updated the example index [here](../examples/README.md).

## Changes
<!-- You could use following template
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)
-->
