### PR TITLE
[GraphBolt][CUDA] Overlap original edge ids fetch.

### DIFF
--- a/graphbolt/src/cuda/extension/gpu_graph_cache.cu
+++ b/graphbolt/src/cuda/extension/gpu_graph_cache.cu
@@ -252,7 +252,8 @@ GpuGraphCache::QueryAsync(torch::Tensor seeds) {
 std::tuple<torch::Tensor, std::vector<torch::Tensor>> GpuGraphCache::Replace(
     torch::Tensor seeds, torch::Tensor indices, torch::Tensor positions,
     int64_t num_hit, int64_t num_threshold, torch::Tensor indptr,
-    std::vector<torch::Tensor> edge_tensors, bool with_edge_ids) {
+    std::vector<torch::Tensor> edge_tensors) {
+  const auto with_edge_ids = offset_.has_value();
   // The last element of edge_tensors has the edge ids.
   const auto num_tensors = edge_tensors.size() - with_edge_ids;
   TORCH_CHECK(
@@ -530,12 +531,12 @@ c10::intrusive_ptr<
 GpuGraphCache::ReplaceAsync(
     torch::Tensor seeds, torch::Tensor indices, torch::Tensor positions,
     int64_t num_hit, int64_t num_threshold, torch::Tensor indptr,
-    std::vector<torch::Tensor> edge_tensors, bool with_edge_ids) {
+    std::vector<torch::Tensor> edge_tensors) {
   return async(
       [=] {
         return Replace(
             seeds, indices, positions, num_hit, num_threshold, indptr,
-            edge_tensors, with_edge_ids);
+            edge_tensors);
       },
       true);
 }

--- a/graphbolt/src/cuda/extension/gpu_graph_cache.cu
+++ b/graphbolt/src/cuda/extension/gpu_graph_cache.cu
@@ -115,14 +115,16 @@ constexpr int kIntBlockSize = 512;
 
 c10::intrusive_ptr<GpuGraphCache> GpuGraphCache::Create(
     const int64_t num_edges, const int64_t threshold,
-    torch::ScalarType indptr_dtype, std::vector<torch::ScalarType> dtypes) {
+    torch::ScalarType indptr_dtype, std::vector<torch::ScalarType> dtypes,
+    bool has_original_edge_ids) {
   return c10::make_intrusive<GpuGraphCache>(
-      num_edges, threshold, indptr_dtype, dtypes);
+      num_edges, threshold, indptr_dtype, dtypes, has_original_edge_ids);
 }
 
 GpuGraphCache::GpuGraphCache(
     const int64_t num_edges, const int64_t threshold,
-    torch::ScalarType indptr_dtype, std::vector<torch::ScalarType> dtypes) {
+    torch::ScalarType indptr_dtype, std::vector<torch::ScalarType> dtypes,
+    bool has_original_edge_ids) {
   const int64_t initial_node_capacity = 1024;
   AT_DISPATCH_INDEX_TYPES(
       dtypes.at(0), "GpuGraphCache::GpuGraphCache", ([&] {
@@ -149,7 +151,9 @@ GpuGraphCache::GpuGraphCache(
   num_edges_ = 0;
   indptr_ =
       torch::zeros(initial_node_capacity + 1, options.dtype(indptr_dtype));
-  offset_ = torch::empty(indptr_.size(0) - 1, indptr_.options());
+  if (!has_original_edge_ids) {
+    offset_ = torch::empty(indptr_.size(0) - 1, indptr_.options());
+  }
   for (auto dtype : dtypes) {
     cached_edge_tensors_.push_back(
         torch::empty(num_edges, options.dtype(dtype)));
@@ -248,9 +252,9 @@ GpuGraphCache::QueryAsync(torch::Tensor seeds) {
 std::tuple<torch::Tensor, std::vector<torch::Tensor>> GpuGraphCache::Replace(
     torch::Tensor seeds, torch::Tensor indices, torch::Tensor positions,
     int64_t num_hit, int64_t num_threshold, torch::Tensor indptr,
-    std::vector<torch::Tensor> edge_tensors) {
+    std::vector<torch::Tensor> edge_tensors, bool with_edge_ids) {
   // The last element of edge_tensors has the edge ids.
-  const auto num_tensors = edge_tensors.size() - 1;
+  const auto num_tensors = edge_tensors.size() - with_edge_ids;
   TORCH_CHECK(
       num_tensors == cached_edge_tensors_.size(),
       "Same number of tensors need to be passed!");
@@ -312,8 +316,12 @@ std::tuple<torch::Tensor, std::vector<torch::Tensor>> GpuGraphCache::Replace(
               auto input = allocator.AllocateStorage<std::byte*>(num_buffers);
               auto input_size =
                   allocator.AllocateStorage<size_t>(num_buffers + 1);
-              auto edge_id_offsets = torch::empty(
-                  num_nodes, seeds.options().dtype(offset_.scalar_type()));
+              torch::optional<torch::Tensor> edge_id_offsets;
+              if (with_edge_ids) {
+                edge_id_offsets = torch::empty(
+                    num_nodes,
+                    seeds.options().dtype(offset_.value().scalar_type()));
+              }
               const auto cache_missing_dtype_dev_ptr =
                   cache_missing_dtype_dev.get();
               const auto indices_ptr = indices.data_ptr<indices_t>();
@@ -321,12 +329,15 @@ std::tuple<torch::Tensor, std::vector<torch::Tensor>> GpuGraphCache::Replace(
               const auto input_ptr = input.get();
               const auto input_size_ptr = input_size.get();
               const auto edge_id_offsets_ptr =
-                  edge_id_offsets.data_ptr<indptr_t>();
+                  edge_id_offsets ? edge_id_offsets->data_ptr<indptr_t>()
+                                  : nullptr;
               const auto cache_indptr = indptr_.data_ptr<indptr_t>();
               const auto missing_indptr = indptr.data_ptr<indptr_t>();
-              const auto cache_offset = offset_.data_ptr<indptr_t>();
+              const auto cache_offset =
+                  offset_ ? offset_->data_ptr<indptr_t>() : nullptr;
               const auto missing_edge_ids =
-                  edge_tensors.back().data_ptr<indptr_t>();
+                  edge_id_offsets ? edge_tensors.back().data_ptr<indptr_t>()
+                                  : nullptr;
               CUB_CALL(DeviceFor::Bulk, num_buffers, [=] __device__(int64_t i) {
                 const auto tensor_idx = i / num_nodes;
                 const auto idx = i % num_nodes;
@@ -340,14 +351,14 @@ std::tuple<torch::Tensor, std::vector<torch::Tensor>> GpuGraphCache::Replace(
                 const auto offset_end = is_cached
                                             ? cache_indptr[pos + 1]
                                             : missing_indptr[idx - num_hit + 1];
-                const auto edge_id =
-                    is_cached ? cache_offset[pos] : missing_edge_ids[offset];
                 const auto out_idx = tensor_idx * num_nodes + original_idx;
 
                 input_ptr[out_idx] =
                     (is_cached ? cache_ptr : missing_ptr) + offset * size;
                 input_size_ptr[out_idx] = size * (offset_end - offset);
-                if (i < num_nodes) {
+                if (edge_id_offsets_ptr && i < num_nodes) {
+                  const auto edge_id =
+                      is_cached ? cache_offset[pos] : missing_edge_ids[offset];
                   edge_id_offsets_ptr[out_idx] = edge_id;
                 }
               });
@@ -390,10 +401,12 @@ std::tuple<torch::Tensor, std::vector<torch::Tensor>> GpuGraphCache::Replace(
                       indptr_.size(0) * kIntGrowthFactor, indptr_.options());
                   new_indptr.slice(0, 0, indptr_.size(0)) = indptr_;
                   indptr_ = new_indptr;
-                  auto new_offset =
-                      torch::empty(indptr_.size(0) - 1, offset_.options());
-                  new_offset.slice(0, 0, offset_.size(0)) = offset_;
-                  offset_ = new_offset;
+                  if (offset_) {
+                    auto new_offset =
+                        torch::empty(indptr_.size(0) - 1, offset_->options());
+                    new_offset.slice(0, 0, offset_->size(0)) = *offset_;
+                    offset_ = new_offset;
+                  }
                 }
                 torch::Tensor sindptr;
                 bool enough_space;
@@ -415,22 +428,32 @@ std::tuple<torch::Tensor, std::vector<torch::Tensor>> GpuGraphCache::Replace(
                 }
                 if (enough_space) {
                   auto num_edges = num_edges_;
-                  auto transform_input_it = thrust::make_zip_iterator(
-                      sindptr.data_ptr<indptr_t>() + 1,
-                      sliced_indptr.data_ptr<indptr_t>());
-                  auto transform_output_it = thrust::make_zip_iterator(
-                      indptr_.data_ptr<indptr_t>() + num_nodes_ + 1,
-                      offset_.data_ptr<indptr_t>() + num_nodes_);
-                  THRUST_CALL(
-                      transform, transform_input_it,
-                      transform_input_it + sindptr.size(0) - 1,
-                      transform_output_it,
-                      [=] __host__ __device__(
-                          const thrust::tuple<indptr_t, indptr_t>& x) {
-                        return thrust::make_tuple(
-                            thrust::get<0>(x) + num_edges,
-                            missing_edge_ids[thrust::get<1>(x)]);
-                      });
+                  if (offset_) {
+                    auto transform_input_it = thrust::make_zip_iterator(
+                        sindptr.data_ptr<indptr_t>() + 1,
+                        sliced_indptr.data_ptr<indptr_t>());
+                    auto transform_output_it = thrust::make_zip_iterator(
+                        indptr_.data_ptr<indptr_t>() + num_nodes_ + 1,
+                        offset_->data_ptr<indptr_t>() + num_nodes_);
+                    THRUST_CALL(
+                        transform, transform_input_it,
+                        transform_input_it + sindptr.size(0) - 1,
+                        transform_output_it,
+                        [=] __host__ __device__(
+                            const thrust::tuple<indptr_t, indptr_t>& x) {
+                          return thrust::make_tuple(
+                              thrust::get<0>(x) + num_edges,
+                              missing_edge_ids[thrust::get<1>(x)]);
+                        });
+                  } else {
+                    THRUST_CALL(
+                        transform, sindptr.data_ptr<indptr_t>() + 1,
+                        sindptr.data_ptr<indptr_t>() + sindptr.size(0),
+                        indptr_.data_ptr<indptr_t>() + num_nodes_ + 1,
+                        [=] __host__ __device__(const indptr_t& x) {
+                          return x + num_edges;
+                        });
+                  }
                   auto map = reinterpret_cast<map_t<indices_t>*>(map_);
                   const dim3 block(kIntBlockSize);
                   const dim3 grid(
@@ -467,10 +490,13 @@ std::tuple<torch::Tensor, std::vector<torch::Tensor>> GpuGraphCache::Replace(
                         .view(edge_tensors[i].scalar_type())
                         .slice(0, 0, static_cast<indptr_t>(output_size)));
               }
-              // Append the edge ids as the last element of the output.
-              output_edge_tensors.push_back(ops::IndptrEdgeIdsImpl(
-                  output_indptr, output_indptr.scalar_type(), edge_id_offsets,
-                  static_cast<int64_t>(static_cast<indptr_t>(output_size))));
+              if (edge_id_offsets) {
+                // Append the edge ids as the last element of the output.
+                output_edge_tensors.push_back(ops::IndptrEdgeIdsImpl(
+                    output_indptr, output_indptr.scalar_type(),
+                    *edge_id_offsets,
+                    static_cast<int64_t>(static_cast<indptr_t>(output_size))));
+              }
 
               {
                 thrust::counting_iterator<int64_t> iota{0};
@@ -504,12 +530,12 @@ c10::intrusive_ptr<
 GpuGraphCache::ReplaceAsync(
     torch::Tensor seeds, torch::Tensor indices, torch::Tensor positions,
     int64_t num_hit, int64_t num_threshold, torch::Tensor indptr,
-    std::vector<torch::Tensor> edge_tensors) {
+    std::vector<torch::Tensor> edge_tensors, bool with_edge_ids) {
   return async(
       [=] {
         return Replace(
             seeds, indices, positions, num_hit, num_threshold, indptr,
-            edge_tensors);
+            edge_tensors, with_edge_ids);
       },
       true);
 }

--- a/graphbolt/src/cuda/extension/gpu_graph_cache.h
+++ b/graphbolt/src/cuda/extension/gpu_graph_cache.h
@@ -50,7 +50,8 @@ class GpuGraphCache : public torch::CustomClassHolder {
    */
   GpuGraphCache(
       const int64_t num_edges, const int64_t threshold,
-      torch::ScalarType indptr_dtype, std::vector<torch::ScalarType> dtypes);
+      torch::ScalarType indptr_dtype, std::vector<torch::ScalarType> dtypes,
+      bool has_original_edge_ids);
 
   GpuGraphCache() = default;
 
@@ -98,18 +99,19 @@ class GpuGraphCache : public torch::CustomClassHolder {
   std::tuple<torch::Tensor, std::vector<torch::Tensor>> Replace(
       torch::Tensor seeds, torch::Tensor indices, torch::Tensor positions,
       int64_t num_hit, int64_t num_threshold, torch::Tensor indptr,
-      std::vector<torch::Tensor> edge_tensors);
+      std::vector<torch::Tensor> edge_tensors, bool with_edge_ids);
 
   c10::intrusive_ptr<
       Future<std::tuple<torch::Tensor, std::vector<torch::Tensor>>>>
   ReplaceAsync(
       torch::Tensor seeds, torch::Tensor indices, torch::Tensor positions,
       int64_t num_hit, int64_t num_threshold, torch::Tensor indptr,
-      std::vector<torch::Tensor> edge_tensors);
+      std::vector<torch::Tensor> edge_tensors, bool with_edge_ids);
 
   static c10::intrusive_ptr<GpuGraphCache> Create(
       const int64_t num_edges, const int64_t threshold,
-      torch::ScalarType indptr_dtype, std::vector<torch::ScalarType> dtypes);
+      torch::ScalarType indptr_dtype, std::vector<torch::ScalarType> dtypes,
+      bool has_original_edge_ids);
 
  private:
   void* map_;                     // pointer to the hash table.
@@ -119,7 +121,8 @@ class GpuGraphCache : public torch::CustomClassHolder {
   int64_t num_nodes_;             // The number of cached nodes in the cache.
   int64_t num_edges_;             // The number of cached edges in the cache.
   torch::Tensor indptr_;          // The cached graph structure indptr tensor.
-  torch::Tensor offset_;          // The original graph's sliced_indptr tensor.
+  torch::optional<torch::Tensor>
+      offset_;  // The original graph's sliced_indptr tensor.
   std::vector<torch::Tensor> cached_edge_tensors_;  // The cached graph
                                                     // structure edge tensors.
   std::mutex mtx_;  // Protects the data structure and makes it threadsafe.

--- a/graphbolt/src/cuda/extension/gpu_graph_cache.h
+++ b/graphbolt/src/cuda/extension/gpu_graph_cache.h
@@ -47,6 +47,8 @@ class GpuGraphCache : public torch::CustomClassHolder {
    * @param indptr_dtype The node id datatype.
    * @param dtypes The dtypes of the edge tensors to be cached. dtypes[0] is
    * reserved for the indices edge tensor holding node ids.
+   * @param has_original_edge_ids Whether the graph to be cached has original
+   * edge ids.
    */
   GpuGraphCache(
       const int64_t num_edges, const int64_t threshold,
@@ -99,14 +101,14 @@ class GpuGraphCache : public torch::CustomClassHolder {
   std::tuple<torch::Tensor, std::vector<torch::Tensor>> Replace(
       torch::Tensor seeds, torch::Tensor indices, torch::Tensor positions,
       int64_t num_hit, int64_t num_threshold, torch::Tensor indptr,
-      std::vector<torch::Tensor> edge_tensors, bool with_edge_ids);
+      std::vector<torch::Tensor> edge_tensors);
 
   c10::intrusive_ptr<
       Future<std::tuple<torch::Tensor, std::vector<torch::Tensor>>>>
   ReplaceAsync(
       torch::Tensor seeds, torch::Tensor indices, torch::Tensor positions,
       int64_t num_hit, int64_t num_threshold, torch::Tensor indptr,
-      std::vector<torch::Tensor> edge_tensors, bool with_edge_ids);
+      std::vector<torch::Tensor> edge_tensors);
 
   static c10::intrusive_ptr<GpuGraphCache> Create(
       const int64_t num_edges, const int64_t threshold,

--- a/python/dgl/graphbolt/impl/fused_csc_sampling_graph.py
+++ b/python/dgl/graphbolt/impl/fused_csc_sampling_graph.py
@@ -721,7 +721,7 @@ class FusedCSCSamplingGraph(SamplingGraph):
                         ]
                     )
                     if indices is None or original_edge_ids is None:
-                        # Only needed to fetch indices.
+                        # Only needed to fetch indices or original edge ids.
                         sampled_hetero_edge_ids_in_fused_csc_sampling_graph[
                             etype
                         ] = edge_ids_in_fused_csc_sampling_graph[

--- a/python/dgl/graphbolt/impl/fused_csc_sampling_graph.py
+++ b/python/dgl/graphbolt/impl/fused_csc_sampling_graph.py
@@ -1556,15 +1556,21 @@ class FusedCSCSamplingGraph(SamplingGraph):
         dtypes = [self.indices.dtype]
         if self.type_per_edge is not None:
             dtypes.append(self.type_per_edge.dtype)
+        has_original_edge_ids = False
         if self.edge_attributes is not None:
             probs_or_mask = self.edge_attributes.get(prob_name, None)
             if probs_or_mask is not None:
                 dtypes.append(probs_or_mask.dtype)
+            original_edge_ids = self.edge_attributes.get(ORIGINAL_EDGE_ID, None)
+            if original_edge_ids is not None:
+                dtypes.append(original_edge_ids.dtype)
+                has_original_edge_ids = True
         self._gpu_graph_cache_ = GPUGraphCache(
             num_gpu_cached_edges,
             gpu_cache_threshold,
             self.csc_indptr.dtype,
             dtypes,
+            has_original_edge_ids,
         )
 
 

--- a/python/dgl/graphbolt/impl/fused_csc_sampling_graph.py
+++ b/python/dgl/graphbolt/impl/fused_csc_sampling_graph.py
@@ -797,7 +797,7 @@ class FusedCSCSamplingGraph(SamplingGraph):
         returning_indices_and_original_edge_ids_are_optional: bool
             Boolean indicating whether it is okay for the call to this function
             to leave the indices and the original edge ids tensors
-            uninitialized. In this case, it is the user's responsibility to 
+            uninitialized. In this case, it is the user's responsibility to
             gather them using _edge_ids_in_fused_csc_sampling_graph if either is
             missing.
         async_op: bool
@@ -1035,7 +1035,7 @@ class FusedCSCSamplingGraph(SamplingGraph):
         returning_indices_and_original_edge_ids_are_optional: bool
             Boolean indicating whether it is okay for the call to this function
             to leave the indices and the original edge ids tensors
-            uninitialized. In this case, it is the user's responsibility to 
+            uninitialized. In this case, it is the user's responsibility to
             gather them using _edge_ids_in_fused_csc_sampling_graph if either is
             missing.
         random_seed: torch.Tensor, optional

--- a/python/dgl/graphbolt/impl/fused_csc_sampling_graph.py
+++ b/python/dgl/graphbolt/impl/fused_csc_sampling_graph.py
@@ -753,8 +753,7 @@ class FusedCSCSamplingGraph(SamplingGraph):
         fanouts: torch.Tensor,
         replace: bool = False,
         probs_name: Optional[str] = None,
-        returning_indices_is_optional: bool = False,
-        fetching_original_edge_ids_is_optional: bool = False,
+        returning_indices_and_original_edge_ids_are_optional: bool = False,
         async_op: bool = False,
     ) -> SampledSubgraphImpl:
         """Sample neighboring edges of the given nodes and return the induced
@@ -795,15 +794,12 @@ class FusedCSCSamplingGraph(SamplingGraph):
             corresponding to each neighboring edge of a node. It must be a 1D
             floating-point or boolean tensor, with the number of elements
             equalling the total number of edges.
-        returning_indices_is_optional: bool
+        returning_indices_and_original_edge_ids_are_optional: bool
             Boolean indicating whether it is okay for the call to this function
-            to leave the indices tensor uninitialized. In this case, it is the
-            user's responsibility to gather it using the edge ids.
-        fetching_original_edge_ids_is_optional: bool
-            Boolean indicating whether it is okay for the call to this function
-            to leave the original edge ids tensor uninitialized. In this case,
-            it is the user's responsibility to gather it using
-            _edge_ids_in_fused_csc_sampling_graph.
+            to leave the indices and the original edge ids tensors
+            uninitialized. In this case, it is the user's responsibility to 
+            gather them using _edge_ids_in_fused_csc_sampling_graph if either is
+            missing.
         async_op: bool
             Boolean indicating whether the call is asynchronous. If so, the
             result can be obtained by calling wait on the returned future.
@@ -850,7 +846,7 @@ class FusedCSCSamplingGraph(SamplingGraph):
             fanouts,
             replace=replace,
             probs_or_mask=probs_or_mask,
-            returning_indices_is_optional=returning_indices_is_optional,
+            returning_indices_is_optional=returning_indices_and_original_edge_ids_are_optional,
             async_op=async_op,
         )
         if async_op:
@@ -858,13 +854,13 @@ class FusedCSCSamplingGraph(SamplingGraph):
                 self._convert_to_sampled_subgraph,
                 C_sampled_subgraph,
                 seed_offsets,
-                fetching_original_edge_ids_is_optional,
+                returning_indices_and_original_edge_ids_are_optional,
             )
         else:
             return self._convert_to_sampled_subgraph(
                 C_sampled_subgraph,
                 seed_offsets,
-                fetching_original_edge_ids_is_optional,
+                returning_indices_and_original_edge_ids_are_optional,
             )
 
     def _check_sampler_arguments(self, nodes, fanouts, probs_or_mask):
@@ -991,8 +987,7 @@ class FusedCSCSamplingGraph(SamplingGraph):
         fanouts: torch.Tensor,
         replace: bool = False,
         probs_name: Optional[str] = None,
-        returning_indices_is_optional: bool = False,
-        fetching_original_edge_ids_is_optional: bool = False,
+        returning_indices_and_original_edge_ids_are_optional: bool = False,
         random_seed: torch.Tensor = None,
         seed2_contribution: float = 0.0,
         async_op: bool = False,
@@ -1037,15 +1032,12 @@ class FusedCSCSamplingGraph(SamplingGraph):
             corresponding to each neighboring edge of a node. It must be a 1D
             floating-point or boolean tensor, with the number of elements
             equalling the total number of edges.
-        returning_indices_is_optional: bool
+        returning_indices_and_original_edge_ids_are_optional: bool
             Boolean indicating whether it is okay for the call to this function
-            to leave the indices tensor uninitialized. In this case, it is the
-            user's responsibility to gather it using the edge ids.
-        fetching_original_edge_ids_is_optional: bool
-            Boolean indicating whether it is okay for the call to this function
-            to leave the original edge ids tensor uninitialized. In this case,
-            it is the user's responsibility to gather it using
-            _edge_ids_in_fused_csc_sampling_graph.
+            to leave the indices and the original edge ids tensors
+            uninitialized. In this case, it is the user's responsibility to 
+            gather them using _edge_ids_in_fused_csc_sampling_graph if either is
+            missing.
         random_seed: torch.Tensor, optional
             An int64 tensor with one or two elements.
 
@@ -1133,7 +1125,7 @@ class FusedCSCSamplingGraph(SamplingGraph):
             fanouts.tolist(),
             replace,
             True,  # is_labor
-            returning_indices_is_optional,
+            returning_indices_and_original_edge_ids_are_optional,
             probs_or_mask,
             random_seed,
             seed2_contribution,
@@ -1143,13 +1135,13 @@ class FusedCSCSamplingGraph(SamplingGraph):
                 self._convert_to_sampled_subgraph,
                 C_sampled_subgraph,
                 seed_offsets,
-                fetching_original_edge_ids_is_optional,
+                returning_indices_and_original_edge_ids_are_optional,
             )
         else:
             return self._convert_to_sampled_subgraph(
                 C_sampled_subgraph,
                 seed_offsets,
-                fetching_original_edge_ids_is_optional,
+                returning_indices_and_original_edge_ids_are_optional,
             )
 
     def temporal_sample_neighbors(

--- a/python/dgl/graphbolt/impl/gpu_graph_cache.py
+++ b/python/dgl/graphbolt/impl/gpu_graph_cache.py
@@ -48,9 +48,8 @@ class GPUGraphCache(object):
             A tuple containing (missing_keys, replace_fn) where replace_fn is a
             function that should be called with the graph structure
             corresponding to the missing keys. Its arguments are
-            (Tensor, list(Tensor), bool), where the first tensor is the missing
-            indptr, second list is the missing edge tensors and the boolean
-            indicates whether the edge ids are considered `arange(num_edges)`.
+            (Tensor, list(Tensor)), where the first tensor is the missing indptr
+            and the second list is the missing edge tensors.
         """
         self.total_queries += keys.shape[0]
         (
@@ -61,9 +60,7 @@ class GPUGraphCache(object):
         ) = self._cache.query(keys)
         self.total_miss += keys.shape[0] - num_hit
 
-        def replace_functional(
-            missing_indptr, missing_edge_tensors, with_edge_ids
-        ):
+        def replace_functional(missing_indptr, missing_edge_tensors):
             return self._cache.replace(
                 keys,
                 index,
@@ -72,7 +69,6 @@ class GPUGraphCache(object):
                 num_threshold,
                 missing_indptr,
                 missing_edge_tensors,
-                with_edge_ids,
             )
 
         return keys[index[num_hit:]], replace_functional
@@ -104,9 +100,7 @@ class GPUGraphCache(object):
         self.total_queries += keys.shape[0]
         self.total_miss += keys.shape[0] - num_hit
 
-        missing_indptr, missing_edge_tensors, with_edge_ids = yield keys[
-            index[num_hit:]
-        ]
+        missing_indptr, missing_edge_tensors = yield keys[index[num_hit:]]
 
         yield self._cache.replace_async(
             keys,
@@ -116,7 +110,6 @@ class GPUGraphCache(object):
             num_threshold,
             missing_indptr,
             missing_edge_tensors,
-            with_edge_ids,
         )
 
     @property

--- a/python/dgl/graphbolt/impl/gpu_graph_cache.py
+++ b/python/dgl/graphbolt/impl/gpu_graph_cache.py
@@ -21,7 +21,9 @@ class GPUGraphCache(object):
         Whether the graph to be cached has original edge ids.
     """
 
-    def __init__(self, num_edges, threshold, indptr_dtype, dtypes, has_original_edge_ids):
+    def __init__(
+        self, num_edges, threshold, indptr_dtype, dtypes, has_original_edge_ids
+    ):
         major, _ = torch.cuda.get_device_capability()
         assert (
             major >= 7
@@ -59,7 +61,9 @@ class GPUGraphCache(object):
         ) = self._cache.query(keys)
         self.total_miss += keys.shape[0] - num_hit
 
-        def replace_functional(missing_indptr, missing_edge_tensors, with_edge_ids):
+        def replace_functional(
+            missing_indptr, missing_edge_tensors, with_edge_ids
+        ):
             return self._cache.replace(
                 keys,
                 index,

--- a/python/dgl/graphbolt/impl/neighbor_sampler.py
+++ b/python/dgl/graphbolt/impl/neighbor_sampler.py
@@ -312,12 +312,6 @@ class SamplePerLayer(MiniBatchTransformer):
             if asynchronous:
                 datapipe = datapipe.buffer()
                 datapipe = datapipe.transform(self._wait_subgraph_future)
-            if self.fetching_original_edge_ids_is_optional:
-                datapipe = (
-                    datapipe.transform(fetch_indices_and_original_edge_ids_fn)
-                    .buffer()
-                    .wait()
-                )
         else:
             datapipe = datapipe.transform(self._sample_per_layer)
             if asynchronous:
@@ -363,8 +357,6 @@ class SamplePerLayer(MiniBatchTransformer):
             self.fanout,
             self.replace,
             self.prob_name,
-            False,
-            self.fetching_original_edge_ids_is_optional,
             async_op=self.asynchronous,
             **kwargs,
         )

--- a/python/dgl/graphbolt/impl/neighbor_sampler.py
+++ b/python/dgl/graphbolt/impl/neighbor_sampler.py
@@ -418,8 +418,6 @@ class SamplePerLayer(MiniBatchTransformer):
                             subgraph._edge_ids_in_fused_csc_sampling_graph,
                         )
                     )
-                    # homo case does not need subtraction of offsets from indices.
-                    minibatch._indices_needs_offset_subtraction = False
                 if (
                     orig_edge_ids is not None
                     and subgraph.original_edge_ids is None

--- a/python/dgl/graphbolt/impl/neighbor_sampler.py
+++ b/python/dgl/graphbolt/impl/neighbor_sampler.py
@@ -401,17 +401,19 @@ class SamplePerLayer(MiniBatchTransformer):
                         subgraph.original_edge_ids[etype] = record_stream(
                             index_select(orig_edge_ids, edge_ids)
                         )
-            elif subgraph.sampled_csc.indices is None:
-                subgraph._edge_ids_in_fused_csc_sampling_graph.record_stream(
-                    torch.cuda.current_stream()
-                )
-                subgraph.sampled_csc.indices = record_stream(
-                    index_select(
-                        indices, subgraph._edge_ids_in_fused_csc_sampling_graph
+            else:
+                if subgraph.sampled_csc.indices is None:
+                    subgraph._edge_ids_in_fused_csc_sampling_graph.record_stream(
+                        torch.cuda.current_stream()
                     )
-                )
-                # homo case does not need subtraction of offsets from indices.
-                minibatch._indices_needs_offset_subtraction = False
+                    subgraph.sampled_csc.indices = record_stream(
+                        index_select(
+                            indices,
+                            subgraph._edge_ids_in_fused_csc_sampling_graph,
+                        )
+                    )
+                    # homo case does not need subtraction of offsets from indices.
+                    minibatch._indices_needs_offset_subtraction = False
                 if (
                     orig_edge_ids is not None
                     and subgraph.original_edge_ids is None

--- a/python/dgl/graphbolt/impl/neighbor_sampler.py
+++ b/python/dgl/graphbolt/impl/neighbor_sampler.py
@@ -398,6 +398,12 @@ class SamplePerLayer(MiniBatchTransformer):
                         orig_edge_ids is not None
                         and subgraph.original_edge_ids[etype] is None
                     ):
+                        edge_ids = (
+                            subgraph._edge_ids_in_fused_csc_sampling_graph[
+                                etype
+                            ]
+                        )
+                        edge_ids.record_stream(torch.cuda.current_stream())
                         subgraph.original_edge_ids[etype] = record_stream(
                             index_select(orig_edge_ids, edge_ids)
                         )
@@ -418,6 +424,9 @@ class SamplePerLayer(MiniBatchTransformer):
                     orig_edge_ids is not None
                     and subgraph.original_edge_ids is None
                 ):
+                    subgraph._edge_ids_in_fused_csc_sampling_graph.record_stream(
+                        torch.cuda.current_stream()
+                    )
                     subgraph.original_edge_ids = record_stream(
                         index_select(
                             orig_edge_ids,

--- a/python/dgl/graphbolt/impl/neighbor_sampler.py
+++ b/python/dgl/graphbolt/impl/neighbor_sampler.py
@@ -272,7 +272,13 @@ class SamplePerLayer(MiniBatchTransformer):
         if (
             overlap_fetch
             and sampler.__name__ == "sample_neighbors"
-            and (graph.indices.is_pinned() or (original_edge_ids is not None and original_edge_ids.is_pinned()))
+            and (
+                graph.indices.is_pinned()
+                or (
+                    original_edge_ids is not None
+                    and original_edge_ids.is_pinned()
+                )
+            )
             and graph._gpu_graph_cache is None
         ):
             datapipe = datapipe.transform(self._sample_per_layer)

--- a/tests/python/pytorch/graphbolt/impl/test_gpu_graph_cache.py
+++ b/tests/python/pytorch/graphbolt/impl/test_gpu_graph_cache.py
@@ -36,7 +36,8 @@ import torch
     ],
 )
 @pytest.mark.parametrize("cache_size", [4, 9, 11])
-def test_gpu_graph_cache(indptr_dtype, dtype, cache_size):
+@pytest.mark.parametrize("with_edge_ids", [True, False])
+def test_gpu_graph_cache(indptr_dtype, dtype, cache_size, with_edge_ids):
     indices_dtype = torch.int32
     indptr = torch.tensor([0, 3, 6, 10], dtype=indptr_dtype, pin_memory=True)
     indices = torch.arange(0, indptr[-1], dtype=indices_dtype, pin_memory=True)
@@ -48,6 +49,7 @@ def test_gpu_graph_cache(indptr_dtype, dtype, cache_size):
         2,
         indptr.dtype,
         [e.dtype for e in edge_tensors],
+        not with_edge_ids,
     )
 
     for i in range(10):
@@ -59,17 +61,17 @@ def test_gpu_graph_cache(indptr_dtype, dtype, cache_size):
             missing_indptr,
             missing_edge_tensors,
         ) = torch.ops.graphbolt.index_select_csc_batched(
-            indptr, edge_tensors, missing_keys, True, None
+            indptr, edge_tensors, missing_keys, with_edge_ids, None
         )
         output_indptr, output_edge_tensors = replace(
-            missing_indptr, missing_edge_tensors
+            missing_indptr, missing_edge_tensors, with_edge_ids
         )
 
         (
             reference_indptr,
             reference_edge_tensors,
         ) = torch.ops.graphbolt.index_select_csc_batched(
-            indptr, edge_tensors, keys, True, None
+            indptr, edge_tensors, keys, with_edge_ids, None
         )
 
         assert torch.equal(output_indptr, reference_indptr)

--- a/tests/python/pytorch/graphbolt/impl/test_gpu_graph_cache.py
+++ b/tests/python/pytorch/graphbolt/impl/test_gpu_graph_cache.py
@@ -64,7 +64,7 @@ def test_gpu_graph_cache(indptr_dtype, dtype, cache_size, with_edge_ids):
             indptr, edge_tensors, missing_keys, with_edge_ids, None
         )
         output_indptr, output_edge_tensors = replace(
-            missing_indptr, missing_edge_tensors, with_edge_ids
+            missing_indptr, missing_edge_tensors
         )
 
         (

--- a/tests/python/pytorch/graphbolt/impl/test_neighbor_sampler.py
+++ b/tests/python/pytorch/graphbolt/impl/test_neighbor_sampler.py
@@ -28,7 +28,7 @@ def get_hetero_graph(include_original_edge_ids):
     if include_original_edge_ids:
         edge_attributes[gb.ORIGINAL_EDGE_ID] = torch.arange(
             indices.size(0), 0, -1
-        )
+        ) - 1
     node_type_offset = torch.LongTensor([0, 1, 3, 6])
     return gb.fused_csc_sampling_graph(
         indptr,

--- a/tests/python/pytorch/graphbolt/impl/test_neighbor_sampler.py
+++ b/tests/python/pytorch/graphbolt/impl/test_neighbor_sampler.py
@@ -26,7 +26,9 @@ def get_hetero_graph(include_original_edge_ids):
         "mask": torch.BoolTensor([1, 0, 1, 0, 1, 1, 1, 0, 1, 1]),
     }
     if include_original_edge_ids:
-        edge_attributes[gb.ORIGINAL_EDGE_ID] = torch.arange(indices.size(0), 0, -1)
+        edge_attributes[gb.ORIGINAL_EDGE_ID] = torch.arange(
+            indices.size(0), 0, -1
+        )
     node_type_offset = torch.LongTensor([0, 1, 3, 6])
     return gb.fused_csc_sampling_graph(
         indptr,

--- a/tests/python/pytorch/graphbolt/impl/test_neighbor_sampler.py
+++ b/tests/python/pytorch/graphbolt/impl/test_neighbor_sampler.py
@@ -26,9 +26,9 @@ def get_hetero_graph(include_original_edge_ids):
         "mask": torch.BoolTensor([1, 0, 1, 0, 1, 1, 1, 0, 1, 1]),
     }
     if include_original_edge_ids:
-        edge_attributes[gb.ORIGINAL_EDGE_ID] = torch.arange(
-            indices.size(0), 0, -1
-        ) - 1
+        edge_attributes[gb.ORIGINAL_EDGE_ID] = (
+            torch.arange(indices.size(0), 0, -1) - 1
+        )
     node_type_offset = torch.LongTensor([0, 1, 3, 6])
     return gb.fused_csc_sampling_graph(
         indptr,


### PR DESCRIPTION
## Description
Similar to indices, `ORIGINAL_EDGE_ID` fetch is also handled. When there is no gpu graph cache, its fetch can be delayed similar to indices. When there is a GPU cache, we let the GPUGraphCache know that it will cache ORIGINAL_EDGE_ID as well and does not have to return edge ids assuming it is `arange(num_edges)`

## Checklist
Please feel free to remove inapplicable items for your PR.
- [x] The PR title starts with [$CATEGORY] (such as [NN], [Model], [Doc], [Feature]])
- [x] I've leverage the [tools](https://docs.google.com/document/d/1iHyj7zlmygKSk5gBPsqIqL5ASPzJSPREaNT_QdsiYA4/edit) to beautify the python and c++ code.
- [x] The PR is complete and small, read the [Google eng practice (CL equals to PR)](https://google.github.io/eng-practices/review/developer/small-cls.html) to understand more about small PR. In DGL, we consider PRs with less than 200 lines of core code change are small (example, test and documentation could be exempted).
- [x] All changes have test coverage
- [x] Code is well-documented
- [x] To the best of my knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change
- [ ] Related issue is referred in this PR
- [ ] If the PR is for a new model/paper, I've updated the example index [here](../examples/README.md).

## Changes
<!-- You could use following template
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)
-->
