### PR TITLE
[DistDGL tools] Remove restriction on partition algorithm name

### DIFF
--- a/tools/partition_algo/base.py
+++ b/tools/partition_algo/base.py
@@ -75,8 +75,5 @@ def load_partition_meta(meta_file):
             raise DGLError(
                 f"num_parts[{part_meta.num_parts}] should be greater than 0."
             )
-        if part_meta.algo_name not in ["random", "metis"]:
-            raise DGLError(
-                f"algo_name[{part_meta.num_parts}] is not supported."
-            )
+
         return part_meta


### PR DESCRIPTION
## Description

Since partition assignment algorithms are independent of DGL, there shouldn't be a restriction on the name of the partition algorithm.

For GraphStorm we have implemented a range partition algorithm, and would like to provide the correct name in the metadata file.

@Rhett-Ying for review


## Checklist
Please feel free to remove inapplicable items for your PR.
- [x] The PR title starts with [$CATEGORY] (such as [NN], [Model], [Doc], [Feature]])
- [x] I've leverage the [tools](https://docs.google.com/document/d/1iHyj7zlmygKSk5gBPsqIqL5ASPzJSPREaNT_QdsiYA4/edit) to beautify the python and c++ code.
- [x] The PR is complete and small, read the [Google eng practice (CL equals to PR)](https://google.github.io/eng-practices/review/developer/small-cls.html) to understand more about small PR. In DGL, we consider PRs with less than 200 lines of core code change are small (example, test and documentation could be exempted).
- [ ] All changes have test coverage
- [ ] Code is well-documented
- [x] To the best of my knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change
- [ ] Related issue is referred in this PR
- [ ] If the PR is for a new model/paper, I've updated the example index [here](../examples/README.md).

