### PR TITLE
[GraphBolt] Change `Feature.size` to be whole size.

### DIFF
--- a/examples/graphbolt/disk_based_feature/node_classification.py
+++ b/examples/graphbolt/disk_based_feature/node_classification.py
@@ -496,7 +496,7 @@ def main():
         for itemset, job in zip([train_set, valid_set], ["train", "evaluate"])
     )
 
-    in_channels = features.size("node", None, "feat")[0]
+    in_channels = features.size("node", None, "feat")[1]
     model = SAGE(
         in_channels,
         args.num_hidden,

--- a/examples/graphbolt/lightning/node_classification.py
+++ b/examples/graphbolt/lightning/node_classification.py
@@ -212,7 +212,7 @@ if __name__ == "__main__":
         args.batch_size,
         args.num_workers,
     )
-    in_size = dataset.feature.size("node", None, "feat")[0]
+    in_size = dataset.feature.size("node", None, "feat")[1]
     model = SAGE(in_size, 256, datamodule.num_classes)
 
     # Train.

--- a/examples/graphbolt/link_prediction.py
+++ b/examples/graphbolt/link_prediction.py
@@ -399,7 +399,7 @@ def main(args):
     train_set = dataset.tasks[0].train_set
     args.fanout = list(map(int, args.fanout.split(",")))
 
-    in_size = features.size("node", None, "feat")[0]
+    in_size = features.size("node", None, "feat")[1]
     hidden_channels = 256
     args.device = torch.device(args.device)
     model = SAGE(in_size, hidden_channels).to(args.device)

--- a/examples/graphbolt/node_classification.py
+++ b/examples/graphbolt/node_classification.py
@@ -410,7 +410,7 @@ def main(args):
 
     num_classes = dataset.tasks[0].metadata["num_classes"]
 
-    in_size = features.size("node", None, "feat")[0]
+    in_size = features.size("node", None, "feat")[1]
     hidden_size = 256
     out_size = num_classes
 

--- a/examples/graphbolt/pyg/labor/node_classification.py
+++ b/examples/graphbolt/pyg/labor/node_classification.py
@@ -527,7 +527,7 @@ def main():
         for itemset, job in zip([train_set, valid_set], ["train", "evaluate"])
     )
 
-    in_channels = features.size("node", None, "feat")[0]
+    in_channels = features.size("node", None, "feat")[1]
     model = GraphSAGE(
         in_channels,
         args.num_hidden,

--- a/examples/graphbolt/pyg/node_classification.py
+++ b/examples/graphbolt/pyg/node_classification.py
@@ -257,7 +257,7 @@ def main():
         device,
         job="infer",
     )
-    in_channels = feature.size("node", None, "feat")[0]
+    in_channels = feature.size("node", None, "feat")[1]
     hidden_channels = 256
     model = GraphSAGE(in_channels, hidden_channels, num_classes).to(device)
     optimizer = torch.optim.Adam(model.parameters(), lr=0.003)

--- a/examples/graphbolt/pyg/node_classification_advanced.py
+++ b/examples/graphbolt/pyg/node_classification_advanced.py
@@ -459,7 +459,7 @@ def main():
         for itemset, job in zip([train_set, valid_set], ["train", "evaluate"])
     )
 
