### PR TITLE
[DistGB] enable exclude edges for graphbolt-based DistGraph

### DIFF
--- a/tests/distributed/test_mp_dataloader.py
+++ b/tests/distributed/test_mp_dataloader.py
@@ -839,9 +839,6 @@ def test_dataloader_homograph(
 def test_edge_dataloader_homograph(
     num_workers, use_graphbolt, exclude, negative
 ):
-    # exclude is not supported in graphbolt.
-    if use_graphbolt and (exclude is not None):
-        return
     num_server = 1
     dataloader_type = "edge"
     reset_envs()
@@ -869,6 +866,7 @@ def test_edge_dataloader_homograph(
         num_workers,
         dataloader_type,
         use_graphbolt=use_graphbolt,
+        return_eids=True,
         exclude=exclude,
         reverse_eids=reverse_eids,
         negative=negative,
@@ -902,9 +900,6 @@ def test_dataloader_heterograph(
 def test_edge_dataloader_heterograph(
     num_workers, use_graphbolt, exclude, negative
 ):
-    # exclude is not supported in graphbolt.
-    if use_graphbolt and (exclude is not None):
-        return
     num_server = 1
     dataloader_type = "edge"
     reset_envs()
@@ -916,6 +911,7 @@ def test_edge_dataloader_heterograph(
         num_workers,
         dataloader_type,
         use_graphbolt=use_graphbolt,
+        return_eids=True,
         exclude=exclude,
         reverse_etypes=reverse_etypes,
         negative=negative,


### PR DESCRIPTION
## Description
<!-- Brief description. Refer to the related issues if existed.
It'll be great if relevant reviewers can be assigned as well.-->
For now, exclude edges are done after sampling, right before returning the frontier back to DGL sample_blocks(). Such logic is shared with both DistDGL and DistGB. We need to profile the performance to see if we need to turn to GraphBolt's exclude edges logic/implementation.

https://github.com/dmlc/dgl/blob/002f1bc363508a410ae601dc01e2d33a20f71f09/python/dgl/distributed/dist_graph.py#L1443-L1451
## Checklist
Please feel free to remove inapplicable items for your PR.
- [ ] The PR title starts with [$CATEGORY] (such as [NN], [Model], [Doc], [Feature]])
- [ ] I've leverage the [tools](https://docs.google.com/document/d/1iHyj7zlmygKSk5gBPsqIqL5ASPzJSPREaNT_QdsiYA4/edit) to beautify the python and c++ code.
- [ ] The PR is complete and small, read the [Google eng practice (CL equals to PR)](https://google.github.io/eng-practices/review/developer/small-cls.html) to understand more about small PR. In DGL, we consider PRs with less than 200 lines of core code change are small (example, test and documentation could be exempted).
- [ ] All changes have test coverage
- [ ] Code is well-documented
- [ ] To the best of my knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change
- [ ] Related issue is referred in this PR
- [ ] If the PR is for a new model/paper, I've updated the example index [here](../examples/README.md).

## Changes
<!-- You could use following template
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)
-->
