### PR TITLE
[GraphBolt][CUDA] Fetch indices for NS later.

### DIFF
--- a/graphbolt/include/graphbolt/cuda_sampling_ops.h
+++ b/graphbolt/include/graphbolt/cuda_sampling_ops.h
@@ -54,6 +54,8 @@ namespace ops {
  * @param layer Boolean indicating whether neighbors should be sampled in a
  * layer sampling fashion. Uses the LABOR-0 algorithm to increase overlap of
  * sampled edges, see arXiv:2210.13339.
+ * @param returning_indices_is_optional Boolean indicating whether returning
+ * indices tensor is optional.
  * @param type_per_edge A tensor representing the type of each edge, if present.
  * @param probs_or_mask An optional tensor with (unnormalized) probabilities
  * corresponding to each neighboring edge of a node. It must be
@@ -76,6 +78,7 @@ c10::intrusive_ptr<sampling::FusedSampledSubgraph> SampleNeighbors(
     torch::optional<torch::Tensor> seeds,
     torch::optional<std::vector<int64_t>> seed_offsets,
     const std::vector<int64_t>& fanouts, bool replace, bool layer,
+    bool returning_indices_is_optional,
     torch::optional<torch::Tensor> type_per_edge = torch::nullopt,
     torch::optional<torch::Tensor> probs_or_mask = torch::nullopt,
     torch::optional<torch::Tensor> node_type_offset = torch::nullopt,

--- a/graphbolt/include/graphbolt/fused_csc_sampling_graph.h
+++ b/graphbolt/include/graphbolt/fused_csc_sampling_graph.h
@@ -339,6 +339,8 @@ class FusedCSCSamplingGraph : public torch::CustomClassHolder {
    * @param layer Boolean indicating whether neighbors should be sampled in a
    * layer sampling fashion. Uses the LABOR-0 algorithm to increase overlap of
    * sampled edges, see arXiv:2210.13339.
+   * @param returning_indices_is_optional Boolean indicating whether returning
+   * indices tensor is optional.
    * @param probs_or_mask An optional edge attribute tensor for probablities
    * or masks. This attribute tensor should contain (unnormalized)
    * probabilities corresponding to each neighboring edge of a node. It must be
@@ -355,6 +357,7 @@ class FusedCSCSamplingGraph : public torch::CustomClassHolder {
       torch::optional<torch::Tensor> seeds,
       torch::optional<std::vector<int64_t>> seed_offsets,
       const std::vector<int64_t>& fanouts, bool replace, bool layer,
+      bool returning_indices_is_optional,
       torch::optional<torch::Tensor> probs_or_mask,
       torch::optional<torch::Tensor> random_seed,
       double seed2_contribution) const;

--- a/graphbolt/src/cuda/neighbor_sampler.cu
+++ b/graphbolt/src/cuda/neighbor_sampler.cu
@@ -202,6 +202,7 @@ c10::intrusive_ptr<sampling::FusedSampledSubgraph> SampleNeighbors(
     torch::optional<torch::Tensor> seeds,
     torch::optional<std::vector<int64_t>> seed_offsets,
     const std::vector<int64_t>& fanouts, bool replace, bool layer,
+    bool returning_indices_is_optional,
     torch::optional<torch::Tensor> type_per_edge,
     torch::optional<torch::Tensor> probs_or_mask,
     torch::optional<torch::Tensor> node_type_offset,
@@ -519,9 +520,7 @@ c10::intrusive_ptr<sampling::FusedSampledSubgraph> SampleNeighbors(
           }
         }
 
-        // TODO @mfbalin: remove true from here once fetching indices later is
-        // setup.
-        if (true || layer || utils::is_on_gpu(indices)) {
+        if (!returning_indices_is_optional || utils::is_on_gpu(indices)) {
           output_indices = Gather(indices, picked_eids);
         }
       }));

--- a/graphbolt/src/fused_csc_sampling_graph.cc
+++ b/graphbolt/src/fused_csc_sampling_graph.cc
@@ -804,6 +804,7 @@ c10::intrusive_ptr<FusedSampledSubgraph> FusedCSCSamplingGraph::SampleNeighbors(
     torch::optional<torch::Tensor> seeds,
     torch::optional<std::vector<int64_t>> seed_offsets,
     const std::vector<int64_t>& fanouts, bool replace, bool layer,
+    bool returning_indices_is_optional,
     torch::optional<torch::Tensor> probs_or_mask,
     torch::optional<torch::Tensor> random_seed,
     double seed2_contribution) const {
@@ -828,9 +829,9 @@ c10::intrusive_ptr<FusedSampledSubgraph> FusedCSCSamplingGraph::SampleNeighbors(
         c10::DeviceType::CUDA, "SampleNeighbors", {
           return ops::SampleNeighbors(
               indptr_, indices_, seeds, seed_offsets, fanouts, replace, layer,
-              type_per_edge_, probs_or_mask, node_type_offset_,
-              node_type_to_id_, edge_type_to_id_, random_seed,
-              seed2_contribution);
+              returning_indices_is_optional, type_per_edge_, probs_or_mask,
+              node_type_offset_, node_type_to_id_, edge_type_to_id_,
+              random_seed, seed2_contribution);
         });
   }
   TORCH_CHECK(seeds.has_value(), "Nodes can not be None on the CPU.");