-    in_channels = features.size("node", None, "feat")[0]
+    in_channels = features.size("node", None, "feat")[1]
     hidden_channels = 256
     model = GraphSAGE(
         in_channels, hidden_channels, num_classes, len(args.fanout)

--- a/examples/graphbolt/quickstart/link_prediction.py
+++ b/examples/graphbolt/quickstart/link_prediction.py
@@ -166,7 +166,7 @@ if __name__ == "__main__":
         dataset.graph.pin_memory_()
         dataset.feature.pin_memory_()
 
-    in_size = dataset.feature.size("node", None, "feat")[0]
+    in_size = dataset.feature.size("node", None, "feat")[1]
     model = GraphSAGE(in_size).to(device)
 
     # Model training.

--- a/examples/graphbolt/quickstart/node_classification.py
+++ b/examples/graphbolt/quickstart/node_classification.py
@@ -125,7 +125,7 @@ if __name__ == "__main__":
         dataset.graph.pin_memory_()
         dataset.feature.pin_memory_()
 
-    in_size = dataset.feature.size("node", None, "feat")[0]
+    in_size = dataset.feature.size("node", None, "feat")[1]
     out_size = dataset.tasks[0].metadata["num_classes"]
     model = GCN(in_size, out_size).to(device)
 

--- a/examples/graphbolt/rgcn/hetero_rgcn.py
+++ b/examples/graphbolt/rgcn/hetero_rgcn.py
@@ -582,7 +582,7 @@ def main(args):
         args.overlap_graph_fetch = True
         args.asynchronous = True
 
-    feat_size = features.size("node", "paper", "feat")[0]
+    feat_size = features.size("node", "paper", "feat")[1]
 
     # As `ogb-lsc-mag240m` is a large dataset, features of `author` and
     # `institution` are generated in advance and stored in the feature store.

--- a/examples/graphbolt/sparse/graphsage.py
+++ b/examples/graphbolt/sparse/graphsage.py
@@ -247,7 +247,7 @@ if __name__ == "__main__":
     features = dataset.feature
 
     # Create GraphSAGE model.
-    in_size = features.size("node", None, "feat")[0]
+    in_size = features.size("node", None, "feat")[1]
     num_classes = dataset.tasks[0].metadata["num_classes"]
     out_size = num_classes
     model = SAGE(in_size, 256, out_size).to(device)

--- a/examples/multigpu/graphbolt/node_classification.py
+++ b/examples/multigpu/graphbolt/node_classification.py
@@ -297,7 +297,7 @@ def run(rank, world_size, args, devices, dataset):
     args.fanout = list(map(int, args.fanout.split(",")))
     num_classes = dataset.tasks[0].metadata["num_classes"]
 
-    in_size = feature.size("node", None, "feat")[0]
+    in_size = feature.size("node", None, "feat")[1]
     hidden_size = 256
     out_size = num_classes
 

--- a/notebooks/stochastic_training/link_prediction.ipynb
+++ b/notebooks/stochastic_training/link_prediction.ipynb
@@ -225,7 +225,7 @@
       },
       "outputs": [],
       "source": [
-        "in_size = feature.size(\"node\", None, \"feat\")[0]\n",
+        "in_size = feature.size(\"node\", None, \"feat\")[1]\n",
         "model = SAGE(in_size, 128).to(device)\n",
         "optimizer = torch.optim.Adam(model.parameters(), lr=0.001)"
       ]

--- a/notebooks/stochastic_training/multigpu_node_classification.ipynb
+++ b/notebooks/stochastic_training/multigpu_node_classification.ipynb
@@ -421,7 +421,7 @@
         "    valid_set = dataset.tasks[0].validation_set\n",
         "    num_classes = dataset.tasks[0].metadata[\"num_classes\"]\n",
         "\n",
-        "    in_size = features.size(\"node\", None, \"feat\")[0]\n",
+        "    in_size = features.size(\"node\", None, \"feat\")[1]\n",
         "    hidden_size = 256\n",
         "    out_size = num_classes\n",
         "\n",

--- a/notebooks/stochastic_training/node_classification.ipynb
+++ b/notebooks/stochastic_training/node_classification.ipynb
@@ -231,7 +231,7 @@
         "        return h\n",
         "\n",
         "\n",
-        "in_size = feature.size(\"node\", None, \"feat\")[0]\n",
+        "in_size = feature.size(\"node\", None, \"feat\")[1]\n",
         "model = Model(in_size, 64, num_classes).to(device)"
       ]
     },

