### PR TITLE
[GraphBolt] Cache policy replace fix.

### DIFF
--- a/graphbolt/src/cache_policy.h
+++ b/graphbolt/src/cache_policy.h
@@ -86,7 +86,7 @@ struct CircularQueue {
 
 struct CacheKey {
   CacheKey(int64_t key, int64_t position)
-      : freq_(0), key_(key), position_in_cache_(position), reference_count_(0) {
+      : freq_(0), key_(key), position_in_cache_(position), reference_count_(1) {
     static_assert(sizeof(CacheKey) == 2 * sizeof(int64_t));
   }
 

--- a/python/dgl/graphbolt/impl/feature_cache.py
+++ b/python/dgl/graphbolt/impl/feature_cache.py
@@ -73,6 +73,7 @@ class FeatureCache(object):
         """
         positions = self._policy.replace(keys)
         self._cache.replace(positions, values)
+        self._policy.reading_completed(keys)
 
     @property
     def miss_rate(self):


### PR DESCRIPTION
## Description
Replace looks up a key with Read. Read marks the key as in use after lookup if it exists. Insert didn't mark the keys in use.

Until after the keys have actually been inserted into the feature cache (not policy), we actually need to mark them in use. Thus, changing the default value of the reference count to 1 fixes Insert not marking the keys as in use. After that, we need to unmark them as not in use after the embeddings are inserted into the inmemory feature embedding cache.

## Checklist
Please feel free to remove inapplicable items for your PR.
- [ ] The PR title starts with [$CATEGORY] (such as [NN], [Model], [Doc], [Feature]])
- [ ] I've leverage the [tools](https://docs.google.com/document/d/1iHyj7zlmygKSk5gBPsqIqL5ASPzJSPREaNT_QdsiYA4/edit) to beautify the python and c++ code.
- [ ] The PR is complete and small, read the [Google eng practice (CL equals to PR)](https://google.github.io/eng-practices/review/developer/small-cls.html) to understand more about small PR. In DGL, we consider PRs with less than 200 lines of core code change are small (example, test and documentation could be exempted).
- [ ] All changes have test coverage
- [ ] Code is well-documented
- [ ] To the best of my knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change
- [ ] Related issue is referred in this PR
- [ ] If the PR is for a new model/paper, I've updated the example index [here](../examples/README.md).

## Changes
<!-- You could use following template
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)
-->
