### PR TITLE
[GraphBolt] Per-thread `RandomEngine` initialization fix.

### DIFF
--- a/graphbolt/CMakeLists.txt
+++ b/graphbolt/CMakeLists.txt
@@ -73,7 +73,6 @@ endif()
 add_library(${LIB_GRAPHBOLT_NAME} SHARED ${BOLT_SRC} ${BOLT_HEADERS})
 include_directories(BEFORE ${BOLT_DIR}
                            ${BOLT_HEADERS}
-                           "../third_party/dmlc-core/include"
                            "../third_party/pcg/include"
                            "../third_party/phmap")
 target_link_libraries(${LIB_GRAPHBOLT_NAME} "${TORCH_LIBRARIES}")

--- a/graphbolt/src/random.cc
+++ b/graphbolt/src/random.cc
@@ -35,12 +35,12 @@ std::optional<uint64_t> RandomEngine::manual_seed;
 RandomEngine::RandomEngine() {
   std::random_device rd;
   std::lock_guard lock(manual_seed_mutex);
-  uint64_t seed = manual_seed.value_or(rd());
-  SetSeed(seed);
+  if (!manual_seed.has_value()) manual_seed = rd();
+  SetSeed(manual_seed.value());
 }
 
 /** @brief Constructor with given seed. */
-RandomEngine::RandomEngine(uint64_t seed) { RandomEngine(seed, GetThreadId()); }
+RandomEngine::RandomEngine(uint64_t seed) : RandomEngine(seed, GetThreadId()) {}
 
 /** @brief Constructor with given seed. */
 RandomEngine::RandomEngine(uint64_t seed, uint64_t stream) {
@@ -49,7 +49,8 @@ RandomEngine::RandomEngine(uint64_t seed, uint64_t stream) {
 
 /** @brief Get the thread-local random number generator instance. */
 RandomEngine* RandomEngine::ThreadLocal() {
-  return dmlc::ThreadLocalStore<RandomEngine>::Get();
+  static thread_local RandomEngine engine;
+  return &engine;
 }
 
 /** @brief Set the seed. */

--- a/graphbolt/src/random.h
+++ b/graphbolt/src/random.h
@@ -8,8 +8,6 @@
 #ifndef GRAPHBOLT_RANDOM_H_
 #define GRAPHBOLT_RANDOM_H_
 
-#include <dmlc/thread_local.h>
-
 #include <mutex>
 #include <optional>
 #include <pcg_random.hpp>


### PR DESCRIPTION
## Description
Also remove unnecessary dependency on dmlc just for thread local. I have tested and each threads gets their own engines. Each run results in different random numbers for each thread because manual_seed gets initialized randomly.

## Checklist
Please feel free to remove inapplicable items for your PR.
- [ ] The PR title starts with [$CATEGORY] (such as [NN], [Model], [Doc], [Feature]])
- [ ] I've leverage the [tools](https://docs.google.com/document/d/1iHyj7zlmygKSk5gBPsqIqL5ASPzJSPREaNT_QdsiYA4/edit) to beautify the python and c++ code.
- [ ] The PR is complete and small, read the [Google eng practice (CL equals to PR)](https://google.github.io/eng-practices/review/developer/small-cls.html) to understand more about small PR. In DGL, we consider PRs with less than 200 lines of core code change are small (example, test and documentation could be exempted).
- [ ] All changes have test coverage
- [ ] Code is well-documented
- [ ] To the best of my knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change
- [ ] Related issue is referred in this PR
- [ ] If the PR is for a new model/paper, I've updated the example index [here](../examples/README.md).

## Changes
<!-- You could use following template
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)
-->
