### PR TITLE
[GraphBolt] Remove unused `return_eids` option.

### DIFF
--- a/graphbolt/include/graphbolt/cuda_sampling_ops.h
+++ b/graphbolt/include/graphbolt/cuda_sampling_ops.h
@@ -54,8 +54,6 @@ namespace ops {
  * @param layer Boolean indicating whether neighbors should be sampled in a
  * layer sampling fashion. Uses the LABOR-0 algorithm to increase overlap of
  * sampled edges, see arXiv:2210.13339.
- * @param return_eids Boolean indicating whether edge IDs need to be returned,
- * typically used when edge features are required.
  * @param type_per_edge A tensor representing the type of each edge, if present.
  * @param probs_or_mask An optional tensor with (unnormalized) probabilities
  * corresponding to each neighboring edge of a node. It must be
@@ -78,7 +76,6 @@ c10::intrusive_ptr<sampling::FusedSampledSubgraph> SampleNeighbors(
     torch::optional<torch::Tensor> seeds,
     torch::optional<std::vector<int64_t>> seed_offsets,
     const std::vector<int64_t>& fanouts, bool replace, bool layer,
-    bool return_eids,
     torch::optional<torch::Tensor> type_per_edge = torch::nullopt,
     torch::optional<torch::Tensor> probs_or_mask = torch::nullopt,
     torch::optional<torch::Tensor> node_type_offset = torch::nullopt,

--- a/graphbolt/include/graphbolt/fused_csc_sampling_graph.h
+++ b/graphbolt/include/graphbolt/fused_csc_sampling_graph.h
@@ -339,8 +339,6 @@ class FusedCSCSamplingGraph : public torch::CustomClassHolder {
    * @param layer Boolean indicating whether neighbors should be sampled in a
    * layer sampling fashion. Uses the LABOR-0 algorithm to increase overlap of
    * sampled edges, see arXiv:2210.13339.
-   * @param return_eids Boolean indicating whether edge IDs need to be returned,
-   * typically used when edge features are required.
    * @param probs_or_mask An optional edge attribute tensor for probablities
    * or masks. This attribute tensor should contain (unnormalized)
    * probabilities corresponding to each neighboring edge of a node. It must be
@@ -357,7 +355,7 @@ class FusedCSCSamplingGraph : public torch::CustomClassHolder {
       torch::optional<torch::Tensor> seeds,
       torch::optional<std::vector<int64_t>> seed_offsets,
       const std::vector<int64_t>& fanouts, bool replace, bool layer,
-      bool return_eids, torch::optional<torch::Tensor> probs_or_mask,
+      torch::optional<torch::Tensor> probs_or_mask,
       torch::optional<torch::Tensor> random_seed,
       double seed2_contribution) const;
 
@@ -378,8 +376,6 @@ class FusedCSCSamplingGraph : public torch::CustomClassHolder {
    * @param layer Boolean indicating whether neighbors should be sampled in a
    * layer sampling fashion. Uses the LABOR-0 algorithm to increase overlap of
    * sampled edges, see arXiv:2210.13339.
-   * @param return_eids Boolean indicating whether edge IDs need to be returned,
-   * typically used when edge features are required.
    * @param input_nodes_pre_time_window The time window of the nodes represents
    * a period of time before `input_nodes_timestamp`. If provided, only
    * neighbors and related edges whose timestamps fall within
@@ -400,7 +396,6 @@ class FusedCSCSamplingGraph : public torch::CustomClassHolder {
       const torch::Tensor& input_nodes,
       const torch::Tensor& input_nodes_timestamp,
       const std::vector<int64_t>& fanouts, bool replace, bool layer,
-      bool return_eids,
       torch::optional<torch::Tensor> input_nodes_pre_time_window,
       torch::optional<torch::Tensor> probs_or_mask,
       torch::optional<std::string> node_timestamp_attr_name,
@@ -445,8 +440,8 @@ class FusedCSCSamplingGraph : public torch::CustomClassHolder {
   c10::intrusive_ptr<FusedSampledSubgraph> SampleNeighborsImpl(
       const torch::Tensor& seeds,
       torch::optional<std::vector<int64_t>>& seed_offsets,
-      const std::vector<int64_t>& fanouts, bool return_eids,
-      NumPickFn num_pick_fn, PickFn pick_fn) const;
+      const std::vector<int64_t>& fanouts, NumPickFn num_pick_fn,
+      PickFn pick_fn) const;
 
   /** @brief CSC format index pointer array. */
   torch::Tensor indptr_;

--- a/graphbolt/include/graphbolt/fused_sampled_subgraph.h
+++ b/graphbolt/include/graphbolt/fused_sampled_subgraph.h
@@ -56,21 +56,18 @@ struct FusedSampledSubgraph : torch::CustomClassHolder {
    */
   FusedSampledSubgraph(
       torch::Tensor indptr, torch::optional<torch::Tensor> indices,
+      torch::Tensor original_edge_ids,
       torch::optional<torch::Tensor> original_column_node_ids,
       torch::optional<torch::Tensor> original_row_node_ids = torch::nullopt,
-      torch::optional<torch::Tensor> original_edge_ids = torch::nullopt,
       torch::optional<torch::Tensor> type_per_edge = torch::nullopt,
       torch::optional<torch::Tensor> etype_offsets = torch::nullopt)
       : indptr(indptr),
         indices(indices),
+        original_edge_ids(original_edge_ids),
         original_column_node_ids(original_column_node_ids),
         original_row_node_ids(original_row_node_ids),
-        original_edge_ids(original_edge_ids),
         type_per_edge(type_per_edge),
-        etype_offsets(etype_offsets) {
-    // If indices will be fetched later, we need original_edge_ids.
-    TORCH_CHECK(indices.has_value() || original_edge_ids.has_value());
-  }
+        etype_offsets(etype_offsets) {}
 
   FusedSampledSubgraph() = default;
 
@@ -94,6 +91,14 @@ struct FusedSampledSubgraph : torch::CustomClassHolder {
   torch::optional<torch::Tensor> indices;
 
   /**
+   * @brief Reverse edge ids in the original graph, the edge with id
+   * `original_edge_ids[i]` in the original graph is mapped to `i` in this
+   * subgraph. This is useful when edge features are needed. The edges are
+   * sorted w.r.t. their edge types for the heterogenous case.
+   */
+  torch::Tensor original_edge_ids;
+
+  /**
    * @brief Column's reverse node ids in the original graph. A graph structure
    * can be treated as a coordinated row and column pair, and this is the the
    * mapped ids of the column.
@@ -113,14 +118,6 @@ struct FusedSampledSubgraph : torch::CustomClassHolder {
    * row's.
    */
   torch::optional<torch::Tensor> original_row_node_ids;
-
-  /**
-   * @brief Reverse edge ids in the original graph, the edge with id
-   * `original_edge_ids[i]` in the original graph is mapped to `i` in this
-   * subgraph. This is useful when edge features are needed. The edges are
-   * sorted w.r.t. their edge types for the heterogenous case.
-   */
-  torch::optional<torch::Tensor> original_edge_ids;
 
   /**
    * @brief Type id of each edge, where type id is the corresponding index of

--- a/graphbolt/src/cuda/insubgraph.cu
+++ b/graphbolt/src/cuda/insubgraph.cu
@@ -43,7 +43,7 @@ c10::intrusive_ptr<sampling::FusedSampledSubgraph> InSubgraph(
       output_indptr, sliced_indptr.scalar_type(), sliced_indptr, num_edges);
 
   return c10::make_intrusive<sampling::FusedSampledSubgraph>(
-      output_indptr, output_indices, nodes, torch::nullopt, edge_ids,
+      output_indptr, output_indices, edge_ids, nodes, torch::nullopt,
       output_type_per_edge);
 }
 

--- a/graphbolt/src/cuda/neighbor_sampler.cu
+++ b/graphbolt/src/cuda/neighbor_sampler.cu
@@ -202,7 +202,7 @@ c10::intrusive_ptr<sampling::FusedSampledSubgraph> SampleNeighbors(
     torch::optional<torch::Tensor> seeds,
     torch::optional<std::vector<int64_t>> seed_offsets,
     const std::vector<int64_t>& fanouts, bool replace, bool layer,
-    bool return_eids, torch::optional<torch::Tensor> type_per_edge,
+    torch::optional<torch::Tensor> type_per_edge,
     torch::optional<torch::Tensor> probs_or_mask,
     torch::optional<torch::Tensor> node_type_offset,
     torch::optional<torch::Dict<std::string, int64_t>> node_type_to_id,
@@ -697,12 +697,9 @@ c10::intrusive_ptr<sampling::FusedSampledSubgraph> SampleNeighbors(
       output_type_per_edge = Gather(*type_per_edge, picked_eids);
   }
 
-  torch::optional<torch::Tensor> subgraph_reverse_edge_ids = torch::nullopt;
-  if (return_eids) subgraph_reverse_edge_ids = std::move(picked_eids);
-
   return c10::make_intrusive<sampling::FusedSampledSubgraph>(
-      output_indptr, output_indices, seeds, torch::nullopt,
-      subgraph_reverse_edge_ids, output_type_per_edge, edge_offsets);
+      output_indptr, output_indices, seeds, torch::nullopt, picked_eids,
+      output_type_per_edge, edge_offsets);
 }
 
 }  //  namespace ops

--- a/graphbolt/src/cuda/neighbor_sampler.cu
+++ b/graphbolt/src/cuda/neighbor_sampler.cu
@@ -698,7 +698,7 @@ c10::intrusive_ptr<sampling::FusedSampledSubgraph> SampleNeighbors(
   }
 
   return c10::make_intrusive<sampling::FusedSampledSubgraph>(
-      output_indptr, output_indices, seeds, torch::nullopt, picked_eids,
+      output_indptr, output_indices, picked_eids, seeds, torch::nullopt,
       output_type_per_edge, edge_offsets);
 }
 

--- a/graphbolt/src/index_select.cc
+++ b/graphbolt/src/index_select.cc
@@ -137,7 +137,7 @@ std::tuple<torch::Tensor, std::vector<torch::Tensor>> IndexSelectCSCBatched(
     const auto res = g.InSubgraph(nodes);
     output_indptr = res->indptr;
     results.push_back(res->indices.value());
-    edge_ids = res->original_edge_ids.value();
+    edge_ids = res->original_edge_ids;
   }
   if (with_edge_ids) results.push_back(edge_ids);
   return std::make_tuple(output_indptr, results);

--- a/python/dgl/graphbolt/impl/fused_csc_sampling_graph.py
+++ b/python/dgl/graphbolt/impl/fused_csc_sampling_graph.py
@@ -759,7 +759,6 @@ class FusedCSCSamplingGraph(SamplingGraph):
             fanouts,
             replace=replace,
             probs_or_mask=probs_or_mask,
-            return_eids=True,
         )
         return self._convert_to_sampled_subgraph(
             C_sampled_subgraph, seed_offsets
@@ -811,7 +810,6 @@ class FusedCSCSamplingGraph(SamplingGraph):
         fanouts: torch.Tensor,
         replace: bool = False,
         probs_or_mask: Optional[torch.Tensor] = None,
-        return_eids: bool = False,
     ) -> torch.ScriptObject:
         """Sample neighboring edges of the given nodes and return the induced
         subgraph.
@@ -850,9 +848,6 @@ class FusedCSCSamplingGraph(SamplingGraph):
             corresponding to each neighboring edge of a node. It must be a 1D
             floating-point or boolean tensor, with the number of elements
             equalling the total number of edges.
-        return_eids: bool, optional
-            Boolean indicating whether to return the original edge IDs of the
-            sampled edges.
 
         Returns
         -------
@@ -867,7 +862,6 @@ class FusedCSCSamplingGraph(SamplingGraph):
             fanouts.tolist(),
             replace,
             False,  # is_labor
-            return_eids,
             probs_or_mask,
             None,  # random_seed, labor parameter
             0,  # seed2_contribution, labor_parameter
@@ -1001,7 +995,6 @@ class FusedCSCSamplingGraph(SamplingGraph):
             fanouts.tolist(),
             replace,
             True,  # is_labor
-            True,  # return_eids
             probs_or_mask,
             random_seed,
             seed2_contribution,
@@ -1097,7 +1090,6 @@ class FusedCSCSamplingGraph(SamplingGraph):
             fanouts.tolist(),
             replace,
             False,  # is_labor
-            True,  # return_eids
             input_nodes_pre_time_window,
             probs_or_mask,
             node_timestamp_attr_name,
@@ -1224,7 +1216,6 @@ class FusedCSCSamplingGraph(SamplingGraph):
             fanouts.tolist(),
             replace,
             True,  # is_labor
-            True,  # return_eids
             input_nodes_pre_time_window,
             probs_or_mask,
             node_timestamp_attr_name,


### PR DESCRIPTION
## Description
`return_eids` option is always `True`. No need to keep this option. Since it is always true now, went ahead and modified `FusedSamplingGraph` so that it is always expected to be passed. Made it come right after indices so that the rest of the parameters can have default values.

## Checklist
Please feel free to remove inapplicable items for your PR.
- [ ] The PR title starts with [$CATEGORY] (such as [NN], [Model], [Doc], [Feature]])
- [ ] I've leverage the [tools](https://docs.google.com/document/d/1iHyj7zlmygKSk5gBPsqIqL5ASPzJSPREaNT_QdsiYA4/edit) to beautify the python and c++ code.
- [ ] The PR is complete and small, read the [Google eng practice (CL equals to PR)](https://google.github.io/eng-practices/review/developer/small-cls.html) to understand more about small PR. In DGL, we consider PRs with less than 200 lines of core code change are small (example, test and documentation could be exempted).
- [ ] All changes have test coverage
- [ ] Code is well-documented
- [ ] To the best of my knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change
- [ ] Related issue is referred in this PR
- [ ] If the PR is for a new model/paper, I've updated the example index [here](../examples/README.md).

## Changes
<!-- You could use following template
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)
-->
