### PR TITLE
[GraphBolt][io_uring] Launch `parallel_for` when queues are available.

### DIFF
--- a/graphbolt/CMakeLists.txt
+++ b/graphbolt/CMakeLists.txt
@@ -73,6 +73,8 @@ endif()
 add_library(${LIB_GRAPHBOLT_NAME} SHARED ${BOLT_SRC} ${BOLT_HEADERS})
 include_directories(BEFORE ${BOLT_DIR}
                            ${BOLT_HEADERS}
+                           # For CXX20 features.
+                           "../third_party/cccl/libcudacxx/include"
                            "../third_party/pcg/include"
                            "../third_party/phmap")
 target_link_libraries(${LIB_GRAPHBOLT_NAME} "${TORCH_LIBRARIES}")
@@ -124,7 +126,6 @@ if(USE_CUDA)
   include_directories(BEFORE
                       "../third_party/cccl/thrust"
                       "../third_party/cccl/cub"
-                      "../third_party/cccl/libcudacxx/include"
                       "../third_party/cuco/include")
 
   message(STATUS "Use HugeCTR gpu_cache for graphbolt with INCLUDE_DIRS $ENV{GPU_CACHE_INCLUDE_DIRS}.")

--- a/graphbolt/CMakeLists.txt
+++ b/graphbolt/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.18)
 project(graphbolt C CXX)
-set(CMAKE_CXX_STANDARD 20)
+set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 if(USE_CUDA)

--- a/graphbolt/CMakeLists.txt
+++ b/graphbolt/CMakeLists.txt
@@ -73,7 +73,8 @@ endif()
 add_library(${LIB_GRAPHBOLT_NAME} SHARED ${BOLT_SRC} ${BOLT_HEADERS})
 include_directories(BEFORE ${BOLT_DIR}
                            ${BOLT_HEADERS}
-                           # For CXX20 features.
+                           # For CXX20 features:
+                           # `std::atomic_ref`, `std::counting_semaphore`
                            "../third_party/cccl/libcudacxx/include"
                            "../third_party/pcg/include"
                            "../third_party/phmap")

