### PR TITLE
[GraphBolt][CUDA] Eliminate memory leaks in `FeatureFetcher`.

### DIFF
--- a/python/dgl/graphbolt/impl/cpu_cached_feature.py
+++ b/python/dgl/graphbolt/impl/cpu_cached_feature.py
@@ -173,6 +173,7 @@ class CPUCachedFeature(Feature):
             reading_completed.wait()
             replace_future.wait()
             reading_completed = policy.reading_completed_async(missing_keys)
+            num_found = positions.size(0)
 
             class _Waiter:
                 def __init__(self, events, existing, missing, index):
@@ -190,8 +191,8 @@ class CPUCachedFeature(Feature):
                         dtype=self.missing.dtype,
                         device=ids_device,
                     )
-                    found_index = self.index[: positions.size(0)]
-                    missing_index = self.index[positions.size(0) :]
+                    found_index = self.index[: num_found]
+                    missing_index = self.index[num_found :]
                     values[found_index] = self.existing
                     values[missing_index] = self.missing
                     # Ensure there is no memory leak.

--- a/python/dgl/graphbolt/impl/cpu_cached_feature.py
+++ b/python/dgl/graphbolt/impl/cpu_cached_feature.py
@@ -191,8 +191,8 @@ class CPUCachedFeature(Feature):
                         dtype=self.missing.dtype,
                         device=ids_device,
                     )
-                    found_index = self.index[: num_found]
-                    missing_index = self.index[num_found :]
+                    found_index = self.index[:num_found]
+                    missing_index = self.index[num_found:]
                     values[found_index] = self.existing
                     values[missing_index] = self.missing
                     # Ensure there is no memory leak.


### PR DESCRIPTION
## Description
When the class' static wait method captures tensors, some of them stay in memory for way too long, causing memory leak and running out of memory. Storing the captured variables as member variables instead resolves the issue.

## Checklist
Please feel free to remove inapplicable items for your PR.
- [ ] The PR title starts with [$CATEGORY] (such as [NN], [Model], [Doc], [Feature]])
- [ ] I've leverage the [tools](https://docs.google.com/document/d/1iHyj7zlmygKSk5gBPsqIqL5ASPzJSPREaNT_QdsiYA4/edit) to beautify the python and c++ code.
- [ ] The PR is complete and small, read the [Google eng practice (CL equals to PR)](https://google.github.io/eng-practices/review/developer/small-cls.html) to understand more about small PR. In DGL, we consider PRs with less than 200 lines of core code change are small (example, test and documentation could be exempted).
- [ ] All changes have test coverage
- [ ] Code is well-documented
- [ ] To the best of my knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change
- [ ] Related issue is referred in this PR
- [ ] If the PR is for a new model/paper, I've updated the example index [here](../examples/README.md).

## Changes
<!-- You could use following template
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)
-->
