### PR TITLE
[GraphBolt][CUDA] Use better memory allocation algorithm to avoid OOM.

### DIFF
--- a/python/dgl/graphbolt/__init__.py
+++ b/python/dgl/graphbolt/__init__.py
@@ -25,6 +25,7 @@ else:
             [k + ":" + v for k, v in configs.items()]
         )
 
+# pylint: disable=wrong-import-position
 import torch
 
 ### FROM DGL @todo

--- a/python/dgl/graphbolt/__init__.py
+++ b/python/dgl/graphbolt/__init__.py
@@ -2,6 +2,29 @@
 import os
 import sys
 
+from .internal_utils import *
+
+# https://pytorch.org/docs/stable/notes/cuda.html#optimizing-memory-usage-with-pytorch-cuda-alloc-conf
+cuda_allocator_env = os.getenv("PYTORCH_CUDA_ALLOC_CONF")
+if cuda_allocator_env is None:
+    os.environ["PYTORCH_CUDA_ALLOC_CONF"] = "expandable_segments:True"
+else:
+    configs = {
+        kv_pair.split(":")[0]: kv_pair.split(":")[1]
+        for kv_pair in cuda_allocator_env.split(",")
+    }
+    if "expandable_segments" in configs:
+        if configs["expandable_segments"] != "True":
+            gb_warning(
+                "You should set `expandable_segments:True` in the environent"
+                " variable `PYTORCH_CUDA_ALLOC_CONF` for lower memory usage."
+            )
+    else:
+        configs["expandable_segments"] = "True"
+        os.environ["PYTORCH_CUDA_ALLOC_CONF"] = ",".join(
+            [k + ":" + v for k, v in configs.items()]
+        )
+
 import torch
 
 ### FROM DGL @todo
@@ -47,7 +70,6 @@ from .impl import *
 from .itemset import *
 from .item_sampler import *
 from .minibatch_transformer import *
-from .internal_utils import *
 from .negative_sampler import *
 from .sampled_subgraph import *
 from .subgraph_sampler import *

--- a/python/dgl/graphbolt/__init__.py
+++ b/python/dgl/graphbolt/__init__.py
@@ -7,8 +7,8 @@ from .internal_utils import *
 cuda_allocator_env_warning_str = """
 An experimental feature for CUDA allocations is turned on for better allocation
 pattern resulting in better memory usage for minibatch GNN training workloads.
-See https://pytorch.org/docs/stable/notes/cuda.html#optimizing-memory-usage-with-pytorch-cuda-alloc-conf"
-, and set the environment variable `PYTORCH_CUDA_ALLOC_CONF=expandable_segments:False`
+See https://pytorch.org/docs/stable/notes/cuda.html#optimizing-memory-usage-with-pytorch-cuda-alloc-conf,
+and set the environment variable `PYTORCH_CUDA_ALLOC_CONF=expandable_segments:False`
 if you want to disable it.
 """
 cuda_allocator_env = os.getenv("PYTORCH_CUDA_ALLOC_CONF")

--- a/python/dgl/graphbolt/__init__.py
+++ b/python/dgl/graphbolt/__init__.py
@@ -4,7 +4,7 @@ import sys
 
 from .internal_utils import *
 
-cuda_allocator_env_warning_str = """
+CUDA_ALLOCATOR_ENV_WARNING_STR = """
 An experimental feature for CUDA allocations is turned on for better allocation
 pattern resulting in better memory usage for minibatch GNN training workloads.
 See https://pytorch.org/docs/stable/notes/cuda.html#optimizing-memory-usage-with-pytorch-cuda-alloc-conf,
@@ -14,7 +14,7 @@ if you want to disable it.
 cuda_allocator_env = os.getenv("PYTORCH_CUDA_ALLOC_CONF")
 if cuda_allocator_env is None:
     os.environ["PYTORCH_CUDA_ALLOC_CONF"] = "expandable_segments:True"
