### PR TITLE
[GraphBolt][io_uring] Unlock mutex after semaphore release.

### DIFF
--- a/graphbolt/src/cnumpy.h
+++ b/graphbolt/src/cnumpy.h
@@ -154,11 +154,10 @@ class OnDiskNpyArray : public torch::CustomClassHolder {
       UniqueQueue& operator=(const UniqueQueue&) = delete;
 
       ~UniqueQueue() {
-        {
-          // We give back the slot we used.
-          std::lock_guard lock(available_queues_mtx_);
-          available_queues_.push_back(thread_id_);
-        }
+        // We give back the slot we used and keep the lock until the semaphore
+        // is released.
+        std::lock_guard lock(available_queues_mtx_);
+        available_queues_.push_back(thread_id_);
         // If this is the first thread exiting, release the master thread's
         // ticket as well by releasing 2 slots. Otherwise, release 1 slot.
         const auto releasing =


### PR DESCRIPTION
## Description
@Liu-rj Can you try and see if this fixes the crash problem?

## Checklist
Please feel free to remove inapplicable items for your PR.
- [ ] The PR title starts with [$CATEGORY] (such as [NN], [Model], [Doc], [Feature]])
- [ ] I've leverage the [tools](https://docs.google.com/document/d/1iHyj7zlmygKSk5gBPsqIqL5ASPzJSPREaNT_QdsiYA4/edit) to beautify the python and c++ code.
- [ ] The PR is complete and small, read the [Google eng practice (CL equals to PR)](https://google.github.io/eng-practices/review/developer/small-cls.html) to understand more about small PR. In DGL, we consider PRs with less than 200 lines of core code change are small (example, test and documentation could be exempted).
- [ ] All changes have test coverage
- [ ] Code is well-documented
- [ ] To the best of my knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change
- [ ] Related issue is referred in this PR
- [ ] If the PR is for a new model/paper, I've updated the example index [here](../examples/README.md).

## Changes
<!-- You could use following template
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)
-->
