### PR TITLE
[GraphBolt][CUDA] Ensure GPUCache has can store at least 1 item.

### DIFF
--- a/graphbolt/src/cuda/gpu_cache.cu
+++ b/graphbolt/src/cuda/gpu_cache.cu
@@ -28,6 +28,8 @@ namespace cuda {
 GpuCache::GpuCache(const std::vector<int64_t> &shape, torch::ScalarType dtype) {
   TORCH_CHECK(shape.size() >= 2, "Shape must at least have 2 dimensions.");
   const auto num_items = shape[0];
+  TORCH_CHECK(
+      num_items > 0, "The capacity of GpuCache needs to be a positive.");
   const int64_t num_feats =
       std::accumulate(shape.begin() + 1, shape.end(), 1ll, std::multiplies<>());
   const int element_size =


### PR DESCRIPTION
## Description
When it is constructed with 0, the code can crash unexpectedly. It is better to give a good error message instead.

## Checklist
Please feel free to remove inapplicable items for your PR.
- [ ] The PR title starts with [$CATEGORY] (such as [NN], [Model], [Doc], [Feature]])
- [ ] I've leverage the [tools](https://docs.google.com/document/d/1iHyj7zlmygKSk5gBPsqIqL5ASPzJSPREaNT_QdsiYA4/edit) to beautify the python and c++ code.
- [ ] The PR is complete and small, read the [Google eng practice (CL equals to PR)](https://google.github.io/eng-practices/review/developer/small-cls.html) to understand more about small PR. In DGL, we consider PRs with less than 200 lines of core code change are small (example, test and documentation could be exempted).
- [ ] All changes have test coverage
- [ ] Code is well-documented
- [ ] To the best of my knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change
- [ ] Related issue is referred in this PR
- [ ] If the PR is for a new model/paper, I've updated the example index [here](../examples/README.md).

## Changes
<!-- You could use following template
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)
-->
