### PR TITLE
[GraphBolt] Keep references valid in `CachePolicy`.

### DIFF
--- a/graphbolt/src/cache_policy.cc
+++ b/graphbolt/src/cache_policy.cc
@@ -113,18 +113,17 @@ BaseCachePolicy::QueryAndReplaceImpl(CachePolicy& policy, torch::Tensor keys) {
           } else {
             indices_ptr[--missing_cnt] = i;
             missing_keys_ptr[missing_cnt] = key;
-            CacheKey* cache_key_ptr;
+            int64_t position = -1;
+            CacheKey* cache_key_ptr = nullptr;
             if (it->second == policy.getMapSentinelValue()) {
               cache_key_ptr = policy.Insert(it);
+              position = cache_key_ptr->getPos();
               TORCH_CHECK(
                   // We check for the uniqueness of the positions.
-                  std::get<1>(position_set.insert(cache_key_ptr->getPos())),
+                  std::get<1>(position_set.insert(position)),
                   "Can't insert all, larger cache capacity is needed.");
-            } else {
-              cache_key_ptr = &*it->second;
-              policy.MarkExistingWriting(it);
             }
-            positions_ptr[missing_cnt] = cache_key_ptr->getPos();
+            positions_ptr[missing_cnt] = position;
             pointers_ptr[missing_cnt] = cache_key_ptr;
           }
         }
@@ -155,16 +154,17 @@ std::tuple<torch::Tensor, torch::Tensor> BaseCachePolicy::ReplaceImpl(
         position_set.reserve(keys.size(0));
         for (int64_t i = 0; i < keys.size(0); i++) {
           const auto key = keys_ptr[i];
-          const auto res_optional = policy.template Read<true>(key);
-          const auto [pos, cache_key_ptr] =
-              res_optional ? *res_optional : policy.Insert(key);
+          int64_t pos = -1;
+          CacheKey* cache_key_ptr = nullptr;
+          if (!policy.template Read<true>(key).has_value()) {
+            std::tie(pos, cache_key_ptr) = policy.Insert(key);
+            TORCH_CHECK(
+                // We check for the uniqueness of the positions.
+                std::get<1>(position_set.insert(pos)),
+                "Can't insert all, larger cache capacity is needed.");
+          }
           positions_ptr[i] = pos;
           pointers_ptr[i] = cache_key_ptr;
-          TORCH_CHECK(
-              // If there are duplicate values and the key was just inserted,
-              // we do not have to check for the uniqueness of the positions.
-              res_optional.has_value() || std::get<1>(position_set.insert(pos)),
-              "Can't insert all, larger cache capacity is needed.");
         }
       }));
   return {positions, pointers};
@@ -178,15 +178,16 @@ void BaseCachePolicy::ReadingWritingCompletedImpl(
   auto pointers_ptr =
       reinterpret_cast<CacheKey**>(pointers.data_ptr<int64_t>());
   for (int64_t i = 0; i < pointers.size(0); i++) {
-    policy.template Unmark<write>(pointers_ptr[i]);
+    const auto pointer = pointers_ptr[i];
+    if (!write || pointer) {
+      policy.template Unmark<write>(pointer);
+    }
   }
 }
 
 S3FifoCachePolicy::S3FifoCachePolicy(int64_t capacity)
     // We sometimes first insert and then evict. + 1 is to compensate for that.
