### PR TITLE
[GraphBolt] `CachePolicy::QueryAndThenReplace` for `num_parts>1`.

### DIFF
--- a/graphbolt/src/cache_policy.cc
+++ b/graphbolt/src/cache_policy.cc
@@ -130,6 +130,8 @@ BaseCachePolicy::QueryAndThenReplaceImpl(
                 // we do not have to check for the uniqueness of the positions.
                 std::get<1>(position_set.insert(it->second->getPos())),
                 "Can't insert all, larger cache capacity is needed.");
+          } else {
+            policy.MarkExistingWriting(it);
           }
           auto& cache_key = *it->second;
           positions_ptr[i] = cache_key.getPos();

--- a/graphbolt/src/cache_policy.h
+++ b/graphbolt/src/cache_policy.h
@@ -271,8 +271,6 @@ class S3FifoCachePolicy : public BaseCachePolicy {
         // true to indicate the key is ready to read.
         cache_key.Increment().StartUse<false>();
         return {it, true};
-      } else {
-        cache_key.Increment().StartUse<true>();
       }
     }
     // First time insertion, return false to indicate not ready to read.
@@ -425,8 +423,6 @@ class SieveCachePolicy : public BaseCachePolicy {
         // true to indicate the key is ready to read.
         cache_key.SetFreq().StartUse<false>();
         return {it, true};
-      } else {
-        cache_key.SetFreq().StartUse<true>();
       }
     }
     // First time insertion, return false to indicate not ready to read.
@@ -568,8 +564,6 @@ class LruCachePolicy : public BaseCachePolicy {
         // true to indicate the key is ready to read.
         cache_key.StartUse<false>();
         return {it, true};
-      } else {
-        cache_key.StartUse<true>();
       }
     }
     // First time insertion, return false to indicate not ready to read.

