### PR TITLE
[DistGB] store original homo eids in default for GB partitions

### DIFF
--- a/python/dgl/distributed/partition.py
+++ b/python/dgl/distributed/partition.py
@@ -1380,7 +1380,7 @@ def _cast_to_minimum_dtype(predicate, data, field=None):
 def dgl_partition_to_graphbolt(
     part_config,
     *,
-    store_eids=False,
+    store_eids=True,
     store_inner_node=False,
     store_inner_edge=False,
     graph_formats=None,
@@ -1399,7 +1399,7 @@ def dgl_partition_to_graphbolt(
     part_config : str
         The partition configuration JSON file.
     store_eids : bool, optional
-        Whether to store edge IDs in the new graph. Default: False.
+        Whether to store edge IDs in the new graph. Default: True.
     store_inner_node : bool, optional
         Whether to store inner node mask in the new graph. Default: False.
     store_inner_edge : bool, optional


### PR DESCRIPTION
## Description
<!-- Brief description. Refer to the related issues if existed.
It'll be great if relevant reviewers can be assigned as well.-->

## Checklist
Please feel free to remove inapplicable items for your PR.
- [ ] The PR title starts with [$CATEGORY] (such as [NN], [Model], [Doc], [Feature]])
- [ ] I've leverage the [tools](https://docs.google.com/document/d/1iHyj7zlmygKSk5gBPsqIqL5ASPzJSPREaNT_QdsiYA4/edit) to beautify the python and c++ code.
- [ ] The PR is complete and small, read the [Google eng practice (CL equals to PR)](https://google.github.io/eng-practices/review/developer/small-cls.html) to understand more about small PR. In DGL, we consider PRs with less than 200 lines of core code change are small (example, test and documentation could be exempted).
- [ ] All changes have test coverage
- [ ] Code is well-documented
- [ ] To the best of my knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change
- [ ] Related issue is referred in this PR
- [ ] If the PR is for a new model/paper, I've updated the example index [here](../examples/README.md).

## Changes
<!-- You could use following template
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)
-->