--- a/graphbolt/src/cnumpy.cc
+++ b/graphbolt/src/cnumpy.cc
@@ -62,14 +62,18 @@ OnDiskNpyArray::OnDiskNpyArray(
 
   std::call_once(call_once_flag_, [&] {
     // Get system max interop thread count.
-    num_queues_ = torch::get_num_interop_threads();
+    num_queues_ =
+        io_uring::num_threads.value_or(torch::get_num_interop_threads());
     TORCH_CHECK(num_queues_ > 0, "A positive # queues is required.");
     io_uring_queue_ = std::unique_ptr<::io_uring[], io_uring_queue_destroyer>(
         new ::io_uring[num_queues_], io_uring_queue_destroyer{num_queues_});
-    mtx_ = std::make_unique<std::mutex[]>(num_queues_);
-
+    TORCH_CHECK(num_queues_ + 1 <= counting_semaphore_t::max());
+    // The +1 is for the thread that calls parallel_for.
+    semaphore_ = std::make_unique<counting_semaphore_t>(num_queues_ + 1);
+    available_queues_.reserve(num_queues_);
     // Init io_uring queue.
     for (int64_t t = 0; t < num_queues_; t++) {
+      available_queues_.push_back(t);
       TORCH_CHECK(
           ::io_uring_queue_init(2 * kGroupSize, &io_uring_queue_[t], 0) == 0);
       // We have allocated 2 * kGroupSize submission queue entries and
@@ -78,9 +82,7 @@ OnDiskNpyArray::OnDiskNpyArray(
   });
 
   num_thread_ = std::min(
-      static_cast<int64_t>(num_queues_),
-      num_threads.value_or(
-          io_uring::num_threads.value_or((torch::get_num_threads() + 1) / 2)));
+      static_cast<int64_t>(num_queues_), num_threads.value_or(num_queues_));
   TORCH_CHECK(num_thread_ > 0, "A positive # threads is required.");
 
   read_tensor_ = torch::empty(
@@ -167,14 +169,25 @@ torch::Tensor OnDiskNpyArray::IndexSelectIOUringImpl(torch::Tensor index) {
   // Indicator for index error.
   std::atomic<int> error_flag{};
   std::atomic<int64_t> work_queue{};
-  graphbolt::parallel_for(0, num_thread_, 1, [&](const int thread_id, int) {
-    auto &io_uring_queue = io_uring_queue_[thread_id];
-    auto my_read_buffer = ReadBuffer(thread_id);
+  std::atomic_flag exiting_first = ATOMIC_FLAG_INIT;
+  // Consume a slot so that parallel_for is called only if there are available
+  // queues.
+  semaphore_->acquire();
+  graphbolt::parallel_for(0, num_thread_, 1, [&](int thread_id, int) {
     // The completion queue might contain 4 * kGroupSize while we may submit
     // 4 * kGroupSize more. No harm in overallocation here.
     CircularQueue<ReadRequest> read_queue(8 * kGroupSize);
     int64_t num_submitted = 0;
     int64_t num_completed = 0;
+    {
+      // We consume a slot from the semaphore to use a queue.
+      semaphore_->acquire();
+      std::lock_guard lock(available_queues_mtx_);
+      TORCH_CHECK(!available_queues_.empty());
+      thread_id = available_queues_.back();
+      available_queues_.pop_back();
+    }
+    auto &io_uring_queue = io_uring_queue_[thread_id];
     auto submit_fn = [&](int64_t submission_minimum_batch_size) {
       if (read_queue.Size() < submission_minimum_batch_size) return;
       TORCH_CHECK(  // Check for sqe overflow.
@@ -190,8 +203,7 @@ torch::Tensor OnDiskNpyArray::IndexSelectIOUringImpl(torch::Tensor index) {
         read_queue.PopN(submitted);
       }
     };
-    // Make sure we have sole control of this thread's queue.
-    std::lock_guard io_uring_queue_lock(mtx_[thread_id]);
+    auto my_read_buffer = ReadBuffer(thread_id);
     for (int64_t read_buffer_slot = 0; true;) {
       auto request_read_buffer = [&]() {
         return my_read_buffer + (aligned_length_ + block_size_) *
@@ -291,6 +303,14 @@ torch::Tensor OnDiskNpyArray::IndexSelectIOUringImpl(torch::Tensor index) {
       io_uring_cq_advance(&io_uring_queue, num_cqes_seen);
       num_completed += num_cqes_seen;
     }
+    {
+      // We give back the slot we used.
+      std::lock_guard lock(available_queues_mtx_);
+      available_queues_.push_back(thread_id);
+    }
+    // If this is the first thread exiting, release the master thread's ticket
+    // as well by releasing 2 slots. Otherwise, release 1 slot.
+    semaphore_->release(exiting_first.test_and_set() ? 1 : 2);
   });
   switch (error_flag.load(std::memory_order_relaxed)) {
     case 0:  // Successful.

--- a/graphbolt/src/cnumpy.h
+++ b/graphbolt/src/cnumpy.h
@@ -17,11 +17,11 @@
 #include <cstdio>
 #include <cstdlib>
 #include <cstring>
+#include <cuda/std/semaphore>
 #include <fstream>
 #include <iostream>
 #include <memory>
 #include <mutex>
-#include <semaphore>
 #include <string>
 #include <vector>
 
@@ -49,7 +49,7 @@ struct io_uring_queue_destroyer {
  */
 class OnDiskNpyArray : public torch::CustomClassHolder {
   // No user will need more than 1024 io_uring queues.
-  using counting_semaphore_t = std::counting_semaphore<1024>;
+  using counting_semaphore_t = ::cuda::std::counting_semaphore<1024>;
 
  public:
   static constexpr int kGroupSize = 256;

--- a/graphbolt/src/cnumpy.h
+++ b/graphbolt/src/cnumpy.h
@@ -142,7 +142,7 @@ class OnDiskNpyArray : public torch::CustomClassHolder {
   static inline int num_queues_;  // Number of queues.
   static inline std::unique_ptr<::io_uring[], io_uring_queue_destroyer>
       io_uring_queue_;  // io_uring queue.
-  static inline std::unique_ptr<counting_semaphore_t>
+  static inline counting_semaphore_t
       semaphore_;  // Control access to the io_uring queues.
   static inline std::mutex available_queues_mtx_;  // available_queues_ mutex.
   static inline std::vector<int> available_queues_;


### PR DESCRIPTION
## Description
We can rely on our existing libcudacxx dependency on the CPU backend for its library facilities. Does not require CUDA or GPUs at all.

## Checklist
Please feel free to remove inapplicable items for your PR.
- [ ] The PR title starts with [$CATEGORY] (such as [NN], [Model], [Doc], [Feature]])
- [ ] I've leverage the [tools](https://docs.google.com/document/d/1iHyj7zlmygKSk5gBPsqIqL5ASPzJSPREaNT_QdsiYA4/edit) to beautify the python and c++ code.
- [ ] The PR is complete and small, read the [Google eng practice (CL equals to PR)](https://google.github.io/eng-practices/review/developer/small-cls.html) to understand more about small PR. In DGL, we consider PRs with less than 200 lines of core code change are small (example, test and documentation could be exempted).
- [ ] All changes have test coverage
- [ ] Code is well-documented
- [ ] To the best of my knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change
- [ ] Related issue is referred in this PR
- [ ] If the PR is for a new model/paper, I've updated the example index [here](../examples/README.md).

## Changes
<!-- You could use following template
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)
-->
