### PR TITLE
[GraphBolt][CUDA] `Minibatch.to()` patch.

### DIFF
--- a/python/dgl/graphbolt/internal/utils.py
+++ b/python/dgl/graphbolt/internal/utils.py
@@ -135,6 +135,7 @@ def get_attributes(_obj) -> list:
         attribute
         for attribute in dir(_obj)
         if not attribute.startswith("__")
+        and not isinstance(getattr(type(_obj), attribute), property)
         and not callable(getattr(_obj, attribute))
     ]
     return attributes

--- a/python/dgl/graphbolt/internal/utils.py
+++ b/python/dgl/graphbolt/internal/utils.py
@@ -129,13 +129,23 @@ def copy_or_convert_data(
     save_data(data, output_path, output_format)
 
 
+def get_nonproperty_attributes(_obj) -> list:
+    """Get attributes of the class except for the properties."""
+    attributes = [
+        attribute
+        for attribute in dir(_obj)
+        if not attribute.startswith("__")
+        and (not hasattr(type(_obj), attribute) or not isinstance(getattr(type(_obj), attribute), property))
+        and not callable(getattr(_obj, attribute))
+    ]
+    return attributes
+
 def get_attributes(_obj) -> list:
     """Get attributes of the class."""
     attributes = [
         attribute
         for attribute in dir(_obj)
         if not attribute.startswith("__")
-        and not isinstance(getattr(type(_obj), attribute), property)
         and not callable(getattr(_obj, attribute))
     ]
     return attributes

--- a/python/dgl/graphbolt/internal/utils.py
+++ b/python/dgl/graphbolt/internal/utils.py
@@ -135,10 +135,14 @@ def get_nonproperty_attributes(_obj) -> list:
         attribute
         for attribute in dir(_obj)
         if not attribute.startswith("__")
-        and (not hasattr(type(_obj), attribute) or not isinstance(getattr(type(_obj), attribute), property))
+        and (
+            not hasattr(type(_obj), attribute)
+            or not isinstance(getattr(type(_obj), attribute), property)
+        )
         and not callable(getattr(_obj, attribute))
     ]
     return attributes
+
 
 def get_attributes(_obj) -> list:
     """Get attributes of the class."""

--- a/python/dgl/graphbolt/minibatch.py
+++ b/python/dgl/graphbolt/minibatch.py
@@ -9,7 +9,7 @@ import dgl
 from dgl.utils import recursive_apply
 
 from .base import CSCFormatBase, etype_str_to_tuple, expand_indptr
-from .internal import get_attributes
+from .internal import get_attributes, get_nonproperty_attributes
 from .sampled_subgraph import SampledSubgraph
 
 __all__ = ["MiniBatch"]
@@ -562,7 +562,7 @@ class MiniBatch:
         def apply_to(x, device):
             return recursive_apply(x, lambda x: _to(x, device))
 
-        transfer_attrs = get_attributes(self)
+        transfer_attrs = get_nonproperty_attributes(self)
 
         for attr in transfer_attrs:
             # Only copy member variables.

--- a/python/dgl/graphbolt/minibatch.py
+++ b/python/dgl/graphbolt/minibatch.py
@@ -566,13 +566,7 @@ class MiniBatch:
 
         for attr in transfer_attrs:
             # Only copy member variables.
-            try:
-                # For read-only attributes such as blocks , setattr will throw
-                # an AttributeError. We catch these exceptions and skip those
-                # attributes.
-                setattr(self, attr, apply_to(getattr(self, attr), device))
-            except AttributeError:
-                continue
+            setattr(self, attr, apply_to(getattr(self, attr), device))
 
         return self
 

--- a/python/dgl/graphbolt/minibatch.py
+++ b/python/dgl/graphbolt/minibatch.py
@@ -556,17 +556,17 @@ class MiniBatch:
     def to(self, device: torch.device):  # pylint: disable=invalid-name
         """Copy `MiniBatch` to the specified device using reflection."""
 
-        def _to(x, device):
+        def _to(x):
             return x.to(device) if hasattr(x, "to") else x
 
-        def apply_to(x, device):
-            return recursive_apply(x, lambda x: _to(x, device))
+        def apply_to(x):
+            return recursive_apply(x, _to)
 
         transfer_attrs = get_nonproperty_attributes(self)
 
         for attr in transfer_attrs:
             # Only copy member variables.
-            setattr(self, attr, apply_to(getattr(self, attr), device))
+            setattr(self, attr, apply_to(getattr(self, attr)))
 
         return self
 

--- a/python/dgl/graphbolt/minibatch.py
+++ b/python/dgl/graphbolt/minibatch.py
@@ -559,14 +559,11 @@ class MiniBatch:
         def _to(x):
             return x.to(device) if hasattr(x, "to") else x
 
-        def apply_to(x):
-            return recursive_apply(x, _to)
-
         transfer_attrs = get_nonproperty_attributes(self)
 
         for attr in transfer_attrs:
             # Only copy member variables.
-            setattr(self, attr, apply_to(getattr(self, attr)))
+            setattr(self, attr, recursive_apply(getattr(self, attr), _to))
 
         return self
 


### PR DESCRIPTION
## Description
Details in #7315. In this PR, we ensure that we do not call properties of the minibatch object when filtering its attributes. The CPU usage is still high, we might want to continue the investigation. PyG advanced example regression is mostly resolved though.

## Checklist
Please feel free to remove inapplicable items for your PR.
- [ ] The PR title starts with [$CATEGORY] (such as [NN], [Model], [Doc], [Feature]])
- [ ] I've leverage the [tools](https://docs.google.com/document/d/1iHyj7zlmygKSk5gBPsqIqL5ASPzJSPREaNT_QdsiYA4/edit) to beautify the python and c++ code.
- [ ] The PR is complete and small, read the [Google eng practice (CL equals to PR)](https://google.github.io/eng-practices/review/developer/small-cls.html) to understand more about small PR. In DGL, we consider PRs with less than 200 lines of core code change are small (example, test and documentation could be exempted).
- [ ] All changes have test coverage
- [ ] Code is well-documented
- [ ] To the best of my knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change
- [ ] Related issue is referred in this PR
- [ ] If the PR is for a new model/paper, I've updated the example index [here](../examples/README.md).

## Changes
<!-- You could use following template
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)
-->
