### PR TITLE
[GraphBolt][CUDA] Async sample neighbors and compaction.

### DIFF
--- a/examples/graphbolt/pyg/labor/node_classification.py
+++ b/examples/graphbolt/pyg/labor/node_classification.py
@@ -150,6 +150,7 @@ def create_dataloader(
         graph,
         fanout if job != "infer" else [-1],
         overlap_fetch=args.overlap_graph_fetch,
+        asynchronous=True,
         **kwargs,
     )
     # Copy the data to the specified device.

--- a/examples/graphbolt/pyg/labor/node_classification.py
+++ b/examples/graphbolt/pyg/labor/node_classification.py
@@ -150,7 +150,6 @@ def create_dataloader(
         graph,
         fanout if job != "infer" else [-1],
         overlap_fetch=args.overlap_graph_fetch,
-        asynchronous=True,
         **kwargs,
     )
     # Copy the data to the specified device.

--- a/graphbolt/include/graphbolt/fused_csc_sampling_graph.h
+++ b/graphbolt/include/graphbolt/fused_csc_sampling_graph.h
@@ -6,6 +6,7 @@
 #ifndef GRAPHBOLT_CSC_SAMPLING_GRAPH_H_
 #define GRAPHBOLT_CSC_SAMPLING_GRAPH_H_
 
+#include <graphbolt/async.h>
 #include <graphbolt/continuous_seed.h>
 #include <graphbolt/fused_sampled_subgraph.h>
 #include <graphbolt/shared_memory.h>
