### PR TITLE
[GraphBolt] `QueryAndReplace` replaces `QueryAndThenReplace`.

### DIFF
--- a/graphbolt/src/cache_policy.cc
+++ b/graphbolt/src/cache_policy.cc
@@ -117,9 +117,7 @@ BaseCachePolicy::QueryAndReplaceImpl(CachePolicy& policy, torch::Tensor keys) {
               policy.Insert(it);
               // After Insert, it->second is not nullptr anymore.
               TORCH_CHECK(
-                  // If there are duplicate values and the key was just
-                  // inserted, we do not have to check for the uniqueness of the
-                  // positions.
+                  // We check for the uniqueness of the positions.
                   std::get<1>(position_set.insert(it->second->getPos())),
                   "Can't insert all, larger cache capacity is needed.");
             } else {

--- a/graphbolt/src/cache_policy.h
+++ b/graphbolt/src/cache_policy.h
@@ -144,7 +144,7 @@ class BaseCachePolicy {
    * identical to missing_keys.
    */
   virtual std::tuple<torch::Tensor, torch::Tensor, torch::Tensor, torch::Tensor>
-  QueryAndThenReplace(torch::Tensor keys) = 0;
+  QueryAndReplace(torch::Tensor keys) = 0;
 
   /**
    * @brief The policy replace function.
@@ -182,7 +182,7 @@ class BaseCachePolicy {
 
   template <typename CachePolicy>
   static std::tuple<torch::Tensor, torch::Tensor, torch::Tensor, torch::Tensor>
-  QueryAndThenReplaceImpl(CachePolicy& policy, torch::Tensor keys);
+  QueryAndReplaceImpl(CachePolicy& policy, torch::Tensor keys);
 
   template <typename CachePolicy>
   static std::tuple<torch::Tensor, torch::Tensor> ReplaceImpl(
@@ -220,10 +220,10 @@ class S3FifoCachePolicy : public BaseCachePolicy {
       torch::Tensor keys);
 
   /**
-   * @brief See BaseCachePolicy::QueryAndThenReplace.
+   * @brief See BaseCachePolicy::QueryAndReplace.
    */
   std::tuple<torch::Tensor, torch::Tensor, torch::Tensor, torch::Tensor>
-  QueryAndThenReplace(torch::Tensor keys);
+  QueryAndReplace(torch::Tensor keys);
 
   /**
    * @brief See BaseCachePolicy::Replace.
@@ -380,10 +380,10 @@ class SieveCachePolicy : public BaseCachePolicy {
       torch::Tensor keys);
 
   /**
-   * @brief See BaseCachePolicy::QueryAndThenReplace.
+   * @brief See BaseCachePolicy::QueryAndReplace.
    */
   std::tuple<torch::Tensor, torch::Tensor, torch::Tensor, torch::Tensor>
-  QueryAndThenReplace(torch::Tensor keys);
+  QueryAndReplace(torch::Tensor keys);
 
   /**
    * @brief See BaseCachePolicy::Replace.
@@ -507,10 +507,10 @@ class LruCachePolicy : public BaseCachePolicy {
       torch::Tensor keys);
 
   /**
-   * @brief See BaseCachePolicy::QueryAndThenReplace.
+   * @brief See BaseCachePolicy::QueryAndReplace.
    */
   std::tuple<torch::Tensor, torch::Tensor, torch::Tensor, torch::Tensor>
-  QueryAndThenReplace(torch::Tensor keys);
+  QueryAndReplace(torch::Tensor keys);
 
   /**
    * @brief See BaseCachePolicy::Replace.
@@ -649,10 +649,10 @@ class ClockCachePolicy : public BaseCachePolicy {
       torch::Tensor keys);
 
   /**
-   * @brief See BaseCachePolicy::QueryAndThenReplace.
+   * @brief See BaseCachePolicy::QueryAndReplace.
    */
   std::tuple<torch::Tensor, torch::Tensor, torch::Tensor, torch::Tensor>
-  QueryAndThenReplace(torch::Tensor keys);
+  QueryAndReplace(torch::Tensor keys);
 
   /**
    * @brief See BaseCachePolicy::Replace.

--- a/graphbolt/src/partitioned_cache_policy.h
+++ b/graphbolt/src/partitioned_cache_policy.h
@@ -92,10 +92,10 @@ class PartitionedCachePolicy : public torch::CustomClassHolder {
   std::tuple<
       torch::Tensor, torch::Tensor, torch::Tensor, torch::Tensor, torch::Tensor,
       torch::Tensor>
-  QueryAndThenReplace(torch::Tensor keys);
+  QueryAndReplace(torch::Tensor keys);
 
-  c10::intrusive_ptr<Future<std::vector<torch::Tensor>>>
-  QueryAndThenReplaceAsync(torch::Tensor keys);
+  c10::intrusive_ptr<Future<std::vector<torch::Tensor>>> QueryAndReplaceAsync(
+      torch::Tensor keys);
 
   /**
    * @brief The policy replace function.

--- a/graphbolt/src/python_binding.cc
+++ b/graphbolt/src/python_binding.cc
@@ -108,11 +108,11 @@ TORCH_LIBRARY(graphbolt, m) {
       .def("query", &storage::PartitionedCachePolicy::Query)
       .def("query_async", &storage::PartitionedCachePolicy::QueryAsync)
       .def(
-          "query_and_then_replace",
-          &storage::PartitionedCachePolicy::QueryAndThenReplace)
+          "query_and_replace",
+          &storage::PartitionedCachePolicy::QueryAndReplace)
       .def(
-          "query_and_then_replace_async",
-          &storage::PartitionedCachePolicy::QueryAndThenReplaceAsync)
+          "query_and_replace_async",
+          &storage::PartitionedCachePolicy::QueryAndReplaceAsync)
       .def("replace", &storage::PartitionedCachePolicy::Replace)
       .def("replace_async", &storage::PartitionedCachePolicy::ReplaceAsync)
       .def(

--- a/python/dgl/graphbolt/impl/cpu_cached_feature.py
+++ b/python/dgl/graphbolt/impl/cpu_cached_feature.py
@@ -75,9 +75,7 @@ class CPUCachedFeature(Feature):
         """
         if ids is None:
             return self._fallback_feature.read()
-        return self._feature.query_and_replace(
-            ids, self._fallback_feature.read
-        )
+        return self._feature.query_and_replace(ids, self._fallback_feature.read)
 
     def read_async(self, ids: torch.Tensor):
         """Read the feature by index asynchronously.

--- a/python/dgl/graphbolt/impl/cpu_cached_feature.py
+++ b/python/dgl/graphbolt/impl/cpu_cached_feature.py
@@ -75,7 +75,7 @@ class CPUCachedFeature(Feature):
         """
         if ids is None:
             return self._fallback_feature.read()
-        return self._feature.query_and_then_replace(
+        return self._feature.query_and_replace(
             ids, self._fallback_feature.read
         )
 
@@ -121,7 +121,7 @@ class CPUCachedFeature(Feature):
             yield  # first stage is done.
 
             ids_copy_event.synchronize()
-            policy_future = policy.query_and_then_replace_async(ids)
+            policy_future = policy.query_and_replace_async(ids)
 
             yield
 
@@ -235,7 +235,7 @@ class CPUCachedFeature(Feature):
             yield  # first stage is done.
 
             ids_copy_event.synchronize()
-            policy_future = policy.query_and_then_replace_async(ids)
+            policy_future = policy.query_and_replace_async(ids)
 
             yield
 
@@ -313,7 +313,7 @@ class CPUCachedFeature(Feature):
 
             yield _Waiter([values_copy_event, writing_completed], values)
         else:
-            policy_future = policy.query_and_then_replace_async(ids)
+            policy_future = policy.query_and_replace_async(ids)
 
             yield
 

--- a/python/dgl/graphbolt/impl/feature_cache.py
+++ b/python/dgl/graphbolt/impl/feature_cache.py
@@ -92,7 +92,7 @@ class CPUFeatureCache(object):
         missing_index = index[positions.size(0) :]
         return values, missing_index, missing_keys, missing_offsets
 
-    def query_and_then_replace(self, keys, reader_fn):
+    def query_and_replace(self, keys, reader_fn):
         """Queries the cache. Then inserts the keys that are not found by
         reading them by calling `reader_fn(missing_keys)`, which are then
         inserted into the cache using the selected caching policy algorithm
@@ -120,7 +120,7 @@ class CPUFeatureCache(object):
             missing_keys,
             found_offsets,
             missing_offsets,
-        ) = self._policy.query_and_then_replace(keys)
+        ) = self._policy.query_and_replace(keys)
         found_cnt = keys.size(0) - missing_keys.size(0)
         found_positions = positions[:found_cnt]
         values = self._cache.query(found_positions, index, keys.shape[0])


### PR DESCRIPTION
## Description
The algorithm does not have the exact same semantics as calling Query and Replace back to back anymore. This is done for safety (if the hashmap rehashes, it was going mayhem) and reduce our reliance on iterator stability of the hashmap container. This way, we can switch to faster hashmaps in a later PR that does not have iterator stability.

## Checklist
Please feel free to remove inapplicable items for your PR.
- [ ] The PR title starts with [$CATEGORY] (such as [NN], [Model], [Doc], [Feature]])
- [ ] I've leverage the [tools](https://docs.google.com/document/d/1iHyj7zlmygKSk5gBPsqIqL5ASPzJSPREaNT_QdsiYA4/edit) to beautify the python and c++ code.
- [ ] The PR is complete and small, read the [Google eng practice (CL equals to PR)](https://google.github.io/eng-practices/review/developer/small-cls.html) to understand more about small PR. In DGL, we consider PRs with less than 200 lines of core code change are small (example, test and documentation could be exempted).
- [ ] All changes have test coverage
- [ ] Code is well-documented
- [ ] To the best of my knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change
- [ ] Related issue is referred in this PR
- [ ] If the PR is for a new model/paper, I've updated the example index [here](../examples/README.md).

## Changes
<!-- You could use following template
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)
-->
