### PR TITLE
[GraphBolt][CUDA] Remove python thread from `overlap_graph_fetch`.

### DIFF
--- a/python/dgl/graphbolt/base.py
+++ b/python/dgl/graphbolt/base.py
@@ -450,18 +450,6 @@ class Waiter(IterDataPipe):
             yield data
 
 
-@functional_datapipe("wait_future")
-class FutureWaiter(IterDataPipe):
-    """Calls the result function of all items and returns their results."""
-
-    def __init__(self, datapipe):
-        self.datapipe = datapipe
-
-    def __iter__(self):
-        for data in self.datapipe:
-            yield data.result()
-
-
 @dataclass
 class CSCFormatBase:
     r"""Basic class representing data in Compressed Sparse Column (CSC) format.

--- a/python/dgl/graphbolt/base.py
+++ b/python/dgl/graphbolt/base.py
@@ -31,7 +31,6 @@ __all__ = [
     "etype_str_to_tuple",
     "etype_tuple_to_str",
     "CopyTo",
-    "FutureWaiter",
     "Waiter",
     "Bufferer",
     "EndMarker",

--- a/python/dgl/graphbolt/dataloader.py
+++ b/python/dgl/graphbolt/dataloader.py
@@ -1,7 +1,6 @@
 """Graph Bolt DataLoaders"""
 
 from collections import OrderedDict
-from concurrent.futures import ThreadPoolExecutor
 
 import torch
 import torch.utils.data as torch_data

--- a/python/dgl/graphbolt/dataloader.py
+++ b/python/dgl/graphbolt/dataloader.py
@@ -205,7 +205,6 @@ class DataLoader(torch_data.DataLoader):
                 datapipe_graph,
                 SamplePerLayer,
             )
-            executor = ThreadPoolExecutor(max_workers=1)
             gpu_graph_cache = None
             for sampler in samplers:
                 if num_gpu_cached_edges > 0 and gpu_graph_cache is None:
@@ -218,7 +217,6 @@ class DataLoader(torch_data.DataLoader):
                     sampler.fetch_and_sample(
                         gpu_graph_cache,
                         get_host_to_device_uva_stream(),
-                        executor,
                         1,
                     ),
                 )

--- a/python/dgl/graphbolt/impl/neighbor_sampler.py
+++ b/python/dgl/graphbolt/impl/neighbor_sampler.py
@@ -123,7 +123,6 @@ class FetchInsubgraphData(Mapper):
         sample_per_layer_obj,
         gpu_graph_cache,
         stream=None,
-        executor=None,
     ):
         self.graph = sample_per_layer_obj.sampler.__self__
         datapipe = datapipe.concat_hetero_seeds(sample_per_layer_obj)
@@ -132,10 +131,6 @@ class FetchInsubgraphData(Mapper):
         super().__init__(datapipe, self._fetch_per_layer)
         self.prob_name = sample_per_layer_obj.prob_name
         self.stream = stream
-        if executor is None:
-            self.executor = ThreadPoolExecutor(max_workers=1)
-        else:
-            self.executor = executor
 
     def _fetch_per_layer_impl(self, minibatch, stream):
         with torch.cuda.stream(self.stream):
@@ -219,9 +214,7 @@ class FetchInsubgraphData(Mapper):
         if self.stream is not None:
             current_stream = torch.cuda.current_stream()
             self.stream.wait_stream(current_stream)
-        return self.executor.submit(
-            self._fetch_per_layer_impl, minibatch, current_stream
-        )
+        return self._fetch_per_layer_impl(minibatch, current_stream)
 
 
 @functional_datapipe("sample_per_layer_from_fetched_subgraph")
@@ -330,13 +323,12 @@ class FetcherAndSampler(MiniBatchTransformer):
         sampler,
         gpu_graph_cache,
         stream,
-        executor,
         buffer_size,
     ):
         datapipe = sampler.datapipe.fetch_insubgraph_data(
-            sampler, gpu_graph_cache, stream, executor
+            sampler, gpu_graph_cache, stream
         )
-        datapipe = datapipe.buffer(buffer_size).wait_future().wait()
+        datapipe = datapipe.buffer(buffer_size).wait()
         if gpu_graph_cache is not None:
             datapipe = datapipe.combine_cached_and_fetched_insubgraph(sampler)
         datapipe = datapipe.sample_per_layer_from_fetched_subgraph(sampler)

--- a/python/dgl/graphbolt/impl/neighbor_sampler.py
+++ b/python/dgl/graphbolt/impl/neighbor_sampler.py
@@ -1,6 +1,5 @@
 """Neighbor subgraph samplers for GraphBolt."""
 
-from concurrent.futures import ThreadPoolExecutor
 from functools import partial
 
 import torch

--- a/tests/python/pytorch/graphbolt/impl/test_neighbor_sampler.py
+++ b/tests/python/pytorch/graphbolt/impl/test_neighbor_sampler.py
@@ -80,7 +80,6 @@ def test_NeighborSampler_GraphFetch(
         sample_per_layer,
         gpu_graph_cache,
     )
-    datapipe = datapipe.wait_future()
     if num_cached_edges > 0:
         datapipe = gb.CombineCachedAndFetchedInSubgraph(
             datapipe, sample_per_layer


### PR DESCRIPTION
## Description
Due the Global Interpreter Lock (GIL) in Python, having an extra thread does not provide any benefit. When we make a call to C++, the GIL is taken and not released until back into python, so no benefit. GIL will be removed from Python in 3.13 and future versions (will be opt-in first). We need another C++ sided solution for asynchronous calls.

It turns out that this modification was actually reducing the performance due to GIL.

## Checklist
Please feel free to remove inapplicable items for your PR.
- [ ] The PR title starts with [$CATEGORY] (such as [NN], [Model], [Doc], [Feature]])
- [ ] I've leverage the [tools](https://docs.google.com/document/d/1iHyj7zlmygKSk5gBPsqIqL5ASPzJSPREaNT_QdsiYA4/edit) to beautify the python and c++ code.
- [ ] The PR is complete and small, read the [Google eng practice (CL equals to PR)](https://google.github.io/eng-practices/review/developer/small-cls.html) to understand more about small PR. In DGL, we consider PRs with less than 200 lines of core code change are small (example, test and documentation could be exempted).
- [ ] All changes have test coverage
- [ ] Code is well-documented
- [ ] To the best of my knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change
- [ ] Related issue is referred in this PR
- [ ] If the PR is for a new model/paper, I've updated the example index [here](../examples/README.md).

## Changes
<!-- You could use following template
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)
-->