--- a/python/dgl/graphbolt/impl/torch_based_feature_store.py
+++ b/python/dgl/graphbolt/impl/torch_based_feature_store.py
@@ -66,7 +66,7 @@ class TorchBasedFeature(Feature):
     tensor([[0, 1, 2, 3, 4],
             [1, 1, 1, 1, 1]])
     >>> feature.size()
-    torch.Size([5])
+    torch.Size([2, 5])
 
     2. The feature is on disk. Note that you can use gb.numpy_save_aligned as a
     replacement for np.save to potentially get increased performance.
@@ -237,7 +237,7 @@ class TorchBasedFeature(Feature):
         torch.Size
             The size of the feature.
         """
-        return self._tensor.size()[1:]
+        return self._tensor.size()
 
     def update(self, value: torch.Tensor, ids: torch.Tensor = None):
         """Update the feature store.
@@ -260,9 +260,9 @@ class TorchBasedFeature(Feature):
                 f"ids and value must have the same length, "
                 f"but got {ids.shape[0]} and {value.shape[0]}."
             )
-            assert self.size() == value.size()[1:], (
+            assert self.size()[1:] == value.size()[1:], (
                 f"The size of the feature is {self.size()}, "
-                f"while the size of the value is {value.size()[1:]}."
+                f"while the size of the value is {value.size()}."
             )
             if self._tensor.is_pinned() and value.is_cuda and ids.is_cuda:
                 raise NotImplementedError(
@@ -371,7 +371,7 @@ class DiskBasedFeature(Feature):
     >>> feature.read(torch.tensor([0]))
     tensor([[0, 1, 2, 3, 4]])
     >>> feature.size()
-    torch.Size([5])
+    torch.Size([2, 5])
     """
 
     def __init__(self, path: str, metadata: Dict = None, num_threads=None):
@@ -491,7 +491,7 @@ class DiskBasedFeature(Feature):
         torch.Size
             The size of the feature.
         """
-        return self._tensor.size()[1:]
+        return self._tensor.size()
 
     def update(self, value: torch.Tensor, ids: torch.Tensor = None):
         """Disk based feature does not support update for now."""

--- a/tests/python/pytorch/graphbolt/impl/test_basic_feature_store.py
+++ b/tests/python/pytorch/graphbolt/impl/test_basic_feature_store.py
@@ -44,8 +44,8 @@ def test_basic_feature_store_homo():
     )
 
     # Test get the size of the entire feature.
-    assert feature_store.size("node", None, "a") == torch.Size([3])
-    assert feature_store.size("node", None, "b") == torch.Size([2, 2])
+    assert feature_store.size("node", None, "a") == a.size()
+    assert feature_store.size("node", None, "b") == b.size()
 
     # Test get metadata of the feature.
     assert feature_store.metadata("node", None, "a") == metadata
@@ -102,8 +102,8 @@ def test_basic_feature_store_hetero():
     )
 
     # Test get the size of the entire feature.
-    assert feature_store.size("node", "author", "a") == torch.Size([3])
-    assert feature_store.size("edge", "paper:cites", "b") == torch.Size([2, 1])
+    assert feature_store.size("node", "author", "a") == a.size()
+    assert feature_store.size("edge", "paper:cites", "b") == b.size()
 
     # Test get metadata of the feature.
     assert feature_store.metadata("node", "author", "a") == metadata

--- a/tests/python/pytorch/graphbolt/impl/test_cpu_cached_feature.py
+++ b/tests/python/pytorch/graphbolt/impl/test_cpu_cached_feature.py
@@ -82,8 +82,8 @@ def test_cpu_cached_feature(dtype, policy):
     assert feat_store_a._feature.miss_rate == feat_store_a.miss_rate
 
     # Test get the size of the entire feature with ids.
