### PR TITLE
[GraphBolt] Add additional capabilities to `gb.index_select`.

### DIFF
--- a/graphbolt/src/index_select.cc
+++ b/graphbolt/src/index_select.cc
@@ -20,7 +20,12 @@ torch::Tensor IndexSelect(torch::Tensor input, torch::Tensor index) {
         c10::DeviceType::CUDA, "UVAIndexSelect",
         { return UVAIndexSelectImpl(input, index); });
   }
-  return input.index({index.to(torch::kLong)});
+  auto output_shape = input.sizes().vec();
+  output_shape[0] = index.numel();
+  auto result = torch::empty(
+      output_shape,
+      index.options().dtype(input.dtype()).pinned_memory(index.is_pinned()));
+  return torch::index_select_out(result, input, 0, index);
 }
 
 std::tuple<torch::Tensor, torch::Tensor> IndexSelectCSC(

--- a/python/dgl/graphbolt/base.py
+++ b/python/dgl/graphbolt/base.py
@@ -161,7 +161,8 @@ def index_select(tensor, index):
     Returns
     -------
     torch.Tensor
-        The indexed input tensor, equivalent to tensor[index].
+        The indexed input tensor, equivalent to tensor[index]. If index is in
+        pinned memory, then the result is placed into pinned memory as well.
     """
     assert index.dim() == 1, "Index should be 1D tensor."
     return torch.ops.graphbolt.index_select(tensor, index)

--- a/tests/python/pytorch/graphbolt/impl/test_legacy_dataset.py
+++ b/tests/python/pytorch/graphbolt/impl/test_legacy_dataset.py
@@ -26,7 +26,7 @@ def test_LegacyDataset_homo_node_pred():
     assert dataset.feature.size("node", None, "feat") == torch.Size([1433])
     assert (
         dataset.feature.read(
-            "node", None, "feat", torch.Tensor([num_nodes - 1])
+            "node", None, "feat", torch.tensor([num_nodes - 1])
         ).size(dim=0)
         == 1
     )

--- a/tests/python/pytorch/graphbolt/test_base.py
+++ b/tests/python/pytorch/graphbolt/test_base.py
@@ -249,6 +249,10 @@ def test_index_select(dtype, idtype, pinned):
     gb_result = gb.index_select(tensor, index)
     torch_result = tensor.to(F.ctx())[index.long()]
     assert torch.equal(torch_result, gb_result)
+    if pinned:
+        gb_result = gb.index_select(tensor.cpu(), index.cpu().pin_memory())
+        assert torch.equal(torch_result.cpu(), gb_result)
+        assert gb_result.is_pinned()
 
 
 def torch_expand_indptr(indptr, dtype, nodes=None):


### PR DESCRIPTION
## Description
We need this invariant. If index is in pinned memory, it means that its output will be copied to the GPU later. Copying the pinned result is faster.

## Checklist
Please feel free to remove inapplicable items for your PR.
- [ ] The PR title starts with [$CATEGORY] (such as [NN], [Model], [Doc], [Feature]])
- [ ] I've leverage the [tools](https://docs.google.com/document/d/1iHyj7zlmygKSk5gBPsqIqL5ASPzJSPREaNT_QdsiYA4/edit) to beautify the python and c++ code.
- [ ] The PR is complete and small, read the [Google eng practice (CL equals to PR)](https://google.github.io/eng-practices/review/developer/small-cls.html) to understand more about small PR. In DGL, we consider PRs with less than 200 lines of core code change are small (example, test and documentation could be exempted).
- [ ] All changes have test coverage
- [ ] Code is well-documented
- [ ] To the best of my knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change
- [ ] Related issue is referred in this PR
- [ ] If the PR is for a new model/paper, I've updated the example index [here](../examples/README.md).

## Changes
<!-- You could use following template
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)
-->
