### PR TITLE
[GraphBolt] Rename `ItemSetDict` as `HeteroItemSet`

### DIFF
--- a/docs/source/api/python/dgl.graphbolt.rst
+++ b/docs/source/api/python/dgl.graphbolt.rst
@@ -82,7 +82,7 @@ An item set is an iterable collection of items.
     :template: graphbolt_classtemplate.rst
 
     ItemSet
-    ItemSetDict
+    HeteroItemSet
 
 
 ItemSampler

--- a/docs/source/guide/minibatch-custom-sampler.rst
+++ b/docs/source/guide/minibatch-custom-sampler.rst
@@ -75,7 +75,7 @@ can be used on heterogeneous graphs:
 
     import dgl.graphbolt as gb
     hg = gb.FusedCSCSamplingGraph()
-    train_set = item_set = gb.ItemSetDict(
+    train_set = item_set = gb.HeteroItemSet(
         {
             "user": gb.ItemSet(
                 (torch.arange(0, 5), torch.arange(5, 10)),

--- a/docs/source/guide/minibatch-edge.rst
+++ b/docs/source/guide/minibatch-edge.rst
@@ -248,7 +248,7 @@ over the edge types.
 
 Data loader definition is almost identical to that of homogeneous graph. The
 only difference is that the train_set is now an instance of
-:class:`~dgl.graphbolt.ItemSetDict` instead of :class:`~dgl.graphbolt.ItemSet`.
+:class:`~dgl.graphbolt.HeteroItemSet` instead of :class:`~dgl.graphbolt.ItemSet`.
 
 .. code:: python
 
@@ -266,7 +266,7 @@ only difference is that the train_set is now an instance of
             (seeds, labels), names=("seeds", "labels")
         ),
     }
-    train_set = gb.ItemSetDict(seeds_labels)
+    train_set = gb.HeteroItemSet(seeds_labels)
     datapipe = gb.ItemSampler(train_set, batch_size=128, shuffle=True)
     datapipe = datapipe.sample_neighbor(g, [10, 10]) # 2 layers.
     datapipe = datapipe.fetch_feature(

--- a/docs/source/guide/minibatch-node.rst
+++ b/docs/source/guide/minibatch-node.rst
@@ -200,7 +200,7 @@ For example, one can still use the provided
 :class:`~dgl.graphbolt.NeighborSampler` class and
 :class:`~dgl.graphbolt.DataLoader` class for
 stochastic training. The only difference is that the itemset is now an
-instance of :class:`~dgl.graphbolt.ItemSetDict` which is a dictionary
+instance of :class:`~dgl.graphbolt.HeteroItemSet` which is a dictionary
 of node types to node IDs.
 
 .. code:: python

--- a/python/dgl/graphbolt/dataset.py
+++ b/python/dgl/graphbolt/dataset.py
@@ -1,8 +1,9 @@
 """GraphBolt Dataset."""
+
 from typing import Dict, List, Union
 
 from .feature_store import FeatureStore
-from .itemset import ItemSet, ItemSetDict
+from .itemset import HeteroItemSet, ItemSet
 from .sampling_graph import SamplingGraph
 
 __all__ = [
@@ -32,17 +33,17 @@ class Task:
         raise NotImplementedError
 
     @property
-    def train_set(self) -> Union[ItemSet, ItemSetDict]:
+    def train_set(self) -> Union[ItemSet, HeteroItemSet]:
         """Return the training set."""
         raise NotImplementedError
 
     @property
-    def validation_set(self) -> Union[ItemSet, ItemSetDict]:
+    def validation_set(self) -> Union[ItemSet, HeteroItemSet]:
         """Return the validation set."""
         raise NotImplementedError
 
     @property
-    def test_set(self) -> Union[ItemSet, ItemSetDict]:
+    def test_set(self) -> Union[ItemSet, HeteroItemSet]:
         """Return the test set."""
         raise NotImplementedError
 
@@ -89,6 +90,6 @@ class Dataset:
         raise NotImplementedError
 
     @property
-    def all_nodes_set(self) -> Union[ItemSet, ItemSetDict]:
+    def all_nodes_set(self) -> Union[ItemSet, HeteroItemSet]:
         """Return the itemset containing all nodes."""
         raise NotImplementedError

--- a/python/dgl/graphbolt/impl/legacy_dataset.py
+++ b/python/dgl/graphbolt/impl/legacy_dataset.py
@@ -1,10 +1,11 @@
 """Graphbolt dataset for legacy DGLDataset."""
+
 from typing import List, Union
 
 from dgl.data import AsNodePredDataset, DGLDataset
 from ..base import etype_tuple_to_str
 from ..dataset import Dataset, Task
-from ..itemset import ItemSet, ItemSetDict
+from ..itemset import HeteroItemSet, ItemSet
 from ..sampling_graph import SamplingGraph
 from .basic_feature_store import BasicFeatureStore
 from .fused_csc_sampling_graph import from_dglgraph
@@ -36,7 +37,7 @@ class LegacyDataset(Dataset):
                     names=("seeds", "labels"),
                 )
                 item_set_dict[key] = item_set
-            return ItemSetDict(item_set_dict)
+            return HeteroItemSet(item_set_dict)
 
         # OGB Dataset has the idx split.
         if hasattr(legacy, "get_idx_split"):
@@ -60,7 +61,7 @@ class LegacyDataset(Dataset):
             for ntype in graph.ntypes:
                 item_set = ItemSet(graph.num_nodes(ntype), names="seeds")
                 item_set_dict[ntype] = item_set
-            self._all_nodes_set = ItemSetDict(item_set_dict)
+            self._all_nodes_set = HeteroItemSet(item_set_dict)
 
             features = {}
             for ntype in graph.ntypes:
@@ -151,6 +152,6 @@ class LegacyDataset(Dataset):
         return self._dataset_name
 
     @property
-    def all_nodes_set(self) -> Union[ItemSet, ItemSetDict]:
+    def all_nodes_set(self) -> Union[ItemSet, HeteroItemSet]:
         """Return the itemset containing all nodes."""
         return self._all_nodes_set

--- a/python/dgl/graphbolt/impl/ondisk_dataset.py
+++ b/python/dgl/graphbolt/impl/ondisk_dataset.py
@@ -25,7 +25,7 @@ from ..internal import (
     read_data,
     read_edges,
 )
-from ..itemset import ItemSet, ItemSetDict
+from ..itemset import HeteroItemSet, ItemSet
 from ..sampling_graph import SamplingGraph
 from .fused_csc_sampling_graph import (
     fused_csc_sampling_graph,
@@ -522,9 +522,9 @@ class OnDiskTask:
     def __init__(
         self,
         metadata: Dict,
-        train_set: Union[ItemSet, ItemSetDict],
-        validation_set: Union[ItemSet, ItemSetDict],
-        test_set: Union[ItemSet, ItemSetDict],
+        train_set: Union[ItemSet, HeteroItemSet],
+        validation_set: Union[ItemSet, HeteroItemSet],
+        test_set: Union[ItemSet, HeteroItemSet],
     ):
         """Initialize a task.
 
@@ -532,11 +532,11 @@ class OnDiskTask:
         ----------
         metadata : Dict
             Metadata.
-        train_set : Union[ItemSet, ItemSetDict]
+        train_set : Union[ItemSet, HeteroItemSet]
             Training set.
-        validation_set : Union[ItemSet, ItemSetDict]
+        validation_set : Union[ItemSet, HeteroItemSet]
             Validation set.
-        test_set : Union[ItemSet, ItemSetDict]
+        test_set : Union[ItemSet, HeteroItemSet]
             Test set.
         """
         self._metadata = metadata
@@ -550,17 +550,17 @@ class OnDiskTask:
         return self._metadata
 
     @property
-    def train_set(self) -> Union[ItemSet, ItemSetDict]:
+    def train_set(self) -> Union[ItemSet, HeteroItemSet]:
         """Return the training set."""
         return self._train_set
 
     @property
-    def validation_set(self) -> Union[ItemSet, ItemSetDict]:
+    def validation_set(self) -> Union[ItemSet, HeteroItemSet]:
         """Return the validation set."""
         return self._validation_set
 
     @property
-    def test_set(self) -> Union[ItemSet, ItemSetDict]:
+    def test_set(self) -> Union[ItemSet, HeteroItemSet]:
         """Return the test set."""
         return self._test_set
 
@@ -796,7 +796,7 @@ class OnDiskDataset(Dataset):
         return self._dataset_name
 
     @property
-    def all_nodes_set(self) -> Union[ItemSet, ItemSetDict]:
+    def all_nodes_set(self) -> Union[ItemSet, HeteroItemSet]:
         """Return the itemset containing all nodes."""
         self._check_loaded()
         return self._all_nodes_set
@@ -856,7 +856,7 @@ class OnDiskDataset(Dataset):
 
     def _init_tvt_set(
         self, tvt_set: List[OnDiskTVTSet]
-    ) -> Union[ItemSet, ItemSetDict]:
+    ) -> Union[ItemSet, HeteroItemSet]:
         """Initialize the TVT set."""
         ret = None
         if (tvt_set is None) or (len(tvt_set) == 0):
@@ -882,10 +882,10 @@ class OnDiskDataset(Dataset):
                     ),
                     names=tuple(data.name for data in tvt.data),
                 )
-            ret = ItemSetDict(itemsets)
+            ret = HeteroItemSet(itemsets)
         return ret
 
-    def _init_all_nodes_set(self, graph) -> Union[ItemSet, ItemSetDict]:
+    def _init_all_nodes_set(self, graph) -> Union[ItemSet, HeteroItemSet]:
         if graph is None:
             dgl_warning(
                 "`all_nodes_set` is returned as None, since graph is None."
@@ -906,7 +906,7 @@ class OnDiskDataset(Dataset):
                 )
                 for node_type, num_node in num_nodes.items()
             }
