### PR TITLE
[GraphBolt][CUDA] Compute capability check refactor.

### DIFF
--- a/graphbolt/src/cuda/unique_and_compact_impl.cu
+++ b/graphbolt/src/cuda/unique_and_compact_impl.cu
@@ -277,22 +277,7 @@ UniqueAndCompactBatched(
     const std::vector<torch::Tensor>& src_ids,
     const std::vector<torch::Tensor>& dst_ids,
     const std::vector<torch::Tensor>& unique_dst_ids, int num_bits) {
-  auto dev_id = cuda::GetCurrentStream().device_index();
-  static std::mutex mtx;
-  static std::unordered_map<decltype(dev_id), int> compute_capability_cache;
-  const auto compute_capability_major = [&] {
-    std::lock_guard lock(mtx);
-    auto it = compute_capability_cache.find(dev_id);
-    if (it != compute_capability_cache.end()) {
-      return it->second;
-    } else {
-      int major;
-      CUDA_RUNTIME_CHECK(cudaDeviceGetAttribute(
-          &major, cudaDevAttrComputeCapabilityMajor, dev_id));
-      return compute_capability_cache[dev_id] = major;
-    }
-  }();
-  if (compute_capability_major >= 7) {
+  if (cuda::compute_capability().first >= 7) {
     // Utilizes a hash table based implementation, the mapped id of a vertex
     // will be monotonically increasing as the first occurrence index of it in
     // torch.cat([unique_dst_ids, src_ids]). Thus, it is deterministic.

--- a/graphbolt/src/cuda/unique_and_compact_impl.cu
+++ b/graphbolt/src/cuda/unique_and_compact_impl.cu
@@ -277,7 +277,7 @@ UniqueAndCompactBatched(
     const std::vector<torch::Tensor>& src_ids,
     const std::vector<torch::Tensor>& dst_ids,
     const std::vector<torch::Tensor>& unique_dst_ids, int num_bits) {
-  if (cuda::compute_capability().first >= 7) {
+  if (cuda::compute_capability() >= 70) {
     // Utilizes a hash table based implementation, the mapped id of a vertex
     // will be monotonically increasing as the first occurrence index of it in
     // torch.cat([unique_dst_ids, src_ids]). Thus, it is deterministic.

--- a/graphbolt/src/cuda/utils.h
+++ b/graphbolt/src/cuda/utils.h
@@ -17,14 +17,13 @@ namespace graphbolt {
 namespace cuda {
 
 /**
- * @brief Returns the major and minor compute capabilities of the given cuda
- * as a pair; (major, minor).
+ * @brief Returns the compute capability of the cuda device, e.g. 70 for Volta.
  */
-inline std::pair<int, int> compute_capability(
+inline int compute_capability(
     int device = cuda::GetCurrentStream().device_index()) {
   int sm_version;
   CUDA_RUNTIME_CHECK(cub::SmVersion(sm_version, device));
-  return {sm_version / 100, (sm_version % 100) / 10};
+  return sm_version / 10;
 };
 
 /**

--- a/graphbolt/src/cuda/utils.h
+++ b/graphbolt/src/cuda/utils.h
@@ -17,6 +17,17 @@ namespace graphbolt {
 namespace cuda {
 
 /**
+ * @brief Returns the major and minor compute capabilities of the given cuda
+ * as a pair; (major, minor).
+ */
+inline std::pair<int, int> compute_capability(
+    int device = cuda::GetCurrentStream().device_index()) {
+  int sm_version;
+  CUDA_RUNTIME_CHECK(cub::SmVersion(sm_version, device));
+  return {sm_version / 100, (sm_version % 100) / 10};
+};
+
+/**
  * @brief Calculate the number of threads needed given the size of the dimension
  * to be processed.
  *


### PR DESCRIPTION
## Description
Utilize existing cub function to get compute capability in a cached manner using https://nvidia.github.io/cccl/cub/api/function_namespacecub_1a75d6eade310f187ff42915ae82e963d0.html

## Checklist
Please feel free to remove inapplicable items for your PR.
- [ ] The PR title starts with [$CATEGORY] (such as [NN], [Model], [Doc], [Feature]])
- [ ] I've leverage the [tools](https://docs.google.com/document/d/1iHyj7zlmygKSk5gBPsqIqL5ASPzJSPREaNT_QdsiYA4/edit) to beautify the python and c++ code.
- [ ] The PR is complete and small, read the [Google eng practice (CL equals to PR)](https://google.github.io/eng-practices/review/developer/small-cls.html) to understand more about small PR. In DGL, we consider PRs with less than 200 lines of core code change are small (example, test and documentation could be exempted).
- [ ] All changes have test coverage
- [ ] Code is well-documented
- [ ] To the best of my knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change
- [ ] Related issue is referred in this PR
- [ ] If the PR is for a new model/paper, I've updated the example index [here](../examples/README.md).

## Changes
<!-- You could use following template
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)
-->