--- a/python/dgl/graphbolt/dataloader.py
+++ b/python/dgl/graphbolt/dataloader.py
@@ -141,7 +141,7 @@ class DataLoader(torch_data.DataLoader):
         of the computations can run simultaneously with it. Setting it to a too
         high value will limit the amount of overlap while setting it too low may
         cause the PCI-e bandwidth to not get fully utilized. Manually tuned
-        default is 6144, meaning around 3-4 Streaming Multiprocessors.
+        default is 10240, meaning around 5-7 Streaming Multiprocessors.
     """
 
     def __init__(
@@ -152,7 +152,7 @@ class DataLoader(torch_data.DataLoader):
         overlap_graph_fetch=False,
         num_gpu_cached_edges=0,
         gpu_cache_threshold=1,
-        max_uva_threads=6144,
+        max_uva_threads=10240,
     ):
         # Multiprocessing requires two modifications to the datapipe:
         #

--- a/python/dgl/graphbolt/impl/fused_csc_sampling_graph.py
+++ b/python/dgl/graphbolt/impl/fused_csc_sampling_graph.py
@@ -694,6 +694,7 @@ class FusedCSCSamplingGraph(SamplingGraph):
         fanouts: torch.Tensor,
         replace: bool = False,
         probs_name: Optional[str] = None,
+        returning_indices_is_optional: bool = False,
     ) -> SampledSubgraphImpl:
         """Sample neighboring edges of the given nodes and return the induced
         subgraph.
@@ -733,6 +734,10 @@ class FusedCSCSamplingGraph(SamplingGraph):
             corresponding to each neighboring edge of a node. It must be a 1D
             floating-point or boolean tensor, with the number of elements
             equalling the total number of edges.
+        returning_indices_is_optional: bool
+            Boolean indicating whether it is okay for the call to this function
+            to leave the indices tensor uninitialized. In this case, it is the
+            user's responsibility to gather it using the edge ids.
 
         Returns
         -------
@@ -776,6 +781,7 @@ class FusedCSCSamplingGraph(SamplingGraph):
             fanouts,
             replace=replace,
             probs_or_mask=probs_or_mask,