-    assert feat_store_a.size() == torch.Size([3])
-    assert feat_store_b.size() == torch.Size([2, 2])
+    assert feat_store_a.size() == a.size()
+    assert feat_store_b.size() == b.size()
 
     # Test update the entire feature.
     feat_store_a.update(torch.tensor([[0, 1, 2], [3, 5, 2]], dtype=dtype))

--- a/tests/python/pytorch/graphbolt/impl/test_disk_based_feature_store.py
+++ b/tests/python/pytorch/graphbolt/impl/test_disk_based_feature_store.py
@@ -83,8 +83,8 @@ def test_disk_based_feature():
         assert_equal(feature_c.read(ind_c), c[ind_c])
 
         # Test get the size of the entire feature.
-        assert feature_a.size() == torch.Size([3])
-        assert feature_b.size() == torch.Size([2, 2])
+        assert feature_a.size() == a.size()
+        assert feature_b.size() == b.size()
 
         # Test get metadata of the feature.
         assert feature_a.metadata() == metadata

--- a/tests/python/pytorch/graphbolt/impl/test_gpu_cached_feature.py
+++ b/tests/python/pytorch/graphbolt/impl/test_gpu_cached_feature.py
@@ -86,8 +86,8 @@ def test_gpu_cached_feature(dtype, cache_size_a, cache_size_b):
     assert feat_store_a._feature.miss_rate == feat_store_a.miss_rate
 
     # Test get the size of the entire feature with ids.
