### PR TITLE
[GraphBolt] Pin torchdata version `<0.8.0`.

### DIFF
--- a/python/setup.py
+++ b/python/setup.py
@@ -226,14 +226,14 @@ install_requires = [
     "requests>=2.19.0",
     "tqdm",
     "psutil>=5.8.0",
-    "torchdata>=0.5.0",
+    "torchdata>=0.5.0,<0.8.0",
     "pandas",
     "packaging",
     "pyyaml",
     "pydantic>=2.0",
 ]
 if "DGLBACKEND" in os.environ and os.environ["DGLBACKEND"] != "pytorch":
-    install_requires.pop(install_requires.index("torchdata>=0.5.0"))
+    install_requires.pop(install_requires.index("torchdata>=0.5.0,<0.8.0"))
 
 setup(
     name="dgl" + os.getenv("DGL_PACKAGE_SUFFIX", ""),


### PR DESCRIPTION
## Description
Datapipes are deprecated starting from `0.8.0`. Torch devs told me we can pin it to be lower than `0.8.0`.

https://github.com/pytorch/data/blob/7bfd68954fe590c3885be3623f85fbaa58a3c7df/torchdata/datapipes/__init__.py#L18

## Checklist
Please feel free to remove inapplicable items for your PR.
- [ ] The PR title starts with [$CATEGORY] (such as [NN], [Model], [Doc], [Feature]])
- [ ] I've leverage the [tools](https://docs.google.com/document/d/1iHyj7zlmygKSk5gBPsqIqL5ASPzJSPREaNT_QdsiYA4/edit) to beautify the python and c++ code.
- [ ] The PR is complete and small, read the [Google eng practice (CL equals to PR)](https://google.github.io/eng-practices/review/developer/small-cls.html) to understand more about small PR. In DGL, we consider PRs with less than 200 lines of core code change are small (example, test and documentation could be exempted).
- [ ] All changes have test coverage
- [ ] Code is well-documented
- [ ] To the best of my knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change
- [ ] Related issue is referred in this PR
- [ ] If the PR is for a new model/paper, I've updated the example index [here](../examples/README.md).

## Changes
<!-- You could use following template
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)
-->
