### PR TITLE
[GraphBolt][CUDA] Eliminate GPUCache synchronization.

### DIFF
--- a/graphbolt/src/cuda/extension/gpu_cache.cu
+++ b/graphbolt/src/cuda/extension/gpu_cache.cu
@@ -76,6 +76,14 @@ std::tuple<torch::Tensor, torch::Tensor, torch::Tensor> GpuCache::Query(
   return std::make_tuple(values, missing_index, missing_keys);
 }
 
+c10::intrusive_ptr<Future<std::vector<torch::Tensor>>> GpuCache::QueryAsync(
+    torch::Tensor keys) {
+  return async([=] {
+    auto [values, missing_index, missing_keys] = Query(keys);
+    return std::vector{values, missing_index, missing_keys};
+  });
+}
+
 void GpuCache::Replace(torch::Tensor keys, torch::Tensor values) {
   TORCH_CHECK(keys.device().is_cuda(), "Keys should be on a CUDA device.");
   TORCH_CHECK(

--- a/graphbolt/src/cuda/extension/gpu_cache.h
+++ b/graphbolt/src/cuda/extension/gpu_cache.h
@@ -21,6 +21,7 @@
 #ifndef GRAPHBOLT_GPU_CACHE_H_
 #define GRAPHBOLT_GPU_CACHE_H_
 
+#include <graphbolt/async.h>
 #include <torch/custom_class.h>
 #include <torch/torch.h>
 
@@ -51,6 +52,9 @@ class GpuCache : public torch::CustomClassHolder {
   GpuCache() = default;
 
   std::tuple<torch::Tensor, torch::Tensor, torch::Tensor> Query(
+      torch::Tensor keys);
+
+  c10::intrusive_ptr<Future<std::vector<torch::Tensor>>> QueryAsync(
       torch::Tensor keys);
 
   void Replace(torch::Tensor keys, torch::Tensor values);

--- a/graphbolt/src/python_binding.cc
+++ b/graphbolt/src/python_binding.cc
@@ -109,6 +109,7 @@ TORCH_LIBRARY(graphbolt, m) {
 #ifdef GRAPHBOLT_USE_CUDA
   m.class_<cuda::GpuCache>("GpuCache")
       .def("query", &cuda::GpuCache::Query)
+      .def("query_async", &cuda::GpuCache::QueryAsync)
       .def("replace", &cuda::GpuCache::Replace);
   m.def("gpu_cache", &cuda::GpuCache::Create);
   m.class_<cuda::GpuGraphCache>("GpuGraphCache")

--- a/python/dgl/graphbolt/impl/gpu_cache.py
+++ b/python/dgl/graphbolt/impl/gpu_cache.py
@@ -32,6 +32,7 @@ class GPUCache(object):
             values[missing_indices] corresponds to cache misses that should be
             filled by quering another source with missing_keys.
         """
+
         class _Waiter:
             def __init__(self, gpu_cache, future):
                 self.gpu_cache = gpu_cache
@@ -40,14 +41,16 @@ class GPUCache(object):
             def wait(self):
                 """Returns the stored value when invoked."""
                 gpu_cache = self.gpu_cache
-                values, missing_index, missing_keys = self.future.wait() if async_op else self.future
+                values, missing_index, missing_keys = (
+                    self.future.wait() if async_op else self.future
+                )
                 # Ensure there is no leak.
                 self.gpu_cache = self.future = None
 
                 gpu_cache.total_queries += values.shape[0]
                 gpu_cache.total_miss += missing_keys.shape[0]
                 return values, missing_index, missing_keys
-        
+
         if async_op:
             return _Waiter(self, self._cache.query_async(keys))
         else:

--- a/python/dgl/graphbolt/impl/gpu_cache.py
+++ b/python/dgl/graphbolt/impl/gpu_cache.py
@@ -14,13 +14,16 @@ class GPUCache(object):
         self.total_miss = 0
         self.total_queries = 0
 
-    def query(self, keys):
+    def query(self, keys, async_op=False):
         """Queries the GPU cache.
 
         Parameters
         ----------
         keys : Tensor
             The keys to query the GPU cache with.
+        async_op: bool
+            Boolean indicating whether the call is asynchronous. If so, the
+            result can be obtained by calling wait on the returned future.
 
         Returns
         -------
@@ -29,10 +32,26 @@ class GPUCache(object):
             values[missing_indices] corresponds to cache misses that should be
             filled by quering another source with missing_keys.
         """
-        self.total_queries += keys.shape[0]
-        values, missing_index, missing_keys = self._cache.query(keys)
-        self.total_miss += missing_keys.shape[0]
-        return values, missing_index, missing_keys
+        class _Waiter:
+            def __init__(self, gpu_cache, future):
+                self.gpu_cache = gpu_cache
+                self.future = future
+
+            def wait(self):
+                """Returns the stored value when invoked."""
+                gpu_cache = self.gpu_cache
+                values, missing_index, missing_keys = self.future.wait() if async_op else self.future
+                # Ensure there is no leak.
+                self.gpu_cache = self.future = None
+
+                gpu_cache.total_queries += values.shape[0]
+                gpu_cache.total_miss += missing_keys.shape[0]
+                return values, missing_index, missing_keys
+        
+        if async_op:
+            return _Waiter(self, self._cache.query_async(keys))
+        else:
+            return _Waiter(self, self._cache.query(keys)).wait()
 
     def replace(self, keys, values):
         """Inserts key-value pairs into the GPU cache using the Least-Recently

--- a/python/dgl/graphbolt/impl/gpu_cached_feature.py
+++ b/python/dgl/graphbolt/impl/gpu_cached_feature.py
@@ -114,7 +114,11 @@ class GPUCachedFeature(Feature):
         >>> assert stage + 1 == feature.read_async_num_stages(ids.device)
         >>> result = future.wait()  # result contains the read values.
         """
-        values, missing_index, missing_keys = self._feature.query(ids)
+        future = self._feature.query(ids, async_op=True)
+        
+        yield
+
+        values, missing_index, missing_keys = future.wait()
 
         fallback_reader = self._fallback_feature.read_async(missing_keys)
         fallback_num_stages = self._fallback_feature.read_async_num_stages(
@@ -175,7 +179,7 @@ class GPUCachedFeature(Feature):
             The number of stages of the read_async operation.
         """
         assert ids_device.type == "cuda"
-        return self._fallback_feature.read_async_num_stages(ids_device)
+        return 1 + self._fallback_feature.read_async_num_stages(ids_device)
 
     def size(self):
         """Get the size of the feature.

--- a/python/dgl/graphbolt/impl/gpu_cached_feature.py
+++ b/python/dgl/graphbolt/impl/gpu_cached_feature.py
@@ -115,7 +115,7 @@ class GPUCachedFeature(Feature):
         >>> result = future.wait()  # result contains the read values.
         """
         future = self._feature.query(ids, async_op=True)
-        
+
         yield
 
         values, missing_index, missing_keys = future.wait()


### PR DESCRIPTION
## Description
Use async launch to hide the latency of CPU GPU synchronization for GPU cache query.

Runtime: 1.36s (old) to 1.16s (this PR)

## Checklist
Please feel free to remove inapplicable items for your PR.
- [ ] The PR title starts with [$CATEGORY] (such as [NN], [Model], [Doc], [Feature]])
- [ ] I've leverage the [tools](https://docs.google.com/document/d/1iHyj7zlmygKSk5gBPsqIqL5ASPzJSPREaNT_QdsiYA4/edit) to beautify the python and c++ code.
- [ ] The PR is complete and small, read the [Google eng practice (CL equals to PR)](https://google.github.io/eng-practices/review/developer/small-cls.html) to understand more about small PR. In DGL, we consider PRs with less than 200 lines of core code change are small (example, test and documentation could be exempted).
- [ ] All changes have test coverage
- [ ] Code is well-documented
- [ ] To the best of my knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change
- [ ] Related issue is referred in this PR
- [ ] If the PR is for a new model/paper, I've updated the example index [here](../examples/README.md).

## Changes
<!-- You could use following template
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)
-->
