### PR TITLE
[GraphBolt] Alias `ItemSetDict` to `HeteroItemSet`

### DIFF
--- a/python/dgl/graphbolt/itemset.py
+++ b/python/dgl/graphbolt/itemset.py
@@ -5,7 +5,9 @@ from typing import Dict, Iterable, Tuple, Union
 
 import torch
 
-__all__ = ["ItemSet", "HeteroItemSet"]
+from ..base import dgl_warning
+
+__all__ = ["ItemSet", "HeteroItemSet", "ItemSetDict"]
 
 
 def is_scalar(x):
@@ -401,6 +403,50 @@ class HeteroItemSet:
             repr(self._itemsets), " " * len("    itemsets=")
         ).strip()
 
+        return ret.format(
+            Classname=self.__class__.__name__,
+            itemsets=itemsets_str,
+            names=self._names,
+        )
+
+
+class ItemSetDict:
+    """`ItemSetDict` is a deprecated class and will be removed in a future
+    version. Please use `HeteroItemSet` instead.
+
+    This class is an alias for `HeteroItemSet` and serves as a wrapper to
+    provide a smooth transition for users of the old class name. It issues a
+    deprecation warning upon instantiation and forwards all attribute access
+    and method calls to an instance of `HeteroItemSet`.
+    """
+
+    def __init__(self, itemsets: Dict[str, ItemSet]) -> None:
+        dgl_warning(
+            "ItemSetDict is deprecated and will be removed in the future. "
+            "Please use HeteroItemSet instead.",
+            category=DeprecationWarning,
+        )
+        self._new_instance = HeteroItemSet(itemsets)
+
+    def __getattr__(self, name: str):
+        return getattr(self._new_instance, name)
+
+    def __getitem__(self, index):
+        return self._new_instance[index]
+
+    def __len__(self) -> int:
+        return len(self._new_instance)
+
+    def __repr__(self) -> str:
+        ret = (
+            "{Classname}(\n"
+            "    itemsets={itemsets},\n"
+            "    names={names},\n"
+            ")"
+        )
+        itemsets_str = textwrap.indent(
+            repr(self._itemsets), " " * len("    itemsets=")
+        ).strip()
         return ret.format(
             Classname=self.__class__.__name__,
             itemsets=itemsets_str,


### PR DESCRIPTION
## Description
<!-- Brief description. Refer to the related issues if existed.
It'll be great if relevant reviewers can be assigned as well.-->
Alias `ItemSetDict` to `HeteroItemSet` and add deprecation warning to provide a smooth transition for external users who use the old class name.

## Checklist
Please feel free to remove inapplicable items for your PR.
- [ ] The PR title starts with [$CATEGORY] (such as [NN], [Model], [Doc], [Feature]])
- [ ] I've leverage the [tools](https://docs.google.com/document/d/1iHyj7zlmygKSk5gBPsqIqL5ASPzJSPREaNT_QdsiYA4/edit) to beautify the python and c++ code.
- [ ] The PR is complete and small, read the [Google eng practice (CL equals to PR)](https://google.github.io/eng-practices/review/developer/small-cls.html) to understand more about small PR. In DGL, we consider PRs with less than 200 lines of core code change are small (example, test and documentation could be exempted).
- [ ] All changes have test coverage
- [ ] Code is well-documented
- [ ] To the best of my knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change
- [ ] Related issue is referred in this PR
- [ ] If the PR is for a new model/paper, I've updated the example index [here](../examples/README.md).

## Changes
<!-- You could use following template
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)
-->
