### PR TITLE
[GraphBolt] `scatter_async`.

### DIFF
--- a/graphbolt/src/index_select.cc
+++ b/graphbolt/src/index_select.cc
@@ -43,7 +43,7 @@ c10::intrusive_ptr<Future<torch::Tensor>> ScatterAsync(
   for (size_t i = 1; i < input.sizes().size(); i++) {
     TORCH_CHECK(
         input.size(i) == src.size(i),
-        "dimension mismatch between input and src at " i,
+        "dimension mismatch between input and src at ", i,
         "th dimension: ", input.size(i), " != ", src.size(i), ".");
   }
   return async([=] {

--- a/graphbolt/src/index_select.cc
+++ b/graphbolt/src/index_select.cc
@@ -34,6 +34,38 @@ c10::intrusive_ptr<Future<torch::Tensor>> IndexSelectAsync(
   return async([=] { return IndexSelect(input, index); });
 }
 
+c10::intrusive_ptr<Future<torch::Tensor>> ScatterAsync(
+    torch::Tensor input, torch::Tensor index, torch::Tensor src) {
+  TORCH_CHECK(
+      !utils::is_on_gpu(input) && !utils::is_on_gpu(index) &&
+      !utils::is_on_gpu(src));
+  TORCH_CHECK(index.sizes().size() == 1, "index tensor needs to be 1d.");
+  for (size_t i = 1; i < input.sizes().size(); i++) {
+    TORCH_CHECK(
+        input.size(i) == src.size(i),
+        "dimension mismatch between input.size(i) and src.size(i), ",
+        input.size(i), " != ", src.size(i), ".");
+  }
+  return async([=] {
+    const auto row_bytes = src.slice(0, 0, 1).numel() * src.element_size();
+    const auto src_ptr = reinterpret_cast<std::byte*>(src.data_ptr());
+    auto input_ptr = reinterpret_cast<std::byte*>(input.data_ptr());
+    AT_DISPATCH_INDEX_TYPES(
+        index.scalar_type(), "ScatterAsync::index::scalar_type()", ([&] {
+          const auto index_ptr = index.data_ptr<index_t>();
+          torch::parallel_for(
+              0, index.size(0), 64, [&](int64_t begin, int64_t end) {
+                for (int64_t i = begin; i < end; i++) {
+                  std::memcpy(
+                      input_ptr + index_ptr[i] * row_bytes,
+                      src_ptr + i * row_bytes, row_bytes);
+                }
+              });
+        }));
+    return input;
+  });
+}
+
 std::tuple<torch::Tensor, torch::Tensor> IndexSelectCSC(
     torch::Tensor indptr, torch::Tensor indices, torch::Tensor nodes,
     torch::optional<int64_t> output_size) {

--- a/graphbolt/src/index_select.cc
+++ b/graphbolt/src/index_select.cc
@@ -43,8 +43,8 @@ c10::intrusive_ptr<Future<torch::Tensor>> ScatterAsync(
   for (size_t i = 1; i < input.sizes().size(); i++) {
     TORCH_CHECK(
         input.size(i) == src.size(i),
-        "dimension mismatch between input.size(i) and src.size(i), ",
-        input.size(i), " != ", src.size(i), ".");
+        "dimension mismatch between input and src at " i,
+        "th dimension: ", input.size(i), " != ", src.size(i), ".");
   }
   return async([=] {
     const auto row_bytes = src.slice(0, 0, 1).numel() * src.element_size();

--- a/graphbolt/src/index_select.h
+++ b/graphbolt/src/index_select.h
@@ -59,6 +59,17 @@ c10::intrusive_ptr<Future<torch::Tensor>> IndexSelectAsync(
     torch::Tensor input, torch::Tensor index);
 
 /**
+ * @brief The async version of operation input[index] = src.
+ * @param input The input tensor.
+ * @param index The index tensor into input.
+ * @param src The src tensor being assigned into input.
+ *
+ * @return Returns a future containing input, a torch::Tensor.
+ */
+c10::intrusive_ptr<Future<torch::Tensor>> ScatterAsync(
+    torch::Tensor input, torch::Tensor index, torch::Tensor src);
+
+/**
  * @brief Select columns for a sparse matrix in a CSC format according to nodes
  * tensor.
  *

--- a/graphbolt/src/python_binding.cc
+++ b/graphbolt/src/python_binding.cc
@@ -140,6 +140,7 @@ TORCH_LIBRARY(graphbolt, m) {
   m.def("isin", &IsIn);
   m.def("index_select", &ops::IndexSelect);
   m.def("index_select_async", &ops::IndexSelectAsync);
+  m.def("scatter_async", &ops::ScatterAsync);
   m.def("index_select_csc", &ops::IndexSelectCSC);
   m.def("index_select_csc_batched", &ops::IndexSelectCSCBatched);
   m.def("ondisk_npy_array", &storage::OnDiskNpyArray::Create);

--- a/tests/python/pytorch/graphbolt/test_base.py
+++ b/tests/python/pytorch/graphbolt/test_base.py
@@ -259,6 +259,31 @@ def test_index_select(dtype, idtype, pinned):
     assert torch.equal(torch_result.cpu(), future.wait())
 
 
+@pytest.mark.parametrize(
+    "dtype",
+    [
+        torch.bool,
+        torch.uint8,
+        torch.int8,
+        torch.int16,
+        torch.int32,
+        torch.int64,
+        torch.float16,
+        torch.bfloat16,
+        torch.float32,
+        torch.float64,
+    ],
+)
+@pytest.mark.parametrize("idtype", [torch.int32, torch.int64])
+def test_scatter_async(dtype, idtype):
+    input = torch.tensor([[2, 3], [5, 5], [20, 13]], dtype=dtype)
+    index = torch.ones([1], dtype=idtype)
+    res = torch.ops.graphbolt.scatter_async(input, index, input[2:3])
+    assert torch.equal(
+        torch.tensor([[2, 3], [20, 13], [20, 13]], dtype=dtype), res.wait()
+    )
+
+
 def torch_expand_indptr(indptr, dtype, nodes=None):
     if nodes is None:
         nodes = torch.arange(len(indptr) - 1, dtype=dtype, device=indptr.device)


### PR DESCRIPTION
## Description
`torch::scatter` does not accept 1d index tensor, needs it to match the dimensionality of src tensor.

## Checklist
Please feel free to remove inapplicable items for your PR.
- [x] The PR title starts with [$CATEGORY] (such as [NN], [Model], [Doc], [Feature]])
- [x] I've leverage the [tools](https://docs.google.com/document/d/1iHyj7zlmygKSk5gBPsqIqL5ASPzJSPREaNT_QdsiYA4/edit) to beautify the python and c++ code.
- [x] The PR is complete and small, read the [Google eng practice (CL equals to PR)](https://google.github.io/eng-practices/review/developer/small-cls.html) to understand more about small PR. In DGL, we consider PRs with less than 200 lines of core code change are small (example, test and documentation could be exempted).
- [x] All changes have test coverage
- [x] Code is well-documented
- [x] To the best of my knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change
- [ ] Related issue is referred in this PR
- [ ] If the PR is for a new model/paper, I've updated the example index [here](../examples/README.md).

## Changes
<!-- You could use following template
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)
-->
