### PR TITLE
[GraphBolt] Make `CachePolicy` hetero capable [1]

### DIFF
--- a/graphbolt/src/partitioned_cache_policy.h
+++ b/graphbolt/src/partitioned_cache_policy.h
@@ -56,6 +56,7 @@ class PartitionedCachePolicy : public torch::CustomClassHolder {
   /**
    * @brief The policy query function.
    * @param keys The keys to query the cache.
+   * @param offset The offset to be added to the keys.
    *
    * @return (positions, indices, missing_keys, found_ptrs, found_offsets,
    * missing_offsets), where positions has the locations of the keys which were
@@ -69,14 +70,15 @@ class PartitionedCachePolicy : public torch::CustomClassHolder {
   std::tuple<
       torch::Tensor, torch::Tensor, torch::Tensor, torch::Tensor, torch::Tensor,
       torch::Tensor>
-  Query(torch::Tensor keys);
+  Query(torch::Tensor keys, int64_t offset);
 
   c10::intrusive_ptr<Future<std::vector<torch::Tensor>>> QueryAsync(
-      torch::Tensor keys);
+      torch::Tensor keys, int64_t offset);
 
   /**
    * @brief The policy query and then replace function.
    * @param keys The keys to query the cache.
+   * @param offset The offset to be added to the keys.
    *
    * @return (positions, indices, pointers, missing_keys, found_offsets,
    * missing_offsets), where positions has the locations of the keys which were
@@ -92,25 +94,28 @@ class PartitionedCachePolicy : public torch::CustomClassHolder {
   std::tuple<
       torch::Tensor, torch::Tensor, torch::Tensor, torch::Tensor, torch::Tensor,
       torch::Tensor>
-  QueryAndReplace(torch::Tensor keys);
+  QueryAndReplace(torch::Tensor keys, int64_t offset);
 
   c10::intrusive_ptr<Future<std::vector<torch::Tensor>>> QueryAndReplaceAsync(
-      torch::Tensor keys);
+      torch::Tensor keys, int64_t offset);
 
   /**
    * @brief The policy replace function.
    * @param keys The keys to query the cache.
    * @param offsets The partition offsets for the keys.
+   * @param offset The offset to be added to the keys.
    *
    * @return (positions, pointers, offsets), where positions holds the locations
    * of the replaced entries in the cache, pointers holds the CacheKey pointers
    * for the inserted keys and offsets holds the partition offsets for pointers.
    */
   std::tuple<torch::Tensor, torch::Tensor, torch::Tensor> Replace(
-      torch::Tensor keys, torch::optional<torch::Tensor> offsets);
+      torch::Tensor keys, torch::optional<torch::Tensor> offsets,
+      int64_t offset);
 
   c10::intrusive_ptr<Future<std::vector<torch::Tensor>>> ReplaceAsync(
-      torch::Tensor keys, torch::optional<torch::Tensor> offsets);
+      torch::Tensor keys, torch::optional<torch::Tensor> offsets,
+      int64_t offset);
 
   template <bool write>
   void ReadingWritingCompletedImpl(

--- a/python/dgl/graphbolt/impl/feature_cache.py
+++ b/python/dgl/graphbolt/impl/feature_cache.py
@@ -59,13 +59,15 @@ class CPUFeatureCache(object):
         self.total_miss = 0
         self.total_queries = 0
 
-    def query(self, keys):
+    def query(self, keys, offset=0):
         """Queries the cache.
 
         Parameters
         ----------
         keys : Tensor
             The keys to query the cache with.
+        offset : int
+            The offset to be added to the keys. Default is 0.
 
         Returns
         -------
@@ -85,14 +87,14 @@ class CPUFeatureCache(object):
             found_pointers,
             found_offsets,
             missing_offsets,
-        ) = self._policy.query(keys)
+        ) = self._policy.query(keys, offset)
         values = self._cache.query(positions, index, keys.shape[0])
         self._policy.reading_completed(found_pointers, found_offsets)
         self.total_miss += missing_keys.shape[0]
         missing_index = index[positions.size(0) :]
         return values, missing_index, missing_keys, missing_offsets
 
-    def query_and_replace(self, keys, reader_fn):
+    def query_and_replace(self, keys, reader_fn, offset=0):
         """Queries the cache. Then inserts the keys that are not found by
         reading them by calling `reader_fn(missing_keys)`, which are then
         inserted into the cache using the selected caching policy algorithm
@@ -105,6 +107,8 @@ class CPUFeatureCache(object):
         reader_fn : reader_fn(keys: torch.Tensor) -> torch.Tensor
             A function that will take a missing keys tensor and will return
             their values.
+        offset : int
+            The offset to be added to the keys. Default is 0.
 
         Returns
         -------
@@ -120,7 +124,7 @@ class CPUFeatureCache(object):
             missing_keys,
             found_offsets,
             missing_offsets,
-        ) = self._policy.query_and_replace(keys)
+        ) = self._policy.query_and_replace(keys, offset)
         found_cnt = keys.size(0) - missing_keys.size(0)
         found_positions = positions[:found_cnt]
         values = self._cache.query(found_positions, index, keys.shape[0])