-    assert feat_store_a.size() == torch.Size([3])
-    assert feat_store_b.size() == torch.Size([2, 2])
+    assert feat_store_a.size() == a.size()
+    assert feat_store_b.size() == b.size()
 
     # Test update the entire feature.
     feat_store_a.update(

--- a/tests/python/pytorch/graphbolt/impl/test_legacy_dataset.py
+++ b/tests/python/pytorch/graphbolt/impl/test_legacy_dataset.py
@@ -23,7 +23,9 @@ def test_LegacyDataset_homo_node_pred():
     num_nodes = 2708
     assert dataset.graph.num_nodes == num_nodes
     assert len(dataset.all_nodes_set) == num_nodes
-    assert dataset.feature.size("node", None, "feat") == torch.Size([num_nodes, 1433])
+    assert dataset.feature.size("node", None, "feat") == torch.Size(
+        [num_nodes, 1433]
+    )
     assert (
         dataset.feature.read(
             "node", None, "feat", torch.tensor([num_nodes - 1])

--- a/tests/python/pytorch/graphbolt/impl/test_legacy_dataset.py
+++ b/tests/python/pytorch/graphbolt/impl/test_legacy_dataset.py
@@ -23,7 +23,7 @@ def test_LegacyDataset_homo_node_pred():
     num_nodes = 2708
     assert dataset.graph.num_nodes == num_nodes
     assert len(dataset.all_nodes_set) == num_nodes
-    assert dataset.feature.size("node", None, "feat") == torch.Size([1433])
+    assert dataset.feature.size("node", None, "feat") == torch.Size([num_nodes, 1433])
     assert (
         dataset.feature.read(
             "node", None, "feat", torch.tensor([num_nodes - 1])

--- a/tests/python/pytorch/graphbolt/impl/test_ondisk_dataset.py
+++ b/tests/python/pytorch/graphbolt/impl/test_ondisk_dataset.py
@@ -2607,8 +2607,8 @@ def test_OnDiskDataset_homogeneous(
         assert tasks[0].metadata["num_classes"] == num_classes
         assert tasks[0].metadata["name"] == "link_prediction"
 
-        assert dataset.feature.size("node", None, "feat")[0] == num_classes
-        assert dataset.feature.size("edge", None, "feat")[0] == num_classes
+        assert dataset.feature.size("node", None, "feat")[1] == num_classes
+        assert dataset.feature.size("edge", None, "feat")[1] == num_classes
 
         for itemset in [
             tasks[0].train_set,
@@ -2695,8 +2695,8 @@ def test_OnDiskDataset_heterogeneous(
         assert tasks[0].metadata["num_classes"] == num_classes
         assert tasks[0].metadata["name"] == "node_classification"
 
-        assert dataset.feature.size("node", "user", "feat")[0] == num_classes
-        assert dataset.feature.size("node", "item", "feat")[0] == num_classes
+        assert dataset.feature.size("node", "user", "feat")[1] == num_classes
+        assert dataset.feature.size("node", "item", "feat")[1] == num_classes
 
         for itemset in [
             tasks[0].train_set,

--- a/tests/python/pytorch/graphbolt/impl/test_torch_based_feature_store.py
+++ b/tests/python/pytorch/graphbolt/impl/test_torch_based_feature_store.py
@@ -80,8 +80,8 @@ def test_torch_based_feature(in_memory):
         )
 
         # Test get the size of the entire feature.
-        assert feature_a.size() == torch.Size([3])
-        assert feature_b.size() == torch.Size([2, 2])
+        assert feature_a.size() == torch.Size([1, 3])
+        assert feature_b.size() == torch.Size([3, 2, 2])
 
         # Test get metadata of the feature.
         assert feature_a.metadata() == metadata
@@ -299,10 +299,8 @@ def test_torch_based_feature_store(in_memory):
         )
 
         # Test get the size of the entire feature.
-        assert feature_store.size("node", "paper", "a") == torch.Size([3])
-        assert feature_store.size(
-            "edge", "paper:cites:paper", "b"
-        ) == torch.Size([2, 2])
+        assert feature_store.size("node", "paper", "a") == a.size()
+        assert feature_store.size("edge", "paper:cites:paper", "b") == b.size()
 
         # Test get the keys of the features.
         assert feature_store.keys() == [
@@ -343,7 +341,7 @@ def test_torch_based_feature_store(in_memory):
             torch.tensor([[1, 2, 4], [2, 5, 3]]),
         )
         # Test get the size of the entire feature.
-        assert feature_store.size("node", None, "a") == torch.Size([3])
+        assert feature_store.size("node", None, "a") == torch.Size([2, 3])
 
         feature_store = None
 

--- a/tutorials/multi/2_node_classification.py
+++ b/tutorials/multi/2_node_classification.py
@@ -290,7 +290,7 @@ def run(rank, world_size, devices, dataset):
     valid_set = dataset.tasks[0].validation_set
     num_classes = dataset.tasks[0].metadata["num_classes"]
 
-    in_size = features.size("node", None, "feat")[0]
+    in_size = features.size("node", None, "feat")[1]
     hidden_size = 256
     out_size = num_classes
 


### PR DESCRIPTION
## Description
When I am constructing `CachedFeature`s sharing the same cache, I need access to their number of rows so that I can compute offsets for the hetero case. I thought of adding `.num_rows` in addition to .size but that didn't feel right. So I am changing `.size` to be equivalent to `torch.Tensor.size`.

## Checklist
Please feel free to remove inapplicable items for your PR.
- [ ] The PR title starts with [$CATEGORY] (such as [NN], [Model], [Doc], [Feature]])
- [ ] I've leverage the [tools](https://docs.google.com/document/d/1iHyj7zlmygKSk5gBPsqIqL5ASPzJSPREaNT_QdsiYA4/edit) to beautify the python and c++ code.
- [ ] The PR is complete and small, read the [Google eng practice (CL equals to PR)](https://google.github.io/eng-practices/review/developer/small-cls.html) to understand more about small PR. In DGL, we consider PRs with less than 200 lines of core code change are small (example, test and documentation could be exempted).
- [ ] All changes have test coverage
- [ ] Code is well-documented
- [ ] To the best of my knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change
- [ ] Related issue is referred in this PR
- [ ] If the PR is for a new model/paper, I've updated the example index [here](../examples/README.md).

## Changes
<!-- You could use following template
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)
-->
