### PR TITLE
[GraphBolt] `index_select_csc_batched`.

### DIFF
--- a/graphbolt/include/graphbolt/cuda_ops.h
+++ b/graphbolt/include/graphbolt/cuda_ops.h
@@ -122,6 +122,25 @@ std::tuple<torch::Tensor, torch::Tensor> IndexSelectCSCImpl(
     torch::optional<int64_t> output_size = torch::nullopt);
 
 /**
+ * @brief Select columns for a sparse matrix in a CSC format according to nodes
+ * tensor for a given list of tensors.
+ *
+ * NOTE: The shape of all tensors must be 1-D.
+ *
+ * @param indptr Indptr tensor containing offsets with shape (N,).
+ * @param indices_list Vector of indices tensor with edge information of shape
+ * (indptr[N],).
+ * @param nodes Nodes tensor with shape (M,).
+ * @param output_size The total number of edges being copied.
+ * @return (torch::Tensor, std::vector<torch::Tensor>) Output indptr and vector
+ * of indices tensors of shapes (M + 1,) and ((indptr[nodes + 1] -
+ * indptr[nodes]).sum(),).
+ */
+std::tuple<torch::Tensor, std::vector<torch::Tensor>> IndexSelectCSCImpl(
+    torch::Tensor indptr, std::vector<torch::Tensor> indices_list,
+    torch::Tensor nodes, torch::optional<int64_t> output_size);
+
+/**
  * @brief Slices the indptr tensor with nodes and returns the indegrees of the
  * given nodes and their indptr values.
  *

--- a/graphbolt/include/graphbolt/cuda_ops.h
+++ b/graphbolt/include/graphbolt/cuda_ops.h
@@ -136,7 +136,7 @@ std::tuple<torch::Tensor, torch::Tensor> IndexSelectCSCImpl(
  * of indices tensors of shapes (M + 1,) and ((indptr[nodes + 1] -
  * indptr[nodes]).sum(),).
  */
