### PR TITLE
[GraphBolt] Temporary workaround for `CachePolicy`.

### DIFF
--- a/graphbolt/src/cache_policy.cc
+++ b/graphbolt/src/cache_policy.cc
@@ -122,6 +122,10 @@ BaseCachePolicy::QueryAndReplaceImpl(CachePolicy& policy, torch::Tensor keys) {
                   std::get<1>(position_set.insert(position)),
                   "Can't insert all, larger cache capacity is needed.");
             }
+            else {
+              cache_key_ptr = &it->second->StartWrite();
+              position = cache_key_ptr->getPos();
+            }
             positions_ptr[missing_cnt] = position;
             pointers_ptr[missing_cnt] = cache_key_ptr;
           }

--- a/graphbolt/src/cache_policy.cc
+++ b/graphbolt/src/cache_policy.cc
@@ -121,8 +121,7 @@ BaseCachePolicy::QueryAndReplaceImpl(CachePolicy& policy, torch::Tensor keys) {
                   // We check for the uniqueness of the positions.
                   std::get<1>(position_set.insert(position)),
                   "Can't insert all, larger cache capacity is needed.");
-            }
-            else {
+            } else {
               cache_key_ptr = &it->second->StartWrite();
               position = cache_key_ptr->getPos();
             }

--- a/graphbolt/src/cache_policy.h
+++ b/graphbolt/src/cache_policy.h
@@ -84,10 +84,16 @@ struct CacheKey {
     return *this;
   }
 
+  CacheKey& StartWrite() {
+    TORCH_CHECK(reference_count_ < 0);
+    TORCH_CHECK(reference_count_-- > std::numeric_limits<int16_t>::lowest());
+    return *this;
+  }
+
   template <bool write>
   CacheKey& EndUse() {
     if constexpr (write) {
-      TORCH_CHECK(reference_count_ == -1);
+      TORCH_CHECK(reference_count_ < 0);
       ++reference_count_;
     } else {
       TORCH_CHECK(reference_count_ > 0);


### PR DESCRIPTION
## Description
@frozenbugs When a key is already being written, the cache query treats it as missing and it is fetched from the fallback feature. However, this is somehow causing correctness bugs when `FeatureFetcher` `overlap_fetch` argument is enabled.

When a key is already being written, taking the writer lock again and also writing ourself too seems to fix it at the cost of the writer lock might stay taken forever. I am looking into permanently fixing this issue and rolling this workaround back.

## Checklist
Please feel free to remove inapplicable items for your PR.
- [ ] The PR title starts with [$CATEGORY] (such as [NN], [Model], [Doc], [Feature]])
- [ ] I've leverage the [tools](https://docs.google.com/document/d/1iHyj7zlmygKSk5gBPsqIqL5ASPzJSPREaNT_QdsiYA4/edit) to beautify the python and c++ code.
- [ ] The PR is complete and small, read the [Google eng practice (CL equals to PR)](https://google.github.io/eng-practices/review/developer/small-cls.html) to understand more about small PR. In DGL, we consider PRs with less than 200 lines of core code change are small (example, test and documentation could be exempted).
- [ ] All changes have test coverage
- [ ] Code is well-documented
- [ ] To the best of my knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change
- [ ] Related issue is referred in this PR
- [ ] If the PR is for a new model/paper, I've updated the example index [here](../examples/README.md).

## Changes
<!-- You could use following template
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)
-->
