### PR TITLE
[dev] limit numpy < 2.0.0 for compatibility

### DIFF
--- a/python/setup.py
+++ b/python/setup.py
@@ -220,7 +220,7 @@ if include_libs:
 
 # Configure dependencies.
 install_requires = [
-    "numpy>=1.14.0",
+    "numpy>=1.14.0,<2.0.0",
     "scipy>=1.1.0",
     "networkx>=2.1",
     "requests>=2.19.0",

--- a/script/dgl_dev.yml.template
+++ b/script/dgl_dev.yml.template
@@ -14,7 +14,7 @@ dependencies:
     - networkx
     - nltk
     - nose
-    - numpy
+    - numpy<2.0.0
     - ogb
     - pandas
     - psutil


### PR DESCRIPTION
## Description
<!-- Brief description. Refer to the related issues if existed.
It'll be great if relevant reviewers can be assigned as well.-->

let's limit the numpy < 2.0.0 for now. we need to support 2.0.0 in near future.

## Checklist
Please feel free to remove inapplicable items for your PR.
- [ ] The PR title starts with [$CATEGORY] (such as [NN], [Model], [Doc], [Feature]])
- [ ] I've leverage the [tools](https://docs.google.com/document/d/1iHyj7zlmygKSk5gBPsqIqL5ASPzJSPREaNT_QdsiYA4/edit) to beautify the python and c++ code.
- [ ] The PR is complete and small, read the [Google eng practice (CL equals to PR)](https://google.github.io/eng-practices/review/developer/small-cls.html) to understand more about small PR. In DGL, we consider PRs with less than 200 lines of core code change are small (example, test and documentation could be exempted).
- [ ] All changes have test coverage
- [ ] Code is well-documented
- [ ] To the best of my knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change
- [ ] Related issue is referred in this PR
- [ ] If the PR is for a new model/paper, I've updated the example index [here](../examples/README.md).

## Changes
<!-- You could use following template
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)
-->
