### PR TITLE
[GraphBolt] Refactor and extend `FeatureStore`.

### DIFF
--- a/python/dgl/graphbolt/feature_store.py
+++ b/python/dgl/graphbolt/feature_store.py
@@ -127,6 +127,17 @@ class FeatureStore:
         """
         raise NotImplementedError
 
+    def __setitem__(self, feature_key: FeatureKey, feature: Feature):
+        """Set the underlying `Feature` with its (domain, type, name) as
+        the feature_key and feature as the value.
+        """
+        raise NotImplementedError
+
+    def __contains__(self, feature_key: FeatureKey) -> bool:
+        """Checks whether the provided (domain, type, name) as the feature_key
+        is container in the FeatureStore."""
+        raise NotImplementedError
+
     def read(
         self,
         domain: str,
@@ -153,7 +164,7 @@ class FeatureStore:
         torch.Tensor
             The read feature.
         """
-        raise NotImplementedError
+        return self.__getitem__((domain, type_name, feature_name)).read(ids)
 
     def size(
         self,
@@ -176,7 +187,7 @@ class FeatureStore:
         torch.Size
             The size of the specified feature in the feature store.
         """
-        raise NotImplementedError
+        return self.__getitem__((domain, type_name, feature_name)).size()
 
     def metadata(
         self,
@@ -199,7 +210,7 @@ class FeatureStore:
         Dict
             The metadata of the feature.
         """
-        raise NotImplementedError
+        return self.__getitem__((domain, type_name, feature_name)).metadata()
 
     def update(
         self,
@@ -228,7 +239,7 @@ class FeatureStore:
             must have the same length. If None, the entire feature will be
             updated.
         """
-        raise NotImplementedError
+        self.__getitem__((domain, type_name, feature_name)).update(value, ids)
 
     def keys(self):
         """Get the keys of the features.

--- a/python/dgl/graphbolt/feature_store.py
+++ b/python/dgl/graphbolt/feature_store.py
@@ -1,8 +1,20 @@
 """Feature store for GraphBolt."""
 
+from typing import NamedTuple
+
 import torch
 
-__all__ = ["Feature", "FeatureStore"]
+__all__ = ["Feature", "FeatureStore", "FeatureKey"]
+
+
+class FeatureKey(NamedTuple):
+    """A named tuple class to represent feature keys in FeatureStore classes.
+    The fields are domain, type and name all of which take string values.
+    """
+
+    domain: str
+    type: str
+    name: int
 
 
 class Feature:
@@ -108,6 +120,9 @@ class FeatureStore:
 
     def __init__(self):
         pass
+
+    def __getitem__(self, feature_key: FeatureKey) -> Feature:
+        raise NotImplementedError
 
     def read(
         self,

--- a/python/dgl/graphbolt/feature_store.py
+++ b/python/dgl/graphbolt/feature_store.py
@@ -122,6 +122,9 @@ class FeatureStore:
         pass
 
     def __getitem__(self, feature_key: FeatureKey) -> Feature:
+        """Access the underlying `Feature` with its (domain, type, name) as
+        the feature_key.
+        """
         raise NotImplementedError
 
     def read(

--- a/python/dgl/graphbolt/impl/basic_feature_store.py
+++ b/python/dgl/graphbolt/impl/basic_feature_store.py
@@ -35,109 +35,16 @@ class BasicFeatureStore(FeatureStore):
         """
         return self._features[feature_key]
 
-    def read(
-        self,
-        domain: str,
-        type_name: str,
-        feature_name: str,
-        ids: torch.Tensor = None,
-    ):
-        """Read from the feature store.
-
-        Parameters
-        ----------
-        domain : str
-            The domain of the feature such as "node", "edge" or "graph".
-        type_name : str
-            The node or edge type name.
-        feature_name : str
-            The feature name.
-        ids : torch.Tensor, optional
-            The index of the feature. If specified, only the specified indices
-            of the feature are read. If None, the entire feature is returned.
-
-        Returns
-        -------
-        torch.Tensor
-            The read feature.
+    def __setitem__(self, feature_key: FeatureKey, feature: Feature):
+        """Set the underlying `Feature` with its (domain, type, name) as
+        the feature_key and feature as the value.
         """
-        return self._features[(domain, type_name, feature_name)].read(ids)
+        self._features[feature_key] = feature
 
-    def size(
-        self,
-        domain: str,
-        type_name: str,
-        feature_name: str,
-    ):
-        """Get the size of the specified feature in the feature store.
-
-        Parameters
-        ----------
-        domain : str
-            The domain of the feature such as "node", "edge" or "graph".
-        type_name : str
-            The node or edge type name.
-        feature_name : str
-            The feature name.
-
-        Returns
-        -------
-        torch.Size
-            The size of the specified feature in the feature store.
-        """
-        return self._features[(domain, type_name, feature_name)].size()
-
-    def metadata(
-        self,
-        domain: str,
-        type_name: str,
-        feature_name: str,
-    ):
-        """Get the metadata of the specified feature in the feature store.
-
-        Parameters
-        ----------
-        domain : str
-            The domain of the feature such as "node", "edge" or "graph".
-        type_name : str
-            The node or edge type name.
-        feature_name : str
-            The feature name.
-        Returns
-        -------
-        Dict
-            The metadata of the feature.
-        """
-        return self._features[(domain, type_name, feature_name)].metadata()
-
-    def update(
-        self,
-        domain: str,
-        type_name: str,
-        feature_name: str,
-        value: torch.Tensor,
-        ids: torch.Tensor = None,
-    ):
-        """Update the feature store.
-
-        Parameters
-        ----------
-        domain : str
-            The domain of the feature such as "node", "edge" or "graph".
-        type_name : str
-            The node or edge type name.
-        feature_name : str
-            The feature name.
-        value : torch.Tensor
-            The updated value of the feature.
-        ids : torch.Tensor, optional
-            The indices of the feature to update. If specified, only the
-            specified indices of the feature will be updated. For the feature,
-            the `ids[i]` row is updated to `value[i]`. So the indices and value
-            must have the same length. If None, the entire feature will be
-            updated.
-        """
-        self._features[(domain, type_name, feature_name)].update(value, ids)
+    def __contains__(self, feature_key: FeatureKey) -> bool:
+        """Checks whether the provided (domain, type, name) as the feature_key
+        is container in the BasicFeatureStore."""
+        return feature_key in self._features
 
     def __len__(self):
         """Return the number of features."""

--- a/python/dgl/graphbolt/impl/basic_feature_store.py
+++ b/python/dgl/graphbolt/impl/basic_feature_store.py
@@ -4,7 +4,7 @@ from typing import Dict, Tuple
 
 import torch
 
-from ..feature_store import Feature, FeatureStore
+from ..feature_store import Feature, FeatureKey, FeatureStore
 
 __all__ = ["BasicFeatureStore"]
 
@@ -28,6 +28,9 @@ class BasicFeatureStore(FeatureStore):
         """
         super().__init__()
         self._features = features
+
+    def __getitem__(self, feature_key: FeatureKey) -> Feature:
+        return self._features[feature_key]
 
     def read(
         self,

--- a/python/dgl/graphbolt/impl/basic_feature_store.py
+++ b/python/dgl/graphbolt/impl/basic_feature_store.py
@@ -30,6 +30,9 @@ class BasicFeatureStore(FeatureStore):
         self._features = features
 
     def __getitem__(self, feature_key: FeatureKey) -> Feature:
+        """Access the underlying `Feature` with its (domain, type, name) as
+        the feature_key.
+        """
         return self._features[feature_key]
 
     def read(

--- a/python/dgl/graphbolt/impl/basic_feature_store.py
+++ b/python/dgl/graphbolt/impl/basic_feature_store.py
@@ -2,8 +2,6 @@
 
 from typing import Dict, Tuple
 
-import torch
-
 from ..feature_store import Feature, FeatureKey, FeatureStore
 
 __all__ = ["BasicFeatureStore"]

--- a/tests/python/pytorch/graphbolt/impl/test_basic_feature_store.py
+++ b/tests/python/pytorch/graphbolt/impl/test_basic_feature_store.py
@@ -15,6 +15,14 @@ def test_basic_feature_store_homo():
 
     feature_store = gb.BasicFeatureStore(features)
 
+    # Test __getitem__ to access the stored Feature.
+    feature = feature_store[("node", None, "a")]
+    assert isinstance(feature, gb.Feature)
+    assert torch.equal(
+        feature.read(),
+        torch.tensor([[1, 2, 4], [2, 5, 3]]),
+    )
+
     # Test read the entire feature.
     assert torch.equal(
         feature_store.read("node", None, "a"),
@@ -59,6 +67,14 @@ def test_basic_feature_store_hetero():
     features[("edge", "paper:cites", "b")] = gb.TorchBasedFeature(b)
 
     feature_store = gb.BasicFeatureStore(features)
+
+    # Test __getitem__ to access the stored Feature.
+    feature = feature_store[("node", "author", "a")]
+    assert isinstance(feature, gb.Feature)
+    assert torch.equal(
+        feature.read(),
+        torch.tensor([[1, 2, 4], [2, 5, 3]]),
+    )
 
     # Test read the entire feature.
     assert torch.equal(

--- a/tests/python/pytorch/graphbolt/impl/test_basic_feature_store.py
+++ b/tests/python/pytorch/graphbolt/impl/test_basic_feature_store.py
@@ -109,10 +109,18 @@ def test_basic_feature_store_hetero():
     assert feature_store.metadata("node", "author", "a") == metadata
     assert feature_store.metadata("edge", "paper:cites", "b") == {}
 
+    # Test __setitem__ and __contains__ of FeatureStore.
+    assert ("node", "author", "c") not in feature_store
+    feature_store[("node", "author", "c")] = feature_store[
+        ("node", "author", "a")
+    ]
+    assert ("node", "author", "c") in feature_store
+
     # Test get keys of the features.
     assert feature_store.keys() == [
         ("node", "author", "a"),
         ("edge", "paper:cites", "b"),
+        ("node", "author", "c"),
     ]
 
 

--- a/tests/python/pytorch/graphbolt/impl/test_basic_feature_store.py
+++ b/tests/python/pytorch/graphbolt/impl/test_basic_feature_store.py
@@ -51,8 +51,17 @@ def test_basic_feature_store_homo():
     assert feature_store.metadata("node", None, "a") == metadata
     assert feature_store.metadata("node", None, "b") == {}
 
+    # Test __setitem__ and __contains__ of FeatureStore.
+    assert ("node", None, "c") not in feature_store
+    feature_store[("node", None, "c")] = feature_store[("node", None, "a")]
+    assert ("node", None, "c") in feature_store
+
     # Test get keys of the features.
-    assert feature_store.keys() == [("node", None, "a"), ("node", None, "b")]
+    assert feature_store.keys() == [
+        ("node", None, "a"),
+        ("node", None, "b"),
+        ("node", None, "c"),
+    ]
 
 
 def test_basic_feature_store_hetero():


### PR DESCRIPTION
## Description
We don't need to expose `Feature.read_async` and related functions in `FeatureStore`. This functionality will let us access the stored Features in FeatureFetcher and we will be able to call the hidden read_async functions as the user will mostly keep 
FeatureStore objects around, not Features. Moreover, it is possible to provide the implementations of read, update and other functions if we expose a `__getitem__` method, increasing code reuse.

It will also make the examples look better and our components easier to use.
https://github.com/dmlc/dgl/blob/69fd95e370fb935dbce9896ad56165b8097dcd3e/examples/multigpu/graphbolt/node_classification.py#L299-L303

## Checklist
Please feel free to remove inapplicable items for your PR.
- [ ] The PR title starts with [$CATEGORY] (such as [NN], [Model], [Doc], [Feature]])
- [ ] I've leverage the [tools](https://docs.google.com/document/d/1iHyj7zlmygKSk5gBPsqIqL5ASPzJSPREaNT_QdsiYA4/edit) to beautify the python and c++ code.
- [ ] The PR is complete and small, read the [Google eng practice (CL equals to PR)](https://google.github.io/eng-practices/review/developer/small-cls.html) to understand more about small PR. In DGL, we consider PRs with less than 200 lines of core code change are small (example, test and documentation could be exempted).
- [ ] All changes have test coverage
- [ ] Code is well-documented
- [ ] To the best of my knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change
- [ ] Related issue is referred in this PR
- [ ] If the PR is for a new model/paper, I've updated the example index [here](../examples/README.md).

## Changes
<!-- You could use following template
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)
-->
