### PR TITLE
[GraphBolt] Remove unused output from `InSubgraph`.

### DIFF
--- a/graphbolt/src/fused_csc_sampling_graph.cc
+++ b/graphbolt/src/fused_csc_sampling_graph.cc
@@ -307,6 +307,7 @@ c10::intrusive_ptr<FusedSampledSubgraph> FusedCSCSamplingGraph::InSubgraph(
   }
 
   return c10::make_intrusive<FusedSampledSubgraph>(
+      // original_row_node_ids is not computed here and is unused.
       output_indptr, results.at(0), results.back(), nodes, torch::nullopt,
       type_per_edge);
 }

--- a/graphbolt/src/fused_csc_sampling_graph.cc
+++ b/graphbolt/src/fused_csc_sampling_graph.cc
@@ -307,8 +307,8 @@ c10::intrusive_ptr<FusedSampledSubgraph> FusedCSCSamplingGraph::InSubgraph(
   }
 
   return c10::make_intrusive<FusedSampledSubgraph>(
-      output_indptr, results.at(0), results.back(), nodes,
-      torch::arange(0, NumNodes()), type_per_edge);
+      output_indptr, results.at(0), results.back(), nodes, torch::nullopt,
+      type_per_edge);
 }
 
 /**


### PR DESCRIPTION
## Description
This output is unused. SampleNeighbors returns it nullopt as well. The output computes ids for every node in the original graph, which I think is completely wrong.

## Checklist
Please feel free to remove inapplicable items for your PR.
- [ ] The PR title starts with [$CATEGORY] (such as [NN], [Model], [Doc], [Feature]])
- [ ] I've leverage the [tools](https://docs.google.com/document/d/1iHyj7zlmygKSk5gBPsqIqL5ASPzJSPREaNT_QdsiYA4/edit) to beautify the python and c++ code.
- [ ] The PR is complete and small, read the [Google eng practice (CL equals to PR)](https://google.github.io/eng-practices/review/developer/small-cls.html) to understand more about small PR. In DGL, we consider PRs with less than 200 lines of core code change are small (example, test and documentation could be exempted).
- [ ] All changes have test coverage
- [ ] Code is well-documented
- [ ] To the best of my knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change
- [ ] Related issue is referred in this PR
- [ ] If the PR is for a new model/paper, I've updated the example index [here](../examples/README.md).

## Changes
<!-- You could use following template
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)
-->
