### PR TITLE
[GraphBolt] Refactor S3-FIFO and add SIEVE, LRU and CLOCK.

### DIFF
--- a/graphbolt/src/cache_policy.cc
+++ b/graphbolt/src/cache_policy.cc
@@ -122,7 +122,7 @@ torch::Tensor LruCachePolicy::Replace(torch::Tensor keys) {
 }
 
 ClockCachePolicy::ClockCachePolicy(int64_t capacity)
-    : capacity_(capacity), cache_usage_(0) {
+    : queue_(capacity), capacity_(capacity), cache_usage_(0) {
   TORCH_CHECK(capacity > 0, "Capacity needs to be positive.");
   key_to_cache_key_.reserve(capacity);
 }

--- a/graphbolt/src/cache_policy.cc
+++ b/graphbolt/src/cache_policy.cc
@@ -64,11 +64,7 @@ torch::Tensor BaseCachePolicy::ReplaceImpl(
         for (int64_t i = 0; i < keys.size(0); i++) {
           const auto key = keys_ptr[i];
           const auto pos = policy.Read(key);
-          if (pos.has_value()) {  // Already in the cache, inc freq.
-            positions_ptr[i] = *pos;
-          } else {
-            positions_ptr[i] = policy.Insert(key);
-          }
+          positions_ptr[i] = pos.has_value() ? *pos : policy.Insert(key);
         }
       }));
   return positions;

--- a/graphbolt/src/cache_policy.cc
+++ b/graphbolt/src/cache_policy.cc
@@ -125,5 +125,20 @@ torch::Tensor LruCachePolicy::Replace(torch::Tensor keys) {
   return ReplaceImpl(*this, keys);
 }
 
+ClockCachePolicy::ClockCachePolicy(int64_t capacity)
+    : capacity_(capacity), cache_usage_(0) {
+  TORCH_CHECK(capacity > 0, "Capacity needs to be positive.");
+  key_to_cache_key_.reserve(capacity);
+}
+
+std::tuple<torch::Tensor, torch::Tensor, torch::Tensor> ClockCachePolicy::Query(
+    torch::Tensor keys) {
+  return QueryImpl(*this, keys);
+}
+
+torch::Tensor ClockCachePolicy::Replace(torch::Tensor keys) {
+  return ReplaceImpl(*this, keys);
+}
+
 }  // namespace storage
 }  // namespace graphbolt

--- a/graphbolt/src/cache_policy.cc
+++ b/graphbolt/src/cache_policy.cc
@@ -110,5 +110,20 @@ torch::Tensor SieveCachePolicy::Replace(torch::Tensor keys) {
   return ReplaceImpl(*this, keys);
 }
 
+LruCachePolicy::LruCachePolicy(int64_t capacity)
+    : capacity_(capacity), cache_usage_(0) {
+  TORCH_CHECK(capacity > 0, "Capacity needs to be positive.");
+  key_to_cache_key_.reserve(capacity);
+}
+
+std::tuple<torch::Tensor, torch::Tensor, torch::Tensor> LruCachePolicy::Query(
+    torch::Tensor keys) {
+  return QueryImpl(*this, keys);
+}
+
+torch::Tensor LruCachePolicy::Replace(torch::Tensor keys) {
+  return ReplaceImpl(*this, keys);
+}
+
 }  // namespace storage
 }  // namespace graphbolt

