### PR TITLE
[GRAPHBOLT] Activation of `test_exclude_seed_edges` for CPU

### DIFF
--- a/tests/python/pytorch/graphbolt/test_utils.py
+++ b/tests/python/pytorch/graphbolt/test_utils.py
@@ -117,7 +117,7 @@ def test_exclude_seed_edges_homo_cpu():
             )
 
 
-def test_exclude_seed_edges_gpu():
+def test_exclude_seed_edges():
     graph = dgl.graph(([5, 0, 7, 7, 2, 4], [0, 1, 2, 2, 3, 4]))
     graph = gb.from_dglgraph(graph, is_homogeneous=True).to(F.ctx())
     items = torch.LongTensor([[0, 3], [4, 4]])

--- a/tests/python/pytorch/graphbolt/test_utils.py
+++ b/tests/python/pytorch/graphbolt/test_utils.py
@@ -117,10 +117,6 @@ def test_exclude_seed_edges_homo_cpu():
             )
 
 
-@unittest.skipIf(
-    F._default_context_str == "cpu",
-    reason="Fails due to different result on the CPU.",
-)
 def test_exclude_seed_edges_gpu():
     graph = dgl.graph(([5, 0, 7, 7, 2, 4], [0, 1, 2, 2, 3, 4]))
     graph = gb.from_dglgraph(graph, is_homogeneous=True).to(F.ctx())

--- a/tests/python/pytorch/graphbolt/test_utils.py
+++ b/tests/python/pytorch/graphbolt/test_utils.py
@@ -134,7 +134,7 @@ def test_exclude_seed_edges_gpu():
         deduplicate=True,
     )
     datapipe = datapipe.transform(partial(gb.exclude_seed_edges))
-    if torch.cuda.get_device_capability()[0] < 7:
+    if F.ctx() != F.cpu() and torch.cuda.get_device_capability()[0] < 7:
         original_row_node_ids = [
             torch.tensor([0, 3, 4, 2, 5, 7]).to(F.ctx()),
             torch.tensor([0, 3, 4, 2, 5]).to(F.ctx()),


### PR DESCRIPTION
## Description
<!-- Brief description. Refer to the related issues if existed.
It'll be great if relevant reviewers can be assigned as well.-->
The existing `test_exclude_seed_edges_gpu` has been modified to run on the CPU as well.

## Checklist
Please feel free to remove inapplicable items for your PR.
- [x] The PR title starts with [$CATEGORY] (such as [NN], [Model], [Doc], [Feature]])
- [x] I've leverage the [tools](https://docs.google.com/document/d/1iHyj7zlmygKSk5gBPsqIqL5ASPzJSPREaNT_QdsiYA4/edit) to beautify the python and c++ code.
- [x] The PR is complete and small, read the [Google eng practice (CL equals to PR)](https://google.github.io/eng-practices/review/developer/small-cls.html) to understand more about small PR. In DGL, we consider PRs with less than 200 lines of core code change are small (example, test and documentation could be exempted).
- [x] To the best of my knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change


## Changes
<!-- You could use following template
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)
-->
