### PR TITLE
[GraphBolt][CUDA] Force CUDA version if torch is.

### DIFF
--- a/python/dgl/graphbolt/__init__.py
+++ b/python/dgl/graphbolt/__init__.py
@@ -58,4 +58,9 @@ from .internal import (
     unique_and_compact_csc_formats,
 )
 
-is_cuda_available()
+if torch.cuda.is_available() and not is_cuda_available():
+    gb_warning(
+        "torch was installed with CUDA support while GraphBolt's CPU version "
+        "is installed. Consider reinstalling GraphBolt with CUDA support, see "
+        "installation instructions at https://www.dgl.ai/pages/start.html"
+    )

--- a/python/dgl/graphbolt/__init__.py
+++ b/python/dgl/graphbolt/__init__.py
@@ -58,7 +58,7 @@ from .internal import (
     unique_and_compact_csc_formats,
 )
 
-if torch.cuda.is_available() and not is_cuda_available():
+if torch.cuda.is_available() and not built_with_cuda():
     gb_warning(
         "torch was installed with CUDA support while GraphBolt's CPU version "
         "is installed. Consider reinstalling GraphBolt with CUDA support, see "

--- a/python/dgl/graphbolt/__init__.py
+++ b/python/dgl/graphbolt/__init__.py
@@ -59,7 +59,7 @@ from .internal import (
 )
 
 if torch.cuda.is_available() and not built_with_cuda():
-    gb_warning(
+    raise ImportError(
         "torch was installed with CUDA support while GraphBolt's CPU version "
         "is installed. Consider reinstalling GraphBolt with CUDA support, see "
         "installation instructions at https://www.dgl.ai/pages/start.html"

--- a/python/dgl/graphbolt/__init__.py
+++ b/python/dgl/graphbolt/__init__.py
@@ -57,3 +57,5 @@ from .internal import (
     unique_and_compact,
     unique_and_compact_csc_formats,
 )
+
+is_cuda_available()

--- a/python/dgl/graphbolt/internal_utils.py
+++ b/python/dgl/graphbolt/internal_utils.py
@@ -20,6 +20,7 @@ _default_formatwarning = warnings.formatwarning
 
 
 def is_cuda_available():
+    """Returns whether GraphBolt was built with CUDA support."""
     try:
         # This op is defined if graphbolt is built with CUDA support.
         _ = torch.ops.graphbolt.set_max_uva_threads
@@ -27,10 +28,12 @@ def is_cuda_available():
     except AttributeError:
         graphbolt_cuda_available = False
 
-    if graphbolt_cuda_available != torch.cuda.is_available():
-        _boolean_to_enabled_disabled = {True: "enabled", False: "disabled"}
+    if torch.cuda.is_available() and not graphbolt_cuda_available:
         gb_warning(
-            f"The torch installation CUDA support is {_boolean_to_enabled_disabled[torch.cuda.is_available()]} but the graphbolt installation CUDA support is {graphbolt_cuda_available}. Consider reinstalling graphbolt so that its CUDA support matches the installed torch package."
+            "torch was installed with CUDA support while GraphBolt's CPU "
+            "version is installed. Consider reinstalling GraphBolt with CUDA "
+            "support, see installation instructions at: "
+            "https://www.dgl.ai/pages/start.html"
         )
     return graphbolt_cuda_available
 

--- a/python/dgl/graphbolt/internal_utils.py
+++ b/python/dgl/graphbolt/internal_utils.py
@@ -32,7 +32,7 @@ def is_cuda_available():
         gb_warning(
             "torch was installed with CUDA support while GraphBolt's CPU "
             "version is installed. Consider reinstalling GraphBolt with CUDA "
-            "support, see installation instructions at: "
+            "support, see installation instructions at "
             "https://www.dgl.ai/pages/start.html"
         )
     return graphbolt_cuda_available

--- a/python/dgl/graphbolt/internal_utils.py
+++ b/python/dgl/graphbolt/internal_utils.py
@@ -5,6 +5,7 @@ import warnings
 from collections.abc import Mapping, Sequence
 
 import requests
+import torch
 from tqdm.auto import tqdm
 
 try:
@@ -16,6 +17,22 @@ except ImportError:
 
 # pylint: disable=invalid-name
 _default_formatwarning = warnings.formatwarning
+
+
+def is_cuda_available():
+    try:
+        # This op is defined if graphbolt is built with CUDA support.
+        torch.ops.graphbolt.set_max_uva_threads(2**30)
+        graphbolt_cuda_available = True
+    except AttributeError:
+        graphbolt_cuda_available = False
+
+    if graphbolt_cuda_available != torch.cuda.is_available():
+        _boolean_to_enabled_disabled = {True: "enabled", False: "disabled"}
+        gb_warning(
+            f"The torch installation CUDA support is {_boolean_to_enabled_disabled[torch.cuda.is_available()]} but the graphbolt installation CUDA support is {graphbolt_cuda_available}. Consider reinstalling graphbolt so that its CUDA support matches the installed torch package."
+        )
+    return graphbolt_cuda_available
 
 
 class GBWarning(UserWarning):

--- a/python/dgl/graphbolt/internal_utils.py
+++ b/python/dgl/graphbolt/internal_utils.py
@@ -22,16 +22,7 @@ _default_formatwarning = warnings.formatwarning
 def is_cuda_available():
     """Returns whether GraphBolt was built with CUDA support."""
     # This op is defined if graphbolt is built with CUDA support.
-    gb_cuda_available = hasattr(torch.ops.graphbolt, "set_max_uva_threads")
-
-    if torch.cuda.is_available() and not gb_cuda_available:
-        gb_warning(
-            "torch was installed with CUDA support while GraphBolt's CPU "
-            "version is installed. Consider reinstalling GraphBolt with CUDA "
-            "support, see installation instructions at "
-            "https://www.dgl.ai/pages/start.html"
-        )
-    return gb_cuda_available
+    return hasattr(torch.ops.graphbolt, "set_max_uva_threads")
 
 
 class GBWarning(UserWarning):

--- a/python/dgl/graphbolt/internal_utils.py
+++ b/python/dgl/graphbolt/internal_utils.py
@@ -21,21 +21,17 @@ _default_formatwarning = warnings.formatwarning
 
 def is_cuda_available():
     """Returns whether GraphBolt was built with CUDA support."""
-    try:
-        # This op is defined if graphbolt is built with CUDA support.
-        _ = torch.ops.graphbolt.set_max_uva_threads
-        graphbolt_cuda_available = True
-    except AttributeError:
-        graphbolt_cuda_available = False
+    # This op is defined if graphbolt is built with CUDA support.
+    gb_cuda_available = hasattr(torch.ops.graphbolt, "set_max_uva_threads")
 
-    if torch.cuda.is_available() and not graphbolt_cuda_available:
+    if torch.cuda.is_available() and not gb_cuda_available:
         gb_warning(
             "torch was installed with CUDA support while GraphBolt's CPU "
             "version is installed. Consider reinstalling GraphBolt with CUDA "
             "support, see installation instructions at "
             "https://www.dgl.ai/pages/start.html"
         )
-    return graphbolt_cuda_available
+    return gb_cuda_available
 
 
 class GBWarning(UserWarning):

--- a/python/dgl/graphbolt/internal_utils.py
+++ b/python/dgl/graphbolt/internal_utils.py
@@ -22,7 +22,7 @@ _default_formatwarning = warnings.formatwarning
 def is_cuda_available():
     try:
         # This op is defined if graphbolt is built with CUDA support.
-        torch.ops.graphbolt.set_max_uva_threads(2**30)
+        _ = torch.ops.graphbolt.set_max_uva_threads
         graphbolt_cuda_available = True
     except AttributeError:
         graphbolt_cuda_available = False

--- a/python/dgl/graphbolt/internal_utils.py
+++ b/python/dgl/graphbolt/internal_utils.py
@@ -19,7 +19,7 @@ except ImportError:
 _default_formatwarning = warnings.formatwarning
 
 
-def is_cuda_available():
+def built_with_cuda():
     """Returns whether GraphBolt was built with CUDA support."""
     # This op is defined if graphbolt is built with CUDA support.
     return hasattr(torch.ops.graphbolt, "set_max_uva_threads")


### PR DESCRIPTION
## Description
Force the user to reinstall if the user has a GPU, installed the CUDA version of torch but installs the CPU version of GraphBolt.

Feel free to close the PR if we do not want that. This mismatch causes problems for them so I thought not even letting them use it is the best way to resolve these issues.

Fixes #7512 and #7494

## Checklist
Please feel free to remove inapplicable items for your PR.
- [ ] The PR title starts with [$CATEGORY] (such as [NN], [Model], [Doc], [Feature]])
- [ ] I've leverage the [tools](https://docs.google.com/document/d/1iHyj7zlmygKSk5gBPsqIqL5ASPzJSPREaNT_QdsiYA4/edit) to beautify the python and c++ code.
- [ ] The PR is complete and small, read the [Google eng practice (CL equals to PR)](https://google.github.io/eng-practices/review/developer/small-cls.html) to understand more about small PR. In DGL, we consider PRs with less than 200 lines of core code change are small (example, test and documentation could be exempted).
- [ ] All changes have test coverage
- [ ] Code is well-documented
- [ ] To the best of my knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change
- [ ] Related issue is referred in this PR
- [ ] If the PR is for a new model/paper, I've updated the example index [here](../examples/README.md).

## Changes
<!-- You could use following template
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)
-->