--- a/graphbolt/src/cache_policy.h
+++ b/graphbolt/src/cache_policy.h
@@ -557,9 +557,9 @@ class LruCachePolicy : public BaseCachePolicy {
   std::pair<map_iterator, bool> Emplace(int64_t key) {
     auto [it, _] = key_to_cache_key_.emplace(key, getMapSentinelValue());
     if (it->second != getMapSentinelValue()) {
-      MoveToFront(it->second);
       auto& cache_key = *it->second;
       if (!cache_key.BeingWritten()) {
+        MoveToFront(it->second);
         // Not being written so we use StartUse<write=false>() and return
         // true to indicate the key is ready to read.
         cache_key.StartUse<false>();

--- a/python/dgl/graphbolt/impl/cpu_cached_feature.py
+++ b/python/dgl/graphbolt/impl/cpu_cached_feature.py
@@ -75,6 +75,9 @@ class CPUCachedFeature(Feature):
         """
         if ids is None:
             return self._fallback_feature.read()
+        return self._feature.query_and_then_replace(
+            ids, self._fallback_feature.read
+        )
         (
             values,
             missing_index,

--- a/python/dgl/graphbolt/impl/cpu_cached_feature.py
+++ b/python/dgl/graphbolt/impl/cpu_cached_feature.py
@@ -78,16 +78,6 @@ class CPUCachedFeature(Feature):
         return self._feature.query_and_then_replace(
             ids, self._fallback_feature.read
         )
-        (
-            values,
-            missing_index,
-            missing_keys,
-            missing_offsets,
-        ) = self._feature.query(ids)
-        missing_values = self._fallback_feature.read(missing_keys)
-        values[missing_index] = missing_values
-        self._feature.replace(missing_keys, missing_values, missing_offsets)
-        return values
 
     def read_async(self, ids: torch.Tensor):
         """Read the feature by index asynchronously.

--- a/tests/python/pytorch/graphbolt/impl/test_feature_cache.py
+++ b/tests/python/pytorch/graphbolt/impl/test_feature_cache.py
@@ -51,9 +51,7 @@ def test_feature_cache(offsets, dtype, feature_size, num_parts, policy):
     cache.replace(missing_keys, missing_values, missing_offsets)
     values[missing_index] = missing_values
     assert torch.equal(values, a[keys])
-    assert torch.equal(
-        cache2.query_and_then_replace(keys, reader_fn), a[keys]
-    )
+    assert torch.equal(cache2.query_and_then_replace(keys, reader_fn), a[keys])
 
     pin_memory = F._default_context_str == "gpu"
 
@@ -71,9 +69,7 @@ def test_feature_cache(offsets, dtype, feature_size, num_parts, policy):
     cache.replace(missing_keys, missing_values, missing_offsets)
     values[missing_index] = missing_values
     assert torch.equal(values, a[keys])
-    assert torch.equal(
-        cache2.query_and_then_replace(keys, reader_fn), a[keys]
-    )
+    assert torch.equal(cache2.query_and_then_replace(keys, reader_fn), a[keys])
 
     values, missing_index, missing_keys, missing_offsets = cache.query(keys)
     if not offsets:
@@ -84,9 +80,7 @@ def test_feature_cache(offsets, dtype, feature_size, num_parts, policy):
     cache.replace(missing_keys, missing_values, missing_offsets)
     values[missing_index] = missing_values
     assert torch.equal(values, a[keys])
-    assert torch.equal(
-        cache2.query_and_then_replace(keys, reader_fn), a[keys]
-    )
+    assert torch.equal(cache2.query_and_then_replace(keys, reader_fn), a[keys])
 
     values, missing_index, missing_keys, missing_offsets = cache.query(keys)
     if not offsets:
@@ -97,9 +91,7 @@ def test_feature_cache(offsets, dtype, feature_size, num_parts, policy):
     cache.replace(missing_keys, missing_values, missing_offsets)
     values[missing_index] = missing_values
     assert torch.equal(values, a[keys])
-    assert torch.equal(
-        cache2.query_and_then_replace(keys, reader_fn), a[keys]
-    )
+    assert torch.equal(cache2.query_and_then_replace(keys, reader_fn), a[keys])
 
     assert cache.miss_rate == cache2.miss_rate
 

--- a/tests/python/pytorch/graphbolt/impl/test_feature_cache.py
+++ b/tests/python/pytorch/graphbolt/impl/test_feature_cache.py
@@ -51,11 +51,9 @@ def test_feature_cache(offsets, dtype, feature_size, num_parts, policy):
     cache.replace(missing_keys, missing_values, missing_offsets)
     values[missing_index] = missing_values
     assert torch.equal(values, a[keys])
-
-    if num_parts == 1:
-        assert torch.equal(
-            cache2.query_and_then_replace(keys, reader_fn), a[keys]
-        )
+    assert torch.equal(
+        cache2.query_and_then_replace(keys, reader_fn), a[keys]
+    )
 
     pin_memory = F._default_context_str == "gpu"
 
@@ -73,11 +71,9 @@ def test_feature_cache(offsets, dtype, feature_size, num_parts, policy):
     cache.replace(missing_keys, missing_values, missing_offsets)
     values[missing_index] = missing_values
     assert torch.equal(values, a[keys])
-
-    if num_parts == 1:
-        assert torch.equal(
-            cache2.query_and_then_replace(keys, reader_fn), a[keys]
-        )
+    assert torch.equal(
+        cache2.query_and_then_replace(keys, reader_fn), a[keys]
+    )
 
     values, missing_index, missing_keys, missing_offsets = cache.query(keys)
     if not offsets:
@@ -88,11 +84,9 @@ def test_feature_cache(offsets, dtype, feature_size, num_parts, policy):
     cache.replace(missing_keys, missing_values, missing_offsets)
     values[missing_index] = missing_values
     assert torch.equal(values, a[keys])
-
-    if num_parts == 1:
-        assert torch.equal(
-            cache2.query_and_then_replace(keys, reader_fn), a[keys]
-        )
+    assert torch.equal(
+        cache2.query_and_then_replace(keys, reader_fn), a[keys]
+    )
 
     values, missing_index, missing_keys, missing_offsets = cache.query(keys)
     if not offsets:
@@ -103,12 +97,11 @@ def test_feature_cache(offsets, dtype, feature_size, num_parts, policy):
     cache.replace(missing_keys, missing_values, missing_offsets)
     values[missing_index] = missing_values
     assert torch.equal(values, a[keys])
+    assert torch.equal(
+        cache2.query_and_then_replace(keys, reader_fn), a[keys]
+    )
 
-    if num_parts == 1:
-        assert torch.equal(
-            cache2.query_and_then_replace(keys, reader_fn), a[keys]
-        )
-        assert cache.miss_rate == cache2.miss_rate
+    assert cache.miss_rate == cache2.miss_rate
 
     raw_feature_cache = torch.ops.graphbolt.feature_cache(
         (cache_size,) + a.shape[1:], a.dtype, pin_memory


### PR DESCRIPTION
## Description
Follow-up to #7620.

TODO: Refactor the code so that the permute portions of the Query, QueryAndThenReplace and Replace can be shared.

## Checklist
Please feel free to remove inapplicable items for your PR.
- [ ] The PR title starts with [$CATEGORY] (such as [NN], [Model], [Doc], [Feature]])
- [ ] I've leverage the [tools](https://docs.google.com/document/d/1iHyj7zlmygKSk5gBPsqIqL5ASPzJSPREaNT_QdsiYA4/edit) to beautify the python and c++ code.
- [ ] The PR is complete and small, read the [Google eng practice (CL equals to PR)](https://google.github.io/eng-practices/review/developer/small-cls.html) to understand more about small PR. In DGL, we consider PRs with less than 200 lines of core code change are small (example, test and documentation could be exempted).
- [ ] All changes have test coverage
- [ ] Code is well-documented
- [ ] To the best of my knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change
- [ ] Related issue is referred in this PR
- [ ] If the PR is for a new model/paper, I've updated the example index [here](../examples/README.md).

## Changes
<!-- You could use following template
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)
-->
