### PR TITLE
[GraphBolt][CUDA] Refactor `overlap_graph_fetch`, simplify `gb.DataLoader`.

### DIFF
--- a/examples/graphbolt/disk_based_feature/node_classification.py
+++ b/examples/graphbolt/disk_based_feature/node_classification.py
@@ -115,7 +115,10 @@ def create_dataloader(
         else {}
     )
     datapipe = getattr(datapipe, args.sample_mode)(
-        graph, fanout if job != "infer" else [-1], **kwargs
+        graph,
+        fanout if job != "infer" else [-1],
+        overlap_fetch=args.overlap_graph_fetch,
+        **kwargs,
     )
     # Copy the data to the specified device.
     if args.feature_device != "cpu":
@@ -130,11 +133,7 @@ def create_dataloader(
     if args.feature_device == "cpu":
         datapipe = datapipe.copy_to(device=device)
     # Create and return a DataLoader to handle data loading.
-    return gb.DataLoader(
-        datapipe,
-        num_workers=args.num_workers,
-        overlap_graph_fetch=args.overlap_graph_fetch,
-    )
+    return gb.DataLoader(datapipe, num_workers=args.num_workers)
 
 
 def train_step(minibatch, optimizer, model, loss_fn):

--- a/examples/graphbolt/node_classification.py
+++ b/examples/graphbolt/node_classification.py
@@ -117,7 +117,9 @@ def create_dataloader(
     # Initialize a neighbor sampler for sampling the neighborhoods of nodes.
     ############################################################################
     datapipe = getattr(datapipe, args.sample_mode)(
-        graph, fanout if job != "infer" else [-1]
+        graph,
+        fanout if job != "infer" else [-1],
+        overlap_fetch=args.storage_device == "pinned",
     )
 
     ############################################################################
@@ -156,11 +158,7 @@ def create_dataloader(
     # [Role]:
     # Initialize a multi-process dataloader to load the data in parallel.
     ############################################################################
-    dataloader = gb.DataLoader(
-        datapipe,
-        num_workers=num_workers,
-        overlap_graph_fetch=args.storage_device == "pinned",
-    )
+    dataloader = gb.DataLoader(datapipe, num_workers=num_workers)
 
     # Return the fully-initialized DataLoader object.
     return dataloader

--- a/examples/graphbolt/pyg/labor/node_classification.py
+++ b/examples/graphbolt/pyg/labor/node_classification.py
@@ -147,7 +147,10 @@ def create_dataloader(
         else {}
     )
     datapipe = getattr(datapipe, args.sample_mode)(
-        graph, fanout if job != "infer" else [-1], **kwargs
+        graph,
+        fanout if job != "infer" else [-1],
+        overlap_fetch=args.overlap_graph_fetch,
+        **kwargs,
     )
     # Copy the data to the specified device.
     if args.feature_device != "cpu" and need_copy:
@@ -163,11 +166,7 @@ def create_dataloader(
     if need_copy:
         datapipe = datapipe.copy_to(device=device)
     # Create and return a DataLoader to handle data loading.
-    return gb.DataLoader(
-        datapipe,
-        num_workers=args.num_workers,
-        overlap_graph_fetch=args.overlap_graph_fetch,
-    )
+    return gb.DataLoader(datapipe, num_workers=args.num_workers)
 
 
 @torch.compile

--- a/examples/graphbolt/pyg/node_classification_advanced.py
+++ b/examples/graphbolt/pyg/node_classification_advanced.py
@@ -195,7 +195,11 @@ def create_dataloader(
         need_copy = False
     # Sample neighbors for each node in the mini-batch.
     datapipe = getattr(datapipe, args.sample_mode)(
-        graph, fanout if job != "infer" else [-1]
+        graph,
+        fanout if job != "infer" else [-1],
+        overlap_fetch=args.overlap_graph_fetch,
+        num_gpu_cached_edges=args.num_gpu_cached_edges,
+        gpu_cache_threshold=args.gpu_graph_caching_threshold,
     )
     # Copy the data to the specified device.
     if args.feature_device != "cpu" and need_copy:
@@ -211,13 +215,7 @@ def create_dataloader(
     if need_copy:
         datapipe = datapipe.copy_to(device=device)
     # Create and return a DataLoader to handle data loading.
-    return gb.DataLoader(
-        datapipe,
-        num_workers=args.num_workers,
-        overlap_graph_fetch=args.overlap_graph_fetch,
-        num_gpu_cached_edges=args.num_gpu_cached_edges,
-        gpu_cache_threshold=args.gpu_graph_caching_threshold,
-    )
+    return gb.DataLoader(datapipe, num_workers=args.num_workers)
 
 
 @torch.compile

--- a/examples/graphbolt/rgcn/hetero_rgcn.py
+++ b/examples/graphbolt/rgcn/hetero_rgcn.py
@@ -124,7 +124,9 @@ def create_dataloader(
     #   The graph(FusedCSCSamplingGraph) from which to sample neighbors.
     # `fanouts`:
     #   The number of neighbors to sample for each node in each layer.
-    datapipe = datapipe.sample_neighbor(graph, fanouts=fanouts)
+    datapipe = datapipe.sample_neighbor(
+        graph, fanouts=fanouts, overlap_fetch=args.overlap_graph_fetch
+    )
 
     # Fetch the features for each node in the mini-batch.
     # `features`:
@@ -141,11 +143,7 @@ def create_dataloader(
     # Create a DataLoader from the datapipe.
     # `num_workers`:
     #   The number of worker processes to use for data loading.
-    return gb.DataLoader(
-        datapipe,
-        num_workers=num_workers,
-        overlap_graph_fetch=args.overlap_graph_fetch,
-    )
+    return gb.DataLoader(datapipe, num_workers=num_workers)
 
 
 def extract_embed(node_embed, input_nodes):

--- a/examples/multigpu/graphbolt/node_classification.py
+++ b/examples/multigpu/graphbolt/node_classification.py
@@ -134,16 +134,14 @@ def create_dataloader(
     ############################################################################
     if args.storage_device != "cpu":
         datapipe = datapipe.copy_to(device)
-    datapipe = datapipe.sample_neighbor(graph, args.fanout)
+    datapipe = datapipe.sample_neighbor(
+        graph, args.fanout, overlap_fetch=args.storage_device == "pinned"
+    )
     datapipe = datapipe.fetch_feature(features, node_feature_keys=["feat"])
     if args.storage_device == "cpu":
         datapipe = datapipe.copy_to(device)
 
-    dataloader = gb.DataLoader(
-        datapipe,
-        args.num_workers,
-        overlap_graph_fetch=args.storage_device == "pinned",
-    )
+    dataloader = gb.DataLoader(datapipe, args.num_workers)
 
     # Return the fully-initialized DataLoader object.
     return dataloader

--- a/python/dgl/graphbolt/dataloader.py
+++ b/python/dgl/graphbolt/dataloader.py
@@ -177,7 +177,6 @@ class DataLoader(torch_data.DataLoader):
             for sampler in samplers:
                 if sampler.overlap_fetch:
                     torch.ops.graphbolt.set_max_uva_threads(max_uva_threads)
-                
 
         # (4) Cut datapipe at CopyTo and wrap with pinning and prefetching
         # before it. This enables enables non_blocking copies to the device.

--- a/python/dgl/graphbolt/dataloader.py
+++ b/python/dgl/graphbolt/dataloader.py
@@ -97,18 +97,6 @@ class DataLoader(torch_data.DataLoader):
         If True, the data loader will not shut down the worker processes after a
         dataset has been consumed once. This allows to maintain the workers
         instances alive.
-    overlap_graph_fetch : bool, optional
-        If True, the data loader will overlap the UVA graph fetching operations
-        with the rest of operations by using an alternative CUDA stream. This
-        option should be enabled if you have moved your graph to the pinned
-        memory for optimal performance. Default is False.
-    num_gpu_cached_edges : int, optional
-        If positive and overlap_graph_fetch is True, then the GPU will cache
-        frequently accessed vertex neighborhoods to reduce the PCI-e bandwidth
-        demand due to pinned graph accesses.
-    gpu_cache_threshold : int, optional
-        Determines how many times a vertex needs to be accessed before its
-        neighborhood ends up being cached on the GPU.
     max_uva_threads : int, optional
         Limits the number of CUDA threads used for UVA copies so that the rest
         of the computations can run simultaneously with it. Setting it to a too

--- a/python/dgl/graphbolt/dataloader.py
+++ b/python/dgl/graphbolt/dataloader.py
@@ -1,13 +1,10 @@
 """Graph Bolt DataLoaders"""
 
-from collections import OrderedDict
-
 import torch
 import torch.utils.data as torch_data
 
-from .base import CopyTo, get_host_to_device_uva_stream
+from .base import CopyTo
 from .feature_fetcher import FeatureFetcher, FeatureFetcherStartMarker
-from .impl.gpu_graph_cache import GPUGraphCache
 from .impl.neighbor_sampler import SamplePerLayer
 
 from .internal import (
@@ -22,32 +19,7 @@ from .item_sampler import ItemSampler
 
 __all__ = [
     "DataLoader",
-    "construct_gpu_graph_cache",
 ]
-
-
-def construct_gpu_graph_cache(
-    sample_per_layer_obj, num_gpu_cached_edges, gpu_cache_threshold
-):
-    "Construct a GPUGraphCache given a sample_per_layer_obj and cache parameters."
-    graph = sample_per_layer_obj.sampler.__self__
-    num_gpu_cached_edges = min(num_gpu_cached_edges, graph.total_num_edges)
-    dtypes = OrderedDict()
-    dtypes["indices"] = graph.indices.dtype
-    if graph.type_per_edge is not None:
-        dtypes["type_per_edge"] = graph.type_per_edge.dtype
-    if graph.edge_attributes is not None:
-        probs_or_mask = graph.edge_attributes.get(
-            sample_per_layer_obj.prob_name, None
-        )
-        if probs_or_mask is not None:
-            dtypes["probs_or_mask"] = probs_or_mask.dtype
-    return GPUGraphCache(
-        num_gpu_cached_edges,
-        gpu_cache_threshold,
-        graph.csc_indptr.dtype,
-        list(dtypes.values()),
-    )
 
 
 def _find_and_wrap_parent(datapipe_graph, target_datapipe, wrapper, **kwargs):
@@ -150,9 +122,6 @@ class DataLoader(torch_data.DataLoader):
         datapipe,
         num_workers=0,
         persistent_workers=True,
-        overlap_graph_fetch=False,
-        num_gpu_cached_edges=0,
-        gpu_cache_threshold=1,
         max_uva_threads=10240,
     ):
         # Multiprocessing requires two modifications to the datapipe:
@@ -200,54 +169,15 @@ class DataLoader(torch_data.DataLoader):
                 if feature_fetcher.max_num_stages > 0:  # Overlap enabled.
                     torch.ops.graphbolt.set_max_uva_threads(max_uva_threads)
 
-        if (
-            overlap_graph_fetch
-            and num_workers == 0
-            and torch.cuda.is_available()
-        ):
-            torch.ops.graphbolt.set_max_uva_threads(max_uva_threads)
+        if num_workers == 0 and torch.cuda.is_available():
             samplers = find_dps(
                 datapipe_graph,
                 SamplePerLayer,
             )
-            gpu_graph_cache = None
             for sampler in samplers:
-                if num_gpu_cached_edges > 0 and gpu_graph_cache is None:
-                    gpu_graph_cache = construct_gpu_graph_cache(
-                        sampler, num_gpu_cached_edges, gpu_cache_threshold
-                    )
-                if (
-                    sampler.sampler.__name__ == "sample_layer_neighbors"
-                    or gpu_graph_cache is not None
-                ):
-                    # This code path is not faster for sample_neighbors.
-                    datapipe_graph = replace_dp(
-                        datapipe_graph,
-                        sampler,
-                        sampler.fetch_and_sample(
-                            gpu_graph_cache,
-                            get_host_to_device_uva_stream(),
-                            1,
-                        ),
-                    )
-                elif sampler.sampler.__name__ == "sample_neighbors":
-                    # This code path is faster for sample_neighbors.
-                    datapipe_graph = replace_dp(
-                        datapipe_graph,
-                        sampler,
-                        sampler.datapipe.sample_per_layer(
-                            sampler=sampler.sampler,
-                            fanout=sampler.fanout,
-                            replace=sampler.replace,
-                            prob_name=sampler.prob_name,
-                            returning_indices_is_optional=True,
-                        ),
-                    )
-                else:
-                    raise AssertionError(
-                        "overlap_graph_fetch is supported only for "
-                        "sample_neighbor and sample_layer_neighbor."
-                    )
+                if sampler.overlap_fetch:
+                    torch.ops.graphbolt.set_max_uva_threads(max_uva_threads)
+                
 
         # (4) Cut datapipe at CopyTo and wrap with pinning and prefetching
         # before it. This enables enables non_blocking copies to the device.

--- a/python/dgl/graphbolt/impl/fused_csc_sampling_graph.py
+++ b/python/dgl/graphbolt/impl/fused_csc_sampling_graph.py
@@ -315,7 +315,7 @@ class FusedCSCSamplingGraph(SamplingGraph):
     ):
         """Sets the indptr node type offset list if present."""
         self._indptr_node_type_offset_list_ = indptr_node_type_offset_list
-    
+
     @property
     def _gpu_graph_cache(self) -> Optional[GPUGraphCache]:
         return (
@@ -1442,7 +1442,10 @@ class FusedCSCSamplingGraph(SamplingGraph):
         return self._apply_to_members(_pin)
 
     def _initialize_gpu_graph_cache(
-        self, num_gpu_cached_edges: int, gpu_cache_threshold: int, prob_name: Optional[str] = None
+        self,
+        num_gpu_cached_edges: int,
+        gpu_cache_threshold: int,
+        prob_name: Optional[str] = None,
     ):
         "Construct a GPUGraphCache given the cache parameters."
         num_gpu_cached_edges = min(num_gpu_cached_edges, self.total_num_edges)

--- a/python/dgl/graphbolt/impl/fused_csc_sampling_graph.py
+++ b/python/dgl/graphbolt/impl/fused_csc_sampling_graph.py
@@ -10,6 +10,7 @@ import torch
 from ..base import etype_str_to_tuple, etype_tuple_to_str, ORIGINAL_EDGE_ID
 from ..internal_utils import gb_warning, is_wsl, recursive_apply
 from ..sampling_graph import SamplingGraph
+from .gpu_graph_cache import GPUGraphCache
 from .sampled_subgraph_impl import CSCFormatBase, SampledSubgraphImpl
 
 
@@ -314,6 +315,14 @@ class FusedCSCSamplingGraph(SamplingGraph):
     ):
         """Sets the indptr node type offset list if present."""
         self._indptr_node_type_offset_list_ = indptr_node_type_offset_list
+    
+    @property
+    def _gpu_graph_cache(self) -> Optional[GPUGraphCache]:
+        return (
+            self._gpu_graph_cache_
+            if hasattr(self, "_gpu_graph_cache_")
+            else None
+        )
 
     @property
     def type_per_edge(self) -> Optional[torch.Tensor]:
@@ -1431,6 +1440,25 @@ class FusedCSCSamplingGraph(SamplingGraph):
             return x
 
         return self._apply_to_members(_pin)
+
+    def _initialize_gpu_graph_cache(
+        self, num_gpu_cached_edges: int, gpu_cache_threshold: int, prob_name: Optional[str] = None
+    ):
+        "Construct a GPUGraphCache given the cache parameters."
+        num_gpu_cached_edges = min(num_gpu_cached_edges, self.total_num_edges)
+        dtypes = [self.indices.dtype]
+        if self.type_per_edge is not None:
+            dtypes.append(self.type_per_edge.dtype)
+        if self.edge_attributes is not None:
+            probs_or_mask = self.edge_attributes.get(prob_name, None)
+            if probs_or_mask is not None:
+                dtypes.append(probs_or_mask.dtype)
+        self._gpu_graph_cache_ = GPUGraphCache(
+            num_gpu_cached_edges,
+            gpu_cache_threshold,
+            self.csc_indptr.dtype,
+            dtypes,
+        )
 
 
 def fused_csc_sampling_graph(

--- a/python/dgl/graphbolt/impl/neighbor_sampler.py
+++ b/python/dgl/graphbolt/impl/neighbor_sampler.py
@@ -417,6 +417,11 @@ class NeighborSamplerImpl(SubgraphSampler):
         layer_dependency=None,
         batch_dependency=None,
     ):
+        if overlap_fetch and num_gpu_cached_edges > 0:
+            if graph._gpu_graph_cache is None:
+                graph._initialize_gpu_graph_cache(
+                    num_gpu_cached_edges, gpu_cache_threshold, prob_name
+                )
         if sampler.__name__ == "sample_layer_neighbors":
             self._init_seed(batch_dependency)
         super().__init__(
@@ -428,8 +433,6 @@ class NeighborSamplerImpl(SubgraphSampler):
             deduplicate,
             sampler,
             overlap_fetch,
-            num_gpu_cached_edges,
-            gpu_cache_threshold,
             layer_dependency,
         )
 
@@ -505,15 +508,8 @@ class NeighborSamplerImpl(SubgraphSampler):
         deduplicate,
         sampler,
         overlap_fetch,
-        num_gpu_cached_edges,
-        gpu_cache_threshold,
         layer_dependency,
     ):
-        if overlap_fetch and num_gpu_cached_edges > 0:
-            if graph._gpu_graph_cache is None:
-                graph._initialize_gpu_graph_cache(
-                    num_gpu_cached_edges, gpu_cache_threshold, prob_name
-                )
         datapipe = datapipe.transform(
             partial(self._prepare, graph.node_type_to_id)
         )

--- a/python/dgl/graphbolt/impl/neighbor_sampler.py
+++ b/python/dgl/graphbolt/impl/neighbor_sampler.py
@@ -581,6 +581,18 @@ class NeighborSampler(NeighborSamplerImpl):
         Boolean indicating whether seeds between hops will be deduplicated.
         If True, the same elements in seeds will be deleted to only one.
         Otherwise, the same elements will be remained.
+    overlap_fetch : bool, optional
+        If True, the data loader will overlap the UVA graph fetching operations
+        with the rest of operations by using an alternative CUDA stream. This
+        option should be enabled if you have moved your graph to the pinned
+        memory for optimal performance. Default is False.
+    num_gpu_cached_edges : int, optional
+        If positive and overlap_graph_fetch is True, then the GPU will cache
+        frequently accessed vertex neighborhoods to reduce the PCI-e bandwidth
+        demand due to pinned graph accesses.
+    gpu_cache_threshold : int, optional
+        Determines how many times a vertex needs to be accessed before its
+        neighborhood ends up being cached on the GPU.
 
     Examples
     -------
@@ -716,6 +728,18 @@ class LayerNeighborSampler(NeighborSamplerImpl):
         the random variates proportional to :math:`\\frac{1}{\\kappa}`. Implements
         the dependent minibatching approach in `arXiv:2310.12403
         <https://arxiv.org/abs/2310.12403>`__.
+    overlap_fetch : bool, optional
+        If True, the data loader will overlap the UVA graph fetching operations
+        with the rest of operations by using an alternative CUDA stream. This
+        option should be enabled if you have moved your graph to the pinned
+        memory for optimal performance. Default is False.
+    num_gpu_cached_edges : int, optional
+        If positive and overlap_graph_fetch is True, then the GPU will cache
+        frequently accessed vertex neighborhoods to reduce the PCI-e bandwidth
+        demand due to pinned graph accesses.
+    gpu_cache_threshold : int, optional
+        Determines how many times a vertex needs to be accessed before its
+        neighborhood ends up being cached on the GPU.
 
     Examples
     -------

--- a/python/dgl/graphbolt/impl/neighbor_sampler.py
+++ b/python/dgl/graphbolt/impl/neighbor_sampler.py
@@ -128,7 +128,9 @@ class FetchInsubgraphData(Mapper):
     ):
         datapipe = datapipe.concat_hetero_seeds(graph)
         if graph._gpu_graph_cache is not None:
-            datapipe = datapipe.fetch_cached_insubgraph_data(graph._gpu_graph_cache)
+            datapipe = datapipe.fetch_cached_insubgraph_data(
+                graph._gpu_graph_cache
+            )
         self.graph = graph
         self.prob_name = prob_name
         super().__init__(datapipe, self._fetch_per_layer)
@@ -230,7 +232,12 @@ class SamplePerLayer(MiniBatchTransformer):
     ):
         graph = sampler.__self__
         self.returning_indices_is_optional = False
-        if overlap_fetch and sampler.__name__ == "sample_neighbors" and graph.indices.is_pinned() and graph._gpu_graph_cache is None:
+        if (
+            overlap_fetch
+            and sampler.__name__ == "sample_neighbors"
+            and graph.indices.is_pinned()
+            and graph._gpu_graph_cache is None
+        ):
             datapipe = datapipe.transform(self._sample_per_layer)
             datapipe = (
                 datapipe.transform(partial(self._fetch_indices, graph.indices))
@@ -252,8 +259,12 @@ class SamplePerLayer(MiniBatchTransformer):
             datapipe = datapipe.fetch_insubgraph_data(graph, prob_name)
             datapipe = datapipe.buffer().wait()
             if graph._gpu_graph_cache is not None:
-                datapipe = datapipe.combine_cached_and_fetched_insubgraph(prob_name)
-            super().__init__(datapipe, self._sample_per_layer_from_fetched_subgraph)
+                datapipe = datapipe.combine_cached_and_fetched_insubgraph(
+                    prob_name
+                )
+            super().__init__(
+                datapipe, self._sample_per_layer_from_fetched_subgraph
+            )
         else:
             super().__init__(datapipe, self._sample_per_layer)
         self.sampler = sampler

--- a/python/dgl/graphbolt/impl/neighbor_sampler.py
+++ b/python/dgl/graphbolt/impl/neighbor_sampler.py
@@ -512,7 +512,7 @@ class NeighborSamplerImpl(SubgraphSampler):
         if overlap_fetch and num_gpu_cached_edges > 0:
             if graph._gpu_graph_cache is None:
                 graph._initialize_gpu_graph_cache(
-                    num_gpu_cached_edges, gpu_cache_threshold
+                    num_gpu_cached_edges, gpu_cache_threshold, prob_name
                 )
         datapipe = datapipe.transform(
             partial(self._prepare, graph.node_type_to_id)

--- a/tests/python/pytorch/graphbolt/impl/test_neighbor_sampler.py
+++ b/tests/python/pytorch/graphbolt/impl/test_neighbor_sampler.py
@@ -71,7 +71,8 @@ def test_NeighborSampler_GraphFetch(
     compact_per_layer = sample_per_layer.compact_per_layer(True)
     gb.seed(123)
     expected_results = list(compact_per_layer)
-    graph._initialize_gpu_graph_cache(num_cached_edges, 1, prob_name)
+    if num_cached_edges > 0:
+        graph._initialize_gpu_graph_cache(num_cached_edges, 1, prob_name)
     datapipe = datapipe.sample_per_layer(
         graph.sample_neighbors, fanout, False, prob_name, True
     )

--- a/tests/python/pytorch/graphbolt/impl/test_neighbor_sampler.py
+++ b/tests/python/pytorch/graphbolt/impl/test_neighbor_sampler.py
@@ -72,7 +72,9 @@ def test_NeighborSampler_GraphFetch(
     gb.seed(123)
     expected_results = list(compact_per_layer)
     graph._initialize_gpu_graph_cache(num_cached_edges, 1, prob_name)
-    datapipe = datapipe.sample_per_layer(graph.sample_neighbors, fanout, False, prob_name, True)
+    datapipe = datapipe.sample_per_layer(
+        graph.sample_neighbors, fanout, False, prob_name, True
+    )
     datapipe = datapipe.compact_per_layer(True)
     gb.seed(123)
     new_results = list(datapipe)

--- a/tests/python/pytorch/graphbolt/impl/test_neighbor_sampler.py
+++ b/tests/python/pytorch/graphbolt/impl/test_neighbor_sampler.py
@@ -102,6 +102,8 @@ def test_NeighborSampler_GraphFetch(
 @pytest.mark.parametrize("layer_dependency", [False, True])
 @pytest.mark.parametrize("overlap_graph_fetch", [False, True])
 def test_labor_dependent_minibatching(layer_dependency, overlap_graph_fetch):
+    if F._default_context_str != "gpu" and overlap_graph_fetch:
+        pytest.skip("overlap_graph_fetch is only available for GPU.")
     num_edges = 200
     csc_indptr = torch.cat(
         (

--- a/tests/python/pytorch/graphbolt/impl/test_neighbor_sampler.py
+++ b/tests/python/pytorch/graphbolt/impl/test_neighbor_sampler.py
@@ -7,7 +7,6 @@ import dgl
 import dgl.graphbolt as gb
 import pytest
 import torch
-from dgl.graphbolt.dataloader import construct_gpu_graph_cache
 
 
 def get_hetero_graph():
@@ -72,21 +71,8 @@ def test_NeighborSampler_GraphFetch(
     compact_per_layer = sample_per_layer.compact_per_layer(True)
     gb.seed(123)
     expected_results = list(compact_per_layer)
-    gpu_graph_cache = None
-    if num_cached_edges > 0:
-        gpu_graph_cache = construct_gpu_graph_cache(
-            sample_per_layer, num_cached_edges, 1
-        )
-    datapipe = gb.FetchInsubgraphData(
-        datapipe,
-        sample_per_layer,
-        gpu_graph_cache,
-    )
-    if num_cached_edges > 0:
-        datapipe = gb.CombineCachedAndFetchedInSubgraph(
-            datapipe, sample_per_layer
-        )
-    datapipe = gb.SamplePerLayerFromFetchedSubgraph(datapipe, sample_per_layer)
+    graph._initialize_gpu_graph_cache(num_cached_edges, 1, prob_name)
+    datapipe = datapipe.sample_per_layer(graph.sample_neighbors, fanout, False, prob_name, True)
     datapipe = datapipe.compact_per_layer(True)
     gb.seed(123)
     new_results = list(datapipe)
@@ -99,10 +85,10 @@ def test_NeighborSampler_GraphFetch(
         return minibatch
 
     datapipe = item_sampler.sample_neighbor(
-        graph, [fanout], False, prob_name=prob_name
+        graph, [fanout], False, prob_name=prob_name, overlap_fetch=True
     )
     datapipe = datapipe.transform(remove_input_nodes)
-    dataloader = gb.DataLoader(datapipe, overlap_graph_fetch=True)
+    dataloader = gb.DataLoader(datapipe)
     gb.seed(123)
     new_results = list(dataloader)
     assert len(expected_results) == len(new_results)
@@ -133,12 +119,11 @@ def test_labor_dependent_minibatching(layer_dependency, overlap_graph_fetch):
     datapipe = datapipe.sample_layer_neighbor(
         graph,
         fanouts,
+        overlap_fetch=overlap_graph_fetch,
         layer_dependency=layer_dependency,
         batch_dependency=batch_dependency,
     )
-    dataloader = gb.DataLoader(
-        datapipe, overlap_graph_fetch=overlap_graph_fetch
-    )
+    dataloader = gb.DataLoader(datapipe)
     res = list(dataloader)
     assert len(res) == batch_dependency + 1
     if layer_dependency:

--- a/tests/python/pytorch/graphbolt/test_dataloader.py
+++ b/tests/python/pytorch/graphbolt/test_dataloader.py
@@ -104,13 +104,13 @@ def test_gpu_sampling_DataLoader(
     for i in range(2):
         datapipe = dgl.graphbolt.ItemSampler(itemset, batch_size=B)
         datapipe = datapipe.copy_to(F.ctx())
-        kwargs = {}
-        if i == 0:
-            kwargs = {
-                "overlap_fetch": overlap_graph_fetch,
-                "num_gpu_cached_edges": num_gpu_cached_edges,
-                "gpu_cache_threshold": gpu_cache_threshold,
-            }
+        kwargs = {
+            "overlap_fetch": overlap_graph_fetch,
+            "num_gpu_cached_edges": num_gpu_cached_edges,
+            "gpu_cache_threshold": gpu_cache_threshold,
+        }
+        if i != 0:
+            kwargs = {}
         datapipe = getattr(dgl.graphbolt, sampler_name)(
             datapipe,
             graph,

--- a/tests/python/pytorch/graphbolt/test_dataloader.py
+++ b/tests/python/pytorch/graphbolt/test_dataloader.py
@@ -108,6 +108,9 @@ def test_gpu_sampling_DataLoader(
             datapipe,
             graph,
             fanouts=[torch.LongTensor([2]) for _ in range(num_layers)],
+            overlap_fetch=overlap_graph_fetch,
+            num_gpu_cached_edges=num_gpu_cached_edges,
+            gpu_cache_threshold=gpu_cache_threshold,
         )
         if enable_feature_fetch:
             datapipe = dgl.graphbolt.FeatureFetcher(
@@ -119,12 +122,7 @@ def test_gpu_sampling_DataLoader(
             )
         if i == 0:
             dataloaders.append(
-                dgl.graphbolt.DataLoader(
-                    datapipe,
-                    overlap_graph_fetch=overlap_graph_fetch,
-                    num_gpu_cached_edges=num_gpu_cached_edges,
-                    gpu_cache_threshold=gpu_cache_threshold,
-                )
+                dgl.graphbolt.DataLoader(datapipe)
             )
         else:
             dataloaders.append(dgl.graphbolt.DataLoader(datapipe))

--- a/tests/python/pytorch/graphbolt/test_dataloader.py
+++ b/tests/python/pytorch/graphbolt/test_dataloader.py
@@ -104,13 +104,18 @@ def test_gpu_sampling_DataLoader(
     for i in range(2):
         datapipe = dgl.graphbolt.ItemSampler(itemset, batch_size=B)
         datapipe = datapipe.copy_to(F.ctx())
+        kwargs = {}
+        if i == 0:
+            kwargs = {
+                "overlap_fetch": overlap_graph_fetch,
+                "num_gpu_cached_edges": num_gpu_cached_edges,
+                "gpu_cache_threshold": gpu_cache_threshold,
+            }
         datapipe = getattr(dgl.graphbolt, sampler_name)(
             datapipe,
             graph,
             fanouts=[torch.LongTensor([2]) for _ in range(num_layers)],
-            overlap_fetch=overlap_graph_fetch,
-            num_gpu_cached_edges=num_gpu_cached_edges,
-            gpu_cache_threshold=gpu_cache_threshold,
+            **kwargs
         )
         if enable_feature_fetch:
             datapipe = dgl.graphbolt.FeatureFetcher(
@@ -120,10 +125,7 @@ def test_gpu_sampling_DataLoader(
                 ["d"],
                 overlap_fetch=overlap_feature_fetch and i == 0,
             )
-        if i == 0:
-            dataloaders.append(dgl.graphbolt.DataLoader(datapipe))
-        else:
-            dataloaders.append(dgl.graphbolt.DataLoader(datapipe))
+        dataloaders.append(dgl.graphbolt.DataLoader(datapipe))
     dataloader, dataloader2 = dataloaders
 
     bufferer_cnt = int(enable_feature_fetch and overlap_feature_fetch)

--- a/tests/python/pytorch/graphbolt/test_dataloader.py
+++ b/tests/python/pytorch/graphbolt/test_dataloader.py
@@ -121,9 +121,7 @@ def test_gpu_sampling_DataLoader(
                 overlap_fetch=overlap_feature_fetch and i == 0,
             )
         if i == 0:
-            dataloaders.append(
-                dgl.graphbolt.DataLoader(datapipe)
-            )
+            dataloaders.append(dgl.graphbolt.DataLoader(datapipe))
         else:
             dataloaders.append(dgl.graphbolt.DataLoader(datapipe))
     dataloader, dataloader2 = dataloaders


### PR DESCRIPTION
## Description

1. Move the logic from `gb.DataLoader` to the sampling classes for `overlap_graph_fetch`. It is an argument of the sampler now.
2. Move the `gpu_graph_cache` to the FusedCSCSamplingGraph because otherwise it won't be shared across train or validation dataloader for example. That way, there will be a single graph cache for multiple dataloader instances.

The end goal is to make sampling and compaction async and hide the latency of GPU CPU synchronizations during these stages. A lot of our optimizations also have inherent GPU CPU synchronization, which will be handled in the same way. I needed to clean the code and refactor before #7682.

I might refactor more and reduce the amount of code in our code base in the future.

## Checklist
Please feel free to remove inapplicable items for your PR.
- [ ] The PR title starts with [$CATEGORY] (such as [NN], [Model], [Doc], [Feature]])
- [ ] I've leverage the [tools](https://docs.google.com/document/d/1iHyj7zlmygKSk5gBPsqIqL5ASPzJSPREaNT_QdsiYA4/edit) to beautify the python and c++ code.
- [x] The PR is complete and small, read the [Google eng practice (CL equals to PR)](https://google.github.io/eng-practices/review/developer/small-cls.html) to understand more about small PR. In DGL, we consider PRs with less than 200 lines of core code change are small (example, test and documentation could be exempted).
- [ ] All changes have test coverage
- [ ] Code is well-documented
- [ ] To the best of my knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change
- [ ] Related issue is referred in this PR
- [ ] If the PR is for a new model/paper, I've updated the example index [here](../examples/README.md).

## Changes
<!-- You could use following template
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)
-->