--- a/graphbolt/src/cache_policy.h
+++ b/graphbolt/src/cache_policy.h
@@ -172,6 +172,7 @@ class BaseCachePolicy {
    */
   virtual void ReadingCompleted(torch::Tensor keys) = 0;
 
+ protected:
   template <typename CachePolicy>
   static std::tuple<torch::Tensor, torch::Tensor, torch::Tensor, torch::Tensor>
   QueryImpl(CachePolicy& policy, torch::Tensor keys);

--- a/graphbolt/src/cache_policy.h
+++ b/graphbolt/src/cache_policy.h
@@ -102,6 +102,11 @@ struct CacheKey {
 
   void Decrement() { freq_ = std::max(0, static_cast<int>(freq_ - 1)); }
 
+  CacheKey& SetFreq() {
+    freq_ = 1;
+    return *this;
+  }
+
   CacheKey& ResetFreq() {
     freq_ = 0;
     return *this;
@@ -141,6 +146,13 @@ class BaseCachePolicy {
    * entries in the cache.
    */
   virtual torch::Tensor Replace(torch::Tensor keys) = 0;
+
+  template <typename CachePolicy>
+  static std::tuple<torch::Tensor, torch::Tensor, torch::Tensor> QueryImpl(
+      CachePolicy& policy, torch::Tensor keys);
+
+  template <typename CachePolicy>
+  static torch::Tensor ReplaceImpl(CachePolicy& policy, torch::Tensor keys);
 };
 
 /**
@@ -186,6 +198,24 @@ class S3FifoCachePolicy : public BaseCachePolicy {
               << "main_queue_: " << policy.main_queue_ << "\n"
               << "cache_usage_: " << policy.cache_usage_ << "\n"
               << "capacity_: " << policy.capacity_ << "\n";
+  }
+
+  std::optional<int64_t> Read(int64_t key) {
+    auto it = key_to_cache_key_.find(key);
+    if (it != key_to_cache_key_.end()) {
+      auto& cache_key = *it->second;
+      cache_key.Increment();
+      return cache_key.getPos();
+    }
+    return std::nullopt;
+  }
+
+  int64_t Insert(int64_t key) {
+    const auto pos = Evict();
+    const auto in_ghost_queue = ghost_set_.erase(key);
+    auto& queue = in_ghost_queue ? main_queue_ : small_queue_;
+    key_to_cache_key_[key] = queue.Push(CacheKey(key, pos));
+    return pos;
   }
 
  private:
@@ -238,6 +268,89 @@ class S3FifoCachePolicy : public BaseCachePolicy {
   int64_t small_queue_size_target_;
   phmap::flat_hash_set<int64_t> ghost_set_;
   phmap::flat_hash_map<int64_t, CacheKey*> key_to_cache_key_;
+};
+
+/**
+ * @brief SIEVE is a simple, scalable FIFObased algorithm with a single static
+ * queue. https://www.usenix.org/system/files/nsdi24-zhang-yazhuo.pdf
+ **/
+class SieveCachePolicy : public BaseCachePolicy {
+ public:
+  /**
+   * @brief Constructor for the S3FifoCachePolicy class.
+   *
+   * @param capacity The capacity of the cache in terms of # elements.
+   */
+  SieveCachePolicy(int64_t capacity);
+
+  SieveCachePolicy() = default;
+
+  /**
+   * @brief The policy query function.
+   * @param keys The keys to query the cache.
+   *
+   * @return (positions, indices, missing_keys), where positions has the
+   * locations of the keys which were found in the cache, missing_keys has the
+   * keys that were not found and indices is defined such that
+   * keys[indices[:positions.size(0)]] gives us the found keys and
+   * keys[indices[positions.size(0):]] is identical to missing_keys.
+   */
+  std::tuple<torch::Tensor, torch::Tensor, torch::Tensor> Query(
+      torch::Tensor keys);
+
+  /**
+   * @brief The policy replace function.
+   * @param keys The keys to query the cache.
+   *
+   * @return positions tensor is returned holding the locations of the
+   * replaced entries in the cache.
+   */
+  torch::Tensor Replace(torch::Tensor keys);
+
+  std::optional<int64_t> Read(int64_t key) {
+    auto it = key_to_cache_key_.find(key);
+    if (it != key_to_cache_key_.end()) {
+      auto& cache_key = *it->second;
+      cache_key.SetFreq();
+      return cache_key.getPos();
+    }
+    return std::nullopt;
+  }
+
+  int64_t Insert(int64_t key) {
+    const auto pos = Evict();
+    queue_.push_front(CacheKey(key, pos));
+    key_to_cache_key_[key] = queue_.begin();
+    return pos;
+  }
+
+ private:
+  int64_t Evict() {
+    // If the cache has space, get an unused slot otherwise perform eviction.
+    if (cache_usage_ < capacity_) return cache_usage_++;
+    --hand_;
+    while (hand_->getFreq()) {
+      hand_->ResetFreq();
+      if (hand_ == queue_.begin()) hand_ = queue_.end();
+      --hand_;
+    }
+    TORCH_CHECK(key_to_cache_key_.erase(hand_->getKey()));
+    const auto pos = hand_->getPos();
+    const auto temp = hand_;
+    if (hand_ == queue_.begin()) {
+      hand_ = queue_.end();
+    } else {
+      ++hand_;
+    }
+    queue_.erase(temp);
+    return pos;
+  }
+
+  std::list<CacheKey> queue_;
+  decltype(queue_)::iterator hand_;
+  int64_t capacity_;
+  int64_t cache_usage_;
+  phmap::flat_hash_map<int64_t, decltype(hand_)> key_to_cache_key_;
 };
 
 }  // namespace storage

--- a/graphbolt/src/cache_policy.h
+++ b/graphbolt/src/cache_policy.h
@@ -277,7 +277,7 @@ class S3FifoCachePolicy : public BaseCachePolicy {
 class SieveCachePolicy : public BaseCachePolicy {
  public:
   /**
-   * @brief Constructor for the S3FifoCachePolicy class.
+   * @brief Constructor for the SieveCachePolicy class.
    *
    * @param capacity The capacity of the cache in terms of # elements.
    */

--- a/graphbolt/src/cache_policy.h
+++ b/graphbolt/src/cache_policy.h
@@ -353,6 +353,79 @@ class SieveCachePolicy : public BaseCachePolicy {
   phmap::flat_hash_map<int64_t, decltype(hand_)> key_to_cache_key_;
 };
 
+/**
+ * @brief LeastRecentlyUsed is a simple, scalable FIFObased algorithm with a
+ * single static queue.
+ **/
+class LruCachePolicy : public BaseCachePolicy {
+ public:
+  /**
+   * @brief Constructor for the LruCachePolicy class.
+   *
+   * @param capacity The capacity of the cache in terms of # elements.
+   */
+  LruCachePolicy(int64_t capacity);
+
+  LruCachePolicy() = default;
+
+  /**
+   * @brief The policy query function.
+   * @param keys The keys to query the cache.
+   *
+   * @return (positions, indices, missing_keys), where positions has the
+   * locations of the keys which were found in the cache, missing_keys has the
+   * keys that were not found and indices is defined such that
+   * keys[indices[:positions.size(0)]] gives us the found keys and
+   * keys[indices[positions.size(0):]] is identical to missing_keys.
+   */
+  std::tuple<torch::Tensor, torch::Tensor, torch::Tensor> Query(
+      torch::Tensor keys);
+
+  /**
+   * @brief The policy replace function.
+   * @param keys The keys to query the cache.
+   *
+   * @return positions tensor is returned holding the locations of the
+   * replaced entries in the cache.
+   */
+  torch::Tensor Replace(torch::Tensor keys);
+
+  std::optional<int64_t> Read(int64_t key) {
+    auto it = key_to_cache_key_.find(key);
+    if (it != key_to_cache_key_.end()) {
+      const auto cache_key = *it->second;
+      queue_.erase(it->second);
+      queue_.push_front(cache_key);
+      it->second = queue_.begin();
+      return cache_key.getPos();
+    }
+    return std::nullopt;
+  }
+
+  int64_t Insert(int64_t key) {
+    const auto pos = Evict();
+    queue_.push_front(CacheKey(key, pos));
+    key_to_cache_key_[key] = queue_.begin();
+    return pos;
+  }
+
+ private:
+  int64_t Evict() {
+    // If the cache has space, get an unused slot otherwise perform eviction.
+    if (cache_usage_ < capacity_) return cache_usage_++;
+    const auto& cache_key = queue_.back();
+    TORCH_CHECK(key_to_cache_key_.erase(cache_key.getKey()));
+    const auto pos = cache_key.getPos();
+    queue_.pop_back();
+    return pos;
+  }
+
+  std::list<CacheKey> queue_;
+  int64_t capacity_;
+  int64_t cache_usage_;
+  phmap::flat_hash_map<int64_t, decltype(queue_)::iterator> key_to_cache_key_;
+};
+
 }  // namespace storage
 }  // namespace graphbolt
 

--- a/graphbolt/src/feature_cache.h
+++ b/graphbolt/src/feature_cache.h
@@ -55,8 +55,7 @@ struct FeatureCache : public torch::CustomClassHolder {
    * is true.
    */
   torch::Tensor Query(
-      torch::Tensor positions, torch::Tensor indices, int64_t size,
-      bool pin_memory);
+      torch::Tensor positions, torch::Tensor indices, int64_t size);
 
   /**
    * @brief The cache replace function.

--- a/graphbolt/src/partitioned_cache_policy.cc
+++ b/graphbolt/src/partitioned_cache_policy.cc
@@ -112,15 +112,16 @@ PartitionedCachePolicy::Partition(torch::Tensor keys) {
       permuted_keys};
 }
 
-std::tuple<torch::Tensor, torch::Tensor, torch::Tensor>
+std::tuple<torch::Tensor, torch::Tensor, torch::Tensor, torch::Tensor>
 PartitionedCachePolicy::Query(torch::Tensor keys) {
   if (policies_.size() == 1) return policies_[0]->Query(keys);
   torch::Tensor offsets, indices, permuted_keys;
   std::tie(offsets, indices, permuted_keys) = Partition(keys);
   auto offsets_ptr = offsets.data_ptr<int64_t>();
   auto indices_ptr = indices.data_ptr<int64_t>();
-  std::vector<std::tuple<torch::Tensor, torch::Tensor, torch::Tensor>> results(
-      policies_.size());
+  std::vector<
+      std::tuple<torch::Tensor, torch::Tensor, torch::Tensor, torch::Tensor>>
+      results(policies_.size());
   torch::Tensor result_offsets_tensor =
       torch::empty(policies_.size() * 2 + 1, offsets.options());
   auto result_offsets = result_offsets_tensor.data_ptr<int64_t>();
@@ -145,6 +146,9 @@ PartitionedCachePolicy::Query(torch::Tensor keys) {
   torch::Tensor missing_keys = torch::empty(
       indices.size(0) - positions.size(0),
       std::get<2>(results[0]).options().pinned_memory(keys.is_pinned()));
+  torch::Tensor found_keys = torch::empty(
+      positions.size(0),
+      std::get<3>(results[0]).options().pinned_memory(keys.is_pinned()));
   auto output_indices_ptr = output_indices.data_ptr<int64_t>();
   torch::parallel_for(0, policies_.size(), 1, [&](int64_t begin, int64_t end) {
     if (begin == end) return;
@@ -162,6 +166,11 @@ PartitionedCachePolicy::Query(torch::Tensor keys) {
         selected_positions_ptr, selected_positions_ptr + num_selected,
         positions.data_ptr<int64_t>() + begin,
         [off = tid * capacity_ / policies_.size()](auto x) { return x + off; });
+    std::memcpy(
+        reinterpret_cast<std::byte*>(found_keys.data_ptr()) +
+            begin * found_keys.element_size(),
+        std::get<3>(results[tid]).data_ptr(),
+        num_selected * found_keys.element_size());
     begin = result_offsets[policies_.size() + tid];
     end = result_offsets[policies_.size() + tid + 1];
     const auto num_missing = end - begin;
@@ -175,7 +184,7 @@ PartitionedCachePolicy::Query(torch::Tensor keys) {
         std::get<2>(results[tid]).data_ptr(),
         num_missing * missing_keys.element_size());
   });
-  return std::make_tuple(positions, output_indices, missing_keys);
+  return std::make_tuple(positions, output_indices, missing_keys, found_keys);
 }
 
 torch::Tensor PartitionedCachePolicy::Replace(torch::Tensor keys) {
@@ -202,6 +211,23 @@ torch::Tensor PartitionedCachePolicy::Replace(torch::Tensor keys) {
     }
   });
   return output_positions;
+}
+
+void PartitionedCachePolicy::ReadingCompleted(torch::Tensor keys) {
+  if (policies_.size() == 1) {
+    policies_[0]->ReadingCompleted(keys);
+    return;
+  }
+  torch::Tensor offsets, indices, permuted_keys;
+  std::tie(offsets, indices, permuted_keys) = Partition(keys);
+  auto offsets_ptr = offsets.data_ptr<int64_t>();
+  torch::parallel_for(0, policies_.size(), 1, [&](int64_t begin, int64_t end) {
+    if (begin == end) return;
+    const auto tid = begin;
+    begin = offsets_ptr[tid];
+    end = offsets_ptr[tid + 1];
+    policies_.at(tid)->ReadingCompleted(permuted_keys.slice(0, begin, end));
+  });
 }
 
 template <typename CachePolicy>

--- a/graphbolt/src/partitioned_cache_policy.cc
+++ b/graphbolt/src/partitioned_cache_policy.cc
@@ -212,6 +212,8 @@ template c10::intrusive_ptr<PartitionedCachePolicy>
     PartitionedCachePolicy::Create<S3FifoCachePolicy>(int64_t, int64_t);
 template c10::intrusive_ptr<PartitionedCachePolicy>
     PartitionedCachePolicy::Create<SieveCachePolicy>(int64_t, int64_t);
+template c10::intrusive_ptr<PartitionedCachePolicy>
+    PartitionedCachePolicy::Create<LruCachePolicy>(int64_t, int64_t);
 
 }  // namespace storage
 }  // namespace graphbolt

--- a/graphbolt/src/partitioned_cache_policy.cc
+++ b/graphbolt/src/partitioned_cache_policy.cc
@@ -210,6 +210,8 @@ c10::intrusive_ptr<PartitionedCachePolicy> PartitionedCachePolicy::Create(
 
 template c10::intrusive_ptr<PartitionedCachePolicy>
     PartitionedCachePolicy::Create<S3FifoCachePolicy>(int64_t, int64_t);
+template c10::intrusive_ptr<PartitionedCachePolicy>
+    PartitionedCachePolicy::Create<SieveCachePolicy>(int64_t, int64_t);
 
 }  // namespace storage
 }  // namespace graphbolt

--- a/graphbolt/src/partitioned_cache_policy.cc
+++ b/graphbolt/src/partitioned_cache_policy.cc
@@ -214,6 +214,8 @@ template c10::intrusive_ptr<PartitionedCachePolicy>
     PartitionedCachePolicy::Create<SieveCachePolicy>(int64_t, int64_t);
 template c10::intrusive_ptr<PartitionedCachePolicy>
     PartitionedCachePolicy::Create<LruCachePolicy>(int64_t, int64_t);
+template c10::intrusive_ptr<PartitionedCachePolicy>
+    PartitionedCachePolicy::Create<ClockCachePolicy>(int64_t, int64_t);
 
 }  // namespace storage
 }  // namespace graphbolt

--- a/graphbolt/src/partitioned_cache_policy.h
+++ b/graphbolt/src/partitioned_cache_policy.h
@@ -62,7 +62,7 @@ class PartitionedCachePolicy : public BaseCachePolicy,
    * keys[indices[:positions.size(0)]] gives us the found keys and
    * keys[indices[positions.size(0):]] is identical to missing_keys.
    */
-  std::tuple<torch::Tensor, torch::Tensor, torch::Tensor> Query(
+  std::tuple<torch::Tensor, torch::Tensor, torch::Tensor, torch::Tensor> Query(
       torch::Tensor keys);
 
   /**
@@ -73,6 +73,12 @@ class PartitionedCachePolicy : public BaseCachePolicy,
    * entries in the cache.
    */
   torch::Tensor Replace(torch::Tensor keys);
+
+  /**
+   * @brief A reader has finished reading these keys, so they can be evicted.
+   * @param keys The keys to unmark.
+   */
+  void ReadingCompleted(torch::Tensor keys);
 
   template <typename CachePolicy>
   static c10::intrusive_ptr<PartitionedCachePolicy> Create(

--- a/graphbolt/src/python_binding.cc
+++ b/graphbolt/src/python_binding.cc
@@ -103,6 +103,9 @@ TORCH_LIBRARY(graphbolt, m) {
   m.def(
       "s3_fifo_cache_policy",
       &storage::PartitionedCachePolicy::Create<storage::S3FifoCachePolicy>);
+  m.def(
+      "sieve_cache_policy",
+      &storage::PartitionedCachePolicy::Create<storage::SieveCachePolicy>);
   m.class_<storage::FeatureCache>("FeatureCache")
       .def("query", &storage::FeatureCache::Query)
       .def("replace", &storage::FeatureCache::Replace);

--- a/graphbolt/src/python_binding.cc
+++ b/graphbolt/src/python_binding.cc
@@ -99,7 +99,10 @@ TORCH_LIBRARY(graphbolt, m) {
   m.def("fused_csc_sampling_graph", &FusedCSCSamplingGraph::Create);
   m.class_<storage::PartitionedCachePolicy>("PartitionedCachePolicy")
       .def("query", &storage::PartitionedCachePolicy::Query)
-      .def("replace", &storage::PartitionedCachePolicy::Replace);
+      .def("replace", &storage::PartitionedCachePolicy::Replace)
+      .def(
+          "reading_completed",
+          &storage::PartitionedCachePolicy::ReadingCompleted);
   m.def(
       "s3_fifo_cache_policy",
       &storage::PartitionedCachePolicy::Create<storage::S3FifoCachePolicy>);

--- a/graphbolt/src/python_binding.cc
+++ b/graphbolt/src/python_binding.cc
@@ -109,6 +109,9 @@ TORCH_LIBRARY(graphbolt, m) {
   m.def(
       "lru_cache_policy",
       &storage::PartitionedCachePolicy::Create<storage::LruCachePolicy>);
+  m.def(
+      "clock_cache_policy",
+      &storage::PartitionedCachePolicy::Create<storage::ClockCachePolicy>);
   m.class_<storage::FeatureCache>("FeatureCache")
       .def("query", &storage::FeatureCache::Query)
       .def("replace", &storage::FeatureCache::Replace);

--- a/graphbolt/src/python_binding.cc
+++ b/graphbolt/src/python_binding.cc
@@ -106,6 +106,9 @@ TORCH_LIBRARY(graphbolt, m) {
   m.def(
       "sieve_cache_policy",
       &storage::PartitionedCachePolicy::Create<storage::SieveCachePolicy>);
+  m.def(
+      "lru_cache_policy",
+      &storage::PartitionedCachePolicy::Create<storage::LruCachePolicy>);
   m.class_<storage::FeatureCache>("FeatureCache")
       .def("query", &storage::FeatureCache::Query)
       .def("replace", &storage::FeatureCache::Replace);

--- a/python/dgl/graphbolt/impl/feature_cache.py
+++ b/python/dgl/graphbolt/impl/feature_cache.py
@@ -54,9 +54,7 @@ class FeatureCache(object):
         """
         self.total_queries += keys.shape[0]
         positions, index, missing_keys = self._policy.query(keys)
-        values = self._cache.query(
-            positions, index, keys.shape[0], keys.is_pinned()
-        )
+        values = self._cache.query(positions, index, keys.shape[0])
         self.total_miss += missing_keys.shape[0]
         missing_index = index[positions.size(0) :]
         return values, missing_index, missing_keys

--- a/python/dgl/graphbolt/impl/feature_cache.py
+++ b/python/dgl/graphbolt/impl/feature_cache.py
@@ -7,6 +7,7 @@ caching_policies = {
     "s3-fifo": torch.ops.graphbolt.s3_fifo_cache_policy,
     "sieve": torch.ops.graphbolt.sieve_cache_policy,
     "lru": torch.ops.graphbolt.lru_cache_policy,
+    "clock": torch.ops.graphbolt.clock_cache_policy,
 }
 
 
@@ -22,8 +23,8 @@ class FeatureCache(object):
     num_parts: int, optional
         The number of cache partitions for parallelism. Default is 1.
     policy: str, optional
-        The cache policy. Default is "sieve". "s3-fifo" and "lru" are also
-        available.
+        The cache policy. Default is "sieve". "s3-fifo", "lru" and "clock" are
+        also available.
     """
 
     def __init__(self, cache_shape, dtype, num_parts=1, policy="sieve"):

--- a/python/dgl/graphbolt/impl/feature_cache.py
+++ b/python/dgl/graphbolt/impl/feature_cache.py
@@ -6,6 +6,7 @@ __all__ = ["FeatureCache"]
 caching_policies = {
     "s3-fifo": torch.ops.graphbolt.s3_fifo_cache_policy,
     "sieve": torch.ops.graphbolt.sieve_cache_policy,
+    "lru": torch.ops.graphbolt.lru_cache_policy,
 }
 
 
@@ -21,7 +22,8 @@ class FeatureCache(object):
     num_parts: int, optional
         The number of cache partitions for parallelism. Default is 1.
     policy: str, optional
-        The cache policy. Default is "sieve". "s3-fifo" is also available.
+        The cache policy. Default is "sieve". "s3-fifo" and "lru" are also
+        available.
     """
 
     def __init__(self, cache_shape, dtype, num_parts=1, policy="sieve"):

--- a/python/dgl/graphbolt/impl/feature_cache.py
+++ b/python/dgl/graphbolt/impl/feature_cache.py
@@ -3,7 +3,10 @@ import torch
 
 __all__ = ["FeatureCache"]
 
-caching_policies = {"s3-fifo": torch.ops.graphbolt.s3_fifo_cache_policy}
+caching_policies = {
+    "s3-fifo": torch.ops.graphbolt.s3_fifo_cache_policy,
+    "sieve": torch.ops.graphbolt.sieve_cache_policy,
+}
 
 
 class FeatureCache(object):
@@ -18,10 +21,10 @@ class FeatureCache(object):
     num_parts: int, optional
         The number of cache partitions for parallelism. Default is 1.
     policy: str, optional
-        The cache policy to be used. Default is "s3-fifo".
+        The cache policy. Default is "sieve". "s3-fifo" is also available.
     """
 
-    def __init__(self, cache_shape, dtype, num_parts=1, policy="s3-fifo"):
+    def __init__(self, cache_shape, dtype, num_parts=1, policy="sieve"):
         assert (
             policy in caching_policies
         ), f"{list(caching_policies.keys())} are the available caching policies."

--- a/python/dgl/graphbolt/impl/feature_cache.py
+++ b/python/dgl/graphbolt/impl/feature_cache.py
@@ -53,8 +53,9 @@ class FeatureCache(object):
             pinned, then the returned values tensor is pinned as well.
         """
         self.total_queries += keys.shape[0]
-        positions, index, missing_keys = self._policy.query(keys)
+        positions, index, missing_keys, found_keys = self._policy.query(keys)
         values = self._cache.query(positions, index, keys.shape[0])
+        self._policy.reading_completed(found_keys)
         self.total_miss += missing_keys.shape[0]
         missing_index = index[positions.size(0) :]
         return values, missing_index, missing_keys

--- a/tests/python/pytorch/graphbolt/impl/test_feature_cache.py
+++ b/tests/python/pytorch/graphbolt/impl/test_feature_cache.py
@@ -23,7 +23,7 @@ from dgl import graphbolt as gb
 )
 @pytest.mark.parametrize("feature_size", [2, 16])
 @pytest.mark.parametrize("num_parts", [1, 2])
-@pytest.mark.parametrize("policy", ["s3-fifo", "sieve", "lru"])
+@pytest.mark.parametrize("policy", ["s3-fifo", "sieve", "lru", "clock"])
 def test_feature_cache(dtype, feature_size, num_parts, policy):
     cache_size = 32 * num_parts
     a = torch.randint(0, 2, [1024, feature_size], dtype=dtype)

--- a/tests/python/pytorch/graphbolt/impl/test_feature_cache.py
+++ b/tests/python/pytorch/graphbolt/impl/test_feature_cache.py
@@ -31,7 +31,7 @@ def test_feature_cache(dtype, feature_size, num_parts):
     )
 
     keys = torch.tensor([0, 1])
-    values, missing_index, missing_keys = cache.query(keys, False)
+    values, missing_index, missing_keys = cache.query(keys)
     assert torch.equal(
         missing_keys.flip([0]) if num_parts == 1 else missing_keys.sort()[0],
         keys,
@@ -44,8 +44,8 @@ def test_feature_cache(dtype, feature_size, num_parts):
 
     pin_memory = F._default_context_str == "gpu"
 
-    keys = torch.arange(1, 33)
-    values, missing_index, missing_keys = cache.query(keys, pin_memory)
+    keys = torch.arange(1, 33, pin_memory=pin_memory)
+    values, missing_index, missing_keys = cache.query(keys)
     assert torch.equal(
         missing_keys.flip([0]) if num_parts == 1 else missing_keys.sort()[0],
         torch.arange(2, 33),
@@ -58,9 +58,7 @@ def test_feature_cache(dtype, feature_size, num_parts):
     assert torch.equal(values, a[keys])
 
     values, missing_index, missing_keys = cache.query(keys)
-    assert torch.equal(
-        missing_keys.flip([0]), torch.tensor([5] if num_parts == 1 else [])
-    )
+    assert torch.equal(missing_keys.flip([0]), torch.tensor([]))
 
     missing_values = a[missing_keys]
     cache.replace(missing_keys, missing_values)

--- a/tests/python/pytorch/graphbolt/impl/test_feature_cache.py
+++ b/tests/python/pytorch/graphbolt/impl/test_feature_cache.py
@@ -23,7 +23,7 @@ from dgl import graphbolt as gb
 )
 @pytest.mark.parametrize("feature_size", [2, 16])
 @pytest.mark.parametrize("num_parts", [1, 2])
-@pytest.mark.parametrize("policy", ["s3-fifo", "sieve"])
+@pytest.mark.parametrize("policy", ["s3-fifo", "sieve", "lru"])
 def test_feature_cache(dtype, feature_size, num_parts, policy):
     cache_size = 32 * num_parts
     a = torch.randint(0, 2, [1024, feature_size], dtype=dtype)

--- a/tests/python/pytorch/graphbolt/impl/test_feature_cache.py
+++ b/tests/python/pytorch/graphbolt/impl/test_feature_cache.py
@@ -23,11 +23,12 @@ from dgl import graphbolt as gb
 )
 @pytest.mark.parametrize("feature_size", [2, 16])
 @pytest.mark.parametrize("num_parts", [1, 2])
-def test_feature_cache(dtype, feature_size, num_parts):
+@pytest.mark.parametrize("policy", ["s3-fifo", "sieve"])
+def test_feature_cache(dtype, feature_size, num_parts, policy):
     cache_size = 32 * num_parts
     a = torch.randint(0, 2, [1024, feature_size], dtype=dtype)
     cache = gb.impl.FeatureCache(
-        (cache_size,) + a.shape[1:], a.dtype, num_parts
+        (cache_size,) + a.shape[1:], a.dtype, num_parts, policy
     )
 
     keys = torch.tensor([0, 1])


### PR DESCRIPTION
## Description
Refactored the code and added the [SIEVE](https://cachemon.github.io/SIEVE-website/), LRU and CLOCK cache policy algorithm.

CLOCK: https://people.csail.mit.edu/saltzer/Multics/MHP-Saltzer-060508/bookcases/M00s/M0104%20074-12).PDF

The S3-FIFO implementation was behaving a bit differently from the official implementation (upto 2% higher miss rate). So I wrote a short script to compare against the official implementation on several datasets as can be seen below. Moreover, I got rid of garbage collection if the ghost map gets too big and instead used a queue for it so that we never have to do extra work sometimes. This is because when using parallelism, we will wait for the slowest partition and when we do overlapping in the dataloader, these delays will cause a bubble in the pipeline.

Now, the behaviors consistently match across different datasets for S3-FIFO:
```
My miss rates (s3-fifo: 0.115895, lru: 0.165391, sieve: 0.168564, clock: 0.168460), miss rate original: (s3-fifo: 0.119878, lru: 0.165391), fiu/fiu_casa-110108-112108.oracleGeneral.zst: : 8973201it [20:06, 7437.01it/s]
My miss rates (s3-fifo: 0.316334, lru: 0.350072, sieve: 0.409565, clock: 0.349661), miss rate original: (s3-fifo: 0.316330, lru: 0.350072), fiu/fiu_homes-110108-112108.oracleGeneral.zst: : 17836701it [44:14, 6718.70it/s]
My miss rates (s3-fifo: 0.372138, lru: 0.414476, sieve: 0.384086, clock: 0.414683), miss rate original: (s3-fifo: 0.372138, lru: 0.414476), alibabaBlock/io_traces.ns0.oracleGeneral.zst: : 13800000it [35:29, 6481.64it/s]
My miss rates (s3-fifo: 0.220733, lru: 0.223484, sieve: 0.232164, clock: 0.224612), miss rate original: (s3-fifo: 0.220650, lru: 0.223484), tencentBlock/tencentBlock.ns1182.oracleGeneral.zst: : 16024596it [38:18, 6972.53it/s]
My miss rates (s3-fifo: 0.841126, lru: 0.870302, sieve: 0.850204, clock: 0.868771), miss rate original: (s3-fifo: 0.841126, lru: 0.870302), msr/msr_proj_2.oracleGeneral.zst: : 29266482it [1:30:12, 5407.19it/s]
```

```python
import requests
import zstandard as zstd
from struct import iter_unpack
import torch
from dgl.graphbolt.impl import FeatureCache
from cachemonCache import S3FIFO, LRU
from tqdm import tqdm
import os

dtype = torch.int64
num_partitions = 1

base_URL = "https://ftp.pdl.cmu.edu/pub/datasets/twemcacheWorkload/cacheDatasets/"
datasets = [
    (50000, "fiu/fiu_casa-110108-112108.oracleGeneral.zst"),
    (100000, "fiu/fiu_homes-110108-112108.oracleGeneral.zst"),
    (100000, "alibabaBlock/io_traces.ns0.oracleGeneral.zst"),
    (100000, "tencentBlock/tencentBlock.ns1182.oracleGeneral.zst"),
    (1000000, "msr/msr_proj_2.oracleGeneral.zst"),
]
for capacity, dataset in datasets:
    data = requests.get(os.path.join(base_URL, dataset), stream=False).content
    pbar = tqdm(iter_unpack("=IQIq", zstd.ZstdDecompressor().decompress(data)))
    my_caches = {policy: FeatureCache([capacity, 1], dtype, num_partitions, policy) for policy in ["s3-fifo", "lru", "sieve", "clock"]}
    other_caches = {name: cache(capacity) for name, cache in zip(["s3-fifo", "lru"], [S3FIFO, LRU])}
    for i, (timestamp, obj_id, obj_size, next_access_vtime) in enumerate(pbar):
        for cache in my_caches.values():
            values, missing_index, missing_keys = cache.query(torch.tensor([obj_id]))
            if missing_keys.numel() > 0:
                cache.replace(missing_keys, torch.tensor([obj_size]))
        for cache in other_caches.values():
            val = cache.get(obj_id)
            if val is None:
                cache.put(obj_id, obj_size)
        if i % 1000 == 999:
            pbar.set_description(f"My miss rates ({", ".join([f"{name}: {cache.miss_rate:.6f}" for name, cache in my_caches.items()])}), miss rate original: ({", ".join([f"{name}: {1.0 - cache.n_hit / (i + 1):.6f}" for name, cache in other_caches.items()])}), {dataset}")
```