### PR TITLE
[GraphBolt] Change hash table for performance.

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -37,3 +37,6 @@
 [submodule "third_party/taskflow"]
 	path = third_party/taskflow
 	url = https://github.com/taskflow/taskflow.git
+[submodule "third_party/tsl_robin_map"]
+	path = third_party/tsl_robin_map
+	url = https://github.com/Tessil/robin-map.git

--- a/graphbolt/CMakeLists.txt
+++ b/graphbolt/CMakeLists.txt
@@ -78,7 +78,7 @@ include_directories(BEFORE ${BOLT_DIR}
                            # `std::atomic_ref`, `std::counting_semaphore`
                            "../third_party/cccl/libcudacxx/include"
                            "../third_party/pcg/include"
-                           "../third_party/phmap")
+                           "../third_party/tsl_robin_map/include")
 target_link_libraries(${LIB_GRAPHBOLT_NAME} "${TORCH_LIBRARIES}")
 if(BUILD_WITH_TASKFLOW)
   target_include_directories(${LIB_GRAPHBOLT_NAME} PRIVATE "../third_party/taskflow")


### PR DESCRIPTION
## Description
1.5x faster compared to phmap. This hash table is used across the industry for its excellent performance. See the benchmark results in https://martin.ankerl.com/2022/08/27/hashmap-bench-01/#benchmark-results-table for reference. We chose to use `tsl::robin_map` for our use case after trying out a few alternatives.

@frozenbugs 50% performance improvement is not small so I am hoping it is fine for me to add this hash table dependency.

## Checklist
Please feel free to remove inapplicable items for your PR.
- [ ] The PR title starts with [$CATEGORY] (such as [NN], [Model], [Doc], [Feature]])
- [ ] I've leverage the [tools](https://docs.google.com/document/d/1iHyj7zlmygKSk5gBPsqIqL5ASPzJSPREaNT_QdsiYA4/edit) to beautify the python and c++ code.
- [ ] The PR is complete and small, read the [Google eng practice (CL equals to PR)](https://google.github.io/eng-practices/review/developer/small-cls.html) to understand more about small PR. In DGL, we consider PRs with less than 200 lines of core code change are small (example, test and documentation could be exempted).
- [ ] All changes have test coverage
- [ ] Code is well-documented
- [ ] To the best of my knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change
- [ ] Related issue is referred in this PR
- [ ] If the PR is for a new model/paper, I've updated the example index [here](../examples/README.md).

## Changes
<!-- You could use following template
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)
-->
