### PR TITLE
[GraphBolt][CUDA] `gb::async` supports alternative streams now.

### DIFF
--- a/graphbolt/include/graphbolt/async.h
+++ b/graphbolt/include/graphbolt/async.h
@@ -154,8 +154,8 @@ inline auto async(F&& function, bool is_cuda = false) {
     stream_data = c10::cuda::getCurrentCUDAStream().pack3();
   }
 #endif
-  using return_t = typename Future<T>::return_type;
-  auto fn = [=, func = std::move(function)]() -> return_t {
+  using return_type = typename Future<T>::return_type;
+  auto fn = [=, func = std::move(function)]() -> return_type {
 #ifdef GRAPHBOLT_USE_CUDA
     // We make sure to use the same CUDA stream as the thread launching the
     // async operation.
@@ -190,10 +190,10 @@ inline auto async(F&& function, bool is_cuda = false) {
 #ifdef BUILD_WITH_TASKFLOW
   auto future = interop_pool().async(std::move(fn));
 #else
-  auto promise = std::make_shared<std::promise<decltype(fn())>>();
+  auto promise = std::make_shared<std::promise<return_type>>();
   auto future = promise->get_future();
   at::launch([promise, func = std::move(fn)]() {
-    if constexpr (std::is_void_v<T>) {
+    if constexpr (std::is_void_v<return_type>) {
       func();
       promise->set_value();
     } else

--- a/graphbolt/include/graphbolt/async.h
+++ b/graphbolt/include/graphbolt/async.h
@@ -26,6 +26,7 @@
 #include <future>
 #include <memory>
 #include <mutex>
+#include <variant>
 
 #ifdef BUILD_WITH_TASKFLOW
 #include <taskflow/algorithm/for_each.hpp>
@@ -37,6 +38,7 @@
 #endif
 
 #ifdef GRAPHBOLT_USE_CUDA
+#include <ATen/cuda/CUDAEvent.h>
 #include <c10/cuda/CUDAGuard.h>
 #include <c10/cuda/CUDAStream.h>
 #include <torch/csrc/api/include/torch/cuda.h>
@@ -92,15 +94,50 @@ inline int get_num_interop_threads() {
 
 template <typename T>
 class Future : public torch::CustomClassHolder {
+#ifdef GRAPHBOLT_USE_CUDA
+  using T_no_event = std::conditional_t<std::is_void_v<T>, std::monostate, T>;
+  using T_with_event = std::conditional_t<
+      std::is_void_v<T>, at::cuda::CUDAEvent,
+      std::pair<T, at::cuda::CUDAEvent>>;
+  using future_type = std::future<std::variant<T_no_event, T_with_event>>;
+#else
+  using future_type = std::future<T>;
+#endif
+
  public:
-  Future(std::future<T>&& future) : future_(std::move(future)) {}
+#ifdef GRAPHBOLT_USE_CUDA
+  using return_type = std::variant<T_no_event, T_with_event>;
+#else
+  using return_type = T;
+#endif
+
+  Future(future_type&& future) : future_(std::move(future)) {}
 
   Future() = default;
 
-  T Wait() { return future_.get(); }
+  T Wait() {
+#ifdef GRAPHBOLT_USE_CUDA
+    auto result = future_.get();
+    if constexpr (std::is_void_v<T>) {
+      if (std::holds_alternative<T_with_event>(result)) {
+        auto&& event = std::get<T_with_event>(result);
+        event.block(c10::cuda::getCurrentCUDAStream());
+      }
+      return;
+    } else if (std::holds_alternative<T_with_event>(result)) {
+      auto&& [value, event] = std::get<T_with_event>(result);
+      event.block(c10::cuda::getCurrentCUDAStream());
+      return value;
+    } else {
+      return std::get<T_no_event>(result);
+    }
+#else
+    return future_.get();
+#endif
+  }
 
  private:
-  std::future<T> future_;
+  future_type future_;
 };
 
 /**
@@ -109,33 +146,51 @@ class Future : public torch::CustomClassHolder {
  * task to avoid spawning a new OpenMP threadpool on each interop thread.
  */
 template <typename F>
-inline auto async(F&& function) {
+inline auto async(F&& function, bool is_cuda = false) {
   using T = decltype(function());
 #ifdef GRAPHBOLT_USE_CUDA
-  const auto is_cuda_available = torch::cuda::is_available();
   struct c10::StreamData3 stream_data;
-  if (is_cuda_available) {
+  if (is_cuda) {
     stream_data = c10::cuda::getCurrentCUDAStream().pack3();
   }
 #endif
-  auto fn = [=, func = std::move(function)] {
+  auto fn = [=, func = std::move(function)]() ->
+      typename Future<T>::return_type {
 #ifdef GRAPHBOLT_USE_CUDA
-    // We make sure to use the same CUDA stream as the thread launching the
-    // async operation.
-    if (is_cuda_available) {
-      auto stream = c10::cuda::CUDAStream::unpack3(
-          stream_data.stream_id, stream_data.device_index,
-          stream_data.device_type);
-      c10::cuda::CUDAStreamGuard guard(stream);
-      return func();
-    }
+        // We make sure to use the same CUDA stream as the thread launching the
+        // async operation.
+        if (is_cuda) {
+          auto stream = c10::cuda::CUDAStream::unpack3(
+              stream_data.stream_id, stream_data.device_index,
+              stream_data.device_type);
+          c10::cuda::CUDAStreamGuard guard(stream);
+          at::cuda::CUDAEvent event;
+          // Might be executed on the GPU so we record an event to be able to
+          // synchronize with it later, in case it is executed on an alternative
+          // CUDA stream.
+          if constexpr (std::is_void_v<T>) {
+            func();
+            event.record();
+            return event;
+          } else {
+            auto result = func();
+            event.record();
+            return std::make_pair(std::move(result), std::move(event));
+          }
+        }
+        if constexpr (std::is_void_v<T>) {
+          return std::monostate{};
+        } else {
+          return func();
+        }
+#else
+        return func();
 #endif
-    return func();
-  };
+      };
 #ifdef BUILD_WITH_TASKFLOW
   auto future = interop_pool().async(std::move(fn));
 #else
-  auto promise = std::make_shared<std::promise<T>>();
+  auto promise = std::make_shared<std::promise<decltype(fn())>>();
   auto future = promise->get_future();
   at::launch([promise, func = std::move(fn)]() {
     if constexpr (std::is_void_v<T>) {

--- a/graphbolt/include/graphbolt/async.h
+++ b/graphbolt/include/graphbolt/async.h
@@ -179,6 +179,7 @@ inline auto async(F&& function, bool is_cuda = false) {
       }
     }
     if constexpr (std::is_void_v<T>) {
+      func();
       return std::monostate{};
     } else {
       return func();

--- a/graphbolt/src/cuda/extension/gpu_cache.cu
+++ b/graphbolt/src/cuda/extension/gpu_cache.cu
@@ -78,10 +78,12 @@ std::tuple<torch::Tensor, torch::Tensor, torch::Tensor> GpuCache::Query(
 
 c10::intrusive_ptr<Future<std::vector<torch::Tensor>>> GpuCache::QueryAsync(
     torch::Tensor keys) {
-  return async([=] {
-    auto [values, missing_index, missing_keys] = Query(keys);
-    return std::vector{values, missing_index, missing_keys};
-  });
+  return async(
+      [=] {
+        auto [values, missing_index, missing_keys] = Query(keys);
+        return std::vector{values, missing_index, missing_keys};
+      },
+      true);
 }
 
 void GpuCache::Replace(torch::Tensor keys, torch::Tensor values) {

--- a/graphbolt/src/cuda/extension/gpu_graph_cache.cu
+++ b/graphbolt/src/cuda/extension/gpu_graph_cache.cu
@@ -242,7 +242,7 @@ std::tuple<torch::Tensor, torch::Tensor, int64_t, int64_t> GpuGraphCache::Query(
 c10::intrusive_ptr<
     Future<std::tuple<torch::Tensor, torch::Tensor, int64_t, int64_t>>>
 GpuGraphCache::QueryAsync(torch::Tensor seeds) {
-  return async([=] { return Query(seeds); });
+  return async([=] { return Query(seeds); }, true);
 }
 
 std::tuple<torch::Tensor, std::vector<torch::Tensor>> GpuGraphCache::Replace(
@@ -505,11 +505,13 @@ GpuGraphCache::ReplaceAsync(
     torch::Tensor seeds, torch::Tensor indices, torch::Tensor positions,
     int64_t num_hit, int64_t num_threshold, torch::Tensor indptr,
     std::vector<torch::Tensor> edge_tensors) {
-  return async([=] {
-    return Replace(
-        seeds, indices, positions, num_hit, num_threshold, indptr,
-        edge_tensors);
-  });
+  return async(
+      [=] {
+        return Replace(
+            seeds, indices, positions, num_hit, num_threshold, indptr,
+            edge_tensors);
+      },
+      true);
 }
 
 }  // namespace cuda

--- a/graphbolt/src/fused_csc_sampling_graph.cc
+++ b/graphbolt/src/fused_csc_sampling_graph.cc
@@ -880,12 +880,15 @@ FusedCSCSamplingGraph::SampleNeighborsAsync(
     torch::optional<torch::Tensor> probs_or_mask,
     torch::optional<torch::Tensor> random_seed,
     double seed2_contribution) const {
-  return async([=] {
-    return this->SampleNeighbors(
-        seeds, seed_offsets, fanouts, replace, layer,
-        returning_indices_is_optional, probs_or_mask, random_seed,
-        seed2_contribution);
-  });
+  return async(
+      [=] {
+        return this->SampleNeighbors(
+            seeds, seed_offsets, fanouts, replace, layer,
+            returning_indices_is_optional, probs_or_mask, random_seed,
+            seed2_contribution);
+      },
+      (seeds.has_value() && utils::is_on_gpu(*seeds)) ||
+          utils::is_on_gpu(indptr_));
 }
 
 c10::intrusive_ptr<FusedSampledSubgraph>

--- a/graphbolt/src/unique_and_compact.cc
+++ b/graphbolt/src/unique_and_compact.cc
@@ -71,9 +71,9 @@ UniqueAndCompactBatchedAsync(
     const std::vector<torch::Tensor>& src_ids,
     const std::vector<torch::Tensor>& dst_ids,
     const std::vector<torch::Tensor> unique_dst_ids) {
-  return async([=] {
-    return UniqueAndCompactBatched(src_ids, dst_ids, unique_dst_ids);
-  });
+  return async(
+      [=] { return UniqueAndCompactBatched(src_ids, dst_ids, unique_dst_ids); },
+      utils::is_on_gpu(src_ids.at(0)));
 }
 
 }  // namespace sampling


### PR DESCRIPTION
## Description
Needed by #7709.

## Checklist
Please feel free to remove inapplicable items for your PR.
- [ ] The PR title starts with [$CATEGORY] (such as [NN], [Model], [Doc], [Feature]])
- [ ] I've leverage the [tools](https://docs.google.com/document/d/1iHyj7zlmygKSk5gBPsqIqL5ASPzJSPREaNT_QdsiYA4/edit) to beautify the python and c++ code.
- [ ] The PR is complete and small, read the [Google eng practice (CL equals to PR)](https://google.github.io/eng-practices/review/developer/small-cls.html) to understand more about small PR. In DGL, we consider PRs with less than 200 lines of core code change are small (example, test and documentation could be exempted).
- [ ] All changes have test coverage
- [ ] Code is well-documented
- [ ] To the best of my knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change
- [ ] Related issue is referred in this PR
- [ ] If the PR is for a new model/paper, I've updated the example index [here](../examples/README.md).

## Changes
<!-- You could use following template
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)
-->
