### PR TITLE
[GraphBolt][CUDA] In-place pinning should be out-of-place on WSL.

### DIFF
--- a/python/dgl/graphbolt/impl/fused_csc_sampling_graph.py
+++ b/python/dgl/graphbolt/impl/fused_csc_sampling_graph.py
@@ -1371,7 +1371,7 @@ class FusedCSCSamplingGraph(SamplingGraph):
         if is_wsl():
             gb_warning(
                 "In place pinning is not supported on WSL. "
-                "Returning the pinned result."
+                "Returning the out of place pinned result."
             )
             return self.to("pinned")
         # torch.Tensor.pin_memory() is not an inplace operation. To make it

--- a/python/dgl/graphbolt/impl/fused_csc_sampling_graph.py
+++ b/python/dgl/graphbolt/impl/fused_csc_sampling_graph.py
@@ -8,7 +8,7 @@ from typing import Dict, Optional, Union
 import torch
 
 from ..base import etype_str_to_tuple, etype_tuple_to_str, ORIGINAL_EDGE_ID
-from ..internal_utils import recursive_apply
+from ..internal_utils import gb_warning, is_wsl, recursive_apply
 from ..sampling_graph import SamplingGraph
 from .sampled_subgraph_impl import CSCFormatBase, SampledSubgraphImpl
 
@@ -1368,6 +1368,12 @@ class FusedCSCSamplingGraph(SamplingGraph):
     def pin_memory_(self):
         """Copy `FusedCSCSamplingGraph` to the pinned memory in-place. Returns
         the same object modified in-place."""
+        if is_wsl():
+            gb_warning(
+                "In place pinning is not supported on WSL. "
+                "Returning the pinned result."
+            )
+            return self.to("pinned")
         # torch.Tensor.pin_memory() is not an inplace operation. To make it
         # truly in-place, we need to use cudaHostRegister. Then, we need to use
         # cudaHostUnregister to unpin the tensor in the destructor.

--- a/python/dgl/graphbolt/impl/fused_csc_sampling_graph.py
+++ b/python/dgl/graphbolt/impl/fused_csc_sampling_graph.py
@@ -1371,7 +1371,7 @@ class FusedCSCSamplingGraph(SamplingGraph):
         if is_wsl():
             gb_warning(
                 "In place pinning is not supported on WSL. "
-                "Returning the out of place pinned result."
+                "Returning the out of place pinned `FusedCSCSamplingGraph`."
             )
             return self.to("pinned")
         # torch.Tensor.pin_memory() is not an inplace operation. To make it

--- a/python/dgl/graphbolt/impl/torch_based_feature_store.py
+++ b/python/dgl/graphbolt/impl/torch_based_feature_store.py
@@ -412,7 +412,7 @@ class TorchBasedFeatureStore(BasicFeatureStore):
         if is_wsl():
             gb_warning(
                 "In place pinning is not supported on WSL. "
-                "Returning the out of place pinned result."
+                "Returning the out of place pinned `TorchBasedFeatureStore`."
             )
             return self.to("pinned")
         for feature in self._features.values():

--- a/python/dgl/graphbolt/impl/torch_based_feature_store.py
+++ b/python/dgl/graphbolt/impl/torch_based_feature_store.py
@@ -9,6 +9,7 @@ import torch
 
 from ..base import index_select
 from ..feature_store import Feature
+from ..internal_utils import gb_warning, is_wsl
 from .basic_feature_store import BasicFeatureStore
 from .ondisk_metadata import OnDiskFeatureData
 
@@ -408,6 +409,12 @@ class TorchBasedFeatureStore(BasicFeatureStore):
     def pin_memory_(self):
         """In-place operation to copy the feature store to pinned memory.
         Returns the same object modified in-place."""
+        if is_wsl():
+            gb_warning(
+                "In place pinning is not supported on WSL. "
+                "Returning the pinned result."
+            )
+            return self.to("pinned")
         for feature in self._features.values():
             feature.pin_memory_()
 

--- a/python/dgl/graphbolt/impl/torch_based_feature_store.py
+++ b/python/dgl/graphbolt/impl/torch_based_feature_store.py
@@ -412,7 +412,7 @@ class TorchBasedFeatureStore(BasicFeatureStore):
         if is_wsl():
             gb_warning(
                 "In place pinning is not supported on WSL. "
-                "Returning the pinned result."
+                "Returning the out of place pinned result."
             )
             return self.to("pinned")
         for feature in self._features.values():


### PR DESCRIPTION
## Description
Otherwise our examples crash when run on WSL.

## Checklist
Please feel free to remove inapplicable items for your PR.
- [ ] The PR title starts with [$CATEGORY] (such as [NN], [Model], [Doc], [Feature]])
- [ ] I've leverage the [tools](https://docs.google.com/document/d/1iHyj7zlmygKSk5gBPsqIqL5ASPzJSPREaNT_QdsiYA4/edit) to beautify the python and c++ code.
- [ ] The PR is complete and small, read the [Google eng practice (CL equals to PR)](https://google.github.io/eng-practices/review/developer/small-cls.html) to understand more about small PR. In DGL, we consider PRs with less than 200 lines of core code change are small (example, test and documentation could be exempted).
- [ ] All changes have test coverage
- [ ] Code is well-documented
- [ ] To the best of my knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change
- [ ] Related issue is referred in this PR
- [ ] If the PR is for a new model/paper, I've updated the example index [here](../examples/README.md).

## Changes
<!-- You could use following template
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)
-->
