### PR TITLE
[GraphBolt] Add `read_async` to `gb.Feature`. [1]

### DIFF
--- a/python/dgl/graphbolt/feature_store.py
+++ b/python/dgl/graphbolt/feature_store.py
@@ -26,6 +26,46 @@ class Feature:
         """
         raise NotImplementedError
 
+    def read_async(self, ids: torch.Tensor):
+        """Read the feature by index asynchronously.
+        Parameters
+        ----------
+        ids : torch.Tensor
+            The index of the feature. Only the specified indices of the
+            feature are read.
+        Returns
+        -------
+        A generator object.
+            The returned generator object returns a future on
+            `read_async_num_stages(ids.device)`th invocation. The return result
+            can be accessed by calling `.wait()`. on the returned future object.
+            It is undefined behavior to call `.wait()` more than once.
+        Example Usage
+        --------
+        >>> import dgl.graphbolt as gb
+        >>> feature = gb.Feature(...)
+        >>> ids = torch.tensor([0, 2])
+        >>> async_handle = feature.read_async(ids)
+        >>> for _ in range(feature.read_async_num_stages(ids.device)):
+        ...     future = next(async_handle)
+        >>> result = future.wait()  # result contains the read values.
+        """
+        raise NotImplementedError
+
+    def read_async_num_stages(self, ids_device: torch.device):
+        """The number of stages of the read_async operation. See read_async
+        function for directions on its use.
+        Parameters
+        ----------
+        ids_device : torch.device
+            The device of the ids parameter passed into read_async.
+        Returns
+        -------
+        int
+            The number of stages of the read_async operation.
+        """
+        raise NotImplementedError
+
     def size(self):
         """Get the size of the feature.
 

--- a/python/dgl/graphbolt/impl/cpu_cached_feature.py
+++ b/python/dgl/graphbolt/impl/cpu_cached_feature.py
@@ -79,6 +79,46 @@ class CPUCachedFeature(Feature):
         self._feature.replace(missing_keys, missing_values)
         return values
 
+    def read_async(self, ids: torch.Tensor):
+        """Read the feature by index asynchronously.
+        Parameters
+        ----------
+        ids : torch.Tensor
+            The index of the feature. Only the specified indices of the
+            feature are read.
+        Returns
+        -------
+        A generator object.
+            The returned generator object returns a future on
+            `read_async_num_stages(ids.device)`th invocation. The return result
+            can be accessed by calling `.wait()`. on the returned future object.
+            It is undefined behavior to call `.wait()` more than once.
+        Example Usage
+        --------
+        >>> import dgl.graphbolt as gb
+        >>> feature = gb.Feature(...)
+        >>> ids = torch.tensor([0, 2])
+        >>> async_handle = feature.read_async(ids)
+        >>> for _ in range(feature.read_async_num_stages(ids.device)):
+        ...     future = next(async_handle)
+        >>> result = future.wait()  # result contains the read values.
+        """
+        raise NotImplementedError
+
+    def read_async_num_stages(self, ids_device: torch.device):
+        """The number of stages of the read_async operation. See read_async
+        function for directions on its use.
+        Parameters
+        ----------
+        ids_device : torch.device
+            The device of the ids parameter passed into read_async.
+        Returns
+        -------
+        int
+            The number of stages of the read_async operation.
+        """
+        raise NotImplementedError
+
     def size(self):
         """Get the size of the feature.
 

--- a/python/dgl/graphbolt/impl/gpu_cached_feature.py
+++ b/python/dgl/graphbolt/impl/gpu_cached_feature.py
@@ -88,6 +88,46 @@ class GPUCachedFeature(Feature):
         self._feature.replace(missing_keys, missing_values)
         return values
 
+    def read_async(self, ids: torch.Tensor):
+        """Read the feature by index asynchronously.
+        Parameters
+        ----------
+        ids : torch.Tensor
+            The index of the feature. Only the specified indices of the
+            feature are read.
+        Returns
+        -------
+        A generator object.
+            The returned generator object returns a future on
+            `read_async_num_stages(ids.device)`th invocation. The return result
+            can be accessed by calling `.wait()`. on the returned future object.
+            It is undefined behavior to call `.wait()` more than once.
+        Example Usage
+        --------
+        >>> import dgl.graphbolt as gb
+        >>> feature = gb.Feature(...)
+        >>> ids = torch.tensor([0, 2])
+        >>> async_handle = feature.read_async(ids)
+        >>> for _ in range(feature.read_async_num_stages(ids.device)):
+        ...     future = next(async_handle)
+        >>> result = future.wait()  # result contains the read values.
+        """
+        raise NotImplementedError
+
+    def read_async_num_stages(self, ids_device: torch.device):
+        """The number of stages of the read_async operation. See read_async
+        function for directions on its use.
+        Parameters
+        ----------
+        ids_device : torch.device
+            The device of the ids parameter passed into read_async.
+        Returns
+        -------
+        int
+            The number of stages of the read_async operation.
+        """
+        raise NotImplementedError
+
     def size(self):
         """Get the size of the feature.
 

