### PR TITLE
Heteroitemset getitem iter

### DIFF
--- a/python/dgl/graphbolt/item_sampler.py
+++ b/python/dgl/graphbolt/item_sampler.py
@@ -310,7 +310,8 @@ class ItemSampler(IterDataPipe):
         # used in every epoch.
         self._epoch = 0
 
-    def _collate_batch(self, buffer, indices, offsets=None):
+    @classmethod
+    def _collate_batch(cls, buffer, indices, offsets=None):
         """Collate a batch from the buffer. For internal use only."""
         if isinstance(buffer, torch.Tensor):
             # For item set that's initialized with integer or single tensor,
@@ -332,7 +333,7 @@ class ItemSampler(IterDataPipe):
                 current_indices, _ = ind[
                     indices_offsets[key_id] : indices_offsets[key_id + 1]
                 ].sort()
-                batch[key] = self._collate_batch(
+                batch[key] = cls._collate_batch(
                     buffer[key], indices[current_indices] - offsets[key_id]
                 )
             return batch

--- a/python/dgl/graphbolt/item_sampler.py
+++ b/python/dgl/graphbolt/item_sampler.py
@@ -324,17 +324,18 @@ class ItemSampler(IterDataPipe):
         elif isinstance(buffer, Mapping):
             # For item set that's initialized with a dict of items,
             # `buffer` is a dict of tensors/lists/tuples.
-            sorted_indices, ind = indices.sort()
-            indices_offsets = torch.searchsorted(sorted_indices, offsets)
+            # sorted_indices, ind = indices.sort()
+            indices_offsets = torch.searchsorted(indices, offsets)
             batch = {}
             for key_id, key in enumerate(buffer.keys()):
                 if indices_offsets[key_id] == indices_offsets[key_id + 1]:
                     continue
-                current_indices, _ = ind[
-                    indices_offsets[key_id] : indices_offsets[key_id + 1]
-                ].sort()
+                # current_indices, _ = ind[
+                #     indices_offsets[key_id] : indices_offsets[key_id + 1]
+                # ].sort()
+                current_indices = indices[indices_offsets[key_id] : indices_offsets[key_id + 1]] - offsets[key_id]
                 batch[key] = cls._collate_batch(
-                    buffer[key], indices[current_indices] - offsets[key_id]
+                    buffer[key], current_indices,
                 )
             return batch
         raise TypeError(f"Unsupported buffer type {type(buffer).__name__}.")

--- a/python/dgl/graphbolt/itemset.py
+++ b/python/dgl/graphbolt/itemset.py
@@ -368,20 +368,16 @@ class HeteroItemSet:
             sorted_index, indices = index.sort()
             assert sorted_index[0] >= 0 and sorted_index[-1] < self._length
             index_offsets = torch.searchsorted(sorted_index, self._offsets)
-            # print(f"{index = }\n{sorted_index = }\n{indices = },\n{inv_p = }\n{self._offsets = }\n{index_offsets = }\n{num_per_key = }")
-            # assert 0
             data = {}
             for key_id, key in enumerate(self._keys):
-                if index_offsets[key_id] == index_offsets[key_id+1]:
+                if index_offsets[key_id] == index_offsets[key_id + 1]:
                     continue
-                current_indices, _ = indices[index_offsets[key_id]: index_offsets[key_id+1]].sort()
-                data[key] = self._itemsets[key][index[current_indices] - self._offsets[key_id]]
-                # mask = (key_indices == key_id).nonzero().squeeze(1)
-                # if len(mask) == 0:
-                #     continue
-                # data[key] = self._itemsets[key][
-                #     index[mask] - self._offsets[key_id]
-                # ]
+                current_indices, _ = indices[
+                    index_offsets[key_id] : index_offsets[key_id + 1]
+                ].sort()
+                data[key] = self._itemsets[key][
+                    index[current_indices] - self._offsets[key_id]
+                ]
             return data
         else:
             raise TypeError(


### PR DESCRIPTION
## Description
<!-- Brief description. Refer to the related issues if existed.
It'll be great if relevant reviewers can be assigned as well.-->

First let's take a look at the current code for indexing a HeteroItemSet (occurs in `HeteroItemSet.__getitem__`):

```python
        elif isinstance(index, Iterable):
            if not isinstance(index, torch.Tensor):
                index = torch.tensor(index)
            assert torch.all((index >= 0) & (index < self._length))
            key_indices = (
                torch.searchsorted(self._offsets, index, right=True) - 1
            )
            data = {}
            for key_id, key in enumerate(self._keys):
                mask = (key_indices == key_id).nonzero().squeeze(1)
                if len(mask) == 0:
                    continue
                data[key] = self._itemsets[key][
                    index[mask] - self._offsets[key_id]
                ]
            return data
```

Say the length of indices is `N` and the number of etypes/ntyeps is `K`, then the time complexity of current implementation of indexing a dictionary is `O(N * K)`, which is mainly introduced by the line

```python
mask = (key_indices == key_id).nonzero().squeeze(1)
``` 

If there are a lot of etypes, this line could easily become the bottleneck.

This draft PR intends to propose an alternative to current logic:

```python
        elif isinstance(index, Iterable):
            if not isinstance(index, torch.Tensor):
                index = torch.tensor(index)
            sorted_index, indices = index.sort()
            assert sorted_index[0] >= 0 and sorted_index[-1] < self._length
            index_offsets = torch.searchsorted(sorted_index, self._offsets)
            data = {}
            for key_id, key in enumerate(self._keys):
                if index_offsets[key_id] == index_offsets[key_id + 1]:
                    continue
                current_indices, _ = indices[
                    index_offsets[key_id] : index_offsets[key_id + 1]
                ].sort()
                data[key] = self._itemsets[key][
                    index[current_indices] - self._offsets[key_id]
                ]
            return data
```

whose time complexity is `O(N * logN)` where the `log` is introduced by the sorting operation.

This will imporve the performance when there are many etypes, but might cause more time consuming when there are few etypes. A thoughtful consideration lies in striking a balance between the two approaches.


## Checklist
Please feel free to remove inapplicable items for your PR.
- [ ] The PR title starts with [$CATEGORY] (such as [NN], [Model], [Doc], [Feature]])
- [ ] I've leverage the [tools](https://docs.google.com/document/d/1iHyj7zlmygKSk5gBPsqIqL5ASPzJSPREaNT_QdsiYA4/edit) to beautify the python and c++ code.
- [ ] The PR is complete and small, read the [Google eng practice (CL equals to PR)](https://google.github.io/eng-practices/review/developer/small-cls.html) to understand more about small PR. In DGL, we consider PRs with less than 200 lines of core code change are small (example, test and documentation could be exempted).
- [ ] All changes have test coverage
- [ ] Code is well-documented
- [ ] To the best of my knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change
- [ ] Related issue is referred in this PR
- [ ] If the PR is for a new model/paper, I've updated the example index [here](../examples/README.md).

## Changes
<!-- You could use following template
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)
-->
