### PR TITLE
[GraphBolt] Move the function object into `gb::async`.

### DIFF
--- a/graphbolt/include/graphbolt/async.h
+++ b/graphbolt/include/graphbolt/async.h
@@ -102,19 +102,19 @@ class Future : public torch::CustomClassHolder {
  * task to avoid spawning a new OpenMP threadpool on each interop thread.
  */
 template <typename F>
-inline auto async(F function) {
+inline auto async(F&& function) {
   using T = decltype(function());
 #ifdef BUILD_WITH_TASKFLOW
-  auto future = interop_pool().async(function);
+  auto future = interop_pool().async(std::move(function));
 #else
   auto promise = std::make_shared<std::promise<T>>();
   auto future = promise->get_future();
-  at::launch([=]() {
+  at::launch([promise, func = std::move(function)]() {
     if constexpr (std::is_void_v<T>) {
-      function();
+      func();
       promise->set_value();
     } else
-      promise->set_value(function());
+      promise->set_value(func());
   });
 #endif
   return c10::make_intrusive<Future<T>>(std::move(future));


### PR DESCRIPTION
## Description
The variables captured by the lambda are copied too many times without this move operation.

## Checklist
Please feel free to remove inapplicable items for your PR.
- [ ] The PR title starts with [$CATEGORY] (such as [NN], [Model], [Doc], [Feature]])
- [ ] I've leverage the [tools](https://docs.google.com/document/d/1iHyj7zlmygKSk5gBPsqIqL5ASPzJSPREaNT_QdsiYA4/edit) to beautify the python and c++ code.
- [ ] The PR is complete and small, read the [Google eng practice (CL equals to PR)](https://google.github.io/eng-practices/review/developer/small-cls.html) to understand more about small PR. In DGL, we consider PRs with less than 200 lines of core code change are small (example, test and documentation could be exempted).
- [ ] All changes have test coverage
- [ ] Code is well-documented
- [ ] To the best of my knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change
- [ ] Related issue is referred in this PR
- [ ] If the PR is for a new model/paper, I've updated the example index [here](../examples/README.md).

## Changes
<!-- You could use following template
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)
-->