--- a/python/dgl/graphbolt/impl/torch_based_feature_store.py
+++ b/python/dgl/graphbolt/impl/torch_based_feature_store.py
@@ -342,7 +342,7 @@ class DiskBasedFeature(Feature):
                 raise IndexError
         else:
             return index_select(self._tensor, ids)
-    
+
     def read_async(self, ids: torch.Tensor):
         """Read the feature by index asynchronously.
         Parameters

--- a/python/dgl/graphbolt/impl/torch_based_feature_store.py
+++ b/python/dgl/graphbolt/impl/torch_based_feature_store.py
@@ -121,6 +121,46 @@ class TorchBasedFeature(Feature):
             return self._tensor
         return index_select(self._tensor, ids)
 
+    def read_async(self, ids: torch.Tensor):
+        """Read the feature by index asynchronously.
+        Parameters
+        ----------
+        ids : torch.Tensor
+            The index of the feature. Only the specified indices of the
+            feature are read.
+        Returns
+        -------
+        A generator object.
+            The returned generator object returns a future on
+            `read_async_num_stages(ids.device)`th invocation. The return result
+            can be accessed by calling `.wait()`. on the returned future object.
+            It is undefined behavior to call `.wait()` more than once.
+        Example Usage
+        --------
+        >>> import dgl.graphbolt as gb
+        >>> feature = gb.Feature(...)
+        >>> ids = torch.tensor([0, 2])
+        >>> async_handle = feature.read_async(ids)
+        >>> for _ in range(feature.read_async_num_stages(ids.device)):
+        ...     future = next(async_handle)
+        >>> result = future.wait()  # result contains the read values.
+        """
+        raise NotImplementedError
+
+    def read_async_num_stages(self, ids_device: torch.device):
+        """The number of stages of the read_async operation. See read_async
+        function for directions on its use.
+        Parameters
+        ----------
+        ids_device : torch.device
+            The device of the ids parameter passed into read_async.
+        Returns
+        -------
+        int
+            The number of stages of the read_async operation.
+        """
+        raise NotImplementedError
+
     def size(self):
         """Get the size of the feature.
 
@@ -302,6 +342,46 @@ class DiskBasedFeature(Feature):
                 raise IndexError
         else:
             return index_select(self._tensor, ids)
+    
+    def read_async(self, ids: torch.Tensor):
+        """Read the feature by index asynchronously.
+        Parameters
+        ----------
+        ids : torch.Tensor
+            The index of the feature. Only the specified indices of the
+            feature are read.
+        Returns
+        -------
+        A generator object.
+            The returned generator object returns a future on
+            `read_async_num_stages(ids.device)`th invocation. The return result
+            can be accessed by calling `.wait()`. on the returned future object.
+            It is undefined behavior to call `.wait()` more than once.
+        Example Usage
+        --------
+        >>> import dgl.graphbolt as gb
+        >>> feature = gb.Feature(...)
+        >>> ids = torch.tensor([0, 2])
+        >>> async_handle = feature.read_async(ids)
+        >>> for _ in range(feature.read_async_num_stages(ids.device)):
+        ...     future = next(async_handle)
+        >>> result = future.wait()  # result contains the read values.
+        """
+        raise NotImplementedError
+
+    def read_async_num_stages(self, ids_device: torch.device):
+        """The number of stages of the read_async operation. See read_async
+        function for directions on its use.
+        Parameters
+        ----------
+        ids_device : torch.device
+            The device of the ids parameter passed into read_async.
+        Returns
+        -------
+        int
+            The number of stages of the read_async operation.
+        """
+        raise NotImplementedError
 
     def size(self):
         """Get the size of the feature.


### PR DESCRIPTION
## Description
#7540 first part.

## Checklist
Please feel free to remove inapplicable items for your PR.
- [ ] The PR title starts with [$CATEGORY] (such as [NN], [Model], [Doc], [Feature]])
- [ ] I've leverage the [tools](https://docs.google.com/document/d/1iHyj7zlmygKSk5gBPsqIqL5ASPzJSPREaNT_QdsiYA4/edit) to beautify the python and c++ code.
- [ ] The PR is complete and small, read the [Google eng practice (CL equals to PR)](https://google.github.io/eng-practices/review/developer/small-cls.html) to understand more about small PR. In DGL, we consider PRs with less than 200 lines of core code change are small (example, test and documentation could be exempted).
- [ ] All changes have test coverage
- [ ] Code is well-documented
- [ ] To the best of my knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change
- [ ] Related issue is referred in this PR
- [ ] If the PR is for a new model/paper, I've updated the example index [here](../examples/README.md).

## Changes
<!-- You could use following template
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)
-->