@@ -354,6 +355,16 @@ class FusedCSCSamplingGraph : public torch::CustomClassHolder {
    * the sampled graph's information.
    */
   c10::intrusive_ptr<FusedSampledSubgraph> SampleNeighbors(
+      torch::optional<torch::Tensor> seeds,
+      torch::optional<std::vector<int64_t>> seed_offsets,
+      const std::vector<int64_t>& fanouts, bool replace, bool layer,
+      bool returning_indices_is_optional,
+      torch::optional<torch::Tensor> probs_or_mask,
+      torch::optional<torch::Tensor> random_seed,
+      double seed2_contribution) const;
+
+  c10::intrusive_ptr<Future<c10::intrusive_ptr<FusedSampledSubgraph>>>
+  SampleNeighborsAsync(
       torch::optional<torch::Tensor> seeds,
       torch::optional<std::vector<int64_t>> seed_offsets,
       const std::vector<int64_t>& fanouts, bool replace, bool layer,

--- a/graphbolt/include/graphbolt/unique_and_compact.h
+++ b/graphbolt/include/graphbolt/unique_and_compact.h
@@ -7,6 +7,7 @@
 #ifndef GRAPHBOLT_UNIQUE_AND_COMPACT_H_
 #define GRAPHBOLT_UNIQUE_AND_COMPACT_H_
 
+#include <graphbolt/async.h>
 #include <torch/torch.h>
 
 namespace graphbolt {
@@ -52,6 +53,13 @@ std::tuple<torch::Tensor, torch::Tensor, torch::Tensor> UniqueAndCompact(
 
 std::vector<std::tuple<torch::Tensor, torch::Tensor, torch::Tensor>>
 UniqueAndCompactBatched(
+    const std::vector<torch::Tensor>& src_ids,
+    const std::vector<torch::Tensor>& dst_ids,
+    const std::vector<torch::Tensor> unique_dst_ids);
+
+c10::intrusive_ptr<Future<
+    std::vector<std::tuple<torch::Tensor, torch::Tensor, torch::Tensor>>>>
+UniqueAndCompactBatchedAsync(
     const std::vector<torch::Tensor>& src_ids,
     const std::vector<torch::Tensor>& dst_ids,
     const std::vector<torch::Tensor> unique_dst_ids);

--- a/graphbolt/src/fused_csc_sampling_graph.cc
+++ b/graphbolt/src/fused_csc_sampling_graph.cc
@@ -870,6 +870,23 @@ c10::intrusive_ptr<FusedSampledSubgraph> FusedCSCSamplingGraph::SampleNeighbors(
   }
 }
 
+c10::intrusive_ptr<Future<c10::intrusive_ptr<FusedSampledSubgraph>>>
+FusedCSCSamplingGraph::SampleNeighborsAsync(
+    torch::optional<torch::Tensor> seeds,
+    torch::optional<std::vector<int64_t>> seed_offsets,
+    const std::vector<int64_t>& fanouts, bool replace, bool layer,
+    bool returning_indices_is_optional,
+    torch::optional<torch::Tensor> probs_or_mask,
+    torch::optional<torch::Tensor> random_seed,
+    double seed2_contribution) const {
+  return async([=] {
+    return this->SampleNeighbors(
+        seeds, seed_offsets, fanouts, replace, layer,
+        returning_indices_is_optional, probs_or_mask, random_seed,
+        seed2_contribution);
+  });
+}
+
 c10::intrusive_ptr<FusedSampledSubgraph>
 FusedCSCSamplingGraph::TemporalSampleNeighbors(
     const torch::optional<torch::Tensor>& seeds,

--- a/graphbolt/src/python_binding.cc
+++ b/graphbolt/src/python_binding.cc
@@ -48,6 +48,16 @@ TORCH_LIBRARY(graphbolt, m) {
       .def("wait", &Future<torch::Tensor>::Wait);
   m.class_<Future<std::vector<torch::Tensor>>>("TensorListFuture")
       .def("wait", &Future<std::vector<torch::Tensor>>::Wait);
+  m.class_<Future<c10::intrusive_ptr<FusedSampledSubgraph>>>(
+       "FusedSampledSubgraphFuture")
+      .def("wait", &Future<c10::intrusive_ptr<FusedSampledSubgraph>>::Wait);
+  m.class_<Future<
+      std::vector<std::tuple<torch::Tensor, torch::Tensor, torch::Tensor>>>>(
+       "UniqueAndCompactBatchedFuture")
+      .def(
+          "wait",
+          &Future<std::vector<
+              std::tuple<torch::Tensor, torch::Tensor, torch::Tensor>>>::Wait);
   m.class_<storage::OnDiskNpyArray>("OnDiskNpyArray")
       .def("index_select", &storage::OnDiskNpyArray::IndexSelect);
   m.class_<FusedCSCSamplingGraph>("FusedCSCSamplingGraph")
@@ -75,6 +85,9 @@ TORCH_LIBRARY(graphbolt, m) {
       .def("add_edge_attribute", &FusedCSCSamplingGraph::AddEdgeAttribute)
       .def("in_subgraph", &FusedCSCSamplingGraph::InSubgraph)
       .def("sample_neighbors", &FusedCSCSamplingGraph::SampleNeighbors)
+      .def(
+          "sample_neighbors_async",
+          &FusedCSCSamplingGraph::SampleNeighborsAsync)
       .def(
           "temporal_sample_neighbors",
           &FusedCSCSamplingGraph::TemporalSampleNeighbors)
@@ -150,6 +163,7 @@ TORCH_LIBRARY(graphbolt, m) {
       "load_from_shared_memory", &FusedCSCSamplingGraph::LoadFromSharedMemory);
   m.def("unique_and_compact", &UniqueAndCompact);
   m.def("unique_and_compact_batched", &UniqueAndCompactBatched);
+  m.def("unique_and_compact_batched_async", &UniqueAndCompactBatchedAsync);
   m.def("isin", &IsIn);
   m.def("index_select", &ops::IndexSelect);
   m.def("index_select_async", &ops::IndexSelectAsync);

--- a/graphbolt/src/unique_and_compact.cc
+++ b/graphbolt/src/unique_and_compact.cc
@@ -8,8 +8,6 @@
 #include <graphbolt/cuda_ops.h>
 #include <graphbolt/unique_and_compact.h>
 
-#include <unordered_map>
-
 #include "./concurrent_id_hash_map.h"
 #include "./macro.h"
 #include "./utils.h"
@@ -65,6 +63,17 @@ UniqueAndCompactBatched(
         UniqueAndCompact(src_ids[i], dst_ids[i], unique_dst_ids[i]));
   }
   return results;
+}
+
+c10::intrusive_ptr<Future<
+    std::vector<std::tuple<torch::Tensor, torch::Tensor, torch::Tensor>>>>
+UniqueAndCompactBatchedAsync(
+    const std::vector<torch::Tensor>& src_ids,
+    const std::vector<torch::Tensor>& dst_ids,
+    const std::vector<torch::Tensor> unique_dst_ids) {
+  return async([=] {
+    return UniqueAndCompactBatched(src_ids, dst_ids, unique_dst_ids);
+  });
 }
 
 }  // namespace sampling

--- a/python/dgl/graphbolt/impl/fused_csc_sampling_graph.py
+++ b/python/dgl/graphbolt/impl/fused_csc_sampling_graph.py
@@ -812,6 +812,7 @@ class FusedCSCSamplingGraph(SamplingGraph):
             replace=replace,
             probs_or_mask=probs_or_mask,
             returning_indices_is_optional=returning_indices_is_optional,
+            is_asynchronous=is_asynchronous,
         )
         if is_asynchronous:
             return _SampleNeighborsWaiter(

--- a/python/dgl/graphbolt/impl/fused_csc_sampling_graph.py
+++ b/python/dgl/graphbolt/impl/fused_csc_sampling_graph.py
@@ -1024,6 +1024,9 @@ class FusedCSCSamplingGraph(SamplingGraph):
             A float value between [0, 1) that determines the contribution of the
             second random seed, ``random_seed[-1]``, to generate the random
             variates.
+        async_op: bool
+            Boolean indicating whether the call is asynchronous. If so, the
+            result can be obtained by calling wait on the returned future.
 
         Returns
         -------

--- a/python/dgl/graphbolt/impl/fused_csc_sampling_graph.py
+++ b/python/dgl/graphbolt/impl/fused_csc_sampling_graph.py
@@ -721,7 +721,7 @@ class FusedCSCSamplingGraph(SamplingGraph):
         replace: bool = False,
         probs_name: Optional[str] = None,
         returning_indices_is_optional: bool = False,
-        is_asynchronous: bool = False,
+        async_op: bool = False,
     ) -> SampledSubgraphImpl:
         """Sample neighboring edges of the given nodes and return the induced
         subgraph.
@@ -765,7 +765,7 @@ class FusedCSCSamplingGraph(SamplingGraph):
             Boolean indicating whether it is okay for the call to this function
             to leave the indices tensor uninitialized. In this case, it is the
             user's responsibility to gather it using the edge ids.
-        is_asynchronous: bool
+        async_op: bool
             Boolean indicating whether the call is asynchronous. If so, the
             result can be obtained by calling wait on the returned future.
 
@@ -812,9 +812,9 @@ class FusedCSCSamplingGraph(SamplingGraph):
             replace=replace,
             probs_or_mask=probs_or_mask,
             returning_indices_is_optional=returning_indices_is_optional,
-            is_asynchronous=is_asynchronous,
+            async_op=async_op,
         )
-        if is_asynchronous:
+        if async_op:
             return _SampleNeighborsWaiter(
                 self._convert_to_sampled_subgraph,
                 C_sampled_subgraph,
@@ -872,7 +872,7 @@ class FusedCSCSamplingGraph(SamplingGraph):
         replace: bool = False,
         probs_or_mask: Optional[torch.Tensor] = None,
         returning_indices_is_optional: bool = False,
-        is_asynchronous: bool = False,
+        async_op: bool = False,
     ) -> torch.ScriptObject:
         """Sample neighboring edges of the given nodes and return the induced
         subgraph.
@@ -915,7 +915,7 @@ class FusedCSCSamplingGraph(SamplingGraph):
             Boolean indicating whether it is okay for the call to this function
             to leave the indices tensor uninitialized. In this case, it is the
             user's responsibility to gather it using the edge ids.
-        is_asynchronous: bool
+        async_op: bool
             Boolean indicating whether the call is asynchronous. If so, the
             result can be obtained by calling wait on the returned future.
 
@@ -928,7 +928,7 @@ class FusedCSCSamplingGraph(SamplingGraph):
         self._check_sampler_arguments(seeds, fanouts, probs_or_mask)
         sampling_fn = (
             self._c_csc_graph.sample_neighbors_async
-            if is_asynchronous
+            if async_op
             else self._c_csc_graph.sample_neighbors
         )
         return sampling_fn(
@@ -952,7 +952,7 @@ class FusedCSCSamplingGraph(SamplingGraph):
         returning_indices_is_optional: bool = False,
         random_seed: torch.Tensor = None,
         seed2_contribution: float = 0.0,
-        is_asynchronous: bool = False,
+        async_op: bool = False,
     ) -> SampledSubgraphImpl:
         """Sample neighboring edges of the given nodes and return the induced
         subgraph via layer-neighbor sampling from the NeurIPS 2023 paper
@@ -1073,7 +1073,7 @@ class FusedCSCSamplingGraph(SamplingGraph):
         self._check_sampler_arguments(seeds, fanouts, probs_or_mask)
         sampling_fn = (
             self._c_csc_graph.sample_neighbors_async
-            if is_asynchronous
+            if async_op
             else self._c_csc_graph.sample_neighbors
         )
         C_sampled_subgraph = sampling_fn(
@@ -1087,7 +1087,7 @@ class FusedCSCSamplingGraph(SamplingGraph):
             random_seed,
             seed2_contribution,
         )
-        if is_asynchronous:
+        if async_op:
             return _SampleNeighborsWaiter(
                 self._convert_to_sampled_subgraph,
                 C_sampled_subgraph,

--- a/python/dgl/graphbolt/impl/neighbor_sampler.py
+++ b/python/dgl/graphbolt/impl/neighbor_sampler.py
@@ -296,7 +296,7 @@ class SamplePerLayer(MiniBatchTransformer):
             self.replace,
             self.prob_name,
             self.returning_indices_is_optional,
-            is_asynchronous=self.asynchronous,
+            async_op=self.asynchronous,
             **kwargs,
         )
         minibatch.sampled_subgraphs.insert(0, subgraph)
@@ -315,7 +315,7 @@ class SamplePerLayer(MiniBatchTransformer):
             self.fanout,
             self.replace,
             self.prob_name,
-            is_asynchronous=self.asynchronous,
+            async_op=self.asynchronous,
             **kwargs,
         )
         minibatch.sampled_subgraphs.insert(0, sampled_subgraph)
@@ -423,7 +423,7 @@ class CompactPerLayer(MiniBatchTransformer):
         seeds = minibatch._seed_nodes
         assert self.deduplicate
         minibatch._future = unique_and_compact_csc_formats(
-            subgraph.sampled_csc, seeds, is_asynchronous=True
+            subgraph.sampled_csc, seeds, async_op=True
         )
         return minibatch
 

--- a/python/dgl/graphbolt/impl/neighbor_sampler.py
+++ b/python/dgl/graphbolt/impl/neighbor_sampler.py
@@ -639,6 +639,10 @@ class NeighborSampler(NeighborSamplerImpl):
     gpu_cache_threshold : int, optional
         Determines how many times a vertex needs to be accessed before its
         neighborhood ends up being cached on the GPU.
+    asynchronous: bool
+        Boolean indicating whether sampling and compaction stages should run
+        in background threads to hide the latency of CPU GPU synchronization.
+        Should be enabled only when sampling on the GPU.
 
     Examples
     -------
@@ -788,6 +792,10 @@ class LayerNeighborSampler(NeighborSamplerImpl):
     gpu_cache_threshold : int, optional
         Determines how many times a vertex needs to be accessed before its
         neighborhood ends up being cached on the GPU.
+    asynchronous: bool
+        Boolean indicating whether sampling and compaction stages should run
+        in background threads to hide the latency of CPU GPU synchronization.
+        Should be enabled only when sampling on the GPU.
 
     Examples
     -------

--- a/python/dgl/graphbolt/impl/neighbor_sampler.py
+++ b/python/dgl/graphbolt/impl/neighbor_sampler.py
@@ -382,7 +382,7 @@ class CompactPerLayer(MiniBatchTransformer):
 
     def __init__(self, datapipe, deduplicate, asynchronous=False):
         self.deduplicate = deduplicate
-        if asynchronous and not deduplicate:
+        if asynchronous and deduplicate:
             datapipe = datapipe.transform(self._compact_per_layer_async)
             datapipe = datapipe.buffer()
             super().__init__(datapipe, self._compact_per_layer_wait_future)
@@ -428,7 +428,8 @@ class CompactPerLayer(MiniBatchTransformer):
         return minibatch
 
     @staticmethod
-    def _compact_per_layer_wait_future(self, minibatch):
+    def _compact_per_layer_wait_future(minibatch):
+        subgraph = minibatch.sampled_subgraphs[0]
         seeds = minibatch._seed_nodes
         original_row_node_ids, compacted_csc_format = minibatch._future.wait()
         delattr(minibatch, "_future")

--- a/python/dgl/graphbolt/internal/sample_utils.py
+++ b/python/dgl/graphbolt/internal/sample_utils.py
@@ -124,6 +124,7 @@ def unique_and_compact_csc_formats(
         torch.Tensor,
         Dict[str, torch.Tensor],
     ],
+    is_asynchronous: bool = False,
 ):
     """
     Compact csc formats and return unique nodes (per type).
@@ -144,6 +145,9 @@ def unique_and_compact_csc_formats(
         - If `unique_dst_nodes` is a tensor: It means the graph is homogeneous.
         - If `csc_formats` is a dictionary: The keys are node type and the
         values are corresponding nodes. And IDs inside are heterogeneous ids.
+    is_asynchronous: bool
+        Boolean indicating whether the call is asynchronous. If so, the result
+        can be obtained by calling wait on the returned future.
 
     Returns
     -------
@@ -199,8 +203,6 @@ def unique_and_compact_csc_formats(
     indices = {ntype: torch.cat(nodes) for ntype, nodes in indices.items()}
 
     ntypes = set(indices.keys())
-    unique_nodes = {}
-    compacted_indices = {}
     dtype = list(indices.values())[0].dtype
     default_tensor = torch.tensor([], dtype=dtype, device=device)
     indice_list = []
@@ -211,30 +213,56 @@ def unique_and_compact_csc_formats(
     dst_list = [torch.tensor([], dtype=dtype, device=device)] * len(
         unique_dst_list
     )
-    results = torch.ops.graphbolt.unique_and_compact_batched(
-        indice_list, dst_list, unique_dst_list
+    unique_fn = (
+        torch.ops.graphbolt.unique_and_compact_batched_async
+        if is_asynchronous
+        else torch.ops.graphbolt.unique_and_compact_batched
     )
-    for i, ntype in enumerate(ntypes):
-        unique_nodes[ntype], compacted_indices[ntype], _ = results[i]
+    results = unique_fn(indice_list, dst_list, unique_dst_list)
 
-    compacted_csc_formats = {}
-    # Map back with the same order.
-    for etype, csc_format in csc_formats.items():
-        num_elem = csc_format.indices.size(0)
-        src_type, _, _ = etype_str_to_tuple(etype)
-        indice = compacted_indices[src_type][:num_elem]
-        indptr = csc_format.indptr
-        compacted_csc_formats[etype] = CSCFormatBase(
-            indptr=indptr, indices=indice
-        )
-        compacted_indices[src_type] = compacted_indices[src_type][num_elem:]
+    class _Waiter:
+        def __init__(self, future, csc_formats):
+            self.future = future
+            self.csc_formats = csc_formats
 
-    # Return singleton for a homogeneous graph.
-    if is_homogeneous:
-        compacted_csc_formats = list(compacted_csc_formats.values())[0]
-        unique_nodes = list(unique_nodes.values())[0]
+        def wait(self):
+            """Returns the stored value when invoked."""
+            results = self.future.wait() if is_asynchronous else self.future
+            csc_formats = self.csc_formats
+            # Ensure there is no memory leak.
+            self.future = self.csc_formats = None
 
-    return unique_nodes, compacted_csc_formats
+            unique_nodes = {}
+            compacted_indices = {}
+            for i, ntype in enumerate(ntypes):
+                unique_nodes[ntype], compacted_indices[ntype], _ = results[i]
+
+            compacted_csc_formats = {}
+            # Map back with the same order.
+            for etype, csc_format in csc_formats.items():
+                num_elem = csc_format.indices.size(0)
+                src_type, _, _ = etype_str_to_tuple(etype)
+                indice = compacted_indices[src_type][:num_elem]
+                indptr = csc_format.indptr
+                compacted_csc_formats[etype] = CSCFormatBase(
+                    indptr=indptr, indices=indice
+                )
+                compacted_indices[src_type] = compacted_indices[src_type][
+                    num_elem:
+                ]
+
+            # Return singleton for a homogeneous graph.
+            if is_homogeneous:
+                compacted_csc_formats = list(compacted_csc_formats.values())[0]
+                unique_nodes = list(unique_nodes.values())[0]
+
+            return unique_nodes, compacted_csc_formats
+
+    post_processer = _Waiter(results, csc_formats)
+    if is_asynchronous:
+        return post_processer
+    else:
+        return post_processer.wait()
 
 
 def _broadcast_timestamps(csc, dst_timestamps):

--- a/tests/python/pytorch/graphbolt/test_dataloader.py
+++ b/tests/python/pytorch/graphbolt/test_dataloader.py
@@ -63,6 +63,7 @@ def test_DataLoader(overlap_feature_fetch):
 @pytest.mark.parametrize("enable_feature_fetch", [True, False])
 @pytest.mark.parametrize("overlap_feature_fetch", [True, False])
 @pytest.mark.parametrize("overlap_graph_fetch", [True, False])
+@pytest.mark.parametrize("asynchronous", [True, False])
 @pytest.mark.parametrize("num_gpu_cached_edges", [0, 1024])
 @pytest.mark.parametrize("gpu_cache_threshold", [1, 3])
 def test_gpu_sampling_DataLoader(
@@ -70,6 +71,7 @@ def test_gpu_sampling_DataLoader(
     enable_feature_fetch,
     overlap_feature_fetch,
     overlap_graph_fetch,
+    asynchronous,
     num_gpu_cached_edges,
     gpu_cache_threshold,
 ):
@@ -108,6 +110,7 @@ def test_gpu_sampling_DataLoader(
             "overlap_fetch": overlap_graph_fetch,
             "num_gpu_cached_edges": num_gpu_cached_edges,
             "gpu_cache_threshold": gpu_cache_threshold,
+            "asynchronous": asynchronous,
         }
         if i != 0:
             kwargs = {}

--- a/tests/python/pytorch/graphbolt/test_dataloader.py
+++ b/tests/python/pytorch/graphbolt/test_dataloader.py
@@ -136,6 +136,8 @@ def test_gpu_sampling_DataLoader(
     if overlap_graph_fetch:
         bufferer_cnt += num_layers
         awaiter_cnt += num_layers
+    if asynchronous:
+        bufferer_cnt += 2 * num_layers
     datapipe = dataloader.dataset
     datapipe_graph = traverse_dps(datapipe)
     awaiters = find_dps(
@@ -147,7 +149,7 @@ def test_gpu_sampling_DataLoader(
         datapipe_graph,
         dgl.graphbolt.Bufferer,
     )
-    # assert len(bufferers) == bufferer_cnt
+    assert len(bufferers) == bufferer_cnt
     # Fixes the randomness of LayerNeighborSampler
     torch.manual_seed(1)
     minibatches = list(dataloader)

--- a/tests/python/pytorch/graphbolt/test_dataloader.py
+++ b/tests/python/pytorch/graphbolt/test_dataloader.py
@@ -144,7 +144,7 @@ def test_gpu_sampling_DataLoader(
         datapipe_graph,
         dgl.graphbolt.Bufferer,
     )
-    assert len(bufferers) == bufferer_cnt
+    # assert len(bufferers) == bufferer_cnt
     # Fixes the randomness of LayerNeighborSampler
     torch.manual_seed(1)
     minibatches = list(dataloader)


### PR DESCRIPTION
## Description
We want to hide the latency of GPU CPU synchronization using pipelining. We want to eliminate the white gaps in the profile below:

Before:
![image](https://github.com/user-attachments/assets/57fe7d75-83cf-4694-a055-7800c33046fb)

After:
![image](https://github.com/user-attachments/assets/3a843132-9945-40ba-8ffa-939073d2faa5)


This is going to be achieved by using pipelining so that the output of one stage is not required by the next. Then, we can launch kernels for all stages at the same time in an async manner, ensuring there are no white gaps.

Preliminary results:

Without torch.compile
------------
Without asynchronous: 1.51s
With asynchronous: 1.37s

With torch.compile:
---------------
Without asynchronous: 1.11s
WIth asynchronous: 0.98s


## Checklist
Please feel free to remove inapplicable items for your PR.
- [ ] The PR title starts with [$CATEGORY] (such as [NN], [Model], [Doc], [Feature]])
- [ ] I've leverage the [tools](https://docs.google.com/document/d/1iHyj7zlmygKSk5gBPsqIqL5ASPzJSPREaNT_QdsiYA4/edit) to beautify the python and c++ code.
- [ ] The PR is complete and small, read the [Google eng practice (CL equals to PR)](https://google.github.io/eng-practices/review/developer/small-cls.html) to understand more about small PR. In DGL, we consider PRs with less than 200 lines of core code change are small (example, test and documentation could be exempted).
- [ ] All changes have test coverage
- [ ] Code is well-documented
- [ ] To the best of my knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change
- [ ] Related issue is referred in this PR
- [ ] If the PR is for a new model/paper, I've updated the example index [here](../examples/README.md).

## Changes
<!-- You could use following template
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)
-->
