### PR TITLE
[GraphBolt] Add `gb.numpy_save_aligned`.

### DIFF
--- a/python/dgl/graphbolt/__init__.py
+++ b/python/dgl/graphbolt/__init__.py
@@ -51,13 +51,10 @@ from .internal_utils import *
 from .negative_sampler import *
 from .sampled_subgraph import *
 from .subgraph_sampler import *
-from .external_utils import (
-    add_reverse_edges,
-    exclude_seed_edges,
-    numpy_save_aligned,
-)
+from .external_utils import add_reverse_edges, exclude_seed_edges
 from .internal import (
     compact_csc_format,
+    numpy_save_aligned,
     unique_and_compact,
     unique_and_compact_csc_formats,
 )

--- a/python/dgl/graphbolt/__init__.py
+++ b/python/dgl/graphbolt/__init__.py
@@ -51,7 +51,11 @@ from .internal_utils import *
 from .negative_sampler import *
 from .sampled_subgraph import *
 from .subgraph_sampler import *
-from .external_utils import add_reverse_edges, exclude_seed_edges
+from .external_utils import (
+    add_reverse_edges,
+    exclude_seed_edges,
+    numpy_save_aligned,
+)
 from .internal import (
     compact_csc_format,
     unique_and_compact,

--- a/python/dgl/graphbolt/external_utils.py
+++ b/python/dgl/graphbolt/external_utils.py
@@ -2,6 +2,7 @@
 
 from typing import Dict, Union
 
+import numpy
 import torch
 
 from .minibatch import MiniBatch
@@ -101,3 +102,14 @@ def exclude_seed_edges(
         for subgraph in minibatch.sampled_subgraphs
     ]
     return minibatch
+
+
+def numpy_save_aligned(*args, **kwargs):
+    """A wrapper for numpy.save(), ensures the array is stored 4KiB aligned."""
+    has_array_align = hasattr(numpy.lib.format, "ARRAY_ALIGN")
+    if has_array_align:
+        default_alignment = numpy.lib.format.ARRAY_ALIGN
+        numpy.lib.format.ARRAY_ALIGN = 4096
+    numpy.save(*args, **kwargs)
+    if has_array_align:
+        numpy.lib.format.ARRAY_ALIGN = default_alignment

--- a/python/dgl/graphbolt/external_utils.py
+++ b/python/dgl/graphbolt/external_utils.py
@@ -2,7 +2,6 @@
 
 from typing import Dict, Union
 
-import numpy
 import torch
 
 from .minibatch import MiniBatch
@@ -102,14 +101,3 @@ def exclude_seed_edges(
         for subgraph in minibatch.sampled_subgraphs
     ]
     return minibatch
-
-
-def numpy_save_aligned(*args, **kwargs):
-    """A wrapper for numpy.save(), ensures the array is stored 4KiB aligned."""
-    has_array_align = hasattr(numpy.lib.format, "ARRAY_ALIGN")
-    if has_array_align:
-        default_alignment = numpy.lib.format.ARRAY_ALIGN
-        numpy.lib.format.ARRAY_ALIGN = 4096
-    numpy.save(*args, **kwargs)
-    if has_array_align:
-        numpy.lib.format.ARRAY_ALIGN = default_alignment

--- a/python/dgl/graphbolt/impl/torch_based_feature_store.py
+++ b/python/dgl/graphbolt/impl/torch_based_feature_store.py
@@ -49,7 +49,8 @@ class TorchBasedFeature(Feature):
     >>> feature.size()
     torch.Size([5])
 
-    2. The feature is on disk.
+    2. The feature is on disk. Note that you can use gb.numpy_save_aligned as a
+    replacement for np.save to potentially get increased performance.
 
     >>> import numpy as np
     >>> arr = np.array([[1, 2], [3, 4]])
@@ -237,7 +238,9 @@ class TorchBasedFeature(Feature):
 class DiskBasedFeature(Feature):
     r"""A wrapper of disk based feature.
 
-    Initialize a disk based feature fetcher by a numpy file.
+    Initialize a disk based feature fetcher by a numpy file. Note that you can
+    use gb.numpy_save_aligned as a replacement for np.save to potentially get
+    increased performance.
 
     Parameters
     ----------
@@ -250,7 +253,7 @@ class DiskBasedFeature(Feature):
     >>> from dgl import graphbolt as gb
     >>> torch_feat = torch.arange(10).reshape(2, -1)
     >>> pth = "path/to/feat.npy"
-    >>> np.save(pth,torch_feat)
+    >>> np.save(pth, torch_feat)
     >>> feature = gb.DiskBasedFeature(pth)
     >>> feature.read(torch.tensor([0]))
     tensor([[0, 1, 2, 3, 4]])
@@ -356,7 +359,8 @@ class TorchBasedFeatureStore(BasicFeatureStore):
     For a feature store, its format must be either "pt" or "npy" for Pytorch or
     Numpy formats. If the format is "pt", the feature store must be loaded in
     memory. If the format is "npy", the feature store can be loaded in memory or
-    on disk.
+    on disk. Note that you can use gb.numpy_save_aligned as a replacement for
+    np.save to potentially get increased performance.
 
     Parameters
     ----------

--- a/python/dgl/graphbolt/internal/utils.py
+++ b/python/dgl/graphbolt/internal/utils.py
@@ -11,7 +11,16 @@ import pandas as pd
 import torch
 from numpy.lib.format import read_array_header_1_0, read_array_header_2_0
 
-from ..external_utils import numpy_save_aligned
+
+def numpy_save_aligned(*args, **kwargs):
+    """A wrapper for numpy.save(), ensures the array is stored 4KiB aligned."""
+    has_array_align = hasattr(np.lib.format, "ARRAY_ALIGN")
+    if has_array_align:
+        default_alignment = np.lib.format.ARRAY_ALIGN
+        np.lib.format.ARRAY_ALIGN = 4096
+    np.save(*args, **kwargs)
+    if has_array_align:
+        np.lib.format.ARRAY_ALIGN = default_alignment
 
 
 def _read_torch_data(path):

--- a/python/dgl/graphbolt/internal/utils.py
+++ b/python/dgl/graphbolt/internal/utils.py
@@ -18,6 +18,9 @@ def numpy_save_aligned(*args, **kwargs):
     has_array_align = hasattr(np.lib.format, "ARRAY_ALIGN")
     if has_array_align:
         default_alignment = np.lib.format.ARRAY_ALIGN
+        # The maximum allowed alignment by the numpy code linked above is 4K.
+        # Most filesystems work with block sizes of 4K so in practice, the file
+        # size on the disk won't be larger.
         np.lib.format.ARRAY_ALIGN = 4096
     np.save(*args, **kwargs)
     if has_array_align:

--- a/python/dgl/graphbolt/internal/utils.py
+++ b/python/dgl/graphbolt/internal/utils.py
@@ -11,6 +11,8 @@ import pandas as pd
 import torch
 from numpy.lib.format import read_array_header_1_0, read_array_header_2_0
 
+from ..external_utils import numpy_save_aligned
+
 
 def _read_torch_data(path):
     return torch.load(path)
@@ -54,7 +56,7 @@ def save_data(data, path, fmt):
                 "so it will be copied to contiguous memory."
             )
             data = np.ascontiguousarray(data)
-        np.save(path, data)
+        numpy_save_aligned(path, data)
     elif fmt == "torch":
         if not data.is_contiguous():
             Warning(

--- a/python/dgl/graphbolt/internal/utils.py
+++ b/python/dgl/graphbolt/internal/utils.py
@@ -14,6 +14,7 @@ from numpy.lib.format import read_array_header_1_0, read_array_header_2_0
 
 def numpy_save_aligned(*args, **kwargs):
     """A wrapper for numpy.save(), ensures the array is stored 4KiB aligned."""
+    # https://github.com/numpy/numpy/blob/2093a6d5b933f812d15a3de0eafeeb23c61f948a/numpy/lib/format.py#L179
     has_array_align = hasattr(np.lib.format, "ARRAY_ALIGN")
     if has_array_align:
         default_alignment = np.lib.format.ARRAY_ALIGN

--- a/tests/python/pytorch/graphbolt/internal/test_utils.py
+++ b/tests/python/pytorch/graphbolt/internal/test_utils.py
@@ -2,6 +2,9 @@ import json
 import os
 import re
 import tempfile
+from functools import partial
+
+import dgl.graphbolt as gb
 
 import dgl.graphbolt.internal as internal
 import numpy as np
@@ -266,3 +269,16 @@ def test_check_dataset_change():
             file.write("test contents of directory changed")
 
         assert internal.check_dataset_change(test_dir, "preprocessed")
+
+
+def test_numpy_save_aligned():
+    assert_equal = partial(torch.testing.assert_close, rtol=0, atol=0)
+    a = torch.randn(1024)
+    with tempfile.TemporaryDirectory() as test_dir:
+        aligned_path = os.path.join(test_dir, "aligned.npy")
+        gb.numpy_save_aligned(aligned_path, a.numpy())
+
+        nonaligned_path = os.path.join(test_dir, "nonaligned.npy")
+        np.save(nonaligned_path, a.numpy())
+
+        assert_equal(np.load(aligned_path), np.load(nonaligned_path))

--- a/tests/python/pytorch/graphbolt/internal/test_utils.py
+++ b/tests/python/pytorch/graphbolt/internal/test_utils.py
@@ -282,4 +282,5 @@ def test_numpy_save_aligned():
         np.save(nonaligned_path, a.numpy())
 
         assert_equal(np.load(aligned_path), np.load(nonaligned_path))
+        # The size of the file should be 4K (aligned header) + 4K (tensor).
         assert os.path.getsize(aligned_path) == 4096 * 2

--- a/tests/python/pytorch/graphbolt/internal/test_utils.py
+++ b/tests/python/pytorch/graphbolt/internal/test_utils.py
@@ -273,7 +273,7 @@ def test_check_dataset_change():
 
 def test_numpy_save_aligned():
     assert_equal = partial(torch.testing.assert_close, rtol=0, atol=0)
-    a = torch.randn(1024)
+    a = torch.randn(1024, dtype=torch.float32) # 4096 bytes
     with tempfile.TemporaryDirectory() as test_dir:
         aligned_path = os.path.join(test_dir, "aligned.npy")
         gb.numpy_save_aligned(aligned_path, a.numpy())
@@ -282,3 +282,4 @@ def test_numpy_save_aligned():
         np.save(nonaligned_path, a.numpy())
 
         assert_equal(np.load(aligned_path), np.load(nonaligned_path))
+        assert os.path.getsize(aligned_path) == 4096 * 2

--- a/tests/python/pytorch/graphbolt/internal/test_utils.py
+++ b/tests/python/pytorch/graphbolt/internal/test_utils.py
@@ -273,7 +273,7 @@ def test_check_dataset_change():
 
 def test_numpy_save_aligned():
     assert_equal = partial(torch.testing.assert_close, rtol=0, atol=0)
-    a = torch.randn(1024, dtype=torch.float32) # 4096 bytes
+    a = torch.randn(1024, dtype=torch.float32)  # 4096 bytes
     with tempfile.TemporaryDirectory() as test_dir:
         aligned_path = os.path.join(test_dir, "aligned.npy")
         gb.numpy_save_aligned(aligned_path, a.numpy())


### PR DESCRIPTION
## Description
If we store our features in the numpy format using this new function, our io_uring and mmap disk read operations will speedup significantly (2.1 GiB/s vs 1.7 GiB/s) for nice close to power of 2 embedding sizes such as 768 `float`s or 512 `int8`s

## Checklist
Please feel free to remove inapplicable items for your PR.
- [ ] The PR title starts with [$CATEGORY] (such as [NN], [Model], [Doc], [Feature]])
- [ ] I've leverage the [tools](https://docs.google.com/document/d/1iHyj7zlmygKSk5gBPsqIqL5ASPzJSPREaNT_QdsiYA4/edit) to beautify the python and c++ code.
- [ ] The PR is complete and small, read the [Google eng practice (CL equals to PR)](https://google.github.io/eng-practices/review/developer/small-cls.html) to understand more about small PR. In DGL, we consider PRs with less than 200 lines of core code change are small (example, test and documentation could be exempted).
- [ ] All changes have test coverage
- [ ] Code is well-documented
- [ ] To the best of my knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change
- [ ] Related issue is referred in this PR
- [ ] If the PR is for a new model/paper, I've updated the example index [here](../examples/README.md).

## Changes
<!-- You could use following template
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)
-->
