### PR TITLE
[CUDA] Remove unused headers for CCCL 2.4 compat

### DIFF
--- a/src/array/cuda/labor_sampling.cu
+++ b/src/array/cuda/labor_sampling.cu
@@ -40,9 +40,7 @@
 #include <type_traits>
 #include <utility>
 
-#include "../../array/cuda/atomic.cuh"
 #include "../../array/cuda/utils.h"
-#include "../../graph/transform/cuda/cuda_map_edges.cuh"
 #include "../../random/continuous_seed.h"
 #include "../../runtime/cuda/cuda_common.h"
 #include "./functor.cuh"


### PR DESCRIPTION
## Description
I tried compiling our code with CCCL 2.4. Removing these together with #7325 makes the code base compatible with CCCL 2.4. Looks like these headers are unused so removing them does not break anything.

## Checklist
Please feel free to remove inapplicable items for your PR.
- [ ] The PR title starts with [$CATEGORY] (such as [NN], [Model], [Doc], [Feature]])
- [ ] I've leverage the [tools](https://docs.google.com/document/d/1iHyj7zlmygKSk5gBPsqIqL5ASPzJSPREaNT_QdsiYA4/edit) to beautify the python and c++ code.
- [ ] The PR is complete and small, read the [Google eng practice (CL equals to PR)](https://google.github.io/eng-practices/review/developer/small-cls.html) to understand more about small PR. In DGL, we consider PRs with less than 200 lines of core code change are small (example, test and documentation could be exempted).
- [ ] All changes have test coverage
- [ ] Code is well-documented
- [ ] To the best of my knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change
- [ ] Related issue is referred in this PR
- [ ] If the PR is for a new model/paper, I've updated the example index [here](../examples/README.md).

## Changes
<!-- You could use following template
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)
-->