-    gb_warning(cuda_allocator_env_warning_str)
+    gb_warning(CUDA_ALLOCATOR_ENV_WARNING_STR)
 else:
     configs = {
         kv_pair.split(":")[0]: kv_pair.split(":")[1]
@@ -23,16 +23,17 @@ else:
     if "expandable_segments" in configs:
         if configs["expandable_segments"] != "True":
             gb_warning(
-                "You should consider `expandable_segments:True` in the environment"
-                " variable `PYTORCH_CUDA_ALLOC_CONF` for lower memory usage. See"
-                " https://pytorch.org/docs/stable/notes/cuda.html#optimizing-memory-usage-with-pytorch-cuda-alloc-conf"
+                "You should consider `expandable_segments:True` in the"
+                " environment variable `PYTORCH_CUDA_ALLOC_CONF` for lower"
+                " memory usage. See "
+                "https://pytorch.org/docs/stable/notes/cuda.html#optimizing-memory-usage-with-pytorch-cuda-alloc-conf"
             )
     else:
         configs["expandable_segments"] = "True"
         os.environ["PYTORCH_CUDA_ALLOC_CONF"] = ",".join(
             [k + ":" + v for k, v in configs.items()]
         )
-        gb_warning(cuda_allocator_env_warning_str)
+        gb_warning(CUDA_ALLOCATOR_ENV_WARNING_STR)
 
 
 # pylint: disable=wrong-import-position, wrong-import-order

--- a/python/dgl/graphbolt/__init__.py
+++ b/python/dgl/graphbolt/__init__.py
@@ -26,7 +26,8 @@ else:
                 "You should consider `expandable_segments:True` in the"
                 " environment variable `PYTORCH_CUDA_ALLOC_CONF` for lower"
                 " memory usage. See "
-                "https://pytorch.org/docs/stable/notes/cuda.html#optimizing-memory-usage-with-pytorch-cuda-alloc-conf"
+                "https://pytorch.org/docs/stable/notes/cuda.html"
+                "#optimizing-memory-usage-with-pytorch-cuda-alloc-conf"
             )
     else:
         configs["expandable_segments"] = "True"

--- a/python/dgl/graphbolt/__init__.py
+++ b/python/dgl/graphbolt/__init__.py
@@ -25,7 +25,7 @@ else:
             [k + ":" + v for k, v in configs.items()]
         )
 
-# pylint: disable=wrong-import-position
+# pylint: disable=wrong-import-position, wrong-import-order
 import torch
 
 ### FROM DGL @todo

--- a/tests/python/pytorch/graphbolt/test_base.py
+++ b/tests/python/pytorch/graphbolt/test_base.py
@@ -1,3 +1,4 @@
+import os
 import re
 import unittest
 from collections.abc import Iterable, Mapping
@@ -10,6 +11,13 @@ import torch
 from torch.torch_version import TorchVersion
 
 from . import gb_test_utils
+
+
+def test_pytorch_cuda_allocator_conf():
+    env = os.getenv("PYTORCH_CUDA_ALLOC_CONF")
+    assert env is not None
+    config_list = env.split(",")
+    assert "expandable_segments:True" in config_list
 
 
 @unittest.skipIf(F._default_context_str != "gpu", "CopyTo needs GPU to test")


### PR DESCRIPTION
## Description
I have 24GB GPU. Without this, some examples go OOM. With this, they don't even use half the GPU memory. This is due to the irregular sizes of the minibatches in GNN training. Each minibatch has different sized `node_ids()` for example. The default allocator does not work well in this use case. The added option is much better suited for GNN minibatch training with GraphBolt.

See https://pytorch.org/docs/stable/notes/cuda.html#optimizing-memory-usage-with-pytorch-cuda-alloc-conf.

## Checklist
Please feel free to remove inapplicable items for your PR.
- [ ] The PR title starts with [$CATEGORY] (such as [NN], [Model], [Doc], [Feature]])
- [ ] I've leverage the [tools](https://docs.google.com/document/d/1iHyj7zlmygKSk5gBPsqIqL5ASPzJSPREaNT_QdsiYA4/edit) to beautify the python and c++ code.
- [ ] The PR is complete and small, read the [Google eng practice (CL equals to PR)](https://google.github.io/eng-practices/review/developer/small-cls.html) to understand more about small PR. In DGL, we consider PRs with less than 200 lines of core code change are small (example, test and documentation could be exempted).
- [ ] All changes have test coverage
- [ ] Code is well-documented
- [ ] To the best of my knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change
- [ ] Related issue is referred in this PR
- [ ] If the PR is for a new model/paper, I've updated the example index [here](../examples/README.md).

## Changes
<!-- You could use following template
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)
-->
