### PR TITLE
[GraphBolt][CUDA] Add stream for host to device copies.

### DIFF
--- a/python/dgl/graphbolt/base.py
+++ b/python/dgl/graphbolt/base.py
@@ -49,12 +49,14 @@ ORIGINAL_EDGE_ID = "_ORIGINAL_EDGE_ID"
 # There needs to be a single instance of the uva_stream, if it is created
 # multiple times, it leads to multiple CUDA memory pools and memory leaks.
 def get_host_to_device_uva_stream():
+    """The host to device copy stream to be used for pipeline parallelism."""
     if not hasattr(get_host_to_device_uva_stream, "stream"):
         get_host_to_device_uva_stream.stream = torch.cuda.Stream(priority=-1)
     return get_host_to_device_uva_stream.stream
 
 
 def get_device_to_host_uva_stream():
+    """The device to host copy stream to be used for pipeline parallelism."""
     if not hasattr(get_device_to_host_uva_stream, "stream"):
         get_device_to_host_uva_stream.stream = torch.cuda.Stream(priority=-1)
     return get_device_to_host_uva_stream.stream

--- a/python/dgl/graphbolt/base.py
+++ b/python/dgl/graphbolt/base.py
@@ -38,10 +38,26 @@ __all__ = [
     "CSCFormatBase",
     "seed",
     "seed_type_str_to_ntypes",
+    "get_host_to_device_uva_stream",
+    "get_device_to_host_uva_stream",
 ]
 
 CANONICAL_ETYPE_DELIMITER = ":"
 ORIGINAL_EDGE_ID = "_ORIGINAL_EDGE_ID"
+
+
+# There needs to be a single instance of the uva_stream, if it is created
+# multiple times, it leads to multiple CUDA memory pools and memory leaks.
+def get_host_to_device_uva_stream():
+    if not hasattr(get_host_to_device_uva_stream, "stream"):
+        get_host_to_device_uva_stream.stream = torch.cuda.Stream(priority=-1)
+    return get_host_to_device_uva_stream.stream
+
+
+def get_device_to_host_uva_stream():
+    if not hasattr(get_device_to_host_uva_stream, "stream"):
+        get_device_to_host_uva_stream.stream = torch.cuda.Stream(priority=-1)
+    return get_device_to_host_uva_stream.stream
 
 
 def seed(val):


### PR DESCRIPTION
## Description
These will be used to overlap copies from device to host or host to device in nested caches such as `GPUCachedFeature<-CPUCachedFeature<-DiskBasedFeature`.

I am working on a feature that needs both #7535 and the functionality here so to be able to work, I need to copy code around from these branches.

## Checklist
Please feel free to remove inapplicable items for your PR.
- [ ] The PR title starts with [$CATEGORY] (such as [NN], [Model], [Doc], [Feature]])
- [ ] I've leverage the [tools](https://docs.google.com/document/d/1iHyj7zlmygKSk5gBPsqIqL5ASPzJSPREaNT_QdsiYA4/edit) to beautify the python and c++ code.
- [ ] The PR is complete and small, read the [Google eng practice (CL equals to PR)](https://google.github.io/eng-practices/review/developer/small-cls.html) to understand more about small PR. In DGL, we consider PRs with less than 200 lines of core code change are small (example, test and documentation could be exempted).
- [ ] All changes have test coverage
- [ ] Code is well-documented
- [ ] To the best of my knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change
- [ ] Related issue is referred in this PR
- [ ] If the PR is for a new model/paper, I've updated the example index [here](../examples/README.md).

## Changes
<!-- You could use following template
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)
-->
