### PR TITLE
[BUG][Example] Implementing the deprecated function `is_string_like`.

### DIFF
--- a/examples/pytorch/transformer/modules/viz.py
+++ b/examples/pytorch/transformer/modules/viz.py
@@ -1,6 +1,5 @@
 import os
 
-import matplotlib as mpl
 import matplotlib.animation as animation
 import matplotlib.pyplot as plt
 import networkx as nx
@@ -176,7 +175,7 @@ from matplotlib.patches import ConnectionStyle, FancyArrowPatch
 "The following function was modified from the source code of networkx"
 
 def is_string_like(obj):  # from John Hunter, types-free version
-     """Check if obj is string.
+     """Check if obj is string."""
     
      return isinstance(obj, str)
  

--- a/examples/pytorch/transformer/modules/viz.py
+++ b/examples/pytorch/transformer/modules/viz.py
@@ -175,34 +175,33 @@ from matplotlib.patches import ConnectionStyle, FancyArrowPatch
 "The following function was modified from the source code of networkx"
 
 def is_string_like(obj):  # from John Hunter, types-free version
-     """Check if obj is string."""
+    """Check if obj is string."""
     
-     return isinstance(obj, str)
- 
- 
- def draw_networkx_edges(
-     G,
-     pos,
-     edgelist=None,
-     width=1.0,
-     edge_color="k",
-     style="solid",
-     alpha=1.0,
-     arrowstyle="-|>",
-     arrowsize=10,
-     edge_cmap=None,
-     edge_vmin=None,
-     edge_vmax=None,
-     ax=None,
-     arrows=True,
-     label=None,
-     node_size=300,
-     nodelist=None,
-     node_shape="o",
-     connectionstyle="arc3",
-     **kwds
- ):
-     """Draw the edges of the graph G.
+    return isinstance(obj, str)
+
+def draw_networkx_edges(
+    G,
+    pos,
+    edgelist=None,
+    width=1.0,
+    edge_color="k",
+    style="solid",
+    alpha=1.0,
+    arrowstyle="-|>",
+    arrowsize=10,
+    edge_cmap=None,
+    edge_vmin=None,
+    edge_vmax=None,
+    ax=None,
+    arrows=True,
+    label=None,
+    node_size=300,
+    nodelist=None,
+    node_shape="o",
+    connectionstyle="arc3",
+    **kwds
+):
+    """Draw the edges of the graph G.
 
     This draws only the edges of the graph G.
 

--- a/examples/pytorch/transformer/modules/viz.py
+++ b/examples/pytorch/transformer/modules/viz.py
@@ -171,36 +171,39 @@ def graph_att_head(M, N, weight, ax, title):
     )
 
 
-import networkx as nx
 from matplotlib.patches import ConnectionStyle, FancyArrowPatch
-from networkx.utils import is_string_like
 
 "The following function was modified from the source code of networkx"
 
-
-def draw_networkx_edges(
-    G,
-    pos,
-    edgelist=None,
-    width=1.0,
-    edge_color="k",
-    style="solid",
-    alpha=1.0,
-    arrowstyle="-|>",
-    arrowsize=10,
-    edge_cmap=None,
-    edge_vmin=None,
-    edge_vmax=None,
-    ax=None,
-    arrows=True,
-    label=None,
-    node_size=300,
-    nodelist=None,
-    node_shape="o",
-    connectionstyle="arc3",
-    **kwds
-):
-    """Draw the edges of the graph G.
+def is_string_like(obj):  # from John Hunter, types-free version
+     """Check if obj is string.
+    
+     return isinstance(obj, str)
+ 
+ 
+ def draw_networkx_edges(
+     G,
+     pos,
+     edgelist=None,
+     width=1.0,
+     edge_color="k",
+     style="solid",
+     alpha=1.0,
+     arrowstyle="-|>",
+     arrowsize=10,
+     edge_cmap=None,
+     edge_vmin=None,
+     edge_vmax=None,
+     ax=None,
+     arrows=True,
+     label=None,
+     node_size=300,
+     nodelist=None,
+     node_shape="o",
+     connectionstyle="arc3",
+     **kwds
+ ):
+     """Draw the edges of the graph G.
 
     This draws only the edges of the graph G.
 

--- a/examples/pytorch/transformer/modules/viz.py
+++ b/examples/pytorch/transformer/modules/viz.py
@@ -174,10 +174,12 @@ from matplotlib.patches import ConnectionStyle, FancyArrowPatch
 
 "The following function was modified from the source code of networkx"
 
+
 def is_string_like(obj):  # from John Hunter, types-free version
     """Check if obj is string."""
-    
+
     return isinstance(obj, str)
+
 
 def draw_networkx_edges(
     G,


### PR DESCRIPTION
## Description
<!-- Brief description. Refer to the related issues if existed.
It'll be great if relevant reviewers can be assigned as well.-->
This is a fix for [Issue#7406](https://github.com/dmlc/dgl/issues/7406): **Transformer example is dated and does not work with latest networkx**
I just took this function from the previous version of **networkx**.

## Checklist
Please feel free to remove inapplicable items for your PR.
- [x] The PR title starts with [$CATEGORY] (such as [NN], [Model], [Doc], [Feature]])
- [x] I've leverage the [tools](https://docs.google.com/document/d/1iHyj7zlmygKSk5gBPsqIqL5ASPzJSPREaNT_QdsiYA4/edit) to beautify the python and c++ code.
- [x] The PR is complete and small, read the [Google eng practice (CL equals to PR)](https://google.github.io/eng-practices/review/developer/small-cls.html) to understand more about small PR. In DGL, we consider PRs with less than 200 lines of core code change are small (example, test and documentation could be exempted).
- [x] Code is well-documented
- [x] To the best of my knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

## Changes
<!-- You could use following template
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)
-->