-            return ItemSetDict(data)
+            return HeteroItemSet(data)
 
 
 class BuiltinDataset(OnDiskDataset):

--- a/python/dgl/graphbolt/item_sampler.py
+++ b/python/dgl/graphbolt/item_sampler.py
@@ -11,7 +11,7 @@ from torchdata.datapipes.iter import IterDataPipe
 from ..base import dgl_warning
 
 from .internal import calculate_range
-from .itemset import ItemSet, ItemSetDict
+from .itemset import HeteroItemSet, ItemSet
 from .minibatch import MiniBatch
 
 __all__ = ["ItemSampler", "DistributedItemSampler", "minibatcher_default"]
@@ -119,7 +119,7 @@ class ItemSampler(IterDataPipe):
 
     Parameters
     ----------
-    item_set : Union[ItemSet, ItemSetDict]
+    item_set : Union[ItemSet, HeteroItemSet]
         Data to be sampled.
     batch_size : int
         The size of each batch.
@@ -212,7 +212,7 @@ class ItemSampler(IterDataPipe):
     ...     "user": gb.ItemSet(torch.arange(0, 5), names="seeds"),
     ...     "item": gb.ItemSet(torch.arange(0, 6), names="seeds"),
     ... }
-    >>> item_set = gb.ItemSetDict(ids)
+    >>> item_set = gb.HeteroItemSet(ids)
     >>> item_sampler = gb.ItemSampler(item_set, batch_size=4)
     >>> next(iter(item_sampler))
     MiniBatch(seeds={'user': tensor([0, 1, 2, 3])}, sampled_subgraphs=None,
@@ -223,7 +223,7 @@ class ItemSampler(IterDataPipe):
 
     >>> seeds_like = torch.arange(0, 10).reshape(-1, 2)
     >>> seeds_follow = torch.arange(10, 20).reshape(-1, 2)
-    >>> item_set = gb.ItemSetDict({
+    >>> item_set = gb.HeteroItemSet({
     ...     "user:like:item": gb.ItemSet(
     ...         seeds_like, names="seeds"),
     ...     "user:follow:user": gb.ItemSet(
@@ -242,7 +242,7 @@ class ItemSampler(IterDataPipe):
     >>> labels_like = torch.arange(0, 5)
     >>> seeds_follow = torch.arange(10, 20).reshape(-1, 2)
     >>> labels_follow = torch.arange(5, 10)
-    >>> item_set = gb.ItemSetDict({
+    >>> item_set = gb.HeteroItemSet({
     ...     "user:like:item": gb.ItemSet((seeds_like, labels_like),
     ...         names=("seeds", "labels")),
     ...     "user:follow:user": gb.ItemSet((seeds_follow, labels_follow),
@@ -264,7 +264,7 @@ class ItemSampler(IterDataPipe):
     >>> seeds_follow = torch.arange(20, 30).reshape(-1, 2)
     >>> labels_follow = torch.tensor([1, 1, 0, 0, 0])
     >>> indexes_follow = torch.tensor([0, 1, 0, 0, 1])
-    >>> item_set = gb.ItemSetDict({
+    >>> item_set = gb.HeteroItemSet({
     ...     "user:like:item": gb.ItemSet((seeds_like, labels_like,
     ...         indexes_like), names=("seeds", "labels", "indexes")),
     ...     "user:follow:user": gb.ItemSet((seeds_follow,labels_follow,
@@ -281,7 +281,7 @@ class ItemSampler(IterDataPipe):
 
     def __init__(
         self,
-        item_set: Union[ItemSet, ItemSetDict],
+        item_set: Union[ItemSet, HeteroItemSet],
         batch_size: int,
         minibatcher: Optional[Callable] = minibatcher_default,
         drop_last: Optional[bool] = False,
@@ -418,7 +418,7 @@ class DistributedItemSampler(ItemSampler):
 
     Parameters
     ----------
-    item_set : Union[ItemSet, ItemSetDict]
+    item_set : Union[ItemSet, HeteroItemSet]
         Data to be sampled.
     batch_size : int
         The size of each batch.
@@ -547,7 +547,7 @@ class DistributedItemSampler(ItemSampler):
 
     def __init__(
         self,
-        item_set: Union[ItemSet, ItemSetDict],
+        item_set: Union[ItemSet, HeteroItemSet],
         batch_size: int,
         minibatcher: Optional[Callable] = minibatcher_default,
         drop_last: Optional[bool] = False,

--- a/python/dgl/graphbolt/itemset.py
+++ b/python/dgl/graphbolt/itemset.py
@@ -208,14 +208,15 @@ class ItemSet:
 
 
 class HeteroItemSet:
-    r"""Dictionary wrapper of **ItemSet**.
+    r"""A collection of itemsets, each associated with a unique type.
 
-    This class aims to assemble existing itemsets with different tags, for
+    This class aims to assemble existing itemsets with different types, for
     example, seed_nodes of different node types in a graph.
 
     Parameters
     ----------
     itemsets: Dict[str, ItemSet]
+        A dictionary whose keys are types and values are ItemSet instances.
 
     Examples
     --------

--- a/python/dgl/graphbolt/itemset.py
+++ b/python/dgl/graphbolt/itemset.py
@@ -5,7 +5,7 @@ from typing import Dict, Iterable, Tuple, Union
 
 import torch
 
-__all__ = ["ItemSet", "ItemSetDict"]
+__all__ = ["ItemSet", "HeteroItemSet"]
 
 
 def is_scalar(x):
@@ -207,7 +207,7 @@ class ItemSet:
         return ret
 
 
-class ItemSetDict:
+class HeteroItemSet:
     r"""Dictionary wrapper of **ItemSet**.
 
     This class aims to assemble existing itemsets with different tags, for
@@ -226,7 +226,7 @@ class ItemSetDict:
 
     >>> node_ids_user = torch.arange(0, 5)
     >>> node_ids_item = torch.arange(5, 10)
-    >>> item_set = gb.ItemSetDict({
+    >>> item_set = gb.HeteroItemSet({
     ...     "user": gb.ItemSet(node_ids_user, names="seeds"),
     ...     "item": gb.ItemSet(node_ids_item, names="seeds")})
     >>> list(item_set)
@@ -246,7 +246,7 @@ class ItemSetDict:
     >>> labels_user = torch.arange(0, 2)
     >>> node_ids_item = torch.arange(2, 5)
     >>> labels_item = torch.arange(2, 5)
-    >>> item_set = gb.ItemSetDict({
+    >>> item_set = gb.HeteroItemSet({
     ...     "user": gb.ItemSet(
     ...         (node_ids_user, labels_user),
     ...         names=("seeds", "labels")),
@@ -270,7 +270,7 @@ class ItemSetDict:
     >>> labels_like = torch.tensor([1, 0])
     >>> seeds_follow = torch.arange(0, 6).reshape(-1, 2)
     >>> labels_follow = torch.tensor([1, 1, 0])
-    >>> item_set = gb.ItemSetDict({
+    >>> item_set = gb.HeteroItemSet({
     ...     "user:like:item": gb.ItemSet(
     ...         (seeds_like, labels_like),
     ...         names=("seeds", "labels")),
@@ -298,7 +298,7 @@ class ItemSetDict:
     >>> first_labels = torch.tensor([1, 0])
     >>> second_seeds = torch.arange(0, 2).reshape(-1, 1)
     >>> second_labels = torch.tensor([1, 0])
-    >>> item_set = gb.ItemSetDict({
+    >>> item_set = gb.HeteroItemSet({
     ...     "query:user:item": gb.ItemSet(
     ...         (first_seeds, first_labels),
     ...         names=("seeds", "labels")),

--- a/tests/python/pytorch/graphbolt/impl/test_in_subgraph_sampler.py
+++ b/tests/python/pytorch/graphbolt/impl/test_in_subgraph_sampler.py
@@ -160,7 +160,7 @@ def test_InSubgraphSampler_hetero():
         edge_type_to_id=etypes,
     ).to(F.ctx())
 
-    item_set = gb.ItemSetDict(
+    item_set = gb.HeteroItemSet(
         {
             "N0": gb.ItemSet(torch.LongTensor([1, 0, 2]), names="seeds"),
             "N1": gb.ItemSet(torch.LongTensor([0, 2, 1]), names="seeds"),

--- a/tests/python/pytorch/graphbolt/impl/test_negative_sampler.py
+++ b/tests/python/pytorch/graphbolt/impl/test_negative_sampler.py
@@ -221,7 +221,7 @@ def get_hetero_graph():
 
 def test_NegativeSampler_Hetero_Data():
     graph = get_hetero_graph().to(F.ctx())
-    itemset = gb.ItemSetDict(
+    itemset = gb.HeteroItemSet(
         {
             "n1:e1:n2": gb.ItemSet(
                 torch.LongTensor([[0, 0, 1, 1], [0, 2, 0, 1]]).T,

--- a/tests/python/pytorch/graphbolt/impl/test_neighbor_sampler.py
+++ b/tests/python/pytorch/graphbolt/impl/test_neighbor_sampler.py
@@ -51,7 +51,7 @@ def test_NeighborSampler_GraphFetch(hetero, prob_name, sorted):
     itemset = gb.ItemSet(items, names=names)
     graph = get_hetero_graph().to(F.ctx())
     if hetero:
-        itemset = gb.ItemSetDict({"n3": itemset})
+        itemset = gb.HeteroItemSet({"n3": itemset})
     else:
         graph.type_per_edge = None
     item_sampler = gb.ItemSampler(itemset, batch_size=2).copy_to(F.ctx())

--- a/tests/python/pytorch/graphbolt/impl/test_ondisk_dataset.py
+++ b/tests/python/pytorch/graphbolt/impl/test_ondisk_dataset.py
@@ -187,7 +187,7 @@ def test_OnDiskDataset_TVTSet_ItemSet_names():
         train_set = None
 
 
-def test_OnDiskDataset_TVTSet_ItemSetDict_names():
+def test_OnDiskDataset_TVTSet_HeteroItemSet_names():
     """Test TVTSet which returns ItemSet with IDs, labels and corresponding names."""
     with tempfile.TemporaryDirectory() as test_dir:
         train_ids = np.arange(1000)
@@ -221,7 +221,7 @@ def test_OnDiskDataset_TVTSet_ItemSetDict_names():
         # Verify train set.
         train_set = dataset.tasks[0].train_set
         assert len(train_set) == 1000
-        assert isinstance(train_set, gb.ItemSetDict)
+        assert isinstance(train_set, gb.HeteroItemSet)
         for i, item in enumerate(train_set):
             assert isinstance(item, dict)
             assert "author:writes:paper" in item
@@ -592,8 +592,8 @@ def test_OnDiskDataset_TVTSet_ItemSet_node_pairs_labels_indexes():
         dataset = None
 
 
-def test_OnDiskDataset_TVTSet_ItemSetDict_id_label():
-    """Test TVTSet which returns ItemSetDict with IDs and labels."""
+def test_OnDiskDataset_TVTSet_HeteroItemSet_id_label():
+    """Test TVTSet which returns HeteroItemSet with IDs and labels."""
     with tempfile.TemporaryDirectory() as test_dir:
         train_ids = np.arange(1000)
         train_labels = np.random.randint(0, 10, size=1000)
@@ -657,7 +657,7 @@ def test_OnDiskDataset_TVTSet_ItemSetDict_id_label():
         # Verify train set.
         train_set = dataset.tasks[0].train_set
         assert len(train_set) == 2000
-        assert isinstance(train_set, gb.ItemSetDict)
+        assert isinstance(train_set, gb.HeteroItemSet)
         for i, item in enumerate(train_set):
             assert isinstance(item, dict)
             assert len(item) == 1
@@ -672,7 +672,7 @@ def test_OnDiskDataset_TVTSet_ItemSetDict_id_label():
         # Verify validation set.
         validation_set = dataset.tasks[0].validation_set
         assert len(validation_set) == 2000
-        assert isinstance(validation_set, gb.ItemSetDict)
+        assert isinstance(validation_set, gb.HeteroItemSet)
         for i, item in enumerate(validation_set):
             assert isinstance(item, dict)
             assert len(item) == 1
@@ -687,7 +687,7 @@ def test_OnDiskDataset_TVTSet_ItemSetDict_id_label():
         # Verify test set.
         test_set = dataset.tasks[0].test_set
         assert len(test_set) == 2000
-        assert isinstance(test_set, gb.ItemSetDict)
+        assert isinstance(test_set, gb.HeteroItemSet)
         for i, item in enumerate(test_set):
             assert isinstance(item, dict)
             assert len(item) == 1
@@ -701,8 +701,8 @@ def test_OnDiskDataset_TVTSet_ItemSetDict_id_label():
         dataset = None
 
 
-def test_OnDiskDataset_TVTSet_ItemSetDict_node_pairs_labels():
-    """Test TVTSet which returns ItemSetDict with node pairs and labels."""
+def test_OnDiskDataset_TVTSet_HeteroItemSet_node_pairs_labels():
+    """Test TVTSet which returns HeteroItemSet with node pairs and labels."""
     with tempfile.TemporaryDirectory() as test_dir:
         train_seeds = np.arange(2000).reshape(1000, 2)
         train_seeds_path = os.path.join(test_dir, "train_seeds.npy")
@@ -791,7 +791,7 @@ def test_OnDiskDataset_TVTSet_ItemSetDict_node_pairs_labels():
         # Verify train set.
         train_set = dataset.tasks[0].train_set
         assert len(train_set) == 2000
-        assert isinstance(train_set, gb.ItemSetDict)
+        assert isinstance(train_set, gb.HeteroItemSet)
         for i, item in enumerate(train_set):
             assert isinstance(item, dict)
             assert len(item) == 1
@@ -807,7 +807,7 @@ def test_OnDiskDataset_TVTSet_ItemSetDict_node_pairs_labels():
         # Verify validation set.
         validation_set = dataset.tasks[0].validation_set
         assert len(validation_set) == 2000
-        assert isinstance(validation_set, gb.ItemSetDict)
+        assert isinstance(validation_set, gb.HeteroItemSet)
         for i, item in enumerate(validation_set):
             assert isinstance(item, dict)
             assert len(item) == 1
@@ -823,7 +823,7 @@ def test_OnDiskDataset_TVTSet_ItemSetDict_node_pairs_labels():
         # Verify test set.
         test_set = dataset.tasks[0].test_set
         assert len(test_set) == 2000
-        assert isinstance(test_set, gb.ItemSetDict)
+        assert isinstance(test_set, gb.HeteroItemSet)
         for i, item in enumerate(test_set):
             assert isinstance(item, dict)
             assert len(item) == 1
@@ -2400,7 +2400,7 @@ def test_OnDiskDataset_all_nodes_set_hetero():
         """
         dataset = write_yaml_and_load_dataset(yaml_content, test_dir)
         all_nodes_set = dataset.all_nodes_set
-        assert isinstance(all_nodes_set, gb.ItemSetDict)
+        assert isinstance(all_nodes_set, gb.HeteroItemSet)
         assert all_nodes_set.names == ("seeds",)
         for i, item in enumerate(all_nodes_set):
             assert len(item) == 1
@@ -2690,9 +2690,9 @@ def test_OnDiskDataset_heterogeneous(
 
         tasks = dataset.tasks
         assert len(tasks) == 1
-        assert isinstance(tasks[0].train_set, gb.ItemSetDict)
-        assert isinstance(tasks[0].validation_set, gb.ItemSetDict)
-        assert isinstance(tasks[0].test_set, gb.ItemSetDict)
+        assert isinstance(tasks[0].train_set, gb.HeteroItemSet)
+        assert isinstance(tasks[0].validation_set, gb.HeteroItemSet)
+        assert isinstance(tasks[0].test_set, gb.HeteroItemSet)
         assert tasks[0].metadata["num_classes"] == num_classes
         assert tasks[0].metadata["name"] == "node_classification"
 
@@ -2942,7 +2942,7 @@ def test_OnDiskDataset_not_include_eids():
 
 
 def test_OnDiskTask_repr_heterogeneous():
-    item_set = gb.ItemSetDict(
+    item_set = gb.HeteroItemSet(
         {
             "user": gb.ItemSet(torch.arange(0, 5), names="seeds"),
             "item": gb.ItemSet(torch.arange(5, 10), names="seeds"),
@@ -2951,7 +2951,7 @@ def test_OnDiskTask_repr_heterogeneous():
     metadata = {"name": "node_classification"}
     task = gb.OnDiskTask(metadata, item_set, item_set, item_set)
     expected_str = (
-        "OnDiskTask(validation_set=ItemSetDict(\n"
+        "OnDiskTask(validation_set=HeteroItemSet(\n"
         "               itemsets={'user': ItemSet(\n"
         "                            items=(tensor([0, 1, 2, 3, 4]),),\n"
         "                            names=('seeds',),\n"
@@ -2961,7 +2961,7 @@ def test_OnDiskTask_repr_heterogeneous():
         "                        )},\n"
         "               names=('seeds',),\n"
         "           ),\n"
-        "           train_set=ItemSetDict(\n"
+        "           train_set=HeteroItemSet(\n"
         "               itemsets={'user': ItemSet(\n"
         "                            items=(tensor([0, 1, 2, 3, 4]),),\n"
         "                            names=('seeds',),\n"
@@ -2971,7 +2971,7 @@ def test_OnDiskTask_repr_heterogeneous():
         "                        )},\n"
         "               names=('seeds',),\n"
         "           ),\n"
-        "           test_set=ItemSetDict(\n"
+        "           test_set=HeteroItemSet(\n"
         "               itemsets={'user': ItemSet(\n"
         "                            items=(tensor([0, 1, 2, 3, 4]),),\n"
         "                            names=('seeds',),\n"

--- a/tests/python/pytorch/graphbolt/test_feature_fetcher.py
+++ b/tests/python/pytorch/graphbolt/test_feature_fetcher.py
@@ -150,7 +150,7 @@ def test_FeatureFetcher_hetero():
     features[keys[1]] = gb.TorchBasedFeature(b)
     feature_store = gb.BasicFeatureStore(features)
 
-    itemset = gb.ItemSetDict(
+    itemset = gb.HeteroItemSet(
         {
             "n1": gb.ItemSet(torch.LongTensor([0, 1]), names="seeds"),
             "n2": gb.ItemSet(torch.LongTensor([0, 1, 2]), names="seeds"),
@@ -226,7 +226,7 @@ def test_FeatureFetcher_with_edges_hetero():
     features[keys[1]] = gb.TorchBasedFeature(b)
     feature_store = gb.BasicFeatureStore(features)
 
-    itemset = gb.ItemSetDict(
+    itemset = gb.HeteroItemSet(
         {
             "n1": gb.ItemSet(torch.randint(0, 20, (10,)), names="seeds"),
         }

--- a/tests/python/pytorch/graphbolt/test_item_sampler.py
+++ b/tests/python/pytorch/graphbolt/test_item_sampler.py
@@ -418,7 +418,7 @@ def test_append_with_other_datapipes():
 @pytest.mark.parametrize("batch_size", [1, 4])
 @pytest.mark.parametrize("shuffle", [True, False])
 @pytest.mark.parametrize("drop_last", [True, False])
-def test_ItemSetDict_seed_nodes(batch_size, shuffle, drop_last):
+def test_HeteroItemSet_seed_nodes(batch_size, shuffle, drop_last):
     # Node IDs.
     num_ids = 205
     ids = {
@@ -428,7 +428,7 @@ def test_ItemSetDict_seed_nodes(batch_size, shuffle, drop_last):
     chained_ids = []
     for key, value in ids.items():
         chained_ids += [(key, v) for v in value]
-    item_set = gb.ItemSetDict(ids)
+    item_set = gb.HeteroItemSet(ids)
     item_sampler = gb.ItemSampler(
         item_set, batch_size=batch_size, shuffle=shuffle, drop_last=drop_last
     )
@@ -457,7 +457,7 @@ def test_ItemSetDict_seed_nodes(batch_size, shuffle, drop_last):
 @pytest.mark.parametrize("batch_size", [1, 4])
 @pytest.mark.parametrize("shuffle", [True, False])
 @pytest.mark.parametrize("drop_last", [True, False])
-def test_ItemSetDict_seed_nodes_labels(batch_size, shuffle, drop_last):
+def test_HeteroItemSet_seed_nodes_labels(batch_size, shuffle, drop_last):
     # Node IDs.
     num_ids = 205
     ids = {
@@ -473,7 +473,7 @@ def test_ItemSetDict_seed_nodes_labels(batch_size, shuffle, drop_last):
     chained_ids = []
     for key, value in ids.items():
         chained_ids += [(key, v) for v in value]
-    item_set = gb.ItemSetDict(ids)
+    item_set = gb.HeteroItemSet(ids)
     item_sampler = gb.ItemSampler(
         item_set, batch_size=batch_size, shuffle=shuffle, drop_last=drop_last
     )
@@ -514,7 +514,7 @@ def test_ItemSetDict_seed_nodes_labels(batch_size, shuffle, drop_last):
 @pytest.mark.parametrize("batch_size", [1, 4])
 @pytest.mark.parametrize("shuffle", [True, False])
 @pytest.mark.parametrize("drop_last", [True, False])
-def test_ItemSetDict_node_pairs(batch_size, shuffle, drop_last):
+def test_HeteroItemSet_node_pairs(batch_size, shuffle, drop_last):
     # Node pairs.
     num_ids = 103
     total_pairs = 2 * num_ids
@@ -524,7 +524,7 @@ def test_ItemSetDict_node_pairs(batch_size, shuffle, drop_last):
         "user:like:item": gb.ItemSet(node_pairs_like, names="seeds"),
         "user:follow:user": gb.ItemSet(node_pairs_follow, names="seeds"),
     }
-    item_set = gb.ItemSetDict(node_pairs_dict)
+    item_set = gb.HeteroItemSet(node_pairs_dict)
     item_sampler = gb.ItemSampler(
         item_set, batch_size=batch_size, shuffle=shuffle, drop_last=drop_last
     )
@@ -564,7 +564,7 @@ def test_ItemSetDict_node_pairs(batch_size, shuffle, drop_last):
 @pytest.mark.parametrize("batch_size", [1, 4])
 @pytest.mark.parametrize("shuffle", [True, False])
 @pytest.mark.parametrize("drop_last", [True, False])
-def test_ItemSetDict_node_pairs_labels(batch_size, shuffle, drop_last):
+def test_HeteroItemSet_node_pairs_labels(batch_size, shuffle, drop_last):
     # Node pairs and labels
     num_ids = 103
     total_ids = 2 * num_ids
@@ -581,7 +581,7 @@ def test_ItemSetDict_node_pairs_labels(batch_size, shuffle, drop_last):
             names=("seeds", "labels"),
         ),
     }
-    item_set = gb.ItemSetDict(node_pairs_dict)
+    item_set = gb.HeteroItemSet(node_pairs_dict)
     item_sampler = gb.ItemSampler(
         item_set, batch_size=batch_size, shuffle=shuffle, drop_last=drop_last
     )
@@ -631,7 +631,9 @@ def test_ItemSetDict_node_pairs_labels(batch_size, shuffle, drop_last):
 @pytest.mark.parametrize("batch_size", [1, 4])
 @pytest.mark.parametrize("shuffle", [True, False])
 @pytest.mark.parametrize("drop_last", [True, False])
-def test_ItemSetDict_node_pairs_labels_indexes(batch_size, shuffle, drop_last):
+def test_HeteroItemSet_node_pairs_labels_indexes(
+    batch_size, shuffle, drop_last
+):
     # Head, tail and negative tails.
     num_ids = 103
     total_ids = 6 * num_ids
@@ -691,7 +693,7 @@ def test_ItemSetDict_node_pairs_labels_indexes(batch_size, shuffle, drop_last):
             names=("seeds", "labels", "indexes"),
         ),
     }
-    item_set = gb.ItemSetDict(data_dict)
+    item_set = gb.HeteroItemSet(data_dict)
     item_sampler = gb.ItemSampler(
         item_set, batch_size=batch_size, shuffle=shuffle, drop_last=drop_last
     )
@@ -762,7 +764,7 @@ def test_ItemSetDict_node_pairs_labels_indexes(batch_size, shuffle, drop_last):
 @pytest.mark.parametrize("batch_size", [1, 4])
 @pytest.mark.parametrize("shuffle", [True, False])
 @pytest.mark.parametrize("drop_last", [True, False])
-def test_ItemSetDict_hyperlink(batch_size, shuffle, drop_last):
+def test_HeteroItemSet_hyperlink(batch_size, shuffle, drop_last):
     # Node pairs.
     num_ids = 103
     total_pairs = 2 * num_ids
@@ -772,7 +774,7 @@ def test_ItemSetDict_hyperlink(batch_size, shuffle, drop_last):
         "user:like:item": gb.ItemSet(seeds_like, names="seeds"),
         "user:follow:user": gb.ItemSet(seeds_follow, names="seeds"),
     }
-    item_set = gb.ItemSetDict(seeds_dict)
+    item_set = gb.HeteroItemSet(seeds_dict)
     item_sampler = gb.ItemSampler(
         item_set, batch_size=batch_size, shuffle=shuffle, drop_last=drop_last
     )
@@ -808,7 +810,7 @@ def test_ItemSetDict_hyperlink(batch_size, shuffle, drop_last):
 @pytest.mark.parametrize("batch_size", [1, 4])
 @pytest.mark.parametrize("shuffle", [True, False])
 @pytest.mark.parametrize("drop_last", [True, False])
-def test_ItemSetDict_hyperlink_labels(batch_size, shuffle, drop_last):
+def test_HeteroItemSet_hyperlink_labels(batch_size, shuffle, drop_last):
     # Node pairs and labels
     num_ids = 103
     total_ids = 2 * num_ids
@@ -824,7 +826,7 @@ def test_ItemSetDict_hyperlink_labels(batch_size, shuffle, drop_last):
             names=("seeds", "labels"),
         ),
     }
-    item_set = gb.ItemSetDict(seeds_dict)
+    item_set = gb.HeteroItemSet(seeds_dict)
     item_sampler = gb.ItemSampler(
         item_set, batch_size=batch_size, shuffle=shuffle, drop_last=drop_last
     )

--- a/tests/python/pytorch/graphbolt/test_itemset.py
+++ b/tests/python/pytorch/graphbolt/test_itemset.py
@@ -225,9 +225,9 @@ def test_ItemSet_graphs():
     assert item_set[:] == graphs
 
 
-def test_ItemSetDict_names():
-    # ItemSetDict with single name.
-    item_set = gb.ItemSetDict(
+def test_HeteroItemSet_names():
+    # HeteroItemSet with single name.
+    item_set = gb.HeteroItemSet(
         {
             "user": gb.ItemSet(torch.arange(0, 5), names="seeds"),
             "item": gb.ItemSet(torch.arange(5, 10), names="seeds"),
@@ -235,8 +235,8 @@ def test_ItemSetDict_names():
     )
     assert item_set.names == ("seeds",)
 
-    # ItemSetDict with multiple names.
-    item_set = gb.ItemSetDict(
+    # HeteroItemSet with multiple names.
+    item_set = gb.HeteroItemSet(
         {
             "user": gb.ItemSet(
                 (torch.arange(0, 5), torch.arange(5, 10)),
@@ -250,8 +250,8 @@ def test_ItemSetDict_names():
     )
     assert item_set.names == ("seeds", "labels")
 
-    # ItemSetDict with no name.
-    item_set = gb.ItemSetDict(
+    # HeteroItemSet with no name.
+    item_set = gb.HeteroItemSet(
         {
             "user": gb.ItemSet(torch.arange(0, 5)),
             "item": gb.ItemSet(torch.arange(5, 10)),
@@ -259,12 +259,12 @@ def test_ItemSetDict_names():
     )
     assert item_set.names is None
 
-    # ItemSetDict with mismatched items and names.
+    # HeteroItemSet with mismatched items and names.
     with pytest.raises(
         AssertionError,
         match=re.escape("All itemsets must have the same names."),
     ):
-        _ = gb.ItemSetDict(
+        _ = gb.HeteroItemSet(
             {
                 "user": gb.ItemSet(
                     (torch.arange(0, 5), torch.arange(5, 10)),
@@ -275,11 +275,11 @@ def test_ItemSetDict_names():
         )
 
 
-def test_ItemSetDict_length():
+def test_HeteroItemSet_length():
     # Single iterable with valid length.
     user_ids = torch.arange(0, 5)
     item_ids = torch.arange(0, 5)
-    item_set = gb.ItemSetDict(
+    item_set = gb.HeteroItemSet(
         {
             "user": gb.ItemSet(user_ids),
             "item": gb.ItemSet(item_ids),
@@ -292,7 +292,7 @@ def test_ItemSetDict_length():
     neg_dsts_like = torch.arange(10, 20).reshape(-1, 2)
     node_pairs_follow = torch.arange(0, 10).reshape(-1, 2)
     neg_dsts_follow = torch.arange(10, 20).reshape(-1, 2)
-    item_set = gb.ItemSetDict(
+    item_set = gb.HeteroItemSet(
         {
             "user:like:item": gb.ItemSet((node_pairs_like, neg_dsts_like)),
             "user:follow:user": gb.ItemSet(
@@ -310,7 +310,7 @@ def test_ItemSetDict_length():
     with pytest.raises(
         TypeError, match="object of type 'InvalidLength' has no len()"
     ):
-        item_set = gb.ItemSetDict(
+        item_set = gb.HeteroItemSet(
             {
                 "user": gb.ItemSet(InvalidLength()),
                 "item": gb.ItemSet(InvalidLength()),
@@ -321,7 +321,7 @@ def test_ItemSetDict_length():
     with pytest.raises(
         TypeError, match="object of type 'InvalidLength' has no len()"
     ):
-        item_set = gb.ItemSetDict(
+        item_set = gb.HeteroItemSet(
             {
                 "user:like:item": gb.ItemSet(
                     (InvalidLength(), InvalidLength())
@@ -333,7 +333,7 @@ def test_ItemSetDict_length():
         )
 
 
-def test_ItemSetDict_iteration_seed_nodes():
+def test_HeteroItemSet_iteration_seed_nodes():
     # Node IDs.
     user_ids = torch.arange(0, 5)
     item_ids = torch.arange(5, 10)
@@ -344,9 +344,9 @@ def test_ItemSetDict_iteration_seed_nodes():
     chained_ids = []
     for key, value in ids.items():
         chained_ids += [(key, v) for v in value]
-    item_set = gb.ItemSetDict(ids)
+    item_set = gb.HeteroItemSet(ids)
     assert item_set.names == ("seeds",)
-    # Iterating over ItemSetDict and indexing one by one.
+    # Iterating over HeteroItemSet and indexing one by one.
     for i, item in enumerate(item_set):
         assert len(item) == 1
         assert isinstance(item, dict)
@@ -389,18 +389,18 @@ def test_ItemSetDict_iteration_seed_nodes():
         AssertionError, match="Start must be smaller than stop."
     ):
         _ = item_set[-1:3]
-    with pytest.raises(IndexError, match="ItemSetDict index out of range."):
+    with pytest.raises(IndexError, match="HeteroItemSet index out of range."):
         _ = item_set[20]
-    with pytest.raises(IndexError, match="ItemSetDict index out of range."):
+    with pytest.raises(IndexError, match="HeteroItemSet index out of range."):
         _ = item_set[-20]
     with pytest.raises(
         TypeError,
-        match="ItemSetDict indices must be int, slice, or iterable of int, not <class 'float'>.",
+        match="HeteroItemSet indices must be int, slice, or iterable of int, not <class 'float'>.",
     ):
         _ = item_set[1.5]
 
 
-def test_ItemSetDict_iteration_seed_nodes_labels():
+def test_HeteroItemSet_iteration_seed_nodes_labels():
     # Node IDs and labels.
     user_ids = torch.arange(0, 5)
     user_labels = torch.randint(0, 3, (5,))
@@ -413,9 +413,9 @@ def test_ItemSetDict_iteration_seed_nodes_labels():
     chained_ids = []
     for key, value in ids_labels.items():
         chained_ids += [(key, v) for v in value]
-    item_set = gb.ItemSetDict(ids_labels)
+    item_set = gb.HeteroItemSet(ids_labels)
     assert item_set.names == ("seeds", "labels")
-    # Iterating over ItemSetDict and indexing one by one.
+    # Iterating over HeteroItemSet and indexing one by one.
     for i, item in enumerate(item_set):
         assert len(item) == 1
         assert isinstance(item, dict)
@@ -429,7 +429,7 @@ def test_ItemSetDict_iteration_seed_nodes_labels():
     assert torch.equal(item_set[:]["item"][1], item_labels)
 
 
-def test_ItemSetDict_iteration_node_pairs():
+def test_HeteroItemSet_iteration_node_pairs():
     # Node pairs.
     node_pairs = torch.arange(0, 10).reshape(-1, 2)
     node_pairs_dict = {
@@ -439,9 +439,9 @@ def test_ItemSetDict_iteration_node_pairs():
     expected_data = []
     for key, value in node_pairs_dict.items():
         expected_data += [(key, v) for v in value]
-    item_set = gb.ItemSetDict(node_pairs_dict)
+    item_set = gb.HeteroItemSet(node_pairs_dict)
     assert item_set.names == ("seeds",)
-    # Iterating over ItemSetDict and indexing one by one.
+    # Iterating over HeteroItemSet and indexing one by one.
     for i, item in enumerate(item_set):
         assert len(item) == 1
         assert isinstance(item, dict)
@@ -455,7 +455,7 @@ def test_ItemSetDict_iteration_node_pairs():
     assert torch.equal(item_set[:]["user:follow:user"], node_pairs)
 
 
-def test_ItemSetDict_iteration_node_pairs_labels():
+def test_HeteroItemSet_iteration_node_pairs_labels():
     # Node pairs and labels
     node_pairs = torch.arange(0, 10).reshape(-1, 2)
     labels = torch.randint(0, 3, (5,))
@@ -470,9 +470,9 @@ def test_ItemSetDict_iteration_node_pairs_labels():
     expected_data = []
     for key, value in node_pairs_labels.items():
         expected_data += [(key, v) for v in value]
-    item_set = gb.ItemSetDict(node_pairs_labels)
+    item_set = gb.HeteroItemSet(node_pairs_labels)
     assert item_set.names == ("seeds", "labels")
-    # Iterating over ItemSetDict and indexing one by one.
+    # Iterating over HeteroItemSet and indexing one by one.
     for i, item in enumerate(item_set):
         assert len(item) == 1
         assert isinstance(item, dict)
@@ -491,7 +491,7 @@ def test_ItemSetDict_iteration_node_pairs_labels():
     assert torch.equal(item_set[:]["user:follow:user"][1], labels)
 
 
-def test_ItemSetDict_iteration_node_pairs_labels_indexes():
+def test_HeteroItemSet_iteration_node_pairs_labels_indexes():
     # Node pairs and negative destinations.
     node_pairs = torch.arange(0, 10).reshape(-1, 2)
     labels = torch.tensor([1, 1, 0, 0, 0])
@@ -507,9 +507,9 @@ def test_ItemSetDict_iteration_node_pairs_labels_indexes():
     expected_data = []
     for key, value in node_pairs_neg_dsts.items():
         expected_data += [(key, v) for v in value]
-    item_set = gb.ItemSetDict(node_pairs_neg_dsts)
+    item_set = gb.HeteroItemSet(node_pairs_neg_dsts)
     assert item_set.names == ("seeds", "labels", "indexes")
-    # Iterating over ItemSetDict and indexing one by one.
+    # Iterating over HeteroItemSet and indexing one by one.
     for i, item in enumerate(item_set):
         assert len(item) == 1
         assert isinstance(item, dict)
@@ -558,16 +558,16 @@ def test_ItemSet_repr():
     assert str(item_set) == expected_str, item_set
 
 
-def test_ItemSetDict_repr():
-    # ItemSetDict with single name.
-    item_set = gb.ItemSetDict(
+def test_HeteroItemSet_repr():
+    # HeteroItemSet with single name.
+    item_set = gb.HeteroItemSet(
         {
             "user": gb.ItemSet(torch.arange(0, 5), names="seeds"),
             "item": gb.ItemSet(torch.arange(5, 10), names="seeds"),
         }
     )
     expected_str = (
-        "ItemSetDict(\n"
+        "HeteroItemSet(\n"
         "    itemsets={'user': ItemSet(\n"
         "                 items=(tensor([0, 1, 2, 3, 4]),),\n"
         "                 names=('seeds',),\n"
@@ -580,8 +580,8 @@ def test_ItemSetDict_repr():
     )
     assert str(item_set) == expected_str, item_set
 
-    # ItemSetDict with multiple names.
-    item_set = gb.ItemSetDict(
+    # HeteroItemSet with multiple names.
+    item_set = gb.HeteroItemSet(
         {
             "user": gb.ItemSet(
                 (torch.arange(0, 5), torch.arange(5, 10)),
@@ -594,7 +594,7 @@ def test_ItemSetDict_repr():
         }
     )
     expected_str = (
-        "ItemSetDict(\n"
+        "HeteroItemSet(\n"
         "    itemsets={'user': ItemSet(\n"
         "                 items=(tensor([0, 1, 2, 3, 4]), tensor([5, 6, 7, 8, 9])),\n"
         "                 names=('seeds', 'labels'),\n"

--- a/tests/python/pytorch/graphbolt/test_subgraph_sampler.py
+++ b/tests/python/pytorch/graphbolt/test_subgraph_sampler.py
@@ -315,7 +315,7 @@ def test_SubgraphSampler_Node_Hetero(sampler_type):
         }
         items = (items, torch.randint(0, 10, (3,)))
         names = (names, "timestamp")
-    itemset = gb.ItemSetDict({"n2": gb.ItemSet(items, names=names)})
+    itemset = gb.HeteroItemSet({"n2": gb.ItemSet(items, names=names)})
     item_sampler = gb.ItemSampler(itemset, batch_size=2).copy_to(F.ctx())
     num_layer = 2
     fanouts = [torch.LongTensor([2]) for _ in range(num_layer)]
@@ -350,7 +350,7 @@ def test_SubgraphSampler_Link_Hetero(sampler_type):
         first_names = (first_names, "timestamp")
         second_items = (second_items, torch.randint(0, 10, (6,)))
         second_names = (second_names, "timestamp")
-    itemset = gb.ItemSetDict(
+    itemset = gb.HeteroItemSet(
         {
             "n1:e1:n2": gb.ItemSet(
                 first_items,
@@ -405,7 +405,7 @@ def test_SubgraphSampler_Link_Hetero_With_Negative(sampler_type):
         first_names = (first_names, "timestamp")
         second_items = (second_items, torch.randint(0, 10, (6,)))
         second_names = (second_names, "timestamp")
-    itemset = gb.ItemSetDict(
+    itemset = gb.HeteroItemSet(
         {
             "n1:e1:n2": gb.ItemSet(
                 first_items,
@@ -451,7 +451,7 @@ def test_SubgraphSampler_Link_Hetero_Unknown_Etype(sampler_type):
         second_items = (second_items, torch.randint(0, 10, (6,)))
         second_names = (second_names, "timestamp")
     # "e11" and "e22" are not valid edge types.
-    itemset = gb.ItemSetDict(
+    itemset = gb.HeteroItemSet(
         {
             "n1:e11:n2": gb.ItemSet(
                 first_items,
@@ -496,7 +496,7 @@ def test_SubgraphSampler_Link_Hetero_With_Negative_Unknown_Etype(sampler_type):
         second_items = (second_items, torch.randint(0, 10, (6,)))
         second_names = (second_names, "timestamp")
     # "e11" and "e22" are not valid edge types.
-    itemset = gb.ItemSetDict(
+    itemset = gb.HeteroItemSet(
         {
             "n1:e11:n2": gb.ItemSet(
                 first_items,
@@ -537,7 +537,7 @@ def test_SubgraphSampler_HyperLink_Hetero(sampler_type):
         }
         items = (items, torch.randint(0, 10, (2,)))
         names = (names, "timestamp")
-    itemset = gb.ItemSetDict(
+    itemset = gb.HeteroItemSet(
         {
             "n2:n1:n2:n1:n2": gb.ItemSet(
                 items,
@@ -623,7 +623,7 @@ def test_SubgraphSampler_Random_Hetero_Graph(sampler_type, replace):
         first_names = (first_names, "timestamp")
         second_items = (second_items, torch.randint(0, 10, (1,)))
         second_names = (second_names, "timestamp")
-    itemset = gb.ItemSetDict(
+    itemset = gb.HeteroItemSet(
         {
             "n2": gb.ItemSet(first_items, names=first_names),
             "n1": gb.ItemSet(second_items, names=second_names),
@@ -758,7 +758,7 @@ def test_SubgraphSampler_without_deduplication_Hetero_Node(sampler_type):
         }
         items = (items, torch.randint(1, 10, (2,)))
         names = (names, "timestamp")
-    itemset = gb.ItemSetDict({"n2": gb.ItemSet(items, names=names)})
+    itemset = gb.HeteroItemSet({"n2": gb.ItemSet(items, names=names)})
     item_sampler = gb.ItemSampler(itemset, batch_size=2).copy_to(F.ctx())
     num_layer = 2
     fanouts = [torch.LongTensor([2]) for _ in range(num_layer)]
@@ -936,7 +936,9 @@ def test_SubgraphSampler_unique_csc_format_Homo_Node_gpu(labor):
 @pytest.mark.parametrize("labor", [False, True])
 def test_SubgraphSampler_unique_csc_format_Hetero_Node(labor):
     graph = get_hetero_graph().to(F.ctx())
-    itemset = gb.ItemSetDict({"n2": gb.ItemSet(torch.arange(2), names="seeds")})
+    itemset = gb.HeteroItemSet(
+        {"n2": gb.ItemSet(torch.arange(2), names="seeds")}
+    )
     item_sampler = gb.ItemSampler(itemset, batch_size=2).copy_to(F.ctx())
     num_layer = 2
     fanouts = [torch.LongTensor([2]) for _ in range(num_layer)]
@@ -1016,7 +1018,7 @@ def test_SubgraphSampler_Hetero_multifanout_per_layer(sampler_type):
         items_n1 = (items_n1, torch.tensor([10]))
         items_n2 = (items_n2, torch.tensor([10]))
         names = (names, "timestamp")
-    itemset = gb.ItemSetDict(
+    itemset = gb.HeteroItemSet(
         {
             "n1": gb.ItemSet(items=items_n1, names=names),
             "n2": gb.ItemSet(items=items_n2, names=names),
@@ -1146,7 +1148,7 @@ def test_SubgraphSampler_without_deduplication_Hetero_Link(sampler_type):
         }
         items = (items, torch.randint(1, 10, (1,)))
         names = (names, "timestamp")
-    itemset = gb.ItemSetDict({"n1:e1:n2": gb.ItemSet(items, names=names)})
+    itemset = gb.HeteroItemSet({"n1:e1:n2": gb.ItemSet(items, names=names)})
     item_sampler = gb.ItemSampler(itemset, batch_size=2).copy_to(F.ctx())
     num_layer = 2
     fanouts = [torch.LongTensor([2]) for _ in range(num_layer)]
@@ -1356,7 +1358,7 @@ def test_SubgraphSampler_unique_csc_format_Homo_Link_gpu(labor):
 @pytest.mark.parametrize("labor", [False, True])
 def test_SubgraphSampler_unique_csc_format_Hetero_Link(labor):
     graph = get_hetero_graph().to(F.ctx())
-    itemset = gb.ItemSetDict(
+    itemset = gb.HeteroItemSet(
         {"n1:e1:n2": gb.ItemSet(torch.tensor([[0, 1]]), names="seeds")}
     )
     item_sampler = gb.ItemSampler(itemset, batch_size=2).copy_to(F.ctx())
@@ -1517,7 +1519,7 @@ def test_SubgraphSampler_without_deduplication_Hetero_HyperLink(sampler_type):
         }
         items = (items, torch.randint(1, 10, (1,)))
         names = (names, "timestamp")
-    itemset = gb.ItemSetDict({"n2:n1:n2": gb.ItemSet(items, names=names)})
+    itemset = gb.HeteroItemSet({"n2:n1:n2": gb.ItemSet(items, names=names)})
     item_sampler = gb.ItemSampler(itemset, batch_size=2).copy_to(F.ctx())
     num_layer = 2
     fanouts = [torch.LongTensor([2]) for _ in range(num_layer)]
@@ -1727,7 +1729,7 @@ def test_SubgraphSampler_unique_csc_format_Homo_HyperLink_gpu(labor):
 @pytest.mark.parametrize("labor", [False, True])
 def test_SubgraphSampler_unique_csc_format_Hetero_HyperLink(labor):
     graph = get_hetero_graph().to(F.ctx())
-    itemset = gb.ItemSetDict(
+    itemset = gb.HeteroItemSet(
         {"n1:n2:n1": gb.ItemSet(torch.tensor([[0, 1, 0]]), names="seeds")}
     )
     item_sampler = gb.ItemSampler(itemset, batch_size=2).copy_to(F.ctx())

--- a/tests/python/pytorch/graphbolt/test_utils.py
+++ b/tests/python/pytorch/graphbolt/test_utils.py
@@ -213,7 +213,7 @@ def get_hetero_graph():
 
 def test_exclude_seed_edges_hetero():
     graph = get_hetero_graph().to(F.ctx())
-    itemset = gb.ItemSetDict(
+    itemset = gb.HeteroItemSet(
         {"n1:e1:n2": gb.ItemSet(torch.tensor([[0, 1]]), names="seeds")}
     )
     item_sampler = gb.ItemSampler(itemset, batch_size=2).copy_to(F.ctx())


### PR DESCRIPTION
## Description
<!-- Brief description. Refer to the related issues if existed.
It'll be great if relevant reviewers can be assigned as well.-->
Though `ItemSetDict` is named with dict and takes a dictionary as input, it does not behave as a dictionary, but like a Sequence instead. So maybe we should rename it to avoid confusion.
Relative issues: #6672 #6785 


## Checklist
Please feel free to remove inapplicable items for your PR.
- [ ] The PR title starts with [$CATEGORY] (such as [NN], [Model], [Doc], [Feature]])
- [ ] I've leverage the [tools](https://docs.google.com/document/d/1iHyj7zlmygKSk5gBPsqIqL5ASPzJSPREaNT_QdsiYA4/edit) to beautify the python and c++ code.
- [ ] The PR is complete and small, read the [Google eng practice (CL equals to PR)](https://google.github.io/eng-practices/review/developer/small-cls.html) to understand more about small PR. In DGL, we consider PRs with less than 200 lines of core code change are small (example, test and documentation could be exempted).
- [ ] All changes have test coverage
- [ ] Code is well-documented
- [ ] To the best of my knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change
- [ ] Related issue is referred in this PR
- [ ] If the PR is for a new model/paper, I've updated the example index [here](../examples/README.md).

## Changes
<!-- You could use following template
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)
-->
