### PR TITLE
[GraphBolt] Do not expose `CPUFeatureCache` storage tensor.

### DIFF
--- a/graphbolt/src/feature_cache.h
+++ b/graphbolt/src/feature_cache.h
@@ -41,6 +41,10 @@ struct FeatureCache : public torch::CustomClassHolder {
       const std::vector<int64_t>& shape, torch::ScalarType dtype,
       bool pin_memory);
 
+  bool IsPinned() const { return tensor_.is_pinned(); }
+
+  int64_t NumBytes() const { return tensor_.numel() * tensor_.element_size(); }
+
   /**
    * @brief The cache query function. Allocates an empty tensor `values` with
    * size as the first dimension and runs
@@ -87,6 +91,7 @@ struct FeatureCache : public torch::CustomClassHolder {
       const std::vector<int64_t>& shape, torch::ScalarType dtype,
       bool pin_memory);
 
+ private:
   torch::Tensor tensor_;
 };
 

--- a/graphbolt/src/python_binding.cc
+++ b/graphbolt/src/python_binding.cc
@@ -167,7 +167,8 @@ TORCH_LIBRARY(graphbolt, m) {
       "clock_cache_policy",
       &storage::PartitionedCachePolicy::Create<storage::ClockCachePolicy>);
   m.class_<storage::FeatureCache>("FeatureCache")
-      .def_readonly("tensor", &storage::FeatureCache::tensor_)
+      .def("is_pinned", &storage::FeatureCache::IsPinned)
+      .def_property("nbytes", &storage::FeatureCache::NumBytes)
       .def("index_select", &storage::FeatureCache::IndexSelect)
       .def("query", &storage::FeatureCache::Query)
       .def("query_async", &storage::FeatureCache::QueryAsync)

--- a/python/dgl/graphbolt/impl/cpu_feature_cache.py
+++ b/python/dgl/graphbolt/impl/cpu_feature_cache.py
@@ -61,12 +61,12 @@ class CPUFeatureCache(object):
 
     def is_pinned(self):
         """Returns True if the cache storage is pinned."""
-        return self._cache.tensor.is_pinned()
+        return self._cache.is_pinned()
 
     @property
     def max_size_in_bytes(self):
         """Return the size taken by the cache in bytes."""
-        return self._cache.tensor.nbytes
+        return self._cache.nbytes
 
     def query(self, keys, offset=0):
         """Queries the cache.


### PR DESCRIPTION
## Description
Addressing the reviews in #7729.

## Checklist
Please feel free to remove inapplicable items for your PR.
- [ ] The PR title starts with [$CATEGORY] (such as [NN], [Model], [Doc], [Feature]])
- [ ] I've leverage the [tools](https://docs.google.com/document/d/1iHyj7zlmygKSk5gBPsqIqL5ASPzJSPREaNT_QdsiYA4/edit) to beautify the python and c++ code.
- [ ] The PR is complete and small, read the [Google eng practice (CL equals to PR)](https://google.github.io/eng-practices/review/developer/small-cls.html) to understand more about small PR. In DGL, we consider PRs with less than 200 lines of core code change are small (example, test and documentation could be exempted).
- [ ] All changes have test coverage
- [ ] Code is well-documented
- [ ] To the best of my knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change
- [ ] Related issue is referred in this PR
- [ ] If the PR is for a new model/paper, I've updated the example index [here](../examples/README.md).

## Changes
<!-- You could use following template
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)
-->
