### PR TITLE
[GraphBolt] Test `CachePolicy::QueryAndThenReplace` for `num_parts==1`.

### DIFF
--- a/graphbolt/src/cache_policy.cc
+++ b/graphbolt/src/cache_policy.cc
@@ -136,7 +136,7 @@ BaseCachePolicy::QueryAndThenReplaceImpl(
           pointers_ptr[i] = &cache_key;
         }
       }));
-  return {positions, indices, pointers, missing_keys};
+  return {positions, indices, pointers, missing_keys.slice(0, found_cnt)};
 }
 
 template <typename CachePolicy>

--- a/graphbolt/src/partitioned_cache_policy.h
+++ b/graphbolt/src/partitioned_cache_policy.h
@@ -75,6 +75,29 @@ class PartitionedCachePolicy : public torch::CustomClassHolder {
       torch::Tensor keys);
 
   /**
+   * @brief The policy query and then replace function.
+   * @param keys The keys to query the cache.
+   *
+   * @return (positions, indices, pointers, missing_keys, found_offsets,
+   * missing_offsets), where positions has the locations of the keys which were
+   * emplaced into the cache, pointers point to the emplaced CacheKey pointers
+   * in the cache, missing_keys has the keys that were not found and just
+   * inserted and indices is defined such that keys[indices[:keys.size(0) -
+   * missing_keys.size(0)]] gives us the keys for the found keys and
+   * keys[indices[keys.size(0) - missing_keys.size(0):]] is identical to
+   * missing_keys. The found_offsets tensor holds the partition offsets for the
+   * found pointers. The missing_offsets holds the partition offsets for the
+   * missing_keys and missing pointers.
+   */
+  std::tuple<
+      torch::Tensor, torch::Tensor, torch::Tensor, torch::Tensor, torch::Tensor,
+      torch::Tensor>
+  QueryAndThenReplace(torch::Tensor keys);
+
+  c10::intrusive_ptr<Future<std::vector<torch::Tensor>>>
+  QueryAndThenReplaceAsync(torch::Tensor keys);
+
+  /**
    * @brief The policy replace function.
    * @param keys The keys to query the cache.
    * @param offsets The partition offsets for the keys.

--- a/graphbolt/src/python_binding.cc
+++ b/graphbolt/src/python_binding.cc
@@ -107,6 +107,12 @@ TORCH_LIBRARY(graphbolt, m) {
   m.class_<storage::PartitionedCachePolicy>("PartitionedCachePolicy")
       .def("query", &storage::PartitionedCachePolicy::Query)
       .def("query_async", &storage::PartitionedCachePolicy::QueryAsync)
+      .def(
+          "query_and_then_replace",
+          &storage::PartitionedCachePolicy::QueryAndThenReplace)
+      .def(
+          "query_and_then_replace_async",
+          &storage::PartitionedCachePolicy::QueryAndThenReplaceAsync)
       .def("replace", &storage::PartitionedCachePolicy::Replace)
       .def("replace_async", &storage::PartitionedCachePolicy::ReplaceAsync)
       .def(

--- a/python/dgl/graphbolt/impl/feature_cache.py
+++ b/python/dgl/graphbolt/impl/feature_cache.py
@@ -92,6 +92,50 @@ class CPUFeatureCache(object):
         missing_index = index[positions.size(0) :]
         return values, missing_index, missing_keys, missing_offsets
 
+    def query_and_then_replace(self, keys, reader_fn):
+        """Queries the cache. Then inserts the keys that are not found by
+        reading them by calling `reader_fn(missing_keys)`, which are then
+        inserted into the cache using the selected caching policy algorithm
+        to remove the old entries if it is full.
+
+        Parameters
+        ----------
+        keys : Tensor
+            The keys to query the cache with.
+        reader_fn : reader_fn(keys: torch.Tensor) -> torch.Tensor
+            A function that will take a missing keys tensor and will return
+            their values.
+
+        Returns
+        -------
+        Tensor
+            A tensor containing values corresponding to the keys. Should equal
+            `reader_fn(keys)`, computed in a faster way.
+        """
+        self.total_queries += keys.shape[0]
+        (
+            positions,
+            index,
+            pointers,
+            missing_keys,
+            found_offsets,
+            missing_offsets,
+        ) = self._policy.query_and_then_replace(keys)
+        found_cnt = keys.size(0) - missing_keys.size(0)
+        found_positions = positions[:found_cnt]
+        values = self._cache.query(found_positions, index, keys.shape[0])
+        found_pointers = pointers[:found_cnt]
+        self._policy.reading_completed(found_pointers, found_offsets)
+        self.total_miss += missing_keys.shape[0]
+        missing_index = index[found_cnt:]
+        missing_values = reader_fn(missing_keys)
+        values[missing_index] = missing_values
+        missing_positions = positions[found_cnt:]
+        self._cache.replace(missing_positions, missing_values)
+        missing_pointers = pointers[found_cnt:]
+        self._policy.writing_completed(missing_pointers, missing_offsets)
+        return values
+
     def replace(self, keys, values, offsets=None):
         """Inserts key-value pairs into the cache using the selected caching
         policy algorithm to remove old key-value pairs if it is full.


### PR DESCRIPTION
## Description
Followup to #7619. Testing the implementation for the single part case. Will add multi-part implementation and tests in the next PR.

## Checklist
Please feel free to remove inapplicable items for your PR.
- [ ] The PR title starts with [$CATEGORY] (such as [NN], [Model], [Doc], [Feature]])
- [ ] I've leverage the [tools](https://docs.google.com/document/d/1iHyj7zlmygKSk5gBPsqIqL5ASPzJSPREaNT_QdsiYA4/edit) to beautify the python and c++ code.
- [ ] The PR is complete and small, read the [Google eng practice (CL equals to PR)](https://google.github.io/eng-practices/review/developer/small-cls.html) to understand more about small PR. In DGL, we consider PRs with less than 200 lines of core code change are small (example, test and documentation could be exempted).
- [ ] All changes have test coverage
- [ ] Code is well-documented
- [ ] To the best of my knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change
- [ ] Related issue is referred in this PR
- [ ] If the PR is for a new model/paper, I've updated the example index [here](../examples/README.md).

## Changes
<!-- You could use following template
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)
-->
