### PR TITLE
[GraphBolt] Optimize `CachePolicy` even further.

### DIFF
--- a/graphbolt/src/cache_policy.cc
+++ b/graphbolt/src/cache_policy.cc
@@ -114,7 +114,6 @@ std::tuple<torch::Tensor, torch::Tensor> BaseCachePolicy::ReplaceImpl(
 template <bool write, typename CachePolicy>
 void BaseCachePolicy::ReadingWritingCompletedImpl(
     CachePolicy& policy, torch::Tensor pointers) {
-  NVTX3_FUNC_RANGE();
   static_assert(
       sizeof(CacheKey*) == sizeof(int64_t), "You need 64 bit pointers.");
   auto pointers_ptr =

--- a/graphbolt/src/cache_policy.h
+++ b/graphbolt/src/cache_policy.h
@@ -111,7 +111,7 @@ struct CacheKey {
 
 class BaseCachePolicy {
  public:
-  BaseCachePolicy() : mtx_(std::make_shared<std::mutex>()) {}
+  BaseCachePolicy() = default;
   /**
    * @brief A virtual base class constructor ensures that the derived class
    * destructor gets called.
@@ -122,11 +122,11 @@ class BaseCachePolicy {
    * @brief The policy query function.
    * @param keys The keys to query the cache.
    *
-   * @return (positions, indices, missing_keys, found_keys), where positions has
+   * @return (positions, indices, missing_keys, found_ptrs), where positions has
    * the locations of the keys which were found in the cache, missing_keys has
    * the keys that were not found and indices is defined such that
-   * keys[indices[:positions.size(0)]] gives us the found keys and
-   * keys[indices[positions.size(0):]] is identical to missing_keys.
+   * keys[indices[:positions.size(0)]] gives us the keys for the found pointers
+   * and keys[indices[positions.size(0):]] is identical to missing_keys.
    */
   virtual std::tuple<torch::Tensor, torch::Tensor, torch::Tensor, torch::Tensor>
   Query(torch::Tensor keys) = 0;
@@ -135,22 +135,24 @@ class BaseCachePolicy {
    * @brief The policy replace function.
    * @param keys The keys to query the cache.
    *
-   * @return positions tensor is returned holding the locations of the replaced
-   * entries in the cache.
+   * @return (positions, pointers), where positions has the locations of the
+   * replaced entries and pointers point to their CacheKey pointers in the
+   * cache.
    */
-  virtual torch::Tensor Replace(torch::Tensor keys) = 0;
+  virtual std::tuple<torch::Tensor, torch::Tensor> Replace(
+      torch::Tensor keys) = 0;
 
   /**
    * @brief A reader has finished reading these keys, so they can be evicted.
-   * @param keys The keys to unmark.
+   * @param pointers The CacheKey pointers in the cache to unmark.
    */
-  virtual void ReadingCompleted(torch::Tensor keys) = 0;
+  virtual void ReadingCompleted(torch::Tensor pointers) = 0;
 
   /**
    * @brief A writer has finished writing these keys, so they can be evicted.
-   * @param keys The keys to unmark.
+   * @param pointers The CacheKey pointers in the cache to unmark.
    */
-  virtual void WritingCompleted(torch::Tensor keys) = 0;
+  virtual void WritingCompleted(torch::Tensor pointers) = 0;
 
  protected:
   template <typename CachePolicy>
@@ -158,13 +160,12 @@ class BaseCachePolicy {
   QueryImpl(CachePolicy& policy, torch::Tensor keys);
 
   template <typename CachePolicy>
-  static torch::Tensor ReplaceImpl(CachePolicy& policy, torch::Tensor keys);
+  static std::tuple<torch::Tensor, torch::Tensor> ReplaceImpl(
+      CachePolicy& policy, torch::Tensor keys);
 
   template <bool write, typename CachePolicy>
   static void ReadingWritingCompletedImpl(
-      CachePolicy& policy, torch::Tensor keys);
-
-  std::shared_ptr<std::mutex> mtx_;
+      CachePolicy& policy, torch::Tensor pointers);
 };
 
 /**
@@ -195,17 +196,17 @@ class S3FifoCachePolicy : public BaseCachePolicy {
   /**
    * @brief See BaseCachePolicy::Replace.
    */
-  torch::Tensor Replace(torch::Tensor keys);
+  std::tuple<torch::Tensor, torch::Tensor> Replace(torch::Tensor keys);
 
   /**
    * @brief See BaseCachePolicy::ReadingCompleted.
    */
-  void ReadingCompleted(torch::Tensor keys);
+  void ReadingCompleted(torch::Tensor pointers);
 
   /**
    * @brief See BaseCachePolicy::WritingCompleted.
    */
-  void WritingCompleted(torch::Tensor keys);
+  void WritingCompleted(torch::Tensor pointers);
 
   friend std::ostream& operator<<(
       std::ostream& os, const S3FifoCachePolicy& policy) {
@@ -216,27 +217,29 @@ class S3FifoCachePolicy : public BaseCachePolicy {
   }
 
   template <bool write>
-  std::optional<int64_t> Read(int64_t key) {
+  std::optional<std::pair<int64_t, CacheKey*>> Read(int64_t key) {
     auto it = key_to_cache_key_.find(key);
     if (it != key_to_cache_key_.end()) {
       auto& cache_key = *it->second;
       if (write || !cache_key.BeingWritten())
-        return cache_key.Increment().StartUse<write>().getPos();
+        return std::make_pair(
+            cache_key.Increment().StartUse<write>().getPos(), &cache_key);
     }
     return std::nullopt;
   }
 
-  int64_t Insert(int64_t key) {
+  std::pair<int64_t, CacheKey*> Insert(int64_t key) {
     const auto pos = Evict();
     const auto in_ghost_queue = ghost_set_.erase(key);
     auto& queue = in_ghost_queue ? main_queue_ : small_queue_;
-    key_to_cache_key_[key] = queue.Push(CacheKey(key, pos));
-    return pos;
+    auto cache_key_ptr = queue.Push(CacheKey(key, pos));
+    key_to_cache_key_[key] = cache_key_ptr;
+    return {pos, cache_key_ptr};
   }
 
   template <bool write>
-  void Unmark(int64_t key) {
-    key_to_cache_key_[key]->EndUse<write>();
+  void Unmark(CacheKey* cache_key_ptr) {
+    cache_key_ptr->EndUse<write>();
   }
 
  private:
@@ -317,39 +320,41 @@ class SieveCachePolicy : public BaseCachePolicy {
   /**
    * @brief See BaseCachePolicy::Replace.
    */
-  torch::Tensor Replace(torch::Tensor keys);
+  std::tuple<torch::Tensor, torch::Tensor> Replace(torch::Tensor keys);
 
   /**
    * @brief See BaseCachePolicy::ReadingCompleted.
    */
-  void ReadingCompleted(torch::Tensor keys);
+  void ReadingCompleted(torch::Tensor pointers);
 
   /**
    * @brief See BaseCachePolicy::WritingCompleted.
    */
-  void WritingCompleted(torch::Tensor keys);
+  void WritingCompleted(torch::Tensor pointers);
 
   template <bool write>
-  std::optional<int64_t> Read(int64_t key) {
+  std::optional<std::pair<int64_t, CacheKey*>> Read(int64_t key) {
     auto it = key_to_cache_key_.find(key);
     if (it != key_to_cache_key_.end()) {
       auto& cache_key = *it->second;
       if (write || !cache_key.BeingWritten())
-        return cache_key.SetFreq().StartUse<write>().getPos();
+        return std::make_pair(
+            cache_key.SetFreq().StartUse<write>().getPos(), &cache_key);
     }
     return std::nullopt;
   }
 
-  int64_t Insert(int64_t key) {
+  std::pair<int64_t, CacheKey*> Insert(int64_t key) {
     const auto pos = Evict();
     queue_.push_front(CacheKey(key, pos));
-    key_to_cache_key_[key] = queue_.begin();
-    return pos;
+    auto cache_key_ptr = &queue_.front();
+    key_to_cache_key_[key] = cache_key_ptr;
+    return {pos, cache_key_ptr};
   }
 
   template <bool write>
-  void Unmark(int64_t key) {
-    key_to_cache_key_[key]->EndUse<write>();
+  void Unmark(CacheKey* cache_key_ptr) {
+    cache_key_ptr->EndUse<write>();
   }
 
  private:
@@ -378,7 +383,7 @@ class SieveCachePolicy : public BaseCachePolicy {
   decltype(queue_)::iterator hand_;
   int64_t capacity_;
   int64_t cache_usage_;
-  phmap::flat_hash_map<int64_t, decltype(hand_)> key_to_cache_key_;
+  phmap::flat_hash_map<int64_t, CacheKey*> key_to_cache_key_;
 };
 
 /**
@@ -407,43 +412,43 @@ class LruCachePolicy : public BaseCachePolicy {
   /**
    * @brief See BaseCachePolicy::Replace.
    */
-  torch::Tensor Replace(torch::Tensor keys);
+  std::tuple<torch::Tensor, torch::Tensor> Replace(torch::Tensor keys);
 
   /**
    * @brief See BaseCachePolicy::ReadingCompleted.
    */
-  void ReadingCompleted(torch::Tensor keys);
+  void ReadingCompleted(torch::Tensor pointers);
 
   /**
    * @brief See BaseCachePolicy::WritingCompleted.
    */
-  void WritingCompleted(torch::Tensor keys);
+  void WritingCompleted(torch::Tensor pointers);
 
   template <bool write>
-  std::optional<int64_t> Read(int64_t key) {
+  std::optional<std::pair<int64_t, CacheKey*>> Read(int64_t key) {
     auto it = key_to_cache_key_.find(key);
     if (it != key_to_cache_key_.end()) {
-      auto cache_key = *it->second;
+      auto& cache_key = *it->second;
       if (write || !cache_key.BeingWritten()) {
         queue_.erase(it->second);
         queue_.push_front(cache_key.StartUse<write>());
         it->second = queue_.begin();
-        return cache_key.getPos();
+        return std::make_pair(cache_key.getPos(), &cache_key);
       }
     }
     return std::nullopt;
   }
 
-  int64_t Insert(int64_t key) {
+  std::pair<int64_t, CacheKey*> Insert(int64_t key) {
     const auto pos = Evict();
     queue_.push_front(CacheKey(key, pos));
     key_to_cache_key_[key] = queue_.begin();
-    return pos;
+    return {pos, &queue_.front()};
   }
 
   template <bool write>
-  void Unmark(int64_t key) {
-    key_to_cache_key_[key]->EndUse<write>();
+  void Unmark(CacheKey* cache_key_ptr) {
+    cache_key_ptr->EndUse<write>();
   }
 
  private:
@@ -499,38 +504,40 @@ class ClockCachePolicy : public BaseCachePolicy {
   /**
    * @brief See BaseCachePolicy::Replace.
    */
-  torch::Tensor Replace(torch::Tensor keys);
+  std::tuple<torch::Tensor, torch::Tensor> Replace(torch::Tensor keys);
 
   /**
    * @brief See BaseCachePolicy::ReadingCompleted.
    */
-  void ReadingCompleted(torch::Tensor keys);
+  void ReadingCompleted(torch::Tensor pointers);
 
   /**
    * @brief See BaseCachePolicy::WritingCompleted.
    */
-  void WritingCompleted(torch::Tensor keys);
+  void WritingCompleted(torch::Tensor pointers);
 
   template <bool write>
-  std::optional<int64_t> Read(int64_t key) {
+  std::optional<std::pair<int64_t, CacheKey*>> Read(int64_t key) {
     auto it = key_to_cache_key_.find(key);
     if (it != key_to_cache_key_.end()) {
       auto& cache_key = *it->second;
       if (write || !cache_key.BeingWritten())
-        return cache_key.SetFreq().StartUse<write>().getPos();
+        return std::make_pair(
+            cache_key.SetFreq().StartUse<write>().getPos(), &cache_key);
     }
     return std::nullopt;
   }
 
-  int64_t Insert(int64_t key) {
+  std::pair<int64_t, CacheKey*> Insert(int64_t key) {
     const auto pos = Evict();
-    key_to_cache_key_[key] = queue_.Push(CacheKey(key, pos));
-    return pos;
+    auto cache_key_ptr = queue_.Push(CacheKey(key, pos));
+    key_to_cache_key_[key] = cache_key_ptr;
+    return {pos, cache_key_ptr};
   }
 
   template <bool write>
-  void Unmark(int64_t key) {
-    key_to_cache_key_[key]->EndUse<write>();
+  void Unmark(CacheKey* cache_key_ptr) {
+    cache_key_ptr->EndUse<write>();
   }
 
  private:

--- a/graphbolt/src/cache_policy.h
+++ b/graphbolt/src/cache_policy.h
@@ -443,7 +443,7 @@ class LruCachePolicy : public BaseCachePolicy {
       auto& cache_key = *it->second;
       if (write || !cache_key.BeingWritten()) {
         MoveToFront(it->second);
-        return std::make_pair(cache_key.getPos(), &cache_key);
+        return std::make_pair(cache_key.StartUse<write>().getPos(), &cache_key);
       }
     }
     return std::nullopt;

--- a/graphbolt/src/partitioned_cache_policy.cc
+++ b/graphbolt/src/partitioned_cache_policy.cc
@@ -19,6 +19,7 @@
  */
 #include "./partitioned_cache_policy.h"
 
+#include <algorithm>
 #include <numeric>
 
 #include "./utils.h"
@@ -121,10 +122,19 @@ PartitionedCachePolicy::Partition(torch::Tensor keys) {
   return {offsets_sliced, indices, permuted_keys};
 }
 
-std::tuple<torch::Tensor, torch::Tensor, torch::Tensor, torch::Tensor>
+std::tuple<
+    torch::Tensor, torch::Tensor, torch::Tensor, torch::Tensor, torch::Tensor>
 PartitionedCachePolicy::Query(torch::Tensor keys) {
   if (policies_.size() == 1) {
-    return policies_[0]->Query(keys);
+    std::lock_guard lock(mtx_);
+    auto [positions, output_indices, missing_keys, found_pointers] =
+        policies_[0]->Query(keys);
+    auto found_offsets = torch::empty(2, found_pointers.options());
+    auto found_offsets_ptr = found_offsets.data_ptr<int64_t>();
+    found_offsets_ptr[0] = 0;
+    found_offsets_ptr[1] = found_pointers.size(0);
+    return {
+        positions, output_indices, missing_keys, found_pointers, found_offsets};
   };
   torch::Tensor offsets, indices, permuted_keys;
   std::tie(offsets, indices, permuted_keys) = Partition(keys);
@@ -137,16 +147,21 @@ PartitionedCachePolicy::Query(torch::Tensor keys) {
       torch::empty(policies_.size() * 2 + 1, offsets.options());
   auto result_offsets = result_offsets_tensor.data_ptr<int64_t>();
   namespace gb = graphbolt;
-  gb::parallel_for(0, policies_.size(), 1, [&](int64_t begin, int64_t end) {
-    if (begin == end) return;
-    TORCH_CHECK(end - begin == 1);
-    const auto tid = begin;
-    begin = offsets_ptr[tid];
-    end = offsets_ptr[tid + 1];
-    results[tid] = policies_.at(tid)->Query(permuted_keys.slice(0, begin, end));
-    result_offsets[tid] = std::get<0>(results[tid]).size(0);
-    result_offsets[tid + policies_.size()] = std::get<2>(results[tid]).size(0);
-  });
+  {
+    std::lock_guard lock(mtx_);
+    gb::parallel_for(0, policies_.size(), 1, [&](int64_t begin, int64_t end) {
+      if (begin == end) return;
+      TORCH_CHECK(end - begin == 1);
+      const auto tid = begin;
+      begin = offsets_ptr[tid];
+      end = offsets_ptr[tid + 1];
+      results[tid] =
+          policies_.at(tid)->Query(permuted_keys.slice(0, begin, end));
+      result_offsets[tid] = std::get<0>(results[tid]).size(0);
+      result_offsets[tid + policies_.size()] =
+          std::get<2>(results[tid]).size(0);
+    });
+  }
   std::exclusive_scan(
       result_offsets, result_offsets + result_offsets_tensor.size(0),
       result_offsets, 0);
@@ -196,20 +211,31 @@ PartitionedCachePolicy::Query(torch::Tensor keys) {
         std::get<2>(results[tid]).data_ptr(),
         num_missing * missing_keys.element_size());
   });
-  return std::make_tuple(positions, output_indices, missing_keys, found_keys);
+  return std::make_tuple(
+      positions, output_indices, missing_keys, found_keys,
+      result_offsets_tensor.slice(0, 0, policies_.size() + 1));
 }
 
 c10::intrusive_ptr<Future<std::vector<torch::Tensor>>>
 PartitionedCachePolicy::QueryAsync(torch::Tensor keys) {
   return async([=] {
-    auto [positions, output_indices, missing_keys, found_keys] = Query(keys);
-    return std::vector{positions, output_indices, missing_keys, found_keys};
+    auto [positions, output_indices, missing_keys, found_keys, found_offsets] =
+        Query(keys);
+    return std::vector{
+        positions, output_indices, missing_keys, found_keys, found_offsets};
   });
 }
 
-std::vector<torch::Tensor> PartitionedCachePolicy::Replace(torch::Tensor keys) {
+std::tuple<torch::Tensor, torch::Tensor, torch::Tensor>
+PartitionedCachePolicy::Replace(torch::Tensor keys) {
   if (policies_.size() == 1) {
-    return {policies_[0]->Replace(keys)};
+    std::lock_guard lock(mtx_);
+    auto [positions, pointers] = policies_[0]->Replace(keys);
+    auto offsets = torch::empty(2, pointers.options());
+    auto offsets_ptr = offsets.data_ptr<int64_t>();
+    offsets_ptr[0] = 0;
+    offsets_ptr[1] = pointers.size(0);
+    return {positions, pointers, offsets};
   }
   torch::Tensor offsets, indices, permuted_keys;
   std::tie(offsets, indices, permuted_keys) = Partition(keys);
@@ -217,83 +243,94 @@ std::vector<torch::Tensor> PartitionedCachePolicy::Replace(torch::Tensor keys) {
       keys, keys.options()
                 .dtype(torch::kInt64)
                 .pinned_memory(utils::is_pinned(keys)));
+  auto output_pointers = torch::empty_like(
+      keys, keys.options()
+                .dtype(torch::kInt64)
+                .pinned_memory(utils::is_pinned(keys)));
   auto offsets_ptr = offsets.data_ptr<int64_t>();
   auto indices_ptr = indices.data_ptr<int64_t>();
   auto output_positions_ptr = output_positions.data_ptr<int64_t>();
+  auto output_pointers_ptr = output_pointers.data_ptr<int64_t>();
   namespace gb = graphbolt;
+  std::unique_lock lock(mtx_);
+  std::atomic<size_t> semaphore = policies_.size();
   gb::parallel_for(0, policies_.size(), 1, [&](int64_t begin, int64_t end) {
     if (begin == end) return;
     const auto tid = begin;
     begin = offsets_ptr[tid];
     end = offsets_ptr[tid + 1];
-    torch::Tensor positions =
+    auto [positions, pointers] =
         policies_.at(tid)->Replace(permuted_keys.slice(0, begin, end));
+    const auto ticket = semaphore.fetch_add(-1, std::memory_order_release) - 1;
+    if (ticket == 0) {
+      // This thread was the last thread in the critical region.
+      lock.unlock();
+    }
     auto positions_ptr = positions.data_ptr<int64_t>();
     const auto off = tid * capacity_ / policies_.size();
     for (int64_t i = 0; i < positions.size(0); i++) {
       output_positions_ptr[indices_ptr[begin + i]] = positions_ptr[i] + off;
     }
+    auto pointers_ptr = pointers.data_ptr<int64_t>();
+    std::copy(
+        pointers_ptr, pointers_ptr + pointers.size(0),
+        output_pointers_ptr + begin);
   });
-  return {output_positions, offsets, indices, permuted_keys};
+  return {output_positions, output_pointers, offsets};
 }
 
 c10::intrusive_ptr<Future<std::vector<torch::Tensor>>>
 PartitionedCachePolicy::ReplaceAsync(torch::Tensor keys) {
-  return async([=] { return Replace(keys); });
+  return async([=] {
+    auto [positions, pointers, offsets] = Replace(keys);
+    return std::vector{positions, pointers, offsets};
+  });
 }
 
 template <bool write>
 void PartitionedCachePolicy::ReadingWritingCompletedImpl(
-    torch::Tensor keys, std::vector<torch::Tensor>& partition_result) {
+    torch::Tensor pointers, torch::Tensor offsets) {
   if (policies_.size() == 1) {
+    std::lock_guard lock(mtx_);
     if constexpr (write)
-      policies_[0]->WritingCompleted(keys);
+      policies_[0]->WritingCompleted(pointers);
     else
-      policies_[0]->ReadingCompleted(keys);
+      policies_[0]->ReadingCompleted(pointers);
     return;
-  }
-  torch::Tensor offsets, indices, permuted_keys;
-  if (partition_result.size() == 3) {
-    offsets = partition_result[0];
-    indices = partition_result[1];
-    permuted_keys = partition_result[2];
-  } else if (partition_result.size() == 0) {
-    std::tie(offsets, indices, permuted_keys) = Partition(keys);
-  } else {
-    TORCH_CHECK("partition_result.size() should equal 0 or 3.");
   }
   auto offsets_ptr = offsets.data_ptr<int64_t>();
   namespace gb = graphbolt;
+  std::lock_guard lock(mtx_);
   gb::parallel_for(0, policies_.size(), 1, [&](int64_t begin, int64_t end) {
     if (begin == end) return;
     const auto tid = begin;
     begin = offsets_ptr[tid];
     end = offsets_ptr[tid + 1];
     if constexpr (write)
-      policies_.at(tid)->WritingCompleted(permuted_keys.slice(0, begin, end));
+      policies_.at(tid)->WritingCompleted(pointers.slice(0, begin, end));
     else
-      policies_.at(tid)->ReadingCompleted(permuted_keys.slice(0, begin, end));
+      policies_.at(tid)->ReadingCompleted(pointers.slice(0, begin, end));
   });
 }
 
 void PartitionedCachePolicy::ReadingCompleted(
-    torch::Tensor keys, std::vector<torch::Tensor> partition_result) {
-  ReadingWritingCompletedImpl<false>(keys, partition_result);
+    torch::Tensor pointers, torch::Tensor offsets) {
+  ReadingWritingCompletedImpl<false>(pointers, offsets);
 }
 
 void PartitionedCachePolicy::WritingCompleted(
-    torch::Tensor keys, std::vector<torch::Tensor> partition_result) {
-  ReadingWritingCompletedImpl<true>(keys, partition_result);
+    torch::Tensor pointers, torch::Tensor offsets) {
+  ReadingWritingCompletedImpl<true>(pointers, offsets);
 }
 
 c10::intrusive_ptr<Future<void>> PartitionedCachePolicy::ReadingCompletedAsync(
-    torch::Tensor keys, std::vector<torch::Tensor> partition_result) {
-  return async([=] { return ReadingCompleted(keys, partition_result); });
+    torch::Tensor pointers, torch::Tensor offsets) {
+  return async([=] { return ReadingCompleted(pointers, offsets); });
 }
 
 c10::intrusive_ptr<Future<void>> PartitionedCachePolicy::WritingCompletedAsync(
-    torch::Tensor keys, std::vector<torch::Tensor> partition_result) {
-  return async([=] { return WritingCompleted(keys, partition_result); });
+    torch::Tensor pointers, torch::Tensor offsets) {
+  return async([=] { return WritingCompleted(pointers, offsets); });
 }
 
 template <typename CachePolicy>

--- a/graphbolt/src/partitioned_cache_policy.h
+++ b/graphbolt/src/partitioned_cache_policy.h
@@ -57,14 +57,17 @@ class PartitionedCachePolicy : public torch::CustomClassHolder {
    * @brief The policy query function.
    * @param keys The keys to query the cache.
    *
-   * @return (positions, indices, missing_keys), where positions has the
-   * locations of the keys which were found in the cache, missing_keys has the
-   * keys that were not found and indices is defined such that
-   * keys[indices[:positions.size(0)]] gives us the found keys and
-   * keys[indices[positions.size(0):]] is identical to missing_keys.
+   * @return (positions, indices, missing_keys, found_ptrs, found_offsets),
+   * where positions has the locations of the keys which were found in the
+   * cache, missing_keys has the keys that were not found and indices is defined
+   * such that keys[indices[:positions.size(0)]] gives us the keys for the found
+   * pointers and keys[indices[positions.size(0):]] is identical to
+   * missing_keys. The found_offsets tensor holds the partition offsets for the
+   * found pointers.
    */
-  std::tuple<torch::Tensor, torch::Tensor, torch::Tensor, torch::Tensor> Query(
-      torch::Tensor keys);
+  std::tuple<
+      torch::Tensor, torch::Tensor, torch::Tensor, torch::Tensor, torch::Tensor>
+  Query(torch::Tensor keys);
 
   c10::intrusive_ptr<Future<std::vector<torch::Tensor>>> QueryAsync(
       torch::Tensor keys);
@@ -73,43 +76,40 @@ class PartitionedCachePolicy : public torch::CustomClassHolder {
    * @brief The policy replace function.
    * @param keys The keys to query the cache.
    *
-   * @return result, where result[0] is the positions tensor holding the
-   * locations of the replaced entries in the cache. The rest of the tensors are
-   * (offsets, indices, permuted_keys) output from Partition(keys).
+   * @return (positions, pointers, offsets), where positions holds the locations
+   * of the replaced entries in the cache, pointers holds the CacheKey pointers
+   * for the inserted keys and offsets holds the partition offsets for pointers.
    */
-  std::vector<torch::Tensor> Replace(torch::Tensor keys);
+  std::tuple<torch::Tensor, torch::Tensor, torch::Tensor> Replace(
+      torch::Tensor keys);
 
   c10::intrusive_ptr<Future<std::vector<torch::Tensor>>> ReplaceAsync(
       torch::Tensor keys);
 
   template <bool write>
   void ReadingWritingCompletedImpl(
-      torch::Tensor keys, std::vector<torch::Tensor>& partition_result);
+      torch::Tensor pointers, torch::Tensor offsets);
 
   /**
    * @brief A reader has finished reading these keys, so they can be
    * evicted.
-   * @param keys The keys to unmark.
-   * @param partition_result The output of Partition(keys) if available.
-   * Otherwise when partition_result.empty() is true, it will be computed.
+   * @param pointers The CacheKey pointers in the cache to unmark.
+   * @param offsets The partition offsets for the pointers.
    */
-  void ReadingCompleted(
-      torch::Tensor keys, std::vector<torch::Tensor> partition_result);
+  void ReadingCompleted(torch::Tensor pointers, torch::Tensor offsets);
 
   /**
    * @brief A writer has finished writing these keys, so they can be evicted.
-   * @param keys The keys to unmark.
-   * @param partition_result The output of Partition(keys) if available.
-   * Otherwise when partition_result.empty() is true, it will be computed.
+   * @param pointers The CacheKey pointers in the cache to unmark.
+   * @param offsets The partition offsets for the pointers.
    */
-  void WritingCompleted(
-      torch::Tensor keys, std::vector<torch::Tensor> partition_result);
+  void WritingCompleted(torch::Tensor keys, torch::Tensor offsets);
 
   c10::intrusive_ptr<Future<void>> ReadingCompletedAsync(
-      torch::Tensor keys, std::vector<torch::Tensor> partition_result);
+      torch::Tensor keys, torch::Tensor offsets);
 
   c10::intrusive_ptr<Future<void>> WritingCompletedAsync(
-      torch::Tensor keys, std::vector<torch::Tensor> partition_result);
+      torch::Tensor keys, torch::Tensor offsets);
 
   template <typename CachePolicy>
   static c10::intrusive_ptr<PartitionedCachePolicy> Create(
@@ -141,6 +141,7 @@ class PartitionedCachePolicy : public torch::CustomClassHolder {
 
   int64_t capacity_;
   std::vector<std::unique_ptr<BaseCachePolicy>> policies_;
+  std::mutex mtx_;
 };
 
 }  // namespace storage

--- a/graphbolt/src/partitioned_cache_policy.h
+++ b/graphbolt/src/partitioned_cache_policy.h
@@ -103,13 +103,13 @@ class PartitionedCachePolicy : public torch::CustomClassHolder {
    * @param pointers The CacheKey pointers in the cache to unmark.
    * @param offsets The partition offsets for the pointers.
    */
-  void WritingCompleted(torch::Tensor keys, torch::Tensor offsets);
+  void WritingCompleted(torch::Tensor pointers, torch::Tensor offsets);
 
   c10::intrusive_ptr<Future<void>> ReadingCompletedAsync(
-      torch::Tensor keys, torch::Tensor offsets);
+      torch::Tensor pointers, torch::Tensor offsets);
 
   c10::intrusive_ptr<Future<void>> WritingCompletedAsync(
-      torch::Tensor keys, torch::Tensor offsets);
+      torch::Tensor pointers, torch::Tensor offsets);
 
   template <typename CachePolicy>
   static c10::intrusive_ptr<PartitionedCachePolicy> Create(

--- a/python/dgl/graphbolt/impl/cpu_cached_feature.py
+++ b/python/dgl/graphbolt/impl/cpu_cached_feature.py
@@ -127,7 +127,13 @@ class CPUCachedFeature(Feature):
 
             yield
 
-            positions, index, missing_keys, found_pointers, found_offsets = policy_future.wait()
+            (
+                positions,
+                index,
+                missing_keys,
+                found_pointers,
+                found_offsets,
+            ) = policy_future.wait()
             self._feature.total_queries += ids.shape[0]
             self._feature.total_miss += missing_keys.shape[0]
             host_to_device_stream = get_host_to_device_uva_stream()
@@ -150,7 +156,9 @@ class CPUCachedFeature(Feature):
                 yield  # fallback feature stages.
 
             values_from_cpu_copy_event.wait()
-            reading_completed = policy.reading_completed_async(found_pointers, found_offsets)
+            reading_completed = policy.reading_completed_async(
+                found_pointers, found_offsets
+            )
 
             missing_values = missing_values_future.wait()
             positions, pointers, offsets = positions_future.wait()
@@ -225,7 +233,13 @@ class CPUCachedFeature(Feature):
 
             yield
 
-            positions, index, missing_keys, found_pointers, found_offsets = policy_future.wait()
+            (
+                positions,
+                index,
+                missing_keys,
+                found_pointers,
+                found_offsets,
+            ) = policy_future.wait()
             self._feature.total_queries += ids.shape[0]
             self._feature.total_miss += missing_keys.shape[0]
             values_future = cache.query_async(positions, index, ids.shape[0])
@@ -242,7 +256,9 @@ class CPUCachedFeature(Feature):
                 yield  # fallback feature stages.
 
             values = values_future.wait()
-            reading_completed = policy.reading_completed_async(found_pointers, found_offsets)
+            reading_completed = policy.reading_completed_async(
+                found_pointers, found_offsets
+            )
 
             missing_index = index[positions.size(0) :]
 
@@ -288,7 +304,13 @@ class CPUCachedFeature(Feature):
 
             yield
 
-            positions, index, missing_keys, found_pointers, found_offsets = policy_future.wait()
+            (
+                positions,
+                index,
+                missing_keys,
+                found_pointers,
+                found_offsets,
+            ) = policy_future.wait()
             self._feature.total_queries += ids.shape[0]
             self._feature.total_miss += missing_keys.shape[0]
             values_future = cache.query_async(positions, index, ids.shape[0])
@@ -305,7 +327,9 @@ class CPUCachedFeature(Feature):
                 yield  # fallback feature stages.
 
             values = values_future.wait()
-            reading_completed = policy.reading_completed_async(found_pointers, found_offsets)
+            reading_completed = policy.reading_completed_async(
+                found_pointers, found_offsets
+            )
 
             missing_index = index[positions.size(0) :]
 

--- a/python/dgl/graphbolt/impl/cpu_cached_feature.py
+++ b/python/dgl/graphbolt/impl/cpu_cached_feature.py
@@ -127,7 +127,7 @@ class CPUCachedFeature(Feature):
 
             yield
 
-            positions, index, missing_keys, found_keys = policy_future.wait()
+            positions, index, missing_keys, found_pointers, found_offsets = policy_future.wait()
             self._feature.total_queries += ids.shape[0]
             self._feature.total_miss += missing_keys.shape[0]
             host_to_device_stream = get_host_to_device_uva_stream()
@@ -150,11 +150,10 @@ class CPUCachedFeature(Feature):
                 yield  # fallback feature stages.
 
             values_from_cpu_copy_event.wait()
-            reading_completed = policy.reading_completed_async(found_keys, [])
+            reading_completed = policy.reading_completed_async(found_pointers, found_offsets)
 
             missing_values = missing_values_future.wait()
-            policy_replace_output = positions_future.wait()
-            positions = policy_replace_output[0]
+            positions, pointers, offsets = positions_future.wait()
             replace_future = cache.replace_async(positions, missing_values)
 
             host_to_device_stream = get_host_to_device_uva_stream()
@@ -173,7 +172,7 @@ class CPUCachedFeature(Feature):
             reading_completed.wait()
             replace_future.wait()
             writing_completed = policy.writing_completed_async(
-                missing_keys, policy_replace_output[1:]
+                pointers, offsets
             )
 
             class _Waiter:
@@ -226,7 +225,7 @@ class CPUCachedFeature(Feature):
 
             yield
 
-            positions, index, missing_keys, found_keys = policy_future.wait()
+            positions, index, missing_keys, found_pointers, found_offsets = policy_future.wait()
             self._feature.total_queries += ids.shape[0]
             self._feature.total_miss += missing_keys.shape[0]
             values_future = cache.query_async(positions, index, ids.shape[0])
@@ -243,13 +242,12 @@ class CPUCachedFeature(Feature):
                 yield  # fallback feature stages.
 
             values = values_future.wait()
-            reading_completed = policy.reading_completed_async(found_keys, [])
+            reading_completed = policy.reading_completed_async(found_pointers, found_offsets)
 
             missing_index = index[positions.size(0) :]
 
             missing_values = missing_values_future.wait()
-            policy_replace_output = positions_future.wait()
-            positions = policy_replace_output[0]
+            positions, pointers, offsets = positions_future.wait()
             replace_future = cache.replace_async(positions, missing_values)
             values = torch.ops.graphbolt.scatter_async(
                 values, missing_index, missing_values
@@ -267,7 +265,7 @@ class CPUCachedFeature(Feature):
             reading_completed.wait()
             replace_future.wait()
             writing_completed = policy.writing_completed_async(
-                missing_keys, policy_replace_output[1:]
+                pointers, offsets
             )
 
             class _Waiter:
@@ -290,7 +288,7 @@ class CPUCachedFeature(Feature):
 
             yield
 
-            positions, index, missing_keys, found_keys = policy_future.wait()
+            positions, index, missing_keys, found_pointers, found_offsets = policy_future.wait()
             self._feature.total_queries += ids.shape[0]
             self._feature.total_miss += missing_keys.shape[0]
             values_future = cache.query_async(positions, index, ids.shape[0])
@@ -307,13 +305,12 @@ class CPUCachedFeature(Feature):
                 yield  # fallback feature stages.
 
             values = values_future.wait()
-            reading_completed = policy.reading_completed_async(found_keys, [])
+            reading_completed = policy.reading_completed_async(found_pointers, found_offsets)
 
             missing_index = index[positions.size(0) :]
 
             missing_values = missing_values_future.wait()
-            policy_replace_output = positions_future.wait()
-            positions = policy_replace_output[0]
+            positions, pointers, offsets = positions_future.wait()
             replace_future = cache.replace_async(positions, missing_values)
             values = torch.ops.graphbolt.scatter_async(
                 values, missing_index, missing_values
@@ -324,7 +321,7 @@ class CPUCachedFeature(Feature):
             reading_completed.wait()
             replace_future.wait()
             writing_completed = policy.writing_completed_async(
-                missing_keys, policy_replace_output[1:]
+                pointers, offsets
             )
 
             class _Waiter:

--- a/python/dgl/graphbolt/impl/feature_cache.py
+++ b/python/dgl/graphbolt/impl/feature_cache.py
@@ -76,7 +76,13 @@ class CPUFeatureCache(object):
             pinned, then the returned values tensor is pinned as well.
         """
         self.total_queries += keys.shape[0]
-        positions, index, missing_keys, found_pointers, found_offsets = self._policy.query(keys)
+        (
+            positions,
+            index,
+            missing_keys,
+            found_pointers,
+            found_offsets,
+        ) = self._policy.query(keys)
         values = self._cache.query(positions, index, keys.shape[0])
         self._policy.reading_completed(found_pointers, found_offsets)
         self.total_miss += missing_keys.shape[0]

--- a/python/dgl/graphbolt/impl/feature_cache.py
+++ b/python/dgl/graphbolt/impl/feature_cache.py
@@ -76,9 +76,9 @@ class CPUFeatureCache(object):
             pinned, then the returned values tensor is pinned as well.
         """
         self.total_queries += keys.shape[0]
-        positions, index, missing_keys, found_keys = self._policy.query(keys)
+        positions, index, missing_keys, found_pointers, found_offsets = self._policy.query(keys)
         values = self._cache.query(positions, index, keys.shape[0])
-        self._policy.reading_completed(found_keys, [])
+        self._policy.reading_completed(found_pointers, found_offsets)
         self.total_miss += missing_keys.shape[0]
         missing_index = index[positions.size(0) :]
         return values, missing_index, missing_keys
@@ -94,10 +94,9 @@ class CPUFeatureCache(object):
         values: Tensor
             The values to insert to the cache.
         """
-        output = self._policy.replace(keys)
-        positions = output[0]
+        positions, pointers, offsets = self._policy.replace(keys)
         self._cache.replace(positions, values)
-        self._policy.writing_completed(keys, output[1:])
+        self._policy.writing_completed(pointers, offsets)
 
     @property
     def miss_rate(self):


### PR DESCRIPTION
## Description
The PR is a bit large because the same change is applied to all 4 caching policies and it is not possible to do a majority of the changes 1-by-1. Some of the diff comes from simply indentation difference.

1. The mutex is removed from the caching policy and is moved to partitioned caching policy instead.
2. The optimization we apply here is that we don't have to partition again to mark read entries as complete as query already had computed it.
3. Instead of returning found keys, we return the found cache pointer entries so that the reading completed operation does not have to do hashmap lookup.
4. Instead of returning only positions from replace, we also return the cache pointer entries so that writing completed operation does not have to do a hashmap lookup.
5. LRU caching policy had a bug, `Read` didn't call `StartUse` operation.

TODO: Maybe we don't need even need Partition in Replace. It might be possible to reuse Partition result from Query.

## Checklist
Please feel free to remove inapplicable items for your PR.
- [ ] The PR title starts with [$CATEGORY] (such as [NN], [Model], [Doc], [Feature]])
- [ ] I've leverage the [tools](https://docs.google.com/document/d/1iHyj7zlmygKSk5gBPsqIqL5ASPzJSPREaNT_QdsiYA4/edit) to beautify the python and c++ code.
- [ ] The PR is complete and small, read the [Google eng practice (CL equals to PR)](https://google.github.io/eng-practices/review/developer/small-cls.html) to understand more about small PR. In DGL, we consider PRs with less than 200 lines of core code change are small (example, test and documentation could be exempted).
- [ ] All changes have test coverage
- [ ] Code is well-documented
- [ ] To the best of my knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change
- [ ] Related issue is referred in this PR
- [ ] If the PR is for a new model/paper, I've updated the example index [here](../examples/README.md).

## Changes
<!-- You could use following template
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)
-->
