### PR TITLE
[GraphBolt] Add experimental `ItemSet/Dict4` and `ItemSampler4`

### DIFF
--- a/examples/multigpu/graphbolt/node_classification.py
+++ b/examples/multigpu/graphbolt/node_classification.py
@@ -36,6 +36,7 @@ main
       │
       └───> Test set evaluation
 """
+
 import argparse
 import os
 import time

--- a/python/dgl/graphbolt/item_sampler.py
+++ b/python/dgl/graphbolt/item_sampler.py
@@ -952,7 +952,7 @@ class ItemSampler4(IterDataPipe):
                 i, i + min(self._batch_size, output_count)
             )
             output_count -= self._batch_size
-            yield minibatcher_default(
+            yield self._minibatcher(
                 self._collate_batch(buffer, batch_indices, offsets), self._names
             )
 

--- a/python/dgl/graphbolt/item_sampler.py
+++ b/python/dgl/graphbolt/item_sampler.py
@@ -997,6 +997,5 @@ class DistributedItemSampler4(ItemSampler4):
             seed_tensor = torch.tensor(seed, dtype=torch.int32, device=device)
         else:
             seed_tensor = torch.empty([], dtype=torch.int32, device=device)
-        dist.barrier()
         dist.broadcast(seed_tensor, src=0)
         self._seed = seed_tensor.item()

--- a/python/dgl/graphbolt/item_sampler.py
+++ b/python/dgl/graphbolt/item_sampler.py
@@ -933,7 +933,7 @@ class ItemSampler4(IterDataPipe):
             self._drop_last,
             self._drop_uneven_inputs,
         )
-        if self.shuffle:
+        if self._shuffle:
             g = torch.Generator()
             g.manual_seed(self._seed + self._epoch)
             indices = torch.randperm(total, generator=g)

--- a/python/dgl/graphbolt/item_sampler.py
+++ b/python/dgl/graphbolt/item_sampler.py
@@ -18,7 +18,13 @@ from .internal import calculate_range
 from .itemset import ItemSet, ItemSet4, ItemSetDict, ItemSetDict4
 from .minibatch import MiniBatch
 
-__all__ = ["ItemSampler", "DistributedItemSampler", "minibatcher_default"]
+__all__ = [
+    "ItemSampler",
+    "DistributedItemSampler",
+    "minibatcher_default",
+    "ItemSampler4",
+    "DistributedItemSampler4",
+]
 
 
 def minibatcher_default(batch, names):

--- a/python/dgl/graphbolt/item_sampler.py
+++ b/python/dgl/graphbolt/item_sampler.py
@@ -952,6 +952,9 @@ class ItemSampler4(IterDataPipe):
 
 
 class DistributedItemSampler4(ItemSampler4):
+    """Experimental. Try to implement based on the current 
+    DistributedItemSampler."""
+
     def __init__(
         self,
         item_set: Union[ItemSet4, ItemSetDict4],

--- a/python/dgl/graphbolt/item_sampler.py
+++ b/python/dgl/graphbolt/item_sampler.py
@@ -927,16 +927,18 @@ class ItemSampler4(IterDataPipe):
             self._drop_last,
             self._drop_uneven_inputs,
         )
-        g = torch.Generator()
-        g.manual_seed(self._seed + self._epoch)
-        indices = torch.randperm(total, generator=g)
-        buffer = self._item_set[
-            indices[start_offset : start_offset + assigned_count]
-        ]
+        if self.shuffle:
+            g = torch.Generator()
+            g.manual_seed(self._seed + self._epoch)
+            indices = torch.randperm(total, generator=g)
+            buffer = self._item_set[
+                indices[start_offset : start_offset + assigned_count]
+            ]
+        else:
+            buffer = self._item_set[
+                start_offset : start_offset + assigned_count
+            ]
         offsets = self._calculate_offsets(buffer)
-        # print(
-        #     f"\nworld_size: {self._world_size}, rank: {self._rank}, num_workers: {num_workers}, worker_id: {worker_id},\nstart_offset: {start_offset}, assigned_count: {assigned_count}, output_count: {output_count}\nbuffer: {buffer}\n"
-        # )
         for i in range(0, assigned_count, self._batch_size):
             if output_count <= 0:
                 break
@@ -952,7 +954,7 @@ class ItemSampler4(IterDataPipe):
 
 
 class DistributedItemSampler4(ItemSampler4):
-    """Experimental. Try to implement based on the current 
+    """Experimental. Try to implement based on the current
     DistributedItemSampler."""
 
     def __init__(

--- a/tests/python/pytorch/graphbolt/test_item_sampler.py
+++ b/tests/python/pytorch/graphbolt/test_item_sampler.py
@@ -4,8 +4,6 @@ import unittest
 from collections import defaultdict
 from sys import platform
 
-import backend as F
-
 import dgl
 import pytest
 import torch
@@ -1151,7 +1149,7 @@ def test_RangeCalculation(params):
     assert key == answer
 
 
-@unittest.skipIf(F._default_context_str != "cpu", reason="GPU not required.")
+@unittest.skipIf(os.getenv("DGLTESTDEV", "cpu") != "cpu", reason="GPU not required.")
 @pytest.mark.parametrize("num_ids", [24, 30, 32, 34, 36])
 @pytest.mark.parametrize("num_workers", [0, 2])
 @pytest.mark.parametrize("drop_last", [False, True])
@@ -1252,7 +1250,7 @@ def distributed_item_sampler_subprocess4(
         dist.destroy_process_group()
 
 
-@unittest.skipIf(F._default_context_str != "cpu", reason="GPU not required.")
+@unittest.skipIf(os.getenv("DGLTESTDEV", "cpu") != "cpu", reason="GPU not required.")
 @pytest.mark.parametrize("num_ids", [24, 30, 32, 34, 36])
 @pytest.mark.parametrize("num_workers", [0, 2])
 @pytest.mark.parametrize("drop_last", [False, True])

--- a/tests/python/pytorch/graphbolt/test_item_sampler.py
+++ b/tests/python/pytorch/graphbolt/test_item_sampler.py
@@ -1149,7 +1149,9 @@ def test_RangeCalculation(params):
     assert key == answer
 
 
-@unittest.skipIf(os.getenv("DGLTESTDEV", "cpu") != "cpu", reason="GPU not required.")
+@unittest.skipIf(
+    os.getenv("DGLTESTDEV", "cpu") != "cpu", reason="GPU not required."
+)
 @pytest.mark.parametrize("num_ids", [24, 30, 32, 34, 36])
 @pytest.mark.parametrize("num_workers", [0, 2])
 @pytest.mark.parametrize("drop_last", [False, True])
@@ -1250,7 +1252,9 @@ def distributed_item_sampler_subprocess4(
         dist.destroy_process_group()
 
 
-@unittest.skipIf(os.getenv("DGLTESTDEV", "cpu") != "cpu", reason="GPU not required.")
+@unittest.skipIf(
+    os.getenv("DGLTESTDEV", "cpu") != "cpu", reason="GPU not required."
+)
 @pytest.mark.parametrize("num_ids", [24, 30, 32, 34, 36])
 @pytest.mark.parametrize("num_workers", [0, 2])
 @pytest.mark.parametrize("drop_last", [False, True])

--- a/tests/python/pytorch/graphbolt/test_item_sampler.py
+++ b/tests/python/pytorch/graphbolt/test_item_sampler.py
@@ -1252,7 +1252,6 @@ def distributed_item_sampler_subprocess4(
         dist.destroy_process_group()
 
 
-
 @unittest.skipIf(F._default_context_str != "cpu", reason="GPU not required.")
 @pytest.mark.parametrize("num_ids", [24, 30, 32, 34, 36])
 @pytest.mark.parametrize("num_workers", [0, 2])
@@ -1273,7 +1272,6 @@ def test_DistributedItemSampler4(
         except FileNotFoundError:
             pass
 
-    torch.manual_seed(1234)
     mp.spawn(
         distributed_item_sampler_subprocess4,
         args=(
@@ -1288,17 +1286,3 @@ def test_DistributedItemSampler4(
         nprocs=nprocs,
         join=True,
     )
-
-
-def test_RandomSeedSingleton():
-    random_seed_singleton = gb.RandomSeedSingleton()
-    random_seed = random_seed_singleton.seed
-    print(random_seed)
-    random_seed_singleton2 = gb.RandomSeedSingleton()
-    random_seed2 = random_seed_singleton2.seed
-    print(random_seed2)
-    assert 0
-
-
-if __name__ == "__main__":
-    test_DistributedItemSampler4(24, 2, False, False)


### PR DESCRIPTION
## Description
<!-- Brief description. Refer to the related issues if existed.
It'll be great if relevant reviewers can be assigned as well.-->
benchmark:
```txt
num_ids: 24, num_workers: 0, drop_last: False, drop_uneven_inputs: False
Old: 5.26561164855957
New: 4.075196266174316

num_ids: 24, num_workers: 0, drop_last: False, drop_uneven_inputs: True
Old: 5.038467884063721
New: 5.061769247055054

num_ids: 24, num_workers: 0, drop_last: True, drop_uneven_inputs: False
Old: 5.08016300201416
New: 5.055493116378784

num_ids: 24, num_workers: 0, drop_last: True, drop_uneven_inputs: True
Old: 5.044290542602539
New: 5.022970676422119

num_ids: 24, num_workers: 2, drop_last: False, drop_uneven_inputs: False
Old: 7.418801546096802
New: 6.484843492507935

num_ids: 24, num_workers: 2, drop_last: False, drop_uneven_inputs: True
Old: 7.407760143280029
New: 7.527584791183472

num_ids: 24, num_workers: 2, drop_last: True, drop_uneven_inputs: False
Old: 6.492152690887451
New: 6.431138277053833

num_ids: 24, num_workers: 2, drop_last: True, drop_uneven_inputs: True
Old: 6.491805791854858
New: 7.4210569858551025

num_ids: 30, num_workers: 0, drop_last: False, drop_uneven_inputs: False
Old: 4.09150767326355
New: 5.011434316635132

num_ids: 30, num_workers: 0, drop_last: False, drop_uneven_inputs: True
Old: 5.040276288986206
New: 4.068592071533203

num_ids: 30, num_workers: 0, drop_last: True, drop_uneven_inputs: False
Old: 4.038927793502808
New: 4.038530349731445

num_ids: 30, num_workers: 0, drop_last: True, drop_uneven_inputs: True
Old: 5.019740343093872
New: 5.0285563468933105

num_ids: 30, num_workers: 2, drop_last: False, drop_uneven_inputs: False
Old: 7.428295612335205
New: 6.409729242324829

num_ids: 30, num_workers: 2, drop_last: False, drop_uneven_inputs: True
Old: 7.421130657196045
New: 7.533393383026123

num_ids: 30, num_workers: 2, drop_last: True, drop_uneven_inputs: False
Old: 7.41476035118103
New: 6.400209188461304

num_ids: 30, num_workers: 2, drop_last: True, drop_uneven_inputs: True
Old: 6.40072774887085
New: 6.447648048400879

num_ids: 32, num_workers: 0, drop_last: False, drop_uneven_inputs: False
Old: 4.057007789611816
New: 5.063795328140259

num_ids: 32, num_workers: 0, drop_last: False, drop_uneven_inputs: True
Old: 5.035150051116943
New: 5.006322145462036

num_ids: 32, num_workers: 0, drop_last: True, drop_uneven_inputs: False
Old: 5.089540958404541
New: 5.047980546951294

num_ids: 32, num_workers: 0, drop_last: True, drop_uneven_inputs: True
Old: 4.040552854537964
New: 5.0497941970825195

num_ids: 32, num_workers: 2, drop_last: False, drop_uneven_inputs: False
Old: 7.43973970413208
New: 7.493116855621338

num_ids: 32, num_workers: 2, drop_last: False, drop_uneven_inputs: True
Old: 7.553787469863892
New: 7.6020872592926025

num_ids: 32, num_workers: 2, drop_last: True, drop_uneven_inputs: False
Old: 6.490302085876465
New: 7.487463474273682

num_ids: 32, num_workers: 2, drop_last: True, drop_uneven_inputs: True
Old: 7.364883661270142
New: 7.4597368240356445

num_ids: 34, num_workers: 0, drop_last: False, drop_uneven_inputs: False
Old: 4.082199811935425
New: 4.053929328918457

num_ids: 34, num_workers: 0, drop_last: False, drop_uneven_inputs: True
Old: 4.063207149505615
New: 5.091043710708618

num_ids: 34, num_workers: 0, drop_last: True, drop_uneven_inputs: False
Old: 4.999620676040649
New: 5.112699031829834

num_ids: 34, num_workers: 0, drop_last: True, drop_uneven_inputs: True
Old: 5.024035930633545
New: 4.051522493362427

num_ids: 34, num_workers: 2, drop_last: False, drop_uneven_inputs: False
Old: 7.471214771270752
New: 6.554701328277588

num_ids: 34, num_workers: 2, drop_last: False, drop_uneven_inputs: True
Old: 6.449496269226074
New: 6.529990196228027

num_ids: 34, num_workers: 2, drop_last: True, drop_uneven_inputs: False
Old: 7.431456804275513
New: 7.41823673248291

num_ids: 34, num_workers: 2, drop_last: True, drop_uneven_inputs: True
Old: 6.479130506515503
New: 6.368876695632935

num_ids: 36, num_workers: 0, drop_last: False, drop_uneven_inputs: False
Old: 5.009013652801514
New: 5.050375461578369

num_ids: 36, num_workers: 0, drop_last: False, drop_uneven_inputs: True
Old: 4.0677573680877686
New: 4.125107288360596

num_ids: 36, num_workers: 0, drop_last: True, drop_uneven_inputs: False
Old: 5.023468971252441
New: 5.105181455612183

num_ids: 36, num_workers: 0, drop_last: True, drop_uneven_inputs: True
Old: 5.063021421432495
New: 5.089923143386841

num_ids: 36, num_workers: 2, drop_last: False, drop_uneven_inputs: False
Old: 7.424851179122925
New: 7.432251453399658

num_ids: 36, num_workers: 2, drop_last: False, drop_uneven_inputs: True
Old: 7.543227672576904
New: 7.601431131362915

num_ids: 36, num_workers: 2, drop_last: True, drop_uneven_inputs: False
Old: 6.457719326019287
New: 6.451065540313721

num_ids: 36, num_workers: 2, drop_last: True, drop_uneven_inputs: True
Old: 6.568817377090454
New: 6.491897344589233
```

## Checklist
Please feel free to remove inapplicable items for your PR.
- [ ] The PR title starts with [$CATEGORY] (such as [NN], [Model], [Doc], [Feature]])
- [ ] I've leverage the [tools](https://docs.google.com/document/d/1iHyj7zlmygKSk5gBPsqIqL5ASPzJSPREaNT_QdsiYA4/edit) to beautify the python and c++ code.
- [ ] The PR is complete and small, read the [Google eng practice (CL equals to PR)](https://google.github.io/eng-practices/review/developer/small-cls.html) to understand more about small PR. In DGL, we consider PRs with less than 200 lines of core code change are small (example, test and documentation could be exempted).
- [ ] All changes have test coverage
- [ ] Code is well-documented
- [ ] To the best of my knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change
- [ ] Related issue is referred in this PR
- [ ] If the PR is for a new model/paper, I've updated the example index [here](../examples/README.md).

## Changes
<!-- You could use following template
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)
-->