@@ -136,7 +140,7 @@ class CPUFeatureCache(object):
         self._policy.writing_completed(missing_pointers, missing_offsets)
         return values
 
-    def replace(self, keys, values, offsets=None):
+    def replace(self, keys, values, offsets=None, offset=0):
         """Inserts key-value pairs into the cache using the selected caching
         policy algorithm to remove old key-value pairs if it is full.
 
@@ -148,8 +152,10 @@ class CPUFeatureCache(object):
             The values to insert to the cache.
         offsets : Tensor, optional
             The partition offsets of the keys.
+        offset : int
+            The offset to be added to the keys. Default is 0.
         """
-        positions, pointers, offsets = self._policy.replace(keys, offsets)
+        positions, pointers, offsets = self._policy.replace(keys, offsets, offset)
         self._cache.replace(positions, values)
         self._policy.writing_completed(pointers, offsets)
 

--- a/python/dgl/graphbolt/impl/feature_cache.py
+++ b/python/dgl/graphbolt/impl/feature_cache.py
@@ -155,7 +155,9 @@ class CPUFeatureCache(object):
         offset : int
             The offset to be added to the keys. Default is 0.
         """
-        positions, pointers, offsets = self._policy.replace(keys, offsets, offset)
+        positions, pointers, offsets = self._policy.replace(
+            keys, offsets, offset
+        )
         self._cache.replace(positions, values)
         self._policy.writing_completed(pointers, offsets)
 

--- a/tests/python/pytorch/graphbolt/impl/test_feature_cache.py
+++ b/tests/python/pytorch/graphbolt/impl/test_feature_cache.py
@@ -29,15 +29,15 @@ def _test_query_and_replace(policy1, policy2, keys, offset):
         found_pointers2,
         found_offsets2,
         missing_offsets2,
-    ) = policy2.query(keys, offset)
+    ) = policy2.query(keys + offset, 0)
     policy2.reading_completed(found_pointers2, found_offsets2)
     (_, missing_pointers2, missing_offsets2) = policy2.replace(
-        missing_keys2, missing_offsets2, offset
+        missing_keys2, missing_offsets2, 0
     )
     policy2.writing_completed(missing_pointers2, missing_offsets2)
 
     assert torch.equal(index, index2)
-    assert torch.equal(missing_keys, missing_keys2)
+    assert torch.equal(missing_keys, missing_keys2 - offset)
 
 
 @pytest.mark.parametrize("offsets", [False, True])

--- a/tests/python/pytorch/graphbolt/impl/test_feature_cache.py
+++ b/tests/python/pytorch/graphbolt/impl/test_feature_cache.py
@@ -7,6 +7,7 @@ from dgl import graphbolt as gb
 
 
 def _test_query_and_replace(policy1, policy2, keys):
+    offset = 111111
     # Testing query_and_replace equivalence to query and then replace.
     (
         _,
@@ -15,7 +16,7 @@ def _test_query_and_replace(policy1, policy2, keys):
         missing_keys,
         found_offsets,
         missing_offsets,
-    ) = policy1.query_and_replace(keys)
+    ) = policy1.query_and_replace(keys, offset)
     found_cnt = keys.size(0) - missing_keys.size(0)
     found_pointers = pointers[:found_cnt]
     policy1.reading_completed(found_pointers, found_offsets)
@@ -29,10 +30,10 @@ def _test_query_and_replace(policy1, policy2, keys):
         found_pointers2,
         found_offsets2,
         missing_offsets2,
-    ) = policy2.query(keys)
+    ) = policy2.query(keys, offset)
     policy2.reading_completed(found_pointers2, found_offsets2)
     (_, missing_pointers2, missing_offsets2) = policy2.replace(
-        missing_keys2, missing_offsets2
+        missing_keys2, missing_offsets2, offset
     )
     policy2.writing_completed(missing_pointers2, missing_offsets2)
 


### PR DESCRIPTION
## Description
The cache will be constructed first (applies to both CPU and GPU). The GPUCachedFeature and CPUCachedFeature will have an `_offset` field that is set to 0 by default (no effect). When it is nonzero, the keys will be offset by the `_offset` field according to the node_type_offset in FusedCSCSamplingGraph. Then, the same cache can be used for hetero features that have the same dimensions.

## Checklist
Please feel free to remove inapplicable items for your PR.
- [ ] The PR title starts with [$CATEGORY] (such as [NN], [Model], [Doc], [Feature]])
- [ ] I've leverage the [tools](https://docs.google.com/document/d/1iHyj7zlmygKSk5gBPsqIqL5ASPzJSPREaNT_QdsiYA4/edit) to beautify the python and c++ code.
- [ ] The PR is complete and small, read the [Google eng practice (CL equals to PR)](https://google.github.io/eng-practices/review/developer/small-cls.html) to understand more about small PR. In DGL, we consider PRs with less than 200 lines of core code change are small (example, test and documentation could be exempted).
- [ ] All changes have test coverage
- [ ] Code is well-documented
- [ ] To the best of my knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change
- [ ] Related issue is referred in this PR
- [ ] If the PR is for a new model/paper, I've updated the example index [here](../examples/README.md).

## Changes
<!-- You could use following template
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)
-->
