### PR TITLE
[GraphBolt] `CachePolicy::QueryAndThenReplace`.

### DIFF
--- a/graphbolt/src/cache_policy.cc
+++ b/graphbolt/src/cache_policy.cc
@@ -74,6 +74,72 @@ BaseCachePolicy::QueryImpl(CachePolicy& policy, torch::Tensor keys) {
 }
 
 template <typename CachePolicy>
+std::tuple<torch::Tensor, torch::Tensor, torch::Tensor, torch::Tensor>
+BaseCachePolicy::QueryAndThenReplaceImpl(
+    CachePolicy& policy, torch::Tensor keys) {
+  auto positions = torch::empty_like(
+      keys, keys.options()
+                .dtype(torch::kInt64)
+                .pinned_memory(utils::is_pinned(keys)));
+  auto indices = torch::empty_like(
+      keys, keys.options()
+                .dtype(torch::kInt64)
+                .pinned_memory(utils::is_pinned(keys)));
+  auto pointers = torch::empty_like(keys, keys.options().dtype(torch::kInt64));
+  auto missing_keys = torch::empty_like(
+      keys, keys.options().pinned_memory(utils::is_pinned(keys)));
+  int64_t found_cnt = 0;
+  int64_t missing_cnt = keys.size(0);
+  AT_DISPATCH_INDEX_TYPES(
+      keys.scalar_type(), "BaseCachePolicy::Replace", ([&] {
+        auto keys_ptr = keys.data_ptr<index_t>();
+        auto positions_ptr = positions.data_ptr<int64_t>();
+        auto indices_ptr = indices.data_ptr<int64_t>();
+        static_assert(
+            sizeof(CacheKey*) == sizeof(int64_t), "You need 64 bit pointers.");
+        auto pointers_ptr =
+            reinterpret_cast<CacheKey**>(pointers.data_ptr<int64_t>());
+        auto missing_keys_ptr = missing_keys.data_ptr<index_t>();
+        auto iterators = std::unique_ptr<typename CachePolicy::map_iterator[]>(
+            new typename CachePolicy::map_iterator[keys.size(0)]);
+        // QueryImpl here.
+        for (int64_t i = 0; i < keys.size(0); i++) {
+          const auto key = keys_ptr[i];
+          const auto [it, can_read] = policy.Emplace(key);
+          if (can_read) {
+            auto& cache_key = *it->second;
+            positions_ptr[found_cnt] = cache_key.getPos();
+            pointers_ptr[found_cnt] = &cache_key;
+            indices_ptr[found_cnt++] = i;
+          } else {
+            indices_ptr[--missing_cnt] = i;
+            missing_keys_ptr[missing_cnt] = key;
+            iterators[missing_cnt] = it;
+          }
+        }
+        // ReplaceImpl here.
+        set_t<int64_t> position_set;
+        position_set.reserve(keys.size(0));
+        for (int64_t i = missing_cnt; i < missing_keys.size(0); i++) {
+          auto it = iterators[i];
+          if (it->second == policy.getMapSentinelValue()) {
+            policy.Insert(it);
+            // After Insert, it->second is not nullptr anymore.
+            TORCH_CHECK(
+                // If there are duplicate values and the key was just inserted,
+                // we do not have to check for the uniqueness of the positions.
+                std::get<1>(position_set.insert(it->second->getPos())),
+                "Can't insert all, larger cache capacity is needed.");
+          }
+          auto& cache_key = *it->second;
+          positions_ptr[i] = cache_key.getPos();
+          pointers_ptr[i] = &cache_key;
+        }
+      }));
+  return {positions, indices, pointers, missing_keys};
+}
+
+template <typename CachePolicy>
 std::tuple<torch::Tensor, torch::Tensor> BaseCachePolicy::ReplaceImpl(
     CachePolicy& policy, torch::Tensor keys) {
   auto positions = torch::empty_like(
@@ -140,6 +206,11 @@ S3FifoCachePolicy::Query(torch::Tensor keys) {
   return QueryImpl(*this, keys);
 }
 
+std::tuple<torch::Tensor, torch::Tensor, torch::Tensor, torch::Tensor>
+S3FifoCachePolicy::QueryAndThenReplace(torch::Tensor keys) {
+  return QueryAndThenReplaceImpl(*this, keys);
+}
+
 std::tuple<torch::Tensor, torch::Tensor> S3FifoCachePolicy::Replace(
     torch::Tensor keys) {
   return ReplaceImpl(*this, keys);
@@ -163,6 +234,11 @@ SieveCachePolicy::SieveCachePolicy(int64_t capacity)
 std::tuple<torch::Tensor, torch::Tensor, torch::Tensor, torch::Tensor>
 SieveCachePolicy::Query(torch::Tensor keys) {
   return QueryImpl(*this, keys);
+}
+
+std::tuple<torch::Tensor, torch::Tensor, torch::Tensor, torch::Tensor>
+SieveCachePolicy::QueryAndThenReplace(torch::Tensor keys) {
+  return QueryAndThenReplaceImpl(*this, keys);
 }
 
 std::tuple<torch::Tensor, torch::Tensor> SieveCachePolicy::Replace(
@@ -189,6 +265,11 @@ LruCachePolicy::Query(torch::Tensor keys) {
   return QueryImpl(*this, keys);
 }
 
+std::tuple<torch::Tensor, torch::Tensor, torch::Tensor, torch::Tensor>
+LruCachePolicy::QueryAndThenReplace(torch::Tensor keys) {
+  return QueryAndThenReplaceImpl(*this, keys);
+}
+
 std::tuple<torch::Tensor, torch::Tensor> LruCachePolicy::Replace(
     torch::Tensor keys) {
   return ReplaceImpl(*this, keys);
@@ -211,6 +292,11 @@ ClockCachePolicy::ClockCachePolicy(int64_t capacity)
 std::tuple<torch::Tensor, torch::Tensor, torch::Tensor, torch::Tensor>
 ClockCachePolicy::Query(torch::Tensor keys) {
   return QueryImpl(*this, keys);
+}
+
+std::tuple<torch::Tensor, torch::Tensor, torch::Tensor, torch::Tensor>
+ClockCachePolicy::QueryAndThenReplace(torch::Tensor keys) {
+  return QueryAndThenReplaceImpl(*this, keys);
 }
 
 std::tuple<torch::Tensor, torch::Tensor> ClockCachePolicy::Replace(


### PR DESCRIPTION
## Description
Fusing the query and replace operations will make the cache more performant. The costliest operation was the map lookup in the cache. By fusing the Query and Replace like this, we make sure only 1 map lookup operation is performed per key whether it already exists or not.

The PR ended up a bit large due to the same change being applied to all 4 existing cache policy implementations.

Next PR will add `PartitionCachePolicy::QueryAndThenReplace`.

Then the next PR should add its tests and incorporate it into `CPUCachedFeature` and `CPUFeatureCache` classes.

## Checklist
Please feel free to remove inapplicable items for your PR.
- [ ] The PR title starts with [$CATEGORY] (such as [NN], [Model], [Doc], [Feature]])
- [ ] I've leverage the [tools](https://docs.google.com/document/d/1iHyj7zlmygKSk5gBPsqIqL5ASPzJSPREaNT_QdsiYA4/edit) to beautify the python and c++ code.
- [ ] The PR is complete and small, read the [Google eng practice (CL equals to PR)](https://google.github.io/eng-practices/review/developer/small-cls.html) to understand more about small PR. In DGL, we consider PRs with less than 200 lines of core code change are small (example, test and documentation could be exempted).
- [ ] All changes have test coverage
- [ ] Code is well-documented
- [ ] To the best of my knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change
- [ ] Related issue is referred in this PR
- [ ] If the PR is for a new model/paper, I've updated the example index [here](../examples/README.md).

## Changes
<!-- You could use following template
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)
-->
