### PR TITLE
[DistPart] Fix corner case in dist partition which always led to an assertion error being triggered.

### DIFF
--- a/tools/distpartitioning/data_shuffle.py
+++ b/tools/distpartitioning/data_shuffle.py
@@ -475,8 +475,9 @@ def exchange_feature(
     logging.debug(f"Rank: {rank} {featdata_key.shape=}")
     if featdata_key is not None:
         feat_dims_dtype = list(featdata_key.shape)
-        assert len(featdata_key.shape) == 2 or len(featdata_key.shape) == 1, \
-                f"We expect 1D or 2D tensors for features, got shape {featdata_key.shape}"
+        assert (
+            len(featdata_key.shape) == 2 or len(featdata_key.shape) == 1
+        ), f"We expect 1D or 2D tensors for features, got shape {featdata_key.shape}"
         # When a feature is 2-dim, the shape should match the feature dimension.
         if len(featdata_key.shape) == 2:
             feature_dimension = feat_dims_dtype[1]
@@ -502,8 +503,9 @@ def exchange_feature(
             assert len(all_dims_dtype) % world_size == 0
             dim_len = int(len(all_dims_dtype) / world_size)
             rank0_shape = list(np.zeros((dim_len - 1), dtype=np.int32))
-            assert len(rank0_shape) == 2 or len(rank0_shape) == 1, \
-                f"We expect 1D or 2D tensors for features, got shape {rank0_shape}"
+            assert (
+                len(rank0_shape) == 2 or len(rank0_shape) == 1
+            ), f"We expect 1D or 2D tensors for features, got shape {rank0_shape}"
             # When a feature is 2-dim, the shape[1] (number of columns) should match the feature dimension.
             if len(rank0_shape) == 2:
                 rank0_shape[1] = feature_dimension

--- a/tools/distpartitioning/data_shuffle.py
+++ b/tools/distpartitioning/data_shuffle.py
@@ -475,6 +475,8 @@ def exchange_feature(
     logging.debug(f"Rank: {rank} {featdata_key.shape=}")
     if featdata_key is not None:
         feat_dims_dtype = list(featdata_key.shape)
+        assert len(featdata_key.shape) == 2 or len(featdata_key.shape) == 1, \
+                f"We expect 1D or 2D tensors for features, got shape {featdata_key.shape}"
         # When a feature is 2-dim, the shape should match the feature dimension.
         if len(featdata_key.shape) == 2:
             feature_dimension = feat_dims_dtype[1]
@@ -500,6 +502,8 @@ def exchange_feature(
             assert len(all_dims_dtype) % world_size == 0
             dim_len = int(len(all_dims_dtype) / world_size)
             rank0_shape = list(np.zeros((dim_len - 1), dtype=np.int32))
+            assert len(rank0_shape) == 2 or len(rank0_shape) == 1, \
+                f"We expect 1D or 2D tensors for features, got shape {rank0_shape}"
             # When a feature is 2-dim, the shape[1] (number of columns) should match the feature dimension.
             if len(rank0_shape) == 2:
                 rank0_shape[1] = feature_dimension

--- a/tools/distpartitioning/data_shuffle.py
+++ b/tools/distpartitioning/data_shuffle.py
@@ -402,7 +402,6 @@ def exchange_feature(
     """
     # type_ids for this feature subset on the current rank
     gids_feat = np.arange(gid_start, gid_end)
-    tids_feat = np.arange(type_id_start, type_id_end)
     local_idx = np.arange(0, type_id_end - type_id_start)
 
     feats_per_rank = []
@@ -473,12 +472,19 @@ def exchange_feature(
         )
 
     # exchange actual data here.
-    if featdata_key != None:
+    logging.debug(f"Rank: {rank} {featdata_key.shape=}")
+    if featdata_key is not None:
         feat_dims_dtype = list(featdata_key.shape)
+        # When a feature is 2-dim, the shape should match the feature dimension.
+        if len(featdata_key.shape) == 2:
+            feature_dimension = feat_dims_dtype[1]
+        else:
+            feature_dimension = 0
         feat_dims_dtype.append(DATA_TYPE_ID[featdata_key.dtype])
     else:
         feat_dims_dtype = list(np.zeros((rank0_shape_len), dtype=np.int64))
         feat_dims_dtype.append(DATA_TYPE_ID[torch.float32])
+        feature_dimension = 0
 
     logging.debug(f"Sending the feature shape information - {feat_dims_dtype}")
     all_dims_dtype = allgather_sizes(
@@ -488,13 +494,15 @@ def exchange_feature(
     for idx in range(world_size):
         cond = partid_slice == (idx + local_part_id * world_size)
         gids_per_partid = gids_feat[cond]
-        tids_per_partid = tids_feat[cond]
         local_idx_partid = local_idx[cond]
 
         if gids_per_partid.shape[0] == 0:
             assert len(all_dims_dtype) % world_size == 0
             dim_len = int(len(all_dims_dtype) / world_size)
-            rank0_shape = tuple(list(np.zeros((dim_len - 1), dtype=np.int32)))
+            rank0_shape = list(np.zeros((dim_len - 1), dtype=np.int32))
+            # When a feature is 2-dim, the shape[1] (number of columns) should match the feature dimension.
+            if len(rank0_shape) == 2:
+                rank0_shape[1] = feature_dimension
             rank0_dtype = REV_DATA_TYPE_ID[
                 all_dims_dtype[(dim_len - 1) : (dim_len)][0]
             ]


### PR DESCRIPTION
## Description

In some edge cases where workers end up with no rows of features to send over the network (e.g. in range partition) the existing code was creating tensors of shape (0, 0) and trying to communicate/aggregate those over the network, whereas workers that had non-zero rows assigned would communicate (num_rows, feature_dimension), leading to an assertion error being triggered in https://github.com/dmlc/dgl/blob/6f2ccbff3c94cb3f5767bdfef88f5b535d6843d3/tools/distpartitioning/gloo_wrapper.py#L144-L146

This PR handles the 2D tensor case as a special case, ensuring the correct shape for the tensors being sent over the network, (0, feature_dimension).

This PR also removes an array that was being created but never used, reducing the memory footprint of the function.

Ping @Rhett-Ying for review

## Checklist
Please feel free to remove inapplicable items for your PR.
- [x] The PR title starts with [$CATEGORY] (such as [NN], [Model], [Doc], [Feature]])
- [ ] I've leverage the [tools](https://docs.google.com/document/d/1iHyj7zlmygKSk5gBPsqIqL5ASPzJSPREaNT_QdsiYA4/edit) to beautify the python and c++ code.
- [x] The PR is complete and small, read the [Google eng practice (CL equals to PR)](https://google.github.io/eng-practices/review/developer/small-cls.html) to understand more about small PR. In DGL, we consider PRs with less than 200 lines of core code change are small (example, test and documentation could be exempted).
- [ ] All changes have test coverage
- [ ] Code is well-documented
- [x] To the best of my knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change
- [ ] Related issue is referred in this PR
- [ ] If the PR is for a new model/paper, I've updated the example index [here](../examples/README.md).

## Changes
