### PR TITLE
[GraphBolt] Fix new delete mismatch for CachePolicy.

### DIFF
--- a/graphbolt/src/cache_policy.cc
+++ b/graphbolt/src/cache_policy.cc
@@ -124,7 +124,8 @@ void S3FifoCachePolicy::ReadingCompleted(torch::Tensor keys) {
 }
 
 SieveCachePolicy::SieveCachePolicy(int64_t capacity)
-    : hand_(queue_.end()), capacity_(capacity), cache_usage_(0) {
+    // Ensure that queue_ is constructed first before accessing its `.end()`.
+    : queue_(), hand_(queue_.end()), capacity_(capacity), cache_usage_(0) {
   TORCH_CHECK(capacity > 0, "Capacity needs to be positive.");
   key_to_cache_key_.reserve(capacity);
 }

--- a/graphbolt/src/cache_policy.h
+++ b/graphbolt/src/cache_policy.h
@@ -90,6 +90,12 @@ struct CacheKey {
 class BaseCachePolicy {
  public:
   /**
+   * @brief A virtual base class constructor ensures that the derived class
+   * destructor gets called.
+   */
+  virtual ~BaseCachePolicy() = default;
+
+  /**
    * @brief The policy query function.
    * @param keys The keys to query the cache.
    *
@@ -143,6 +149,10 @@ class S3FifoCachePolicy : public BaseCachePolicy {
   S3FifoCachePolicy(int64_t capacity);
 
   S3FifoCachePolicy() = default;
+
+  S3FifoCachePolicy(S3FifoCachePolicy&&) = default;
+
+  virtual ~S3FifoCachePolicy() = default;
 
   /**
    * @brief See BaseCachePolicy::Query.
@@ -254,6 +264,8 @@ class SieveCachePolicy : public BaseCachePolicy {
 
   SieveCachePolicy() = default;
 
+  virtual ~SieveCachePolicy() = default;
+
   /**
    * @brief See BaseCachePolicy::Query.
    */
@@ -332,6 +344,8 @@ class LruCachePolicy : public BaseCachePolicy {
 
   LruCachePolicy() = default;
 
+  virtual ~LruCachePolicy() = default;
+
   /**
    * @brief See BaseCachePolicy::Query.
    */
@@ -408,6 +422,10 @@ class ClockCachePolicy : public BaseCachePolicy {
   ClockCachePolicy(int64_t capacity);
 
   ClockCachePolicy() = default;
+
+  ClockCachePolicy(ClockCachePolicy&&) = default;
+
+  virtual ~ClockCachePolicy() = default;
 
   /**
    * @brief See BaseCachePolicy::Query.


### PR DESCRIPTION
## Description
When using virtual classes, the destructor needs to be virtual so that the derived object destructor gets called instead of the base class. Running AddressSanitizer revealed the bug, the `BaseCachePolicy` destructor was being called for the derived `CachePolicy` objects.

More information about it is here: https://learn.microsoft.com/en-us/cpp/cpp/destructors-cpp?view=msvc-170#order-of-destruction

Moreover, fixing a potential bug in `SieveCachePolicy` due to accessing uninitialized class member function before the object is constructed. It is better to ensure it is constructed manually.

## Checklist
Please feel free to remove inapplicable items for your PR.
- [ ] The PR title starts with [$CATEGORY] (such as [NN], [Model], [Doc], [Feature]])
- [ ] I've leverage the [tools](https://docs.google.com/document/d/1iHyj7zlmygKSk5gBPsqIqL5ASPzJSPREaNT_QdsiYA4/edit) to beautify the python and c++ code.
- [ ] The PR is complete and small, read the [Google eng practice (CL equals to PR)](https://google.github.io/eng-practices/review/developer/small-cls.html) to understand more about small PR. In DGL, we consider PRs with less than 200 lines of core code change are small (example, test and documentation could be exempted).
- [ ] All changes have test coverage
- [ ] Code is well-documented
- [ ] To the best of my knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change
- [ ] Related issue is referred in this PR
- [ ] If the PR is for a new model/paper, I've updated the example index [here](../examples/README.md).

## Changes
<!-- You could use following template
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)
-->
