### PR TITLE
[GraphBolt] Enable `DistributedItemSampler` test only on CPU.

### DIFF
--- a/tests/python/pytorch/graphbolt/test_item_sampler.py
+++ b/tests/python/pytorch/graphbolt/test_item_sampler.py
@@ -1,6 +1,9 @@
 import os
 import re
+import unittest
 from sys import platform
+
+import backend as F
 
 import dgl
 import pytest
@@ -8,7 +11,6 @@ import torch
 import torch.distributed as dist
 import torch.multiprocessing as mp
 from dgl import graphbolt as gb
-from torch.testing import assert_close
 
 
 def test_ItemSampler_minibatcher():
@@ -1090,6 +1092,7 @@ def test_RangeCalculation(params):
     assert key == answer
 
 
+@unittest.skipIf(F._default_context_str != "cpu", reason="GPU not required.")
 @pytest.mark.parametrize("num_ids", [24, 30, 32, 34, 36])
 @pytest.mark.parametrize("num_workers", [0, 2])
 @pytest.mark.parametrize("drop_last", [False, True])


### PR DESCRIPTION
## Description
This test does not run any differently on GPU machines as it purely runs on the CPU. Hence, I disable it on the GPU so that the CI times and my development workflow are improved. This is due to these tests running very slow, taking as much time as the rest of the GraphBolt tests.

## Checklist
Please feel free to remove inapplicable items for your PR.
- [ ] The PR title starts with [$CATEGORY] (such as [NN], [Model], [Doc], [Feature]])
- [ ] I've leverage the [tools](https://docs.google.com/document/d/1iHyj7zlmygKSk5gBPsqIqL5ASPzJSPREaNT_QdsiYA4/edit) to beautify the python and c++ code.
- [ ] The PR is complete and small, read the [Google eng practice (CL equals to PR)](https://google.github.io/eng-practices/review/developer/small-cls.html) to understand more about small PR. In DGL, we consider PRs with less than 200 lines of core code change are small (example, test and documentation could be exempted).
- [ ] All changes have test coverage
- [ ] Code is well-documented
- [ ] To the best of my knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change
- [ ] Related issue is referred in this PR
- [ ] If the PR is for a new model/paper, I've updated the example index [here](../examples/README.md).

## Changes
<!-- You could use following template
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)
-->
