### PR TITLE
[Misc] Fix edge_ids()'s error messages

### DIFF
--- a/python/dgl/heterograph.py
+++ b/python/dgl/heterograph.py
@@ -3262,10 +3262,11 @@ class DGLGraph(object):
                 # Raise error since some (u, v) pair is not a valid edge.
                 idx = F.nonzero_1d(is_neg_one)
                 raise DGLError(
-                    "Error: (%d, %d) does not form a valid edge."
+                    "Error: %d invalid edges, (%d, %d) is one."
                     % (
-                        F.as_scalar(F.gather_row(u, idx)),
-                        F.as_scalar(F.gather_row(v, idx)),
+                        len(idx),
+                        F.as_scalar(F.gather_row(u, idx[0])),
+                        F.as_scalar(F.gather_row(v, idx[0])),
                     )
                 )
             return F.as_scalar(eid) if is_int else eid


### PR DESCRIPTION
## Description
<!-- Brief description. Refer to the related issues if existed.
It'll be great if relevant reviewers can be assigned as well.-->
When calling edge_ids(), if there are more than one invalid edges, the error message can't print any invalid (src, dst) value, but only print "ValueError: only one element tensors can be converted to Python scalars", fix it.

## Checklist
Please feel free to remove inapplicable items for your PR.
- [ ] The PR title starts with [$CATEGORY] (such as [NN], [Model], [Doc], [Feature]])
- [ ] I've leverage the [tools](https://docs.google.com/document/d/1iHyj7zlmygKSk5gBPsqIqL5ASPzJSPREaNT_QdsiYA4/edit) to beautify the python and c++ code.
- [ ] The PR is complete and small, read the [Google eng practice (CL equals to PR)](https://google.github.io/eng-practices/review/developer/small-cls.html) to understand more about small PR. In DGL, we consider PRs with less than 200 lines of core code change are small (example, test and documentation could be exempted).
- [ ] All changes have test coverage
- [ ] Code is well-documented
- [ ] To the best of my knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change
- [ ] Related issue is referred in this PR
- [ ] If the PR is for a new model/paper, I've updated the example index [here](../examples/README.md).

## Changes
<!-- You could use following template
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)
-->
