### PR TITLE
[GraphBolt] Fix out-of-bounds access in `CachePolicy`.

### DIFF
--- a/graphbolt/src/cache_policy.cc
+++ b/graphbolt/src/cache_policy.cc
@@ -112,7 +112,7 @@ BaseCachePolicy::QueryAndReplaceImpl(CachePolicy& policy, torch::Tensor keys) {
           } else {
             indices_ptr[--missing_cnt] = i;
             missing_keys_ptr[missing_cnt] = key;
-            int64_t position = -1;
+            auto position = std::numeric_limits<int64_t>::min();
             CacheKey* cache_key_ptr = nullptr;
             if (it->second == policy.getMapSentinelValue()) {
               cache_key_ptr = policy.Insert(it);
@@ -121,9 +121,6 @@ BaseCachePolicy::QueryAndReplaceImpl(CachePolicy& policy, torch::Tensor keys) {
                   // We check for the uniqueness of the positions.
                   std::get<1>(position_set.insert(position)),
                   "Can't insert all, larger cache capacity is needed.");
-            } else {
-              cache_key_ptr = &it->second->StartWrite();
-              position = cache_key_ptr->getPos();
             }
             positions_ptr[missing_cnt] = position;
             pointers_ptr[missing_cnt] = cache_key_ptr;
@@ -156,7 +153,7 @@ std::tuple<torch::Tensor, torch::Tensor> BaseCachePolicy::ReplaceImpl(
         position_set.reserve(keys.size(0));
         for (int64_t i = 0; i < keys.size(0); i++) {
           const auto key = keys_ptr[i];
-          int64_t position = -1;
+          auto position = std::numeric_limits<int64_t>::min();
           CacheKey* cache_key_ptr = nullptr;
           const auto [it, _] = policy.Emplace(key);
           if (it->second == policy.getMapSentinelValue()) {
@@ -166,9 +163,6 @@ std::tuple<torch::Tensor, torch::Tensor> BaseCachePolicy::ReplaceImpl(
                 // We check for the uniqueness of the positions.
                 std::get<1>(position_set.insert(position)),
                 "Can't insert all, larger cache capacity is needed.");
-          } else {
-            cache_key_ptr = &it->second->StartWrite();
-            position = cache_key_ptr->getPos();
           }
           positions_ptr[i] = position;
           pointers_ptr[i] = cache_key_ptr;


### PR DESCRIPTION
## Description
When we initialize default position to -1, when the position offsets for the partitioned caches gets added in, it becomes positive. Initializing it to the smallest negative value ensures that whatever positive offset is added, it stays negative.

## Checklist
Please feel free to remove inapplicable items for your PR.
- [ ] The PR title starts with [$CATEGORY] (such as [NN], [Model], [Doc], [Feature]])
- [ ] I've leverage the [tools](https://docs.google.com/document/d/1iHyj7zlmygKSk5gBPsqIqL5ASPzJSPREaNT_QdsiYA4/edit) to beautify the python and c++ code.
- [ ] The PR is complete and small, read the [Google eng practice (CL equals to PR)](https://google.github.io/eng-practices/review/developer/small-cls.html) to understand more about small PR. In DGL, we consider PRs with less than 200 lines of core code change are small (example, test and documentation could be exempted).
- [ ] All changes have test coverage
- [ ] Code is well-documented
- [ ] To the best of my knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change
- [ ] Related issue is referred in this PR
- [ ] If the PR is for a new model/paper, I've updated the example index [here](../examples/README.md).

## Changes
<!-- You could use following template
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)
-->
