### PR TITLE
[GraphBolt] Check data alignment before copying the file

### DIFF
--- a/python/dgl/graphbolt/internal/utils.py
+++ b/python/dgl/graphbolt/internal/utils.py
@@ -134,7 +134,7 @@ def copy_or_convert_data(
         if is_feature and get_npy_dim(input_path) == 1:
             data = data.reshape(-1, 1)
         # If the data does not need to be modified, just copy the file.
-        elif not within_int32:
+        elif not within_int32 and data.numpy().flags["C_CONTIGUOUS"]:
             shutil.copyfile(input_path, output_path)
             return
     else:


### PR DESCRIPTION
## Description
<!-- Brief description. Refer to the related issues if existed.
It'll be great if relevant reviewers can be assigned as well.-->

The `node-feat.npy` of products dataset is not saved in C_CONTIGUOUS (and possibly the same for other small datasets). Currently there is no check on the flags before directly copying the file, which will leads to errors [here](https://github.com/dmlc/dgl/blob/master/python/dgl/graphbolt/impl/torch_based_feature_store.py#L381-L383) if the data file is not C_CONTIGUOUS.

A simple solution here is to judge whether the data file is C_CONTIGUOUS. If yes, we can directly copy the file, otherwise we will need to proceed the save process.

## Checklist
Please feel free to remove inapplicable items for your PR.
- [ ] The PR title starts with [$CATEGORY] (such as [NN], [Model], [Doc], [Feature]])
- [ ] I've leverage the [tools](https://docs.google.com/document/d/1iHyj7zlmygKSk5gBPsqIqL5ASPzJSPREaNT_QdsiYA4/edit) to beautify the python and c++ code.
- [ ] The PR is complete and small, read the [Google eng practice (CL equals to PR)](https://google.github.io/eng-practices/review/developer/small-cls.html) to understand more about small PR. In DGL, we consider PRs with less than 200 lines of core code change are small (example, test and documentation could be exempted).
- [ ] All changes have test coverage
- [ ] Code is well-documented
- [ ] To the best of my knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change
- [ ] Related issue is referred in this PR
- [ ] If the PR is for a new model/paper, I've updated the example index [here](../examples/README.md).

## Changes
<!-- You could use following template
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)
-->