+            returning_indices_is_optional=returning_indices_is_optional,
         )
         return self._convert_to_sampled_subgraph(
             C_sampled_subgraph, seed_offsets
@@ -827,6 +833,7 @@ class FusedCSCSamplingGraph(SamplingGraph):
         fanouts: torch.Tensor,
         replace: bool = False,
         probs_or_mask: Optional[torch.Tensor] = None,
+        returning_indices_is_optional: bool = False,
     ) -> torch.ScriptObject:
         """Sample neighboring edges of the given nodes and return the induced
         subgraph.
@@ -865,6 +872,10 @@ class FusedCSCSamplingGraph(SamplingGraph):
             corresponding to each neighboring edge of a node. It must be a 1D
             floating-point or boolean tensor, with the number of elements
             equalling the total number of edges.
+        returning_indices_is_optional: bool
+            Boolean indicating whether it is okay for the call to this function
+            to leave the indices tensor uninitialized. In this case, it is the
+            user's responsibility to gather it using the edge ids.
 
         Returns
         -------
@@ -879,6 +890,7 @@ class FusedCSCSamplingGraph(SamplingGraph):
             fanouts.tolist(),
             replace,
             False,  # is_labor
+            returning_indices_is_optional,
             probs_or_mask,
             None,  # random_seed, labor parameter
             0,  # seed2_contribution, labor_parameter
@@ -890,6 +902,7 @@ class FusedCSCSamplingGraph(SamplingGraph):
         fanouts: torch.Tensor,
         replace: bool = False,
         probs_name: Optional[str] = None,
+        returning_indices_is_optional: bool = False,
         random_seed: torch.Tensor = None,
         seed2_contribution: float = 0.0,
     ) -> SampledSubgraphImpl:
@@ -933,6 +946,10 @@ class FusedCSCSamplingGraph(SamplingGraph):
             corresponding to each neighboring edge of a node. It must be a 1D
             floating-point or boolean tensor, with the number of elements
             equalling the total number of edges.
+        returning_indices_is_optional: bool
+            Boolean indicating whether it is okay for the call to this function
+            to leave the indices tensor uninitialized. In this case, it is the
+            user's responsibility to gather it using the edge ids.
         random_seed: torch.Tensor, optional
             An int64 tensor with one or two elements.
 
@@ -1012,6 +1029,7 @@ class FusedCSCSamplingGraph(SamplingGraph):
             fanouts.tolist(),
             replace,
             True,  # is_labor
+            returning_indices_is_optional,
             probs_or_mask,
             random_seed,
             seed2_contribution,

--- a/python/dgl/graphbolt/impl/neighbor_sampler.py
+++ b/python/dgl/graphbolt/impl/neighbor_sampler.py
@@ -253,7 +253,15 @@ class SamplePerLayerFromFetchedSubgraph(MiniBatchTransformer):
 class SamplePerLayer(MiniBatchTransformer):
     """Sample neighbor edges from a graph for a single layer."""
 
-    def __init__(self, datapipe, sampler, fanout, replace, prob_name, returning_indices_is_optional):
+    def __init__(
+        self,
+        datapipe,
+        sampler,
+        fanout,
+        replace,
+        prob_name,
+        returning_indices_is_optional,
+    ):
         super().__init__(datapipe, self._sample_per_layer)
         self.sampler = sampler
         self.fanout = fanout
@@ -445,9 +453,7 @@ class NeighborSamplerImpl(SubgraphSampler):
                     for etype, pair in subgraph.sampled_csc.items():
                         if pair.indices is None:
                             edge_ids = subgraph._sampled_edge_ids[etype]
-                            edge_ids.record_stream(
-                                torch.cuda.current_stream()
-                            )
+                            edge_ids.record_stream(torch.cuda.current_stream())
                             pair.indices = record_stream(
                                 index_select(indices, edge_ids)
                             )
@@ -488,7 +494,11 @@ class NeighborSamplerImpl(SubgraphSampler):
             if not isinstance(fanout, torch.Tensor):
                 fanout = torch.LongTensor([int(fanout)])
             datapipe = datapipe.sample_per_layer(
-                sampler, fanout, replace, prob_name, returning_indices_is_optional
+                sampler,
+                fanout,
+                replace,
+                prob_name,
+                returning_indices_is_optional,
             )
             datapipe = datapipe.compact_per_layer(deduplicate)
             if is_labor and not layer_dependency:

--- a/python/dgl/graphbolt/impl/neighbor_sampler.py
+++ b/python/dgl/graphbolt/impl/neighbor_sampler.py
@@ -533,10 +533,7 @@ class NeighborSamplerImpl(SubgraphSampler):
             if not isinstance(fanout, torch.Tensor):
                 fanout = torch.LongTensor([int(fanout)])
             datapipe = datapipe.sample_per_layer(
-                sampler,
-                fanout,
-                replace,
-                prob_name,
+                sampler, fanout, replace, prob_name
             )
             datapipe = datapipe.compact_per_layer(deduplicate)
             if is_labor and not layer_dependency:

--- a/tests/python/pytorch/graphbolt/impl/test_neighbor_sampler.py
+++ b/tests/python/pytorch/graphbolt/impl/test_neighbor_sampler.py
@@ -102,8 +102,9 @@ def test_NeighborSampler_GraphFetch(
         graph, [fanout], False, prob_name=prob_name
     )
     datapipe = datapipe.transform(remove_input_nodes)
+    dataloader = gb.DataLoader(datapipe, overlap_graph_fetch=True)
     gb.seed(123)
-    new_results = list(datapipe)
+    new_results = list(dataloader)
     assert len(expected_results) == len(new_results)
     for a, b in zip(expected_results, new_results):
         assert repr(a) == repr(b)

--- a/tests/python/pytorch/graphbolt/impl/test_neighbor_sampler.py
+++ b/tests/python/pytorch/graphbolt/impl/test_neighbor_sampler.py
@@ -65,7 +65,7 @@ def test_NeighborSampler_GraphFetch(
         partial(gb.NeighborSampler._prepare, graph.node_type_to_id)
     )
     sample_per_layer = gb.SamplePerLayer(
-        datapipe, graph.sample_neighbors, fanout, False, prob_name
+        datapipe, graph.sample_neighbors, fanout, False, prob_name, False
     )
     compact_per_layer = sample_per_layer.compact_per_layer(True)
     gb.seed(123)

--- a/tests/python/pytorch/graphbolt/impl/test_neighbor_sampler.py
+++ b/tests/python/pytorch/graphbolt/impl/test_neighbor_sampler.py
@@ -44,8 +44,9 @@ def get_hetero_graph():
 @pytest.mark.parametrize("prob_name", [None, "weight", "mask"])
 @pytest.mark.parametrize("sorted", [False, True])
 @pytest.mark.parametrize("num_cached_edges", [0, 10])
+@pytest.mark.parametrize("is_pinned", [False, True])
 def test_NeighborSampler_GraphFetch(
-    hetero, prob_name, sorted, num_cached_edges
+    hetero, prob_name, sorted, num_cached_edges, is_pinned
 ):
     if sorted:
         items = torch.arange(3)
@@ -53,7 +54,8 @@ def test_NeighborSampler_GraphFetch(
         items = torch.tensor([2, 0, 1])
     names = "seeds"
     itemset = gb.ItemSet(items, names=names)
-    graph = get_hetero_graph().to(F.ctx())
+    graph = get_hetero_graph()
+    graph = graph.pin_memory_() if is_pinned else graph.to(F.ctx())
     if hetero:
         itemset = gb.HeteroItemSet({"n3": itemset})
     else:
@@ -86,6 +88,20 @@ def test_NeighborSampler_GraphFetch(
         )
     datapipe = gb.SamplePerLayerFromFetchedSubgraph(datapipe, sample_per_layer)
     datapipe = datapipe.compact_per_layer(True)
+    gb.seed(123)
+    new_results = list(datapipe)
+    assert len(expected_results) == len(new_results)
+    for a, b in zip(expected_results, new_results):
+        assert repr(a) == repr(b)
+
+    def remove_input_nodes(minibatch):
+        minibatch.input_nodes = None
+        return minibatch
+
+    datapipe = item_sampler.sample_neighbor(
+        graph, [fanout], False, prob_name=prob_name
+    )
+    datapipe = datapipe.transform(remove_input_nodes)
     gb.seed(123)
     new_results = list(datapipe)
     assert len(expected_results) == len(new_results)

--- a/tests/python/pytorch/graphbolt/test_dataloader.py
+++ b/tests/python/pytorch/graphbolt/test_dataloader.py
@@ -77,9 +77,8 @@ def test_gpu_sampling_DataLoader(
     B = 4
     num_layers = 2
     itemset = dgl.graphbolt.ItemSet(torch.arange(N), names="seeds")
-    graph = gb_test_utils.rand_csc_graph(200, 0.15, bidirection_edge=True).to(
-        F.ctx()
-    )
+    graph = gb_test_utils.rand_csc_graph(200, 0.15, bidirection_edge=True)
+    graph = graph.pin_memory_() if overlap_graph_fetch else graph.to(F.ctx())
     features = {}
     keys = [
         ("node", None, "a"),


### PR DESCRIPTION
## Description
This PR implements overlapping indices fetches for NS after sampling is completed.

The PR ended up on the slightly large side.

The changes are:

1. Add returning_indices_is_optional to C++ and Python API (pretty repetitive change).
2. Add returning_indices_is_optional to SamplePerLayer, with False as default value.
3. Modify gb.DataLoader so that returning_indices_is_optional is enabled for sample_neighbor code path (Important logic here.)
4. Modify the default `max_uva_threads` from `6144` to `10240` as larger value is faster on 4090 (we can watch the regression tests for sample_layer_neighbor).
5. Implement the logic for the indices overlapped fetch in SamplePerLayer (Important logic here.)
6. Modify the tests to fix them and add tests for the new feature.

 
## Checklist
Please feel free to remove inapplicable items for your PR.
- [ ] The PR title starts with [$CATEGORY] (such as [NN], [Model], [Doc], [Feature]])
- [ ] I've leverage the [tools](https://docs.google.com/document/d/1iHyj7zlmygKSk5gBPsqIqL5ASPzJSPREaNT_QdsiYA4/edit) to beautify the python and c++ code.
- [ ] The PR is complete and small, read the [Google eng practice (CL equals to PR)](https://google.github.io/eng-practices/review/developer/small-cls.html) to understand more about small PR. In DGL, we consider PRs with less than 200 lines of core code change are small (example, test and documentation could be exempted).
- [ ] All changes have test coverage
- [ ] Code is well-documented
- [ ] To the best of my knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change
- [ ] Related issue is referred in this PR
- [ ] If the PR is for a new model/paper, I've updated the example index [here](../examples/README.md).

## Changes
<!-- You could use following template
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)
-->
