### PR TITLE
[GraphBolt] `CPUCachedFeature` no overlap fix.

### DIFF
--- a/python/dgl/graphbolt/impl/cpu_cached_feature.py
+++ b/python/dgl/graphbolt/impl/cpu_cached_feature.py
@@ -75,7 +75,9 @@ class CPUCachedFeature(Feature):
         """
         if ids is None:
             return self._fallback_feature.read()
-        return self._feature.query_and_replace(ids, self._fallback_feature.read)
+        return self._feature.query_and_replace(
+            ids.cpu(), self._fallback_feature.read
+        ).to(ids.device)
 
     def read_async(self, ids: torch.Tensor):
         r"""Read the feature by index asynchronously.

--- a/tests/python/pytorch/graphbolt/impl/test_cpu_cached_feature.py
+++ b/tests/python/pytorch/graphbolt/impl/test_cpu_cached_feature.py
@@ -56,8 +56,9 @@ def test_cpu_cached_feature(dtype, policy):
 
     # Test read with ids.
     assert torch.equal(
-        feat_store_a.read(torch.tensor([0])),
-        torch.tensor([[1, 2, 3]], dtype=dtype),
+        # Test read when ids are on a different device.
+        feat_store_a.read(torch.tensor([0], device=F.ctx())),
+        torch.tensor([[1, 2, 3]], dtype=dtype, device=F.ctx()),
     )
     assert torch.equal(
         feat_store_b.read(torch.tensor([1, 1])),


### PR DESCRIPTION
## Description
Fixes the overlap_fetch=False case for CPUCachedFeature. @Liu-rj 

## Checklist
Please feel free to remove inapplicable items for your PR.
- [ ] The PR title starts with [$CATEGORY] (such as [NN], [Model], [Doc], [Feature]])
- [ ] I've leverage the [tools](https://docs.google.com/document/d/1iHyj7zlmygKSk5gBPsqIqL5ASPzJSPREaNT_QdsiYA4/edit) to beautify the python and c++ code.
- [ ] The PR is complete and small, read the [Google eng practice (CL equals to PR)](https://google.github.io/eng-practices/review/developer/small-cls.html) to understand more about small PR. In DGL, we consider PRs with less than 200 lines of core code change are small (example, test and documentation could be exempted).
- [ ] All changes have test coverage
- [ ] Code is well-documented
- [ ] To the best of my knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change
- [ ] Related issue is referred in this PR
- [ ] If the PR is for a new model/paper, I've updated the example index [here](../examples/README.md).

## Changes
<!-- You could use following template
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)
-->
