### PR TITLE
[GraphBolt][CUDA] Fix `overlap_graph_fetch` edge_ids.

### DIFF
--- a/graphbolt/include/graphbolt/cuda_ops.h
+++ b/graphbolt/include/graphbolt/cuda_ops.h
@@ -131,6 +131,8 @@ std::tuple<torch::Tensor, torch::Tensor> IndexSelectCSCImpl(
  * @param indices_list Vector of indices tensor with edge information of shape
  * (indptr[N],).
  * @param nodes Nodes tensor with shape (M,).
+ * @param with_edge_ids Whether to return edge ids tensor corresponding to
+ * sliced edges as the last element of the output.
  * @param output_size The total number of edges being copied.
  * @return (torch::Tensor, std::vector<torch::Tensor>) Output indptr and vector
  * of indices tensors of shapes (M + 1,) and ((indptr[nodes + 1] -
@@ -138,7 +140,8 @@ std::tuple<torch::Tensor, torch::Tensor> IndexSelectCSCImpl(
  */
 std::tuple<torch::Tensor, std::vector<torch::Tensor>> IndexSelectCSCBatchedImpl(
     torch::Tensor indptr, std::vector<torch::Tensor> indices_list,
-    torch::Tensor nodes, torch::optional<int64_t> output_size);
+    torch::Tensor nodes, bool with_edge_ids,
+    torch::optional<int64_t> output_size);
 
 /**
  * @brief Slices the indptr tensor with nodes and returns the indegrees of the

--- a/graphbolt/src/cuda/index_select_csc_impl.cu
+++ b/graphbolt/src/cuda/index_select_csc_impl.cu
@@ -308,7 +308,8 @@ std::tuple<torch::Tensor, torch::Tensor> IndexSelectCSCImpl(
 
 std::tuple<torch::Tensor, std::vector<torch::Tensor>> IndexSelectCSCBatchedImpl(
     torch::Tensor indptr, std::vector<torch::Tensor> indices_list,
-    torch::Tensor nodes, torch::optional<int64_t> output_size) {
+    torch::Tensor nodes, bool with_edge_ids,
+    torch::optional<int64_t> output_size) {
   auto [in_degree, sliced_indptr] = SliceCSCIndptr(indptr, nodes);
   std::vector<torch::Tensor> results;
   results.reserve(indices_list.size());
@@ -321,6 +322,11 @@ std::tuple<torch::Tensor, std::vector<torch::Tensor>> IndexSelectCSCBatchedImpl(
     if (!output_size.has_value()) output_size = output_indices.size(0);
     TORCH_CHECK(*output_size == output_indices.size(0));
     results.push_back(output_indices);
+  }
+  if (with_edge_ids) {
+    results.push_back(IndptrEdgeIdsImpl(
+        output_indptr, sliced_indptr.scalar_type(), sliced_indptr,
+        output_size));
   }
   return {output_indptr, results};
 }

--- a/graphbolt/src/index_select.h
+++ b/graphbolt/src/index_select.h
@@ -79,14 +79,18 @@ c10::intrusive_ptr<Future<torch::Tensor>> ScatterAsync(
  * @param indices_list Vector of indices tensor with edge information of shape
  * (indptr[N],).
  * @param nodes Nodes tensor with shape (M,).
+ * @param with_edge_ids Whether to return edge ids tensor corresponding to
+ * sliced edges as the last element of the output.
  * @param output_size The total number of edges being copied.
+ *
  * @return (torch::Tensor, std::vector<torch::Tensor>) Output indptr and vector
  * of indices tensors of shapes (M + 1,) and ((indptr[nodes + 1] -
  * indptr[nodes]).sum(),).
  */
 std::tuple<torch::Tensor, std::vector<torch::Tensor>> IndexSelectCSCBatched(
     torch::Tensor indptr, std::vector<torch::Tensor> indices_list,
-    torch::Tensor nodes, torch::optional<int64_t> output_size);
+    torch::Tensor nodes, bool with_edge_ids,
+    torch::optional<int64_t> output_size);
 
 }  // namespace ops
 }  // namespace graphbolt

--- a/tests/python/pytorch/graphbolt/impl/test_neighbor_sampler.py
+++ b/tests/python/pytorch/graphbolt/impl/test_neighbor_sampler.py
@@ -92,7 +92,7 @@ def test_NeighborSampler_GraphFetch(
     assert len(expected_results) == len(new_results)
     for a, b in zip(expected_results, new_results):
         # TODO @mfbalin: Fix the edge id bug and enable this test.
-        assert True or repr(a) == repr(b)
+        assert num_cached_edges != 0 or repr(a) == repr(b)
 
 
 @pytest.mark.parametrize("layer_dependency", [False, True])

--- a/tests/python/pytorch/graphbolt/test_dataloader.py
+++ b/tests/python/pytorch/graphbolt/test_dataloader.py
@@ -165,7 +165,10 @@ def test_gpu_sampling_DataLoader(
             assert "b" in minibatch.node_features
             assert "c" in minibatch.node_features
             # TODO @mfbalin: enable this if.
-            if False and sampler_name == "LayerNeighborSampler":
+            if (
+                num_gpu_cached_edges == 0
+                and sampler_name == "LayerNeighborSampler"
+            ):
                 assert torch.equal(
                     minibatch.node_features["a"], minibatch2.node_features["a"]
                 )
@@ -174,6 +177,9 @@ def test_gpu_sampling_DataLoader(
                 edge_feature = minibatch.edge_features[layer_id]["d"]
                 edge_feature_ref = minibatch2.edge_features[layer_id]["d"]
                 # TODO @mfbalin: enable this if.
-                if False and sampler_name == "LayerNeighborSampler":
+                if (
+                    num_gpu_cached_edges == 0
+                    and sampler_name == "LayerNeighborSampler"
+                ):
                     assert torch.equal(edge_feature, edge_feature_ref)
     assert len(list(dataloader)) == N // B


### PR DESCRIPTION
## Description
Fixes the edge id incorrectness issue for the general noncached graph case. Cached graph case will be fixes in a later PR.

## Checklist
Please feel free to remove inapplicable items for your PR.
- [ ] The PR title starts with [$CATEGORY] (such as [NN], [Model], [Doc], [Feature]])
- [ ] I've leverage the [tools](https://docs.google.com/document/d/1iHyj7zlmygKSk5gBPsqIqL5ASPzJSPREaNT_QdsiYA4/edit) to beautify the python and c++ code.
- [ ] The PR is complete and small, read the [Google eng practice (CL equals to PR)](https://google.github.io/eng-practices/review/developer/small-cls.html) to understand more about small PR. In DGL, we consider PRs with less than 200 lines of core code change are small (example, test and documentation could be exempted).
- [ ] All changes have test coverage
- [ ] Code is well-documented
- [ ] To the best of my knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change
- [ ] Related issue is referred in this PR
- [ ] If the PR is for a new model/paper, I've updated the example index [here](../examples/README.md).

## Changes
<!-- You could use following template
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)
-->
