### PR TITLE
[GraphBolt] Always enable prefetch before `CopyTo`.

### DIFF
--- a/python/dgl/graphbolt/dataloader.py
+++ b/python/dgl/graphbolt/dataloader.py
@@ -170,7 +170,8 @@ class DataLoader(torch_data.DataLoader):
         # before it. This enables enables non_blocking copies to the device.
         # Prefetching enables the data pipeline up to the CopyTo to run in a
         # separate thread.
-        if torch.cuda.is_available():
+        always_enable_prefetch = True
+        if torch.cuda.is_available() or always_enable_prefetch:
             copiers = find_dps(datapipe_graph, CopyTo)
             if len(copiers) > 1:
                 gb_warning(
@@ -178,7 +179,7 @@ class DataLoader(torch_data.DataLoader):
                     " This case is not officially supported."
                 )
             for copier in copiers:
-                if copier.device.type == "cuda":
+                if copier.device.type == "cuda" or always_enable_prefetch:
                     datapipe_graph = replace_dp(
                         datapipe_graph,
                         copier,


### PR DESCRIPTION
## Description
The only difference between the new dataloader CopyTo related code and old code replaced in #7603 is the change in this PR. I am hoping it will fix the regression we are having in the `cpu-cpu` case.

I don't know why disabling prefetch in the CPU only case would cause a regression.

@frozenbugs can we test if this PR fixes the regression issue for the cpu-cpu case? I can't seem to reliably verify it but I strongly suspect this PR will fix it.

## Checklist
Please feel free to remove inapplicable items for your PR.
- [ ] The PR title starts with [$CATEGORY] (such as [NN], [Model], [Doc], [Feature]])
- [ ] I've leverage the [tools](https://docs.google.com/document/d/1iHyj7zlmygKSk5gBPsqIqL5ASPzJSPREaNT_QdsiYA4/edit) to beautify the python and c++ code.
- [ ] The PR is complete and small, read the [Google eng practice (CL equals to PR)](https://google.github.io/eng-practices/review/developer/small-cls.html) to understand more about small PR. In DGL, we consider PRs with less than 200 lines of core code change are small (example, test and documentation could be exempted).
- [ ] All changes have test coverage
- [ ] Code is well-documented
- [ ] To the best of my knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change
- [ ] Related issue is referred in this PR
- [ ] If the PR is for a new model/paper, I've updated the example index [here](../examples/README.md).

## Changes
<!-- You could use following template
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)
-->
