### PR TITLE
[GraphBolt] Use parallel_for and return replace partition out.

### DIFF
--- a/graphbolt/src/cache_policy.cc
+++ b/graphbolt/src/cache_policy.cc
@@ -45,6 +45,7 @@ BaseCachePolicy::QueryImpl(CachePolicy& policy, torch::Tensor keys) {
         auto positions_ptr = positions.data_ptr<int64_t>();
         auto indices_ptr = indices.data_ptr<int64_t>();
         auto filtered_keys_ptr = filtered_keys.data_ptr<index_t>();
+        std::lock_guard lock(*policy.mtx_);
         for (int64_t i = 0; i < keys.size(0); i++) {
           const auto key = keys_ptr[i];
           auto pos = policy.template Read<false>(key);
@@ -76,6 +77,7 @@ torch::Tensor BaseCachePolicy::ReplaceImpl(
         auto positions_ptr = positions.data_ptr<int64_t>();
         phmap::flat_hash_set<int64_t> position_set;
         position_set.reserve(keys.size(0));
+        std::lock_guard lock(*policy.mtx_);
         for (int64_t i = 0; i < keys.size(0); i++) {
           const auto key = keys_ptr[i];
           const auto pos_optional = policy.template Read<true>(key);
@@ -97,6 +99,7 @@ void BaseCachePolicy::ReadingWritingCompletedImpl(
   AT_DISPATCH_INDEX_TYPES(
       keys.scalar_type(), "BaseCachePolicy::ReadingCompleted", ([&] {
         auto keys_ptr = keys.data_ptr<index_t>();
+        std::lock_guard lock(*policy.mtx_);
         for (int64_t i = 0; i < keys.size(0); i++) {
           policy.template Unmark<write>(keys_ptr[i]);
         }

--- a/graphbolt/src/cache_policy.h
+++ b/graphbolt/src/cache_policy.h
@@ -25,6 +25,7 @@
 #include <torch/torch.h>
 
 #include <limits>
+#include <mutex>
 
 #include "./circular_queue.h"
 
@@ -110,6 +111,7 @@ struct CacheKey {
 
 class BaseCachePolicy {
  public:
+  BaseCachePolicy() : mtx_(std::make_shared<std::mutex>()) {}
   /**
    * @brief A virtual base class constructor ensures that the derived class
    * destructor gets called.
@@ -161,6 +163,8 @@ class BaseCachePolicy {
   template <bool write, typename CachePolicy>
   static void ReadingWritingCompletedImpl(
       CachePolicy& policy, torch::Tensor keys);
+
+  std::shared_ptr<std::mutex> mtx_;
 };
 
 /**

--- a/graphbolt/src/feature_cache.cc
+++ b/graphbolt/src/feature_cache.cc
@@ -47,7 +47,7 @@ torch::Tensor FeatureCache::Query(
   const auto tensor_ptr = reinterpret_cast<std::byte*>(tensor_.data_ptr());
   const auto positions_ptr = positions.data_ptr<int64_t>();
   const auto indices_ptr = indices.data_ptr<int64_t>();
-  torch::parallel_for(
+  graphbolt::parallel_for(
       0, positions.size(0), kIntGrainSize, [&](int64_t begin, int64_t end) {
         for (int64_t i = begin; i < end; i++) {
           std::memcpy(
@@ -73,7 +73,7 @@ void FeatureCache::Replace(torch::Tensor positions, torch::Tensor values) {
   const auto tensor_ptr = reinterpret_cast<std::byte*>(tensor_.data_ptr());
   const auto positions_ptr = positions.data_ptr<int64_t>();
   std::lock_guard lock(mtx_);
-  torch::parallel_for(
+  graphbolt::parallel_for(
       0, positions.size(0), kIntGrainSize, [&](int64_t begin, int64_t end) {
         for (int64_t i = begin; i < end; i++) {
           std::memcpy(

--- a/graphbolt/src/partitioned_cache_policy.cc
+++ b/graphbolt/src/partitioned_cache_policy.cc
@@ -53,7 +53,7 @@ PartitionedCachePolicy::Partition(torch::Tensor keys) {
   AT_DISPATCH_INDEX_TYPES(
       keys.scalar_type(), "PartitionedCachePolicy::partition", ([&] {
         auto keys_ptr = keys.data_ptr<index_t>();
-        using gb = graphbolt;
+        namespace gb = graphbolt;
         gb::parallel_for(0, num_parts, 1, [&](int64_t begin, int64_t end) {
           if (begin == end) return;
           TORCH_CHECK(end - begin == 1);
@@ -103,7 +103,7 @@ PartitionedCachePolicy::Partition(torch::Tensor keys) {
       keys.scalar_type(), "PartitionedCachePolicy::partition", ([&] {
         auto keys_ptr = keys.data_ptr<index_t>();
         auto permuted_keys_ptr = permuted_keys.data_ptr<index_t>();
-        using gb = graphbolt;
+        namespace gb = graphbolt;
         gb::parallel_for(0, num_parts, 1, [&](int64_t begin, int64_t end) {
           if (begin == end) return;
           const auto tid = begin;
@@ -136,7 +136,7 @@ PartitionedCachePolicy::Query(torch::Tensor keys) {
   torch::Tensor result_offsets_tensor =
       torch::empty(policies_.size() * 2 + 1, offsets.options());
   auto result_offsets = result_offsets_tensor.data_ptr<int64_t>();
-  using gb = graphbolt;
+  namespace gb = graphbolt;
   gb::parallel_for(0, policies_.size(), 1, [&](int64_t begin, int64_t end) {
     if (begin == end) return;
     TORCH_CHECK(end - begin == 1);
@@ -220,7 +220,7 @@ std::vector<torch::Tensor> PartitionedCachePolicy::Replace(torch::Tensor keys) {
   auto offsets_ptr = offsets.data_ptr<int64_t>();
   auto indices_ptr = indices.data_ptr<int64_t>();
   auto output_positions_ptr = output_positions.data_ptr<int64_t>();
-  using gb = graphbolt;
+  namespace gb = graphbolt;
   gb::parallel_for(0, policies_.size(), 1, [&](int64_t begin, int64_t end) {
     if (begin == end) return;
     const auto tid = begin;
@@ -263,7 +263,7 @@ void PartitionedCachePolicy::ReadingWritingCompletedImpl(
     TORCH_CHECK("partition_result.size() should equal 0 or 3.");
   }
   auto offsets_ptr = offsets.data_ptr<int64_t>();
-  using gb = graphbolt;
+  namespace gb = graphbolt;
   gb::parallel_for(0, policies_.size(), 1, [&](int64_t begin, int64_t end) {
     if (begin == end) return;
     const auto tid = begin;

--- a/python/dgl/graphbolt/impl/feature_cache.py
+++ b/python/dgl/graphbolt/impl/feature_cache.py
@@ -78,7 +78,7 @@ class CPUFeatureCache(object):
         self.total_queries += keys.shape[0]
         positions, index, missing_keys, found_keys = self._policy.query(keys)
         values = self._cache.query(positions, index, keys.shape[0])
-        self._policy.reading_completed(found_keys)
+        self._policy.reading_completed(found_keys, [])
         self.total_miss += missing_keys.shape[0]
         missing_index = index[positions.size(0) :]
         return values, missing_index, missing_keys
@@ -94,9 +94,10 @@ class CPUFeatureCache(object):
         values: Tensor
             The values to insert to the cache.
         """
-        positions = self._policy.replace(keys)
+        output = self._policy.replace(keys)
+        positions = output[0]
         self._cache.replace(positions, values)
-        self._policy.writing_completed(keys)
+        self._policy.writing_completed(keys, output[1:])
 
     @property
     def miss_rate(self):


### PR DESCRIPTION
## Description

1. Make `BaseCachePolicy` threadsafe instead of `PartitionedCachePolicy`.
2. Switch to `graphbolt::parallel_for`.
3. Avoid torch native CPU ops that might spawn OpenMP threadpool.
4. Reuse the partition result from `PartitionedCachePolicy::Replace` in `PartitionedCachePolicy::WritingCompleted`.

## Checklist
Please feel free to remove inapplicable items for your PR.
- [ ] The PR title starts with [$CATEGORY] (such as [NN], [Model], [Doc], [Feature]])
- [ ] I've leverage the [tools](https://docs.google.com/document/d/1iHyj7zlmygKSk5gBPsqIqL5ASPzJSPREaNT_QdsiYA4/edit) to beautify the python and c++ code.
- [ ] The PR is complete and small, read the [Google eng practice (CL equals to PR)](https://google.github.io/eng-practices/review/developer/small-cls.html) to understand more about small PR. In DGL, we consider PRs with less than 200 lines of core code change are small (example, test and documentation could be exempted).
- [ ] All changes have test coverage
- [ ] Code is well-documented
- [ ] To the best of my knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change
- [ ] Related issue is referred in this PR
- [ ] If the PR is for a new model/paper, I've updated the example index [here](../examples/README.md).

## Changes
<!-- You could use following template
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)
-->
