### PR TITLE
[GraphBolt] Fix issue on torch 2.3.1

### DIFF
--- a/python/dgl/graphbolt/base.py
+++ b/python/dgl/graphbolt/base.py
@@ -81,7 +81,7 @@ if TorchVersion(torch.__version__) >= TorchVersion("2.2.0a0"):
 
     torch_fake_decorator = (
         torch.library.impl_abstract
-        if TorchVersion(torch.__version__) < TorchVersion("2.3.1")
+        if TorchVersion(torch.__version__) < TorchVersion("2.4.0a0")
         else torch.library.register_fake
     )
 


### PR DESCRIPTION
## Description
Looks like register_fake is not available in 2.3.1, I mistakenly assumed in #7493 that it is. This should fix one issue our user was having in https://discuss.dgl.ai/t/distdgl-v2-4-built-from-source-training-error/4474/3.

PyTorch documentation on deprecation: https://pytorch.org/docs/2.4/library.html#torch.library.impl_abstract

## Checklist
Please feel free to remove inapplicable items for your PR.
- [ ] The PR title starts with [$CATEGORY] (such as [NN], [Model], [Doc], [Feature]])
- [ ] I've leverage the [tools](https://docs.google.com/document/d/1iHyj7zlmygKSk5gBPsqIqL5ASPzJSPREaNT_QdsiYA4/edit) to beautify the python and c++ code.
- [ ] The PR is complete and small, read the [Google eng practice (CL equals to PR)](https://google.github.io/eng-practices/review/developer/small-cls.html) to understand more about small PR. In DGL, we consider PRs with less than 200 lines of core code change are small (example, test and documentation could be exempted).
- [ ] All changes have test coverage
- [ ] Code is well-documented
- [ ] To the best of my knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change
- [ ] Related issue is referred in this PR
- [ ] If the PR is for a new model/paper, I've updated the example index [here](../examples/README.md).

## Changes
<!-- You could use following template
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)
-->
