### PR TITLE
[GraphBolt] CachePolicy Writer lock for read_async correctness.

### DIFF
--- a/graphbolt/src/feature_cache.cc
+++ b/graphbolt/src/feature_cache.cc
@@ -72,6 +72,7 @@ void FeatureCache::Replace(torch::Tensor positions, torch::Tensor values) {
   auto values_ptr = reinterpret_cast<std::byte*>(values.data_ptr());
   const auto tensor_ptr = reinterpret_cast<std::byte*>(tensor_.data_ptr());
   const auto positions_ptr = positions.data_ptr<int64_t>();
+  std::lock_guard lock(mtx_);
   torch::parallel_for(
       0, positions.size(0), kIntGrainSize, [&](int64_t begin, int64_t end) {
         for (int64_t i = begin; i < end; i++) {

--- a/graphbolt/src/feature_cache.h
+++ b/graphbolt/src/feature_cache.h
@@ -89,6 +89,8 @@ struct FeatureCache : public torch::CustomClassHolder {
 
  private:
   torch::Tensor tensor_;
+  // Protects writes only as reads are guaranteed to be safe.
+  std::mutex mtx_;
 };
 
 }  // namespace storage

--- a/graphbolt/src/partitioned_cache_policy.h
+++ b/graphbolt/src/partitioned_cache_policy.h
@@ -81,13 +81,24 @@ class PartitionedCachePolicy : public BaseCachePolicy,
 
   c10::intrusive_ptr<Future<torch::Tensor>> ReplaceAsync(torch::Tensor keys);
 
+  template <bool write>
+  void ReadingWritingCompletedImpl(torch::Tensor keys);
+
   /**
    * @brief A reader has finished reading these keys, so they can be evicted.
    * @param keys The keys to unmark.
    */
   void ReadingCompleted(torch::Tensor keys);
 
+  /**
+   * @brief A writer has finished writing these keys, so they can be evicted.
+   * @param keys The keys to unmark.
+   */
+  void WritingCompleted(torch::Tensor keys);
+
   c10::intrusive_ptr<Future<void>> ReadingCompletedAsync(torch::Tensor keys);
+
+  c10::intrusive_ptr<Future<void>> WritingCompletedAsync(torch::Tensor keys);
 
   template <typename CachePolicy>
   static c10::intrusive_ptr<PartitionedCachePolicy> Create(

--- a/graphbolt/src/python_binding.cc
+++ b/graphbolt/src/python_binding.cc
@@ -114,7 +114,13 @@ TORCH_LIBRARY(graphbolt, m) {
           &storage::PartitionedCachePolicy::ReadingCompleted)
       .def(
           "reading_completed_async",
-          &storage::PartitionedCachePolicy::ReadingCompletedAsync);
+          &storage::PartitionedCachePolicy::ReadingCompletedAsync)
+      .def(
+          "writing_completed",
+          &storage::PartitionedCachePolicy::WritingCompleted)
+      .def(
+          "writing_completed_async",
+          &storage::PartitionedCachePolicy::WritingCompletedAsync);
   m.def(
       "s3_fifo_cache_policy",
       &storage::PartitionedCachePolicy::Create<storage::S3FifoCachePolicy>);

--- a/python/dgl/graphbolt/impl/cpu_cached_feature.py
+++ b/python/dgl/graphbolt/impl/cpu_cached_feature.py
@@ -172,7 +172,7 @@ class CPUCachedFeature(Feature):
 
             reading_completed.wait()
             replace_future.wait()
-            reading_completed = policy.reading_completed_async(missing_keys)
+            writing_completed = policy.writing_completed_async(missing_keys)
             num_found = positions.size(0)
 
             class _Waiter:
@@ -201,7 +201,7 @@ class CPUCachedFeature(Feature):
                     return values
 
             yield _Waiter(
-                [missing_values_copy_event, reading_completed],
+                [missing_values_copy_event, writing_completed],
                 values_from_cpu,
                 missing_values_cuda,
                 index,
@@ -264,7 +264,7 @@ class CPUCachedFeature(Feature):
 
             reading_completed.wait()
             replace_future.wait()
-            reading_completed = policy.reading_completed_async(missing_keys)
+            writing_completed = policy.writing_completed_async(missing_keys)
 
             class _Waiter:
                 def __init__(self, events, values):
@@ -280,7 +280,7 @@ class CPUCachedFeature(Feature):
                     self.events = self.values = None
                     return values
 
-            yield _Waiter([values_copy_event, reading_completed], values_cuda)
+            yield _Waiter([values_copy_event, writing_completed], values_cuda)
         else:
             policy_future = policy.query_async(ids)
 
@@ -319,7 +319,7 @@ class CPUCachedFeature(Feature):
 
             reading_completed.wait()
             replace_future.wait()
-            reading_completed = policy.reading_completed_async(missing_keys)
+            writing_completed = policy.writing_completed_async(missing_keys)
 
             class _Waiter:
                 def __init__(self, event, values):
@@ -334,7 +334,7 @@ class CPUCachedFeature(Feature):
                     self.event = self.values = None
                     return values
 
-            yield _Waiter(reading_completed, values)
+            yield _Waiter(writing_completed, values)
 
     def read_async_num_stages(self, ids_device: torch.device):
         """The number of stages of the read_async operation. See read_async

--- a/python/dgl/graphbolt/impl/feature_cache.py
+++ b/python/dgl/graphbolt/impl/feature_cache.py
@@ -96,7 +96,7 @@ class CPUFeatureCache(object):
         """
         positions = self._policy.replace(keys)
         self._cache.replace(positions, values)
-        self._policy.reading_completed(keys)
+        self._policy.writing_completed(keys)
 
     @property
     def miss_rate(self):


### PR DESCRIPTION
## Description
In async feature loading pipeline, after we insert into the policy, values may not be still written into the cache yet. Using writer locks in addition to reader locks, we can act as if inserted values whose payload has not been inserted yet do not exist during our reads.

The PR is a bit large because I needed to do the change for all 4 cache policies at once.

## Checklist
Please feel free to remove inapplicable items for your PR.
- [ ] The PR title starts with [$CATEGORY] (such as [NN], [Model], [Doc], [Feature]])
- [ ] I've leverage the [tools](https://docs.google.com/document/d/1iHyj7zlmygKSk5gBPsqIqL5ASPzJSPREaNT_QdsiYA4/edit) to beautify the python and c++ code.
- [ ] The PR is complete and small, read the [Google eng practice (CL equals to PR)](https://google.github.io/eng-practices/review/developer/small-cls.html) to understand more about small PR. In DGL, we consider PRs with less than 200 lines of core code change are small (example, test and documentation could be exempted).
- [ ] All changes have test coverage
- [ ] Code is well-documented
- [ ] To the best of my knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change
- [ ] Related issue is referred in this PR
- [ ] If the PR is for a new model/paper, I've updated the example index [here](../examples/README.md).

## Changes
<!-- You could use following template
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)
-->