-std::tuple<torch::Tensor, std::vector<torch::Tensor>> IndexSelectCSCImpl(
+std::tuple<torch::Tensor, std::vector<torch::Tensor>> IndexSelectCSCBatchedImpl(
     torch::Tensor indptr, std::vector<torch::Tensor> indices_list,
     torch::Tensor nodes, torch::optional<int64_t> output_size);
 

--- a/graphbolt/src/cuda/index_select_csc_impl.cu
+++ b/graphbolt/src/cuda/index_select_csc_impl.cu
@@ -80,7 +80,10 @@ __global__ void _CopyIndicesAlignedKernel(
     const auto rofs = idx - output_indptr_aligned[permuted_row_pos] - offset;
     if (rofs >= 0 && rofs < d) {
       const auto in_idx = indptr[row_pos] + rofs;
-      assert((size_t)(indices + in_idx - idx) % GPU_CACHE_LINE_SIZE == 0);
+      assert(
+          reinterpret_cast<std::uintptr_t>(indices + in_idx - idx) %
+              GPU_CACHE_LINE_SIZE ==
+          0);
       const auto u = indices[in_idx];
       output_indices[out_row + rofs] = u;
     }

--- a/graphbolt/src/cuda/index_select_csc_impl.cu
+++ b/graphbolt/src/cuda/index_select_csc_impl.cu
@@ -71,8 +71,9 @@ __global__ void _CopyIndicesAlignedKernel(
     const auto row_pos = perm ? perm[permuted_row_pos] : permuted_row_pos;
     const auto out_row = output_indptr[row_pos];
     const auto d = output_indptr[row_pos + 1] - out_row;
-    const int offset = ((size_t)(indices + indptr[row_pos] -
-                                 output_indptr_aligned[permuted_row_pos]) %
+    const int offset = (static_cast<size_t>(
+                            indices + indptr[row_pos] -
+                            output_indptr_aligned[permuted_row_pos]) %
                         GPU_CACHE_LINE_SIZE) /
                        sizeof(indices_t);
     const auto rofs = idx - output_indptr_aligned[permuted_row_pos] - offset;

--- a/graphbolt/src/index_select.cc
+++ b/graphbolt/src/index_select.cc
@@ -58,15 +58,14 @@ std::tuple<torch::Tensor, std::vector<torch::Tensor>> IndexSelectCSCBatched(
           return IndexSelectCSCImpl(indptr, indices_list, nodes, output_size);
         });
   }
-  // @todo: The CPU supports only integer dtypes for indices tensor.
-  for (auto& indices : indices_list) {
-    TORCH_CHECK(
-        c10::isIntegralType(indices.scalar_type(), false),
-        "IndexSelectCSC is not implemented to slice noninteger types yet.");
-  }
   std::vector<torch::Tensor> results;
   torch::Tensor output_indptr;
   for (auto& indices : indices_list) {
+    // @todo: The CPU supports only integer dtypes for indices tensor.
+    TORCH_CHECK(
+        c10::isIntegralType(indices.scalar_type(), false),
+        "IndexSelectCSCBatched is not implemented to slice noninteger types "
+        "yet.");
     sampling::FusedCSCSamplingGraph g(indptr, indices);
     const auto res = g.InSubgraph(nodes);
     output_indptr = res->indptr;

--- a/graphbolt/src/index_select.cc
+++ b/graphbolt/src/index_select.cc
@@ -55,7 +55,8 @@ std::tuple<torch::Tensor, std::vector<torch::Tensor>> IndexSelectCSCBatched(
       utils::are_accessible_from_gpu(indices_list)) {
     GRAPHBOLT_DISPATCH_CUDA_ONLY_DEVICE(
         c10::DeviceType::CUDA, "IndexSelectCSCImpl", {
-          return IndexSelectCSCImpl(indptr, indices_list, nodes, output_size);
+          return IndexSelectCSCBatchedImpl(
+              indptr, indices_list, nodes, output_size);
         });
   }
   std::vector<torch::Tensor> results;

--- a/graphbolt/src/index_select.h
+++ b/graphbolt/src/index_select.h
@@ -49,6 +49,25 @@ std::tuple<torch::Tensor, torch::Tensor> IndexSelectCSC(
  */
 torch::Tensor IndexSelect(torch::Tensor input, torch::Tensor index);
 
+/**
+ * @brief Select columns for a sparse matrix in a CSC format according to nodes
+ * tensor.
+ *
+ * NOTE: The shape of all tensors must be 1-D.
+ *
+ * @param indptr Indptr tensor containing offsets with shape (N,).
+ * @param indices_list Vector of indices tensor with edge information of shape
+ * (indptr[N],).
+ * @param nodes Nodes tensor with shape (M,).
+ * @param output_size The total number of edges being copied.
+ * @return (torch::Tensor, std::vector<torch::Tensor>) Output indptr and vector
+ * of indices tensors of shapes (M + 1,) and ((indptr[nodes + 1] -
+ * indptr[nodes]).sum(),).
+ */
+std::tuple<torch::Tensor, std::vector<torch::Tensor>> IndexSelectCSCBatched(
+    torch::Tensor indptr, std::vector<torch::Tensor> indices_list,
+    torch::Tensor nodes, torch::optional<int64_t> output_size);
+
 }  // namespace ops
 }  // namespace graphbolt
 

--- a/graphbolt/src/python_binding.cc
+++ b/graphbolt/src/python_binding.cc
@@ -129,6 +129,7 @@ TORCH_LIBRARY(graphbolt, m) {
   m.def("isin", &IsIn);
   m.def("index_select", &ops::IndexSelect);
   m.def("index_select_csc", &ops::IndexSelectCSC);
+  m.def("index_select_csc_batched", &ops::IndexSelectCSCBatched);
   m.def("ondisk_npy_array", &storage::OnDiskNpyArray::Create);
   m.def("detect_io_uring", &io_uring::IsAvailable);
   m.def("set_seed", &RandomEngine::SetManualSeed);

--- a/graphbolt/src/utils.h
+++ b/graphbolt/src/utils.h
@@ -15,15 +15,27 @@ namespace utils {
 /**
  * @brief Checks whether the tensor is stored on the GPU.
  */
-inline bool is_on_gpu(torch::Tensor tensor) {
+inline bool is_on_gpu(const torch::Tensor& tensor) {
   return tensor.device().is_cuda();
 }
 
 /**
  * @brief Checks whether the tensor is stored on the GPU or the pinned memory.
  */
-inline bool is_accessible_from_gpu(torch::Tensor tensor) {
+inline bool is_accessible_from_gpu(const torch::Tensor& tensor) {
   return is_on_gpu(tensor) || tensor.is_pinned();
+}
+
+/**
+ * @brief Checks whether the tensors are all stored on the GPU or the pinned
+ * memory.
+ */
+template <typename TensorContainer>
+inline bool are_accessible_from_gpu(const TensorContainer& tensors) {
+  for (auto& tensor : tensors) {
+    if (!is_accessible_from_gpu(tensor)) return false;
+  }
+  return true;
 }
 
 /**

--- a/python/dgl/graphbolt/impl/neighbor_sampler.py
+++ b/python/dgl/graphbolt/impl/neighbor_sampler.py
@@ -145,24 +145,24 @@ class FetchInsubgraphData(Mapper):
                     tensor.record_stream(stream)
                 return tensor
 
-            # Start packing tensors to be sliced here for the batched call.
+            # Packs tensors for batch slicing.
             tensors_to_be_sliced = [self.graph.indices]
 
-            type_per_edge = None
+            has_type_per_edge = False
             if self.graph.type_per_edge is not None:
                 tensors_to_be_sliced.append(self.graph.type_per_edge)
-                type_per_edge = True
+                has_type_per_edge = True
 
-            probs_or_mask = None
+            has_probs_or_mask = None
             if self.graph.edge_attributes is not None:
                 probs_or_mask = self.graph.edge_attributes.get(
                     self.prob_name, None
                 )
                 if probs_or_mask is not None:
                     tensors_to_be_sliced.append(probs_or_mask)
-                    probs_or_mask = True
+                    has_probs_or_mask = True
 
-            # Actually slice the tensors here.
+            # Slices the batched tensors.
             (
                 indptr,
                 sliced_tensors,
@@ -172,15 +172,15 @@ class FetchInsubgraphData(Mapper):
             for tensor in [indptr] + sliced_tensors:
                 record_stream(tensor)
 
-            # Start unpacking the sliced tensors here.
+            # Unpacks the sliced tensors.
             indices = sliced_tensors[0]
             sliced_tensors = sliced_tensors[1:]
 
-            if type_per_edge:
+            if has_type_per_edge:
                 type_per_edge = sliced_tensors[0]
                 sliced_tensors = sliced_tensors[1:]
 
-            if probs_or_mask:
+            if has_probs_or_mask:
                 probs_or_mask = sliced_tensors[0]
                 sliced_tensors = sliced_tensors[1:]
             assert len(sliced_tensors) == 0

--- a/python/dgl/graphbolt/impl/neighbor_sampler.py
+++ b/python/dgl/graphbolt/impl/neighbor_sampler.py
@@ -176,10 +176,12 @@ class FetchInsubgraphData(Mapper):
             indices = sliced_tensors[0]
             sliced_tensors = sliced_tensors[1:]
 
+            type_per_edge = None
             if has_type_per_edge:
                 type_per_edge = sliced_tensors[0]
                 sliced_tensors = sliced_tensors[1:]
 
+            probs_or_mask = None
             if has_probs_or_mask:
                 probs_or_mask = sliced_tensors[0]
                 sliced_tensors = sliced_tensors[1:]

--- a/python/dgl/graphbolt/impl/neighbor_sampler.py
+++ b/python/dgl/graphbolt/impl/neighbor_sampler.py
@@ -145,34 +145,46 @@ class FetchInsubgraphData(Mapper):
                     tensor.record_stream(stream)
                 return tensor
 
-            index_select_csc_with_indptr = partial(
-                torch.ops.graphbolt.index_select_csc, self.graph.csc_indptr
-            )
+            # Start packing tensors to be sliced here for the batched call.
+            tensors_to_be_sliced = [self.graph.indices]
 
-            indptr, indices = index_select_csc_with_indptr(
-                self.graph.indices, seeds, None
-            )
-            record_stream(indptr)
-            record_stream(indices)
-            output_size = len(indices)
+            type_per_edge = None
             if self.graph.type_per_edge is not None:
-                _, type_per_edge = index_select_csc_with_indptr(
-                    self.graph.type_per_edge, seeds, output_size
-                )
-                record_stream(type_per_edge)
-            else:
-                type_per_edge = None
+                tensors_to_be_sliced.append(self.graph.type_per_edge)
+                type_per_edge = True
+
+            probs_or_mask = None
             if self.graph.edge_attributes is not None:
                 probs_or_mask = self.graph.edge_attributes.get(
                     self.prob_name, None
                 )
                 if probs_or_mask is not None:
-                    _, probs_or_mask = index_select_csc_with_indptr(
-                        probs_or_mask, seeds, output_size
-                    )
-                    record_stream(probs_or_mask)
-            else:
-                probs_or_mask = None
+                    tensors_to_be_sliced.append(probs_or_mask)
+                    probs_or_mask = True
+
+            # Actually slice the tensors here.
+            (
+                indptr,
+                sliced_tensors,
+            ) = torch.ops.graphbolt.index_select_csc_batched(
+                self.graph.csc_indptr, tensors_to_be_sliced, seeds, None
+            )
+            for tensor in [indptr] + sliced_tensors:
+                record_stream(tensor)
+
+            # Start unpacking the sliced tensors here.
+            indices = sliced_tensors[0]
+            sliced_tensors = sliced_tensors[1:]
+
+            if type_per_edge:
+                type_per_edge = sliced_tensors[0]
+                sliced_tensors = sliced_tensors[1:]
+
+            if probs_or_mask:
+                probs_or_mask = sliced_tensors[0]
+                sliced_tensors = sliced_tensors[1:]
+            assert len(sliced_tensors) == 0
+
             subgraph = fused_csc_sampling_graph(
                 indptr,
                 indices,

--- a/tests/python/pytorch/graphbolt/impl/test_in_subgraph_sampler.py
+++ b/tests/python/pytorch/graphbolt/impl/test_in_subgraph_sampler.py
@@ -67,14 +67,21 @@ def test_index_select_csc(
     assert torch.equal(cpu_indices, gpu_indices.cpu())
 
     for output_size_selection in [None, output_size]:
-        indices_list = [indices, indices.int().pin_memory() if is_pinned else indices.int()]
-        gpu_indptr2, gpu_indices_list = torch.ops.graphbolt.index_select_csc_batched(indptr, indices_list, index, output_size_selection)
+        indices_list = [
+            indices,
+            indices.int().pin_memory() if is_pinned else indices.int(),
+        ]
+        (
+            gpu_indptr2,
+            gpu_indices_list,
+        ) = torch.ops.graphbolt.index_select_csc_batched(
+            indptr, indices_list, index, output_size_selection
+        )
 
         assert torch.equal(gpu_indptr, gpu_indptr2)
         assert torch.equal(gpu_indices_list[0], gpu_indices)
         assert torch.equal(gpu_indices_list[1], gpu_indices.int())
 
-    
 
 def test_InSubgraphSampler_homo():
     """Original graph in COO:

--- a/tests/python/pytorch/graphbolt/impl/test_in_subgraph_sampler.py
+++ b/tests/python/pytorch/graphbolt/impl/test_in_subgraph_sampler.py
@@ -66,6 +66,15 @@ def test_index_select_csc(
     assert torch.equal(cpu_indptr, gpu_indptr.cpu())
     assert torch.equal(cpu_indices, gpu_indices.cpu())
 
+    for output_size_selection in [None, output_size]:
+        indices_list = [indices, indices.int().pin_memory() if is_pinned else indices.int()]
+        gpu_indptr2, gpu_indices_list = torch.ops.graphbolt.index_select_csc_batched(indptr, indices_list, index, output_size_selection)
+
+        assert torch.equal(gpu_indptr, gpu_indptr2)
+        assert torch.equal(gpu_indices_list[0], gpu_indices)
+        assert torch.equal(gpu_indices_list[1], gpu_indices.int())
+
+    
 
 def test_InSubgraphSampler_homo():
     """Original graph in COO:


### PR DESCRIPTION
## Description
The overlap_graph_fetch code path benefits from this change by avoiding the duplicate indexing of the indptr tensor multiple times for each `index_select_csc` call..

## Checklist
Please feel free to remove inapplicable items for your PR.
- [ ] The PR title starts with [$CATEGORY] (such as [NN], [Model], [Doc], [Feature]])
- [ ] I've leverage the [tools](https://docs.google.com/document/d/1iHyj7zlmygKSk5gBPsqIqL5ASPzJSPREaNT_QdsiYA4/edit) to beautify the python and c++ code.
- [ ] The PR is complete and small, read the [Google eng practice (CL equals to PR)](https://google.github.io/eng-practices/review/developer/small-cls.html) to understand more about small PR. In DGL, we consider PRs with less than 200 lines of core code change are small (example, test and documentation could be exempted).
- [ ] All changes have test coverage
- [ ] Code is well-documented
- [ ] To the best of my knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change
- [ ] Related issue is referred in this PR
- [ ] If the PR is for a new model/paper, I've updated the example index [here](../examples/README.md).

## Changes
<!-- You could use following template
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)
-->
