### PR TITLE
[GraphBolt][CUDA] Add `FeatureCache::IndexSelect`.

### DIFF
--- a/graphbolt/src/feature_cache.cc
+++ b/graphbolt/src/feature_cache.cc
@@ -19,14 +19,18 @@
  */
 #include "./feature_cache.h"
 
+#include "./index_select.h"
+
 namespace graphbolt {
 namespace storage {
 
 constexpr int kIntGrainSize = 64;
 
 FeatureCache::FeatureCache(
-    const std::vector<int64_t>& shape, torch::ScalarType dtype)
-    : tensor_(torch::empty(shape, c10::TensorOptions().dtype(dtype))) {}
+    const std::vector<int64_t>& shape, torch::ScalarType dtype, bool pin_memory)
+    : tensor_(torch::empty(
+          shape, c10::TensorOptions().dtype(dtype).pinned_memory(pin_memory))) {
+}
 
 torch::Tensor FeatureCache::Query(
     torch::Tensor positions, torch::Tensor indices, int64_t size) {
@@ -52,6 +56,10 @@ torch::Tensor FeatureCache::Query(
   return values;
 }
 
+torch::Tensor FeatureCache::QueryDirect(torch::Tensor positions) {
+  return ops::IndexSelect(tensor_, positions);
+}
+
 void FeatureCache::Replace(torch::Tensor positions, torch::Tensor values) {
   const auto row_bytes = values.slice(0, 0, 1).numel() * values.element_size();
   auto values_ptr = reinterpret_cast<std::byte*>(values.data_ptr());
@@ -68,8 +76,9 @@ void FeatureCache::Replace(torch::Tensor positions, torch::Tensor values) {
 }
 
 c10::intrusive_ptr<FeatureCache> FeatureCache::Create(
-    const std::vector<int64_t>& shape, torch::ScalarType dtype) {
-  return c10::make_intrusive<FeatureCache>(shape, dtype);
+    const std::vector<int64_t>& shape, torch::ScalarType dtype,
+    bool pin_memory) {
+  return c10::make_intrusive<FeatureCache>(shape, dtype, pin_memory);
 }
 
 }  // namespace storage

--- a/graphbolt/src/feature_cache.cc
+++ b/graphbolt/src/feature_cache.cc
@@ -56,7 +56,7 @@ torch::Tensor FeatureCache::Query(
   return values;
 }
 
-torch::Tensor FeatureCache::QueryDirect(torch::Tensor positions) {
+torch::Tensor FeatureCache::IndexSelect(torch::Tensor positions) {
   return ops::IndexSelect(tensor_, positions);
 }
 

--- a/graphbolt/src/feature_cache.h
+++ b/graphbolt/src/feature_cache.h
@@ -46,7 +46,7 @@ struct FeatureCache : public torch::CustomClassHolder {
    * values[indices[:positions.size(0)]] = cache_tensor[positions] before
    * returning it.
    *
-   * @param positions The positions of the queries items.
+   * @param positions The positions of the queried items.
    * @param indices The indices of the queried items among the original keys.
    * Only the first portion corresponding to the provided positions tensor is
    * used, e.g. indices[:positions.size(0)].
@@ -62,7 +62,7 @@ struct FeatureCache : public torch::CustomClassHolder {
   /**
    * @brief The cache tensor index_select returns cache_tensor[positions].
    *
-   * @param positions The positions of the queries items.
+   * @param positions The positions of the queried items.
    *
    * @return The values tensor is returned on the same device as positions.
    */

--- a/graphbolt/src/feature_cache.h
+++ b/graphbolt/src/feature_cache.h
@@ -60,13 +60,13 @@ struct FeatureCache : public torch::CustomClassHolder {
       torch::Tensor positions, torch::Tensor indices, int64_t size);
 
   /**
-   * @brief The cache query function. Returns cache_tensor[positions].
+   * @brief The cache tensor index_select returns cache_tensor[positions].
    *
    * @param positions The positions of the queries items.
    *
    * @return The values tensor is returned on the same device as positions.
    */
-  torch::Tensor QueryDirect(torch::Tensor positions);
+  torch::Tensor IndexSelect(torch::Tensor positions);
 
   /**
    * @brief The cache replace function.

--- a/graphbolt/src/feature_cache.h
+++ b/graphbolt/src/feature_cache.h
@@ -34,7 +34,7 @@ struct FeatureCache : public torch::CustomClassHolder {
    *
    * @param shape The shape of the cache.
    * @param dtype The dtype of elements stored in the cache.
-   * @param pin_memory Whether to pin the memory of the output values tensor.
+   * @param pin_memory Whether to pin the memory of the cache storage tensor.
    */
   FeatureCache(
       const std::vector<int64_t>& shape, torch::ScalarType dtype,

--- a/graphbolt/src/feature_cache.h
+++ b/graphbolt/src/feature_cache.h
@@ -34,6 +34,7 @@ struct FeatureCache : public torch::CustomClassHolder {
    *
    * @param shape The shape of the cache.
    * @param dtype The dtype of elements stored in the cache.
+   * @param pin_memory Whether to pin the memory of the output values tensor.
    */
   FeatureCache(
       const std::vector<int64_t>& shape, torch::ScalarType dtype,
@@ -51,7 +52,6 @@ struct FeatureCache : public torch::CustomClassHolder {
    * used, e.g. indices[:positions.size(0)].
    * @param size The size of the original keys, hence the first dimension of
    * the output shape.
-   * @param pin_memory Whether to pin the memory of the output values tensor.
    *
    * @return The values tensor is returned. Its memory is pinned if pin_memory
    * is true.

--- a/graphbolt/src/feature_cache.h
+++ b/graphbolt/src/feature_cache.h
@@ -35,7 +35,9 @@ struct FeatureCache : public torch::CustomClassHolder {
    * @param shape The shape of the cache.
    * @param dtype The dtype of elements stored in the cache.
    */
-  FeatureCache(const std::vector<int64_t>& shape, torch::ScalarType dtype);
+  FeatureCache(
+      const std::vector<int64_t>& shape, torch::ScalarType dtype,
+      bool pin_memory);
 
   /**
    * @brief The cache query function. Allocates an empty tensor `values` with
@@ -58,6 +60,15 @@ struct FeatureCache : public torch::CustomClassHolder {
       torch::Tensor positions, torch::Tensor indices, int64_t size);
 
   /**
+   * @brief The cache query function. Returns cache_tensor[positions].
+   *
+   * @param positions The positions of the queries items.
+   *
+   * @return The values tensor is returned on the same device as positions.
+   */
+  torch::Tensor QueryDirect(torch::Tensor positions);
+
+  /**
    * @brief The cache replace function.
    *
    * @param positions The positions to replace in the cache.
@@ -66,7 +77,8 @@ struct FeatureCache : public torch::CustomClassHolder {
   void Replace(torch::Tensor positions, torch::Tensor values);
 
   static c10::intrusive_ptr<FeatureCache> Create(
-      const std::vector<int64_t>& shape, torch::ScalarType dtype);
+      const std::vector<int64_t>& shape, torch::ScalarType dtype,
+      bool pin_memory);
 
  private:
   torch::Tensor tensor_;

--- a/graphbolt/src/python_binding.cc
+++ b/graphbolt/src/python_binding.cc
@@ -119,6 +119,7 @@ TORCH_LIBRARY(graphbolt, m) {
       "clock_cache_policy",
       &storage::PartitionedCachePolicy::Create<storage::ClockCachePolicy>);
   m.class_<storage::FeatureCache>("FeatureCache")
+      .def("query_direct", &storage::FeatureCache::QueryDirect)
       .def("query", &storage::FeatureCache::Query)
       .def("replace", &storage::FeatureCache::Replace);
   m.def("feature_cache", &storage::FeatureCache::Create);

--- a/graphbolt/src/python_binding.cc
+++ b/graphbolt/src/python_binding.cc
@@ -119,7 +119,7 @@ TORCH_LIBRARY(graphbolt, m) {
       "clock_cache_policy",
       &storage::PartitionedCachePolicy::Create<storage::ClockCachePolicy>);
   m.class_<storage::FeatureCache>("FeatureCache")
-      .def("query_direct", &storage::FeatureCache::QueryDirect)
+      .def("index_select", &storage::FeatureCache::IndexSelect)
       .def("query", &storage::FeatureCache::Query)
       .def("replace", &storage::FeatureCache::Replace);
   m.def("feature_cache", &storage::FeatureCache::Create);

--- a/python/dgl/graphbolt/impl/feature_cache.py
+++ b/python/dgl/graphbolt/impl/feature_cache.py
@@ -25,14 +25,20 @@ class FeatureCache(object):
     policy: str, optional
         The cache policy. Default is "sieve". "s3-fifo", "lru" and "clock" are
         also available.
+    pin_memory: bool, optional
+        Whether the cache storage should be pinned.
     """
 
-    def __init__(self, cache_shape, dtype, num_parts=1, policy="sieve"):
+    def __init__(
+        self, cache_shape, dtype, num_parts=1, policy="sieve", pin_memory=False
+    ):
         assert (
             policy in caching_policies
         ), f"{list(caching_policies.keys())} are the available caching policies."
         self._policy = caching_policies[policy](cache_shape[0], num_parts)
-        self._cache = torch.ops.graphbolt.feature_cache(cache_shape, dtype)
+        self._cache = torch.ops.graphbolt.feature_cache(
+            cache_shape, dtype, pin_memory
+        )
         self.total_miss = 0
         self.total_queries = 0
 


### PR DESCRIPTION
## Description
This op is needed for zero copy access from the GPU. GPU reading tests will be included in a follow-up PR when I make use of this added functionality.

## Checklist
Please feel free to remove inapplicable items for your PR.
- [ ] The PR title starts with [$CATEGORY] (such as [NN], [Model], [Doc], [Feature]])
- [ ] I've leverage the [tools](https://docs.google.com/document/d/1iHyj7zlmygKSk5gBPsqIqL5ASPzJSPREaNT_QdsiYA4/edit) to beautify the python and c++ code.
- [ ] The PR is complete and small, read the [Google eng practice (CL equals to PR)](https://google.github.io/eng-practices/review/developer/small-cls.html) to understand more about small PR. In DGL, we consider PRs with less than 200 lines of core code change are small (example, test and documentation could be exempted).
- [ ] All changes have test coverage
- [ ] Code is well-documented
- [ ] To the best of my knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change
- [ ] Related issue is referred in this PR
- [ ] If the PR is for a new model/paper, I've updated the example index [here](../examples/README.md).

## Changes
<!-- You could use following template
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)
-->
