### PR TITLE
[DeprecationWarning] Fixing the warnings appearing in `test_traversal.py::test_bfs`.

### DIFF
--- a/python/dgl/graphbolt/base.py
+++ b/python/dgl/graphbolt/base.py
@@ -79,7 +79,7 @@ def isin(elements, test_elements):
 
 if TorchVersion(torch.__version__) >= TorchVersion("2.2.0a0"):
 
-    @torch.library.impl_abstract("graphbolt::expand_indptr")
+    @torch.library.register_fake("graphbolt::expand_indptr")
     def expand_indptr_abstract(indptr, dtype, node_ids, output_size):
         """Abstract implementation of expand_indptr for torch.compile() support."""
         if output_size is None:

--- a/tests/python/common/test_traversal.py
+++ b/tests/python/common/test_traversal.py
@@ -53,7 +53,7 @@ def test_bfs(idtype, n=100):
     assert len(layers_dgl) == len(layers_nx)
     assert all(toset(x) == y for x, y in zip(layers_dgl, layers_nx))
 
-    g_nx = nx.random_tree(n, seed=42)
+    g_nx = nx.random_labeled_tree(n, seed=42)
     g = dgl.from_networkx(g_nx).astype(idtype)
     src = 0
     _, edges_nx = _bfs_nx(g_nx, src)


### PR DESCRIPTION
## Description
<!-- Brief description. Refer to the related issues if existed.
It'll be great if relevant reviewers can be assigned as well.-->

The following two sets of warnings  that appear in `test_traversal.py::test_bfs` have been fixed:
```
./../../usr/local/lib/python3.10/dist-packages/dgl/graphbolt/base.py:80
  /usr/local/lib/python3.10/dist-packages/dgl/graphbolt/base.py:80: DeprecationWarning: torch.library.impl_abstract was renamed to torch.library.register_fake. Please use that instead; we will remove torch.library.impl_abstract in a future version of PyTorch.
    @torch.library.impl_abstract("graphbolt::expand_indptr")

tests/python/common/test_traversal.py::test_bfs[idtype0]
tests/python/common/test_traversal.py::test_bfs[idtype1]
  /usr/local/lib/python3.10/dist-packages/networkx/utils/backends.py:812: DeprecationWarning:
 
  random_tree is deprecated and will be removed in NX v3.4
  Use random_labeled_tree instead.
    return self.orig_func(*args, **kwargs)
```

https://networkx.org/documentation/stable/developer/deprecations.html#version-3-4


## Checklist
Please feel free to remove inapplicable items for your PR.
- [x] The PR title starts with [$CATEGORY] (such as [NN], [Model], [Doc], [Feature]])
- [x] I've leverage the [tools](https://docs.google.com/document/d/1iHyj7zlmygKSk5gBPsqIqL5ASPzJSPREaNT_QdsiYA4/edit) to beautify the python and c++ code.
- [x] The PR is complete and small, read the [Google eng practice (CL equals to PR)](https://google.github.io/eng-practices/review/developer/small-cls.html) to understand more about small PR. In DGL, we consider PRs with less than 200 lines of core code change are small (example, test and documentation could be exempted).
- [x] To the best of my knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change


## Changes
<!-- You could use following template
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)
-->
