### PR TITLE
[GraphBolt][CUDA] Skip in-place pinning tests on WSL.

### DIFF
--- a/python/dgl/graphbolt/internal_utils.py
+++ b/python/dgl/graphbolt/internal_utils.py
@@ -17,7 +17,7 @@ except ImportError:
     from setuptools.extern.packaging import version
 
 
-@functools.cache
+@functools.lru_cache(maxsize=None)
 def is_wsl(v: str = platform.uname().release) -> int:
     """Detects if Python is running in WSL"""
 

--- a/python/dgl/graphbolt/internal_utils.py
+++ b/python/dgl/graphbolt/internal_utils.py
@@ -1,6 +1,8 @@
 """Miscallenous internal utils."""
+import functools
 import hashlib
 import os
+import platform
 import warnings
 from collections.abc import Mapping, Sequence
 
@@ -13,6 +15,18 @@ try:
 except ImportError:
     # If packaging isn't installed, try and use the vendored copy in setuptools
     from setuptools.extern.packaging import version
+
+
+@functools.cache
+def is_wsl(v: str = platform.uname().release) -> int:
+    """Detects if Python is running in WSL"""
+
+    if v.endswith("-Microsoft"):
+        return 1
+    elif v.endswith("microsoft-standard-WSL2"):
+        return 2
+
+    return 0
 
 
 # pylint: disable=invalid-name

--- a/tests/python/pytorch/graphbolt/impl/test_fused_csc_sampling_graph.py
+++ b/tests/python/pytorch/graphbolt/impl/test_fused_csc_sampling_graph.py
@@ -1618,6 +1618,9 @@ def test_csc_sampling_graph_to_device(device):
     F._default_context_str == "cpu",
     reason="Tests for pinned memory are only meaningful on GPU.",
 )
+@unittest.skipIf(
+    gb.is_wsl(), reason="In place pinning is not supported on WSL."
+)
 def test_csc_sampling_graph_to_pinned_memory():
     # Construct FusedCSCSamplingGraph.
     graph = create_fused_csc_sampling_graph()

--- a/tests/python/pytorch/graphbolt/impl/test_torch_based_feature_store.py
+++ b/tests/python/pytorch/graphbolt/impl/test_torch_based_feature_store.py
@@ -1,8 +1,6 @@
 import os
 import tempfile
 import unittest
-from functools import reduce
-from operator import mul
 
 import backend as F
 
@@ -216,6 +214,8 @@ def test_torch_based_pinned_feature(dtype, idtype, shape, in_place):
 
     feature = gb.TorchBasedFeature(tensor)
     if in_place:
+        if gb.is_wsl():
+            pytest.skip("In place pinning is not supported on WSL.")
         feature.pin_memory_()
 
         # Check if pinning is truly in-place.


### PR DESCRIPTION
## Description
I am using WSL myself, I had these manual skips for months now. Merging this patch will enable our tests to pass in Windows Subsystem for Linux users.

## Checklist
Please feel free to remove inapplicable items for your PR.
- [ ] The PR title starts with [$CATEGORY] (such as [NN], [Model], [Doc], [Feature]])
- [ ] I've leverage the [tools](https://docs.google.com/document/d/1iHyj7zlmygKSk5gBPsqIqL5ASPzJSPREaNT_QdsiYA4/edit) to beautify the python and c++ code.
- [ ] The PR is complete and small, read the [Google eng practice (CL equals to PR)](https://google.github.io/eng-practices/review/developer/small-cls.html) to understand more about small PR. In DGL, we consider PRs with less than 200 lines of core code change are small (example, test and documentation could be exempted).
- [ ] All changes have test coverage
- [ ] Code is well-documented
- [ ] To the best of my knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change
- [ ] Related issue is referred in this PR
- [ ] If the PR is for a new model/paper, I've updated the example index [here](../examples/README.md).

## Changes
<!-- You could use following template
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)
-->
