### PR TITLE
[Misc] add dtype convert to avoid IndexError

### DIFF
--- a/examples/sampling/graphbolt/node_classification.py
+++ b/examples/sampling/graphbolt/node_classification.py
@@ -242,7 +242,7 @@ def layerwise_infer(
         job="infer",
     )
     pred = model.inference(graph, features, dataloader, args.storage_device)
-    pred = pred[test_set._items[0]]
+    pred = pred[test_set._items[0].long()]
     label = test_set._items[1].to(pred.device)
 
     return MF.accuracy(


### PR DESCRIPTION
## Description
<!-- Brief description. Refer to the related issues if existed.
It'll be great if relevant reviewers can be assigned as well.-->
To avoid

```txt
Traceback (most recent call last):
  File "examples/sampling/graphbolt/node_classification.py", line 450, in <module>
    main(args)
  File "examples/sampling/graphbolt/node_classification.py", line 436, in main
    test_acc = layerwise_infer(
  File "/home/ubuntu/miniconda3/envs/dgl/lib/python3.8/site-packages/torch/autograd/grad_mode.py", line 27, in decorate_context
    return func(*args, **kwargs)
  File "examples/sampling/graphbolt/node_classification.py", line 245, in layerwise_infer
    pred = pred[test_set._items[0]]
IndexError: tensors used as indices must be long, byte or bool tensors
```


## Checklist
Please feel free to remove inapplicable items for your PR.
- [ ] The PR title starts with [$CATEGORY] (such as [NN], [Model], [Doc], [Feature]])
- [ ] I've leverage the [tools](https://docs.google.com/document/d/1iHyj7zlmygKSk5gBPsqIqL5ASPzJSPREaNT_QdsiYA4/edit) to beautify the python and c++ code.
- [ ] The PR is complete and small, read the [Google eng practice (CL equals to PR)](https://google.github.io/eng-practices/review/developer/small-cls.html) to understand more about small PR. In DGL, we consider PRs with less than 200 lines of core code change are small (example, test and documentation could be exempted).
- [ ] All changes have test coverage
- [ ] Code is well-documented
- [ ] To the best of my knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change
- [ ] Related issue is referred in this PR
- [ ] If the PR is for a new model/paper, I've updated the example index [here](../examples/README.md).

## Changes
<!-- You could use following template
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)
-->
