### PR TITLE
[GraphBolt] Remove duplicate `CachePolicy::Insert` function.

### DIFF
--- a/graphbolt/src/cache_policy.cc
+++ b/graphbolt/src/cache_policy.cc
@@ -55,7 +55,7 @@ BaseCachePolicy::QueryImpl(CachePolicy& policy, torch::Tensor keys) {
         auto missing_keys_ptr = missing_keys.data_ptr<index_t>();
         for (int64_t i = 0; i < keys.size(0); i++) {
           const auto key = keys_ptr[i];
-          auto cache_key_ptr = policy.template Read<false>(key);
+          auto cache_key_ptr = policy.Read(key);
           if (cache_key_ptr) {
             positions_ptr[found_cnt] = cache_key_ptr->getPos();
             found_ptr[found_cnt] = cache_key_ptr;

--- a/graphbolt/src/cache_policy.h
+++ b/graphbolt/src/cache_policy.h
@@ -265,14 +265,11 @@ class S3FifoCachePolicy : public BaseCachePolicy {
    */
   std::tuple<torch::Tensor, torch::Tensor> Replace(torch::Tensor keys);
 
-  template <bool write>
   CacheKey* Read(int64_t key) {
     auto it = key_to_cache_key_.find(key);
     if (it != key_to_cache_key_.end()) {
       auto& cache_key = it->second->Increment();
-      if constexpr (write) {
-        return &cache_key;
-      } else if (!cache_key.BeingWritten()) {
+      if (!cache_key.BeingWritten()) {
         return &cache_key.StartRead();
       }
     }
@@ -399,14 +396,11 @@ class SieveCachePolicy : public BaseCachePolicy {
    */
   std::tuple<torch::Tensor, torch::Tensor> Replace(torch::Tensor keys);
 
-  template <bool write>
   CacheKey* Read(int64_t key) {
     auto it = key_to_cache_key_.find(key);
     if (it != key_to_cache_key_.end()) {
       auto& cache_key = it->second->SetFreq();
-      if constexpr (write) {
-        return &cache_key;
-      } else if (!cache_key.BeingWritten()) {
+      if (!cache_key.BeingWritten()) {
         return &cache_key.StartRead();
       }
     }
@@ -498,15 +492,12 @@ class LruCachePolicy : public BaseCachePolicy {
    */
   std::tuple<torch::Tensor, torch::Tensor> Replace(torch::Tensor keys);
 
-  template <bool write>
   CacheKey* Read(int64_t key) {
     auto it = key_to_cache_key_.find(key);
     if (it != key_to_cache_key_.end()) {
       auto& cache_key = *it->second;
       MoveToFront(queue_, queue_, it->second);
-      if constexpr (write) {
-        return &cache_key;
-      } else if (!cache_key.BeingWritten()) {
+      if (!cache_key.BeingWritten()) {
         return &cache_key.StartRead();
       }
     }
@@ -597,14 +588,11 @@ class ClockCachePolicy : public BaseCachePolicy {
    */
   std::tuple<torch::Tensor, torch::Tensor> Replace(torch::Tensor keys);
 
-  template <bool write>
   CacheKey* Read(int64_t key) {
     auto it = key_to_cache_key_.find(key);
     if (it != key_to_cache_key_.end()) {
       auto& cache_key = it->second->SetFreq();
-      if constexpr (write) {
-        return &cache_key;
-      } else if (!cache_key.BeingWritten()) {
+      if (!cache_key.BeingWritten()) {
         return &cache_key.StartRead();
       }
     }

--- a/graphbolt/src/cache_policy.h
+++ b/graphbolt/src/cache_policy.h
@@ -294,17 +294,6 @@ class S3FifoCachePolicy : public BaseCachePolicy {
     return {it, readable};
   }
 
-  std::pair<int64_t, CacheKey*> Insert(int64_t key) {
-    const auto pos = Evict();
-    const auto in_ghost_queue = ghost_set_.erase(key);
-    auto& queue = in_ghost_queue ? main_queue_ : small_queue_;
-    queue.push_front(CacheKey(key, pos));
-    small_queue_size_ += 1 - in_ghost_queue;
-    auto cache_key_ptr = &queue.front();
-    key_to_cache_key_[key] = cache_key_ptr;
-    return {pos, cache_key_ptr};
-  }
-
   CacheKey* Insert(map_iterator it) {
     const auto key = it->first;
     const auto in_ghost_queue = ghost_set_.erase(key);
@@ -439,14 +428,6 @@ class SieveCachePolicy : public BaseCachePolicy {
     return {it, readable};
   }
 
-  std::pair<int64_t, CacheKey*> Insert(int64_t key) {
-    const auto pos = Evict();
-    queue_.push_front(CacheKey(key, pos));
-    auto cache_key_ptr = &queue_.front();
-    key_to_cache_key_[key] = cache_key_ptr;
-    return {pos, cache_key_ptr};
-  }
-
   CacheKey* Insert(map_iterator it) {
     const auto key = it->first;
     queue_.push_front(CacheKey(key));
@@ -548,18 +529,11 @@ class LruCachePolicy : public BaseCachePolicy {
     return {it, readable};
   }
 
-  std::pair<int64_t, CacheKey*> Insert(int64_t key) {
-    const auto pos = Evict();
-    queue_.push_front(CacheKey(key, pos));
-    key_to_cache_key_[key] = queue_.begin();
-    return {pos, &queue_.front()};
-  }
-
   CacheKey* Insert(map_iterator it) {
     const auto key = it->first;
     queue_.push_front(CacheKey(key));
     mutable_value_ref(it) = queue_.begin();
-    auto cache_key_ptr = &*queue_.begin();
+    auto cache_key_ptr = &queue_.front();
     return &cache_key_ptr->setPos(Evict());
   }
 
@@ -650,14 +624,6 @@ class ClockCachePolicy : public BaseCachePolicy {
       }
     }
     return {it, readable};
-  }
-
-  std::pair<int64_t, CacheKey*> Insert(int64_t key) {
-    const auto pos = Evict();
-    queue_.push_front(CacheKey(key, pos));
-    auto cache_key_ptr = &queue_.front();
-    key_to_cache_key_[key] = cache_key_ptr;
-    return {pos, cache_key_ptr};
   }
 
   CacheKey* Insert(map_iterator it) {


### PR DESCRIPTION
## Description
Removing the duplicate insert function and using the more efficient one for `CachePolicy::Replace`. Less code, less places there could be bugs.

## Checklist
Please feel free to remove inapplicable items for your PR.
- [ ] The PR title starts with [$CATEGORY] (such as [NN], [Model], [Doc], [Feature]])
- [ ] I've leverage the [tools](https://docs.google.com/document/d/1iHyj7zlmygKSk5gBPsqIqL5ASPzJSPREaNT_QdsiYA4/edit) to beautify the python and c++ code.
- [ ] The PR is complete and small, read the [Google eng practice (CL equals to PR)](https://google.github.io/eng-practices/review/developer/small-cls.html) to understand more about small PR. In DGL, we consider PRs with less than 200 lines of core code change are small (example, test and documentation could be exempted).
- [ ] All changes have test coverage
- [ ] Code is well-documented
- [ ] To the best of my knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change
- [ ] Related issue is referred in this PR
- [ ] If the PR is for a new model/paper, I've updated the example index [here](../examples/README.md).

## Changes
<!-- You could use following template
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)
-->
