### PR TITLE
[GraphBolt][CUDA] Optimize `CopyTo` performance.

### DIFF
--- a/python/dgl/graphbolt/base.py
+++ b/python/dgl/graphbolt/base.py
@@ -369,9 +369,6 @@ class CopyTo(IterDataPipe):
 
     def __iter__(self):
         for data in self.datapipe:
-            if self.non_blocking:
-                # The copy is non blocking only if contents of data are pinned.
-                assert data.is_pinned(), f"{data} should be pinned."
             yield recursive_apply(
                 data, apply_to, self.device, self.non_blocking
             )

--- a/python/dgl/graphbolt/dataloader.py
+++ b/python/dgl/graphbolt/dataloader.py
@@ -231,11 +231,10 @@ class DataLoader(torch_data.DataLoader):
                     datapipe_graph = dp_utils.replace_dp(
                         datapipe_graph,
                         copier,
-                        copier.datapipe.transform(
-                            lambda x: x.pin_memory()
-                        ).prefetch(2)
-                        # After the data gets pinned, we can copy non_blocking.
-                        .copy_to(copier.device, non_blocking=True),
+                        # Add prefetch so that CPU and GPU can run concurrently.
+                        copier.datapipe.prefetch(2).copy_to(
+                            copier.device, non_blocking=True
+                        ),
                     )
 
         # The stages after feature fetching is still done in the main process.


### PR DESCRIPTION
## Description
https://pytorch.org/tutorials/intermediate/pinmem_nonblock.html

According to this tutorial, pinning before copying is not a requirement for `non_blocking` copies. However, when the data is pinned, it is possible to run the copies in a separate stream, this optimization can be enabled later. This should bring down the regression test runtimes for `cpu-cuda`.

## Checklist
Please feel free to remove inapplicable items for your PR.
- [ ] The PR title starts with [$CATEGORY] (such as [NN], [Model], [Doc], [Feature]])
- [ ] I've leverage the [tools](https://docs.google.com/document/d/1iHyj7zlmygKSk5gBPsqIqL5ASPzJSPREaNT_QdsiYA4/edit) to beautify the python and c++ code.
- [ ] The PR is complete and small, read the [Google eng practice (CL equals to PR)](https://google.github.io/eng-practices/review/developer/small-cls.html) to understand more about small PR. In DGL, we consider PRs with less than 200 lines of core code change are small (example, test and documentation could be exempted).
- [ ] All changes have test coverage
- [ ] Code is well-documented
- [ ] To the best of my knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change
- [ ] Related issue is referred in this PR
- [ ] If the PR is for a new model/paper, I've updated the example index [here](../examples/README.md).

## Changes
<!-- You could use following template
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)
-->