-    : small_queue_(capacity + 1),
-      main_queue_(capacity + 1),
-      ghost_queue_(capacity - capacity / 10),
+    : ghost_queue_(capacity - capacity / 10),
       capacity_(capacity),
       cache_usage_(0),
       small_queue_size_target_(capacity / 10) {
@@ -279,7 +280,7 @@ void LruCachePolicy::WritingCompleted(torch::Tensor keys) {
 
 ClockCachePolicy::ClockCachePolicy(int64_t capacity)
     // We sometimes first insert and then evict. + 1 is to compensate for that.
-    : queue_(capacity + 1), capacity_(capacity), cache_usage_(0) {
+    : capacity_(capacity), cache_usage_(0) {
   TORCH_CHECK(capacity > 0, "Capacity needs to be positive.");
   key_to_cache_key_.reserve(kCapacityFactor * (capacity + 1));
 }

--- a/graphbolt/src/cache_policy.h
+++ b/graphbolt/src/cache_policy.h
@@ -268,17 +268,17 @@ class S3FifoCachePolicy : public BaseCachePolicy {
   void WritingCompleted(torch::Tensor pointers);
 
   template <bool write>
-  std::optional<std::pair<int64_t, CacheKey*>> Read(int64_t key) {
+  CacheKey* Read(int64_t key) {
     auto it = key_to_cache_key_.find(key);
     if (it != key_to_cache_key_.end()) {
       auto& cache_key = it->second->Increment();
       if constexpr (write) {
-        return std::make_pair(cache_key.getPos(), &cache_key);
+        return &cache_key;
       } else if (!cache_key.BeingWritten()) {
-        return std::make_pair(cache_key.StartUse<write>().getPos(), &cache_key);
+        return &cache_key.StartUse<write>();
       }
     }
-    return std::nullopt;
+    return nullptr;
   }
 
   auto getMapSentinelValue() const { return nullptr; }
@@ -430,17 +430,17 @@ class SieveCachePolicy : public BaseCachePolicy {
   void WritingCompleted(torch::Tensor pointers);
 
   template <bool write>
-  std::optional<std::pair<int64_t, CacheKey*>> Read(int64_t key) {
+  CacheKey* Read(int64_t key) {
     auto it = key_to_cache_key_.find(key);
     if (it != key_to_cache_key_.end()) {
       auto& cache_key = it->second->SetFreq();
       if constexpr (write) {
-        std::make_pair(cache_key.getPos(), &cache_key);
+        return &cache_key;
       } else if (!cache_key.BeingWritten()) {
-        return std::make_pair(cache_key.StartUse<write>().getPos(), &cache_key);
+        return &cache_key.StartUse<write>();
       }
     }
-    return std::nullopt;
+    return nullptr;
   }
 
   auto getMapSentinelValue() const { return nullptr; }
@@ -556,18 +556,18 @@ class LruCachePolicy : public BaseCachePolicy {
   void WritingCompleted(torch::Tensor pointers);
 
   template <bool write>
-  std::optional<std::pair<int64_t, CacheKey*>> Read(int64_t key) {
+  CacheKey* Read(int64_t key) {
     auto it = key_to_cache_key_.find(key);
     if (it != key_to_cache_key_.end()) {
       auto& cache_key = *it->second;
       MoveToFront(queue_, queue_, it->second);
       if constexpr (write) {
-        std::make_pair(cache_key.getPos(), &cache_key);
+        return &cache_key;
       } else if (!cache_key.BeingWritten()) {
-        return std::make_pair(cache_key.StartUse<write>().getPos(), &cache_key);
+        return &cache_key.StartUse<write>();
       }
     }
-    return std::nullopt;
+    return nullptr;
   }
 
   auto getMapSentinelValue() { return queue_.end(); }
@@ -681,17 +681,17 @@ class ClockCachePolicy : public BaseCachePolicy {
   void WritingCompleted(torch::Tensor pointers);
 
   template <bool write>
-  std::optional<std::pair<int64_t, CacheKey*>> Read(int64_t key) {
+  CacheKey* Read(int64_t key) {
     auto it = key_to_cache_key_.find(key);
     if (it != key_to_cache_key_.end()) {
       auto& cache_key = it->second->SetFreq();
       if constexpr (write) {
-        return std::make_pair(cache_key.getPos(), &cache_key);
+        return &cache_key;
       } else if (!cache_key.BeingWritten()) {
-        return std::make_pair(cache_key.StartUse<write>().getPos(), &cache_key);
+        return &cache_key.StartUse<write>();
       }
     }
-    return std::nullopt;
+    return nullptr;
   }
 
   auto getMapSentinelValue() const { return nullptr; }

--- a/graphbolt/src/cache_policy.h
+++ b/graphbolt/src/cache_policy.h
@@ -203,6 +203,21 @@ class BaseCachePolicy {
   template <bool write, typename CachePolicy>
   static void ReadingWritingCompletedImpl(
       CachePolicy& policy, torch::Tensor pointers);
+
+  template <typename T>
+  static void MoveToFront(
+      std::list<T>& from, std::list<T>& to,
+      typename std::list<T>::iterator it) {
+    std::list<T> temp;
+    // Transfer the element to temp to keep references valid.
+    auto next_it = it;
+    std::advance(next_it, 1);
+    temp.splice(temp.begin(), from, it, next_it);
+    // Move the element to the beginning of the queue.
+    to.splice(to.begin(), temp);
+    // The iterators and references are not invalidated.
+    // TORCH_CHECK(it == to.begin());
+  }
 };
 
 /**
@@ -252,22 +267,16 @@ class S3FifoCachePolicy : public BaseCachePolicy {
    */
   void WritingCompleted(torch::Tensor pointers);
 
-  friend std::ostream& operator<<(
-      std::ostream& os, const S3FifoCachePolicy& policy) {
-    return os << "small_queue_: " << policy.small_queue_ << "\n"
-              << "main_queue_: " << policy.main_queue_ << "\n"
-              << "cache_usage_: " << policy.cache_usage_ << "\n"
-              << "capacity_: " << policy.capacity_ << "\n";
-  }
-
   template <bool write>
   std::optional<std::pair<int64_t, CacheKey*>> Read(int64_t key) {
     auto it = key_to_cache_key_.find(key);
     if (it != key_to_cache_key_.end()) {
-      auto& cache_key = *it->second;
-      if (write || !cache_key.BeingWritten())
-        return std::make_pair(
-            cache_key.Increment().StartUse<write>().getPos(), &cache_key);
+      auto& cache_key = it->second->Increment();
+      if constexpr (write) {
+        return std::make_pair(cache_key.getPos(), &cache_key);
+      } else if (!cache_key.BeingWritten()) {
+        return std::make_pair(cache_key.StartUse<write>().getPos(), &cache_key);
+      }
     }
     return std::nullopt;
   }
@@ -275,25 +284,26 @@ class S3FifoCachePolicy : public BaseCachePolicy {
   auto getMapSentinelValue() const { return nullptr; }
 
   std::pair<map_iterator, bool> Emplace(int64_t key) {
-    auto [it, _] = key_to_cache_key_.emplace(key, getMapSentinelValue());
-    if (it->second != getMapSentinelValue()) {
-      auto& cache_key = *it->second;
+    auto [it, inserted] = key_to_cache_key_.emplace(key, getMapSentinelValue());
+    bool readable = false;
+    if (!inserted) {
+      auto& cache_key = it->second->Increment();
       if (!cache_key.BeingWritten()) {
         // Not being written so we use StartUse<write=false>() and return
         // true to indicate the key is ready to read.
-        cache_key.Increment().StartUse<false>();
-        return {it, true};
+        cache_key.StartUse<false>();
+        readable = true;
       }
     }
-    // First time insertion, return false to indicate not ready to read.
-    return {it, false};
+    return {it, readable};
   }
 
   std::pair<int64_t, CacheKey*> Insert(int64_t key) {
     const auto pos = Evict();
     const auto in_ghost_queue = ghost_set_.erase(key);
     auto& queue = in_ghost_queue ? main_queue_ : small_queue_;
-    auto cache_key_ptr = queue.Push(CacheKey(key, pos));
+    queue.push_front(CacheKey(key, pos));
+    auto cache_key_ptr = &queue.front();
     key_to_cache_key_[key] = cache_key_ptr;
     return {pos, cache_key_ptr};
   }
@@ -302,13 +312,10 @@ class S3FifoCachePolicy : public BaseCachePolicy {
     const auto key = it->first;
     const auto in_ghost_queue = ghost_set_.erase(key);
     auto& queue = in_ghost_queue ? main_queue_ : small_queue_;
-    auto cache_key_ptr = queue.Push(CacheKey(key));
+    queue.push_front(CacheKey(key));
+    auto cache_key_ptr = &queue.front();
     mutable_value_ref(it) = cache_key_ptr;
     return &cache_key_ptr->setPos(Evict());
-  }
-
-  void MarkExistingWriting(map_iterator it) {
-    it->second->Increment().StartUse<true>();
   }
 
   template <bool write>
@@ -319,34 +326,43 @@ class S3FifoCachePolicy : public BaseCachePolicy {
  private:
   int64_t EvictMainQueue() {
     while (true) {
-      auto evicted = main_queue_.Pop();
+      auto& evicted = main_queue_.back();
       auto it = key_to_cache_key_.find(evicted.getKey());
       if (evicted.getFreq() > 0 || evicted.InUse()) {
         evicted.Decrement();
-        mutable_value_ref(it) = main_queue_.Push(evicted);
+        auto it = main_queue_.end();
+        std::advance(it, -1);
+        MoveToFront(main_queue_, main_queue_, it);
       } else {
         key_to_cache_key_.erase(it);
-        return evicted.getPos();
+        const auto evicted_pos = evicted.getPos();
+        main_queue_.pop_back();
+        return evicted_pos;
       }
     }
   }
 
   int64_t EvictSmallQueue() {
-    for (auto size = small_queue_.Size(); size > small_queue_size_target_;
+    for (auto size = small_queue_.size(); size > small_queue_size_target_;
          size--) {
-      auto evicted = small_queue_.Pop();
+      auto& evicted = small_queue_.back();
       auto it = key_to_cache_key_.find(evicted.getKey());
       if (evicted.getFreq() > 0 || evicted.InUse()) {
-        mutable_value_ref(it) = main_queue_.Push(evicted.ResetFreq());
+        evicted.ResetFreq();
+        auto it = small_queue_.end();
+        std::advance(it, -1);
+        MoveToFront(small_queue_, main_queue_, it);
       } else {
         key_to_cache_key_.erase(it);
         const auto evicted_key = evicted.getKey();
+        const auto evicted_pos = evicted.getPos();
+        small_queue_.pop_back();
         if (ghost_queue_.IsFull()) {
           ghost_set_.erase(ghost_queue_.Pop());
         }
         ghost_set_.insert(evicted_key);
         ghost_queue_.Push(evicted_key);
-        return evicted.getPos();
+        return evicted_pos;
       }
     }
     return -1;
@@ -359,11 +375,11 @@ class S3FifoCachePolicy : public BaseCachePolicy {
     return pos >= 0 ? pos : EvictMainQueue();
   }
 
-  CircularQueue<CacheKey> small_queue_, main_queue_;
+  std::list<CacheKey> small_queue_, main_queue_;
   CircularQueue<int64_t> ghost_queue_;
   int64_t capacity_;
   int64_t cache_usage_;
-  int64_t small_queue_size_target_;
+  size_t small_queue_size_target_;
   set_t<int64_t> ghost_set_;
   map_t<int64_t, CacheKey*> key_to_cache_key_;
 };
@@ -417,10 +433,12 @@ class SieveCachePolicy : public BaseCachePolicy {
   std::optional<std::pair<int64_t, CacheKey*>> Read(int64_t key) {
     auto it = key_to_cache_key_.find(key);
     if (it != key_to_cache_key_.end()) {
-      auto& cache_key = *it->second;
-      if (write || !cache_key.BeingWritten())
-        return std::make_pair(
-            cache_key.SetFreq().StartUse<write>().getPos(), &cache_key);
+      auto& cache_key = it->second->SetFreq();
+      if constexpr (write) {
+        std::make_pair(cache_key.getPos(), &cache_key);
+      } else if (!cache_key.BeingWritten()) {
+        return std::make_pair(cache_key.StartUse<write>().getPos(), &cache_key);
+      }
     }
     return std::nullopt;
   }
@@ -428,18 +446,18 @@ class SieveCachePolicy : public BaseCachePolicy {
   auto getMapSentinelValue() const { return nullptr; }
 
   std::pair<map_iterator, bool> Emplace(int64_t key) {
-    auto [it, _] = key_to_cache_key_.emplace(key, getMapSentinelValue());
-    if (it->second != getMapSentinelValue()) {
-      auto& cache_key = *it->second;
+    auto [it, inserted] = key_to_cache_key_.emplace(key, getMapSentinelValue());
+    bool readable = false;
+    if (!inserted) {
+      auto& cache_key = it->second->SetFreq();
       if (!cache_key.BeingWritten()) {
         // Not being written so we use StartUse<write=false>() and return
         // true to indicate the key is ready to read.
-        cache_key.SetFreq().StartUse<false>();
-        return {it, true};
+        cache_key.StartUse<false>();
+        readable = true;
       }
     }
-    // First time insertion, return false to indicate not ready to read.
-    return {it, false};
+    return {it, readable};
   }
 
   std::pair<int64_t, CacheKey*> Insert(int64_t key) {
@@ -456,10 +474,6 @@ class SieveCachePolicy : public BaseCachePolicy {
     auto cache_key_ptr = &queue_.front();
     mutable_value_ref(it) = cache_key_ptr;
     return &cache_key_ptr->setPos(Evict());
-  }
-
-  void MarkExistingWriting(map_iterator it) {
-    it->second->SetFreq().StartUse<true>();
   }
 
   template <bool write>
@@ -541,25 +555,15 @@ class LruCachePolicy : public BaseCachePolicy {
    */
   void WritingCompleted(torch::Tensor pointers);
 
-  void MoveToFront(std::list<CacheKey>::iterator it) {
-    std::list<CacheKey> temp;
-    // Transfer the element to temp to keep references valid.
-    auto next_it = it;
-    std::advance(next_it, 1);
-    temp.splice(temp.begin(), queue_, it, next_it);
-    // Move the element to the beginning of the queue.
-    queue_.splice(queue_.begin(), temp);
-    // The iterators and references are not invalidated.
-    TORCH_CHECK(it == queue_.begin());
-  }
-
   template <bool write>
   std::optional<std::pair<int64_t, CacheKey*>> Read(int64_t key) {
     auto it = key_to_cache_key_.find(key);
     if (it != key_to_cache_key_.end()) {
       auto& cache_key = *it->second;
-      if (write || !cache_key.BeingWritten()) {
-        MoveToFront(it->second);
+      MoveToFront(queue_, queue_, it->second);
+      if constexpr (write) {
+        std::make_pair(cache_key.getPos(), &cache_key);
+      } else if (!cache_key.BeingWritten()) {
         return std::make_pair(cache_key.StartUse<write>().getPos(), &cache_key);
       }
     }
@@ -569,19 +573,19 @@ class LruCachePolicy : public BaseCachePolicy {
   auto getMapSentinelValue() { return queue_.end(); }
 
   std::pair<map_iterator, bool> Emplace(int64_t key) {
-    auto [it, _] = key_to_cache_key_.emplace(key, getMapSentinelValue());
-    if (it->second != getMapSentinelValue()) {
+    auto [it, inserted] = key_to_cache_key_.emplace(key, getMapSentinelValue());
+    bool readable = false;
+    if (!inserted) {
       auto& cache_key = *it->second;
+      MoveToFront(queue_, queue_, it->second);
       if (!cache_key.BeingWritten()) {
-        MoveToFront(it->second);
         // Not being written so we use StartUse<write=false>() and return
         // true to indicate the key is ready to read.
         cache_key.StartUse<false>();
-        return {it, true};
+        readable = true;
       }
     }
-    // First time insertion, return false to indicate not ready to read.
-    return {it, false};
+    return {it, readable};
   }
 
   std::pair<int64_t, CacheKey*> Insert(int64_t key) {
@@ -599,11 +603,6 @@ class LruCachePolicy : public BaseCachePolicy {
     return &cache_key_ptr->setPos(Evict());
   }
 
-  void MarkExistingWriting(map_iterator it) {
-    MoveToFront(it->second);
-    it->second->StartUse<true>();
-  }
-
   template <bool write>
   void Unmark(CacheKey* cache_key_ptr) {
     cache_key_ptr->EndUse<write>();
@@ -614,14 +613,11 @@ class LruCachePolicy : public BaseCachePolicy {
     // If the cache has space, get an unused slot otherwise perform eviction.
     if (cache_usage_ < capacity_) return cache_usage_++;
     // Do not evict items that are still in use.
-    for (auto cache_key = queue_.back(); cache_key.InUse();
-         cache_key = queue_.back()) {
+    while (queue_.back().InUse()) {
       auto it = queue_.end();
       std::advance(it, -1);
       // Move the last element to the front without invalidating references.
-      MoveToFront(it);
-      // The check below will hold true. Disabled for performance reasons.
-      // TORCH_CHECK(key_to_cache_key_[cache_key.getKey()] == queue_.begin());
+      MoveToFront(queue_, queue_, it);
     }
     const auto& cache_key = queue_.back();
     TORCH_CHECK(key_to_cache_key_.erase(cache_key.getKey()));
@@ -688,10 +684,12 @@ class ClockCachePolicy : public BaseCachePolicy {
   std::optional<std::pair<int64_t, CacheKey*>> Read(int64_t key) {
     auto it = key_to_cache_key_.find(key);
     if (it != key_to_cache_key_.end()) {
-      auto& cache_key = *it->second;
-      if (write || !cache_key.BeingWritten())
-        return std::make_pair(
-            cache_key.SetFreq().StartUse<write>().getPos(), &cache_key);
+      auto& cache_key = it->second->SetFreq();
+      if constexpr (write) {
+        return std::make_pair(cache_key.getPos(), &cache_key);
+      } else if (!cache_key.BeingWritten()) {
+        return std::make_pair(cache_key.StartUse<write>().getPos(), &cache_key);
+      }
     }
     return std::nullopt;
   }
@@ -699,36 +697,34 @@ class ClockCachePolicy : public BaseCachePolicy {
   auto getMapSentinelValue() const { return nullptr; }
 
   std::pair<map_iterator, bool> Emplace(int64_t key) {
-    auto [it, _] = key_to_cache_key_.emplace(key, getMapSentinelValue());
-    if (it->second != getMapSentinelValue()) {
-      auto& cache_key = *it->second;
+    auto [it, inserted] = key_to_cache_key_.emplace(key, getMapSentinelValue());
+    bool readable = false;
+    if (!inserted) {
+      auto& cache_key = it->second->SetFreq();
       if (!cache_key.BeingWritten()) {
         // Not being written so we use StartUse<write=false>() and return
         // true to indicate the key is ready to read.
-        cache_key.SetFreq().StartUse<false>();
-        return {it, true};
+        cache_key.StartUse<false>();
+        readable = true;
       }
     }
-    // First time insertion, return false to indicate not ready to read.
-    return {it, false};
+    return {it, readable};
   }
 
   std::pair<int64_t, CacheKey*> Insert(int64_t key) {
     const auto pos = Evict();
-    auto cache_key_ptr = queue_.Push(CacheKey(key, pos));
+    queue_.push_front(CacheKey(key, pos));
+    auto cache_key_ptr = &queue_.front();
     key_to_cache_key_[key] = cache_key_ptr;
     return {pos, cache_key_ptr};
   }
 
   CacheKey* Insert(map_iterator it) {
     const auto key = it->first;
-    auto cache_key_ptr = queue_.Push(CacheKey(key));
+    queue_.push_front(CacheKey(key));
+    auto cache_key_ptr = &queue_.front();
     mutable_value_ref(it) = cache_key_ptr;
     return &cache_key_ptr->setPos(Evict());
-  }
-
-  void MarkExistingWriting(map_iterator it) {
-    it->second->SetFreq().StartUse<true>();
   }
 
   template <bool write>
@@ -740,20 +736,23 @@ class ClockCachePolicy : public BaseCachePolicy {
   int64_t Evict() {
     // If the cache has space, get an unused slot otherwise perform eviction.
     if (cache_usage_ < capacity_) return cache_usage_++;
-    CacheKey cache_key;
     while (true) {
-      cache_key = queue_.Pop();
+      auto& cache_key = queue_.back();
       if (cache_key.getFreq() || cache_key.InUse()) {
-        key_to_cache_key_[cache_key.getKey()] =
-            queue_.Push(cache_key.ResetFreq());
-      } else
-        break;
+        cache_key.ResetFreq();
+        auto it = queue_.end();
+        std::advance(it, -1);
+        MoveToFront(queue_, queue_, it);
+      } else {
+        TORCH_CHECK(key_to_cache_key_.erase(cache_key.getKey()));
+        const auto evicted_pos = cache_key.getPos();
+        queue_.pop_back();
+        return evicted_pos;
+      }
     }
-    TORCH_CHECK(key_to_cache_key_.erase(cache_key.getKey()));
-    return cache_key.getPos();
   }
 
-  CircularQueue<CacheKey> queue_;
+  std::list<CacheKey> queue_;
   int64_t capacity_;
   int64_t cache_usage_;
   map_t<int64_t, CacheKey*> key_to_cache_key_;

--- a/graphbolt/src/cache_policy.h
+++ b/graphbolt/src/cache_policy.h
@@ -334,7 +334,7 @@ class S3FifoCachePolicy : public BaseCachePolicy {
         std::advance(it, -1);
         MoveToFront(main_queue_, main_queue_, it);
       } else {
-        key_to_cache_key_.erase(it);
+        key_to_cache_key_.erase_fast(it);
         const auto evicted_pos = evicted.getPos();
         main_queue_.pop_back();
         return evicted_pos;
@@ -353,7 +353,7 @@ class S3FifoCachePolicy : public BaseCachePolicy {
         std::advance(it, -1);
         MoveToFront(small_queue_, main_queue_, it);
       } else {
-        key_to_cache_key_.erase(it);
+        key_to_cache_key_.erase_fast(it);
         const auto evicted_key = evicted.getKey();
         const auto evicted_pos = evicted.getPos();
         small_queue_.pop_back();

--- a/graphbolt/src/feature_cache.cc
+++ b/graphbolt/src/feature_cache.cc
@@ -76,9 +76,12 @@ void FeatureCache::Replace(torch::Tensor positions, torch::Tensor values) {
   graphbolt::parallel_for(
       0, positions.size(0), kIntGrainSize, [&](int64_t begin, int64_t end) {
         for (int64_t i = begin; i < end; i++) {
-          std::memcpy(
-              tensor_ptr + positions_ptr[i] * row_bytes,
-              values_ptr + i * row_bytes, row_bytes);
+          const auto position = positions_ptr[i];
+          if (position >= 0) {
+            std::memcpy(
+                tensor_ptr + position * row_bytes, values_ptr + i * row_bytes,
+                row_bytes);
+          }
         }
       });
 }

--- a/tests/python/pytorch/graphbolt/impl/test_feature_cache.py
+++ b/tests/python/pytorch/graphbolt/impl/test_feature_cache.py
@@ -9,7 +9,7 @@ from dgl import graphbolt as gb
 def _test_query_and_replace(policy1, policy2, keys):
     # Testing query_and_replace equivalence to query and then replace.
     (
-        positions,
+        _,
         index,
         pointers,
         missing_keys,


### PR DESCRIPTION
## Description
After we switched the hash table we use and the optimizations we applied such as passing pointers to `CacheKey` objects around, we needed to make sure that these pointers and references stay valid by utilizing data structures that guarantee to keep them valid.

## Checklist
Please feel free to remove inapplicable items for your PR.
- [ ] The PR title starts with [$CATEGORY] (such as [NN], [Model], [Doc], [Feature]])
- [ ] I've leverage the [tools](https://docs.google.com/document/d/1iHyj7zlmygKSk5gBPsqIqL5ASPzJSPREaNT_QdsiYA4/edit) to beautify the python and c++ code.
- [ ] The PR is complete and small, read the [Google eng practice (CL equals to PR)](https://google.github.io/eng-practices/review/developer/small-cls.html) to understand more about small PR. In DGL, we consider PRs with less than 200 lines of core code change are small (example, test and documentation could be exempted).
- [ ] All changes have test coverage
- [ ] Code is well-documented
- [ ] To the best of my knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change
- [ ] Related issue is referred in this PR
- [ ] If the PR is for a new model/paper, I've updated the example index [here](../examples/README.md).

## Changes
<!-- You could use following template
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)
-->
