### PR TITLE
[GraphBolt][DeprecationWarning]Deprecation warning resolved.

### DIFF
--- a/python/dgl/graphbolt/base.py
+++ b/python/dgl/graphbolt/base.py
@@ -78,7 +78,7 @@ def isin(elements, test_elements):
 
 if TorchVersion(torch.__version__) >= TorchVersion("2.2.0a0"):
 
-    @torch.library.impl_abstract("graphbolt::expand_indptr")
+    @torch.library.register_fake("graphbolt::expand_indptr")
     def expand_indptr_abstract(indptr, dtype, node_ids, output_size):
         """Abstract implementation of expand_indptr for torch.compile() support."""
         if output_size is None:


### PR DESCRIPTION
## Description
<!-- Brief description. Refer to the related issues if existed.
It'll be great if relevant reviewers can be assigned as well.-->
The following DeprecationWarning is fixed:
```
  /usr/local/lib/python3.10/dist-packages/dgl/graphbolt/base.py:81: DeprecationWarning: torch.library.impl_abstract 
was renamed to torch.library.register_fake. Please use that instead; we will remove torch.library.impl_abstract in a 
future version of PyTorch.
    @torch.library.impl_abstract("graphbolt::expand_indptr")
```

## Checklist
Please feel free to remove inapplicable items for your PR.
- [x] The PR title starts with [$CATEGORY] (such as [NN], [Model], [Doc], [Feature]])
- [x] I've leverage the [tools](https://docs.google.com/document/d/1iHyj7zlmygKSk5gBPsqIqL5ASPzJSPREaNT_QdsiYA4/edit) to beautify the python and c++ code.
- [x] The PR is complete and small, read the [Google eng practice (CL equals to PR)](https://google.github.io/eng-practices/review/developer/small-cls.html) to understand more about small PR. In DGL, we consider PRs with less than 200 lines of core code change are small (example, test and documentation could be exempted).
- [x] To the best of my knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

## Changes
<!-- You could use following template
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)
-->
