### PR TITLE
[GraphBolt][CUDA] Fix error when empty env variable is used.

### DIFF
--- a/python/dgl/graphbolt/__init__.py
+++ b/python/dgl/graphbolt/__init__.py
@@ -15,7 +15,7 @@ cuda_allocator_env = os.getenv("PYTORCH_CUDA_ALLOC_CONF")
 WARNING_STR_TO_BE_SHOWN = None
 configs = (
     {}
-    if cuda_allocator_env is None
+    if cuda_allocator_env is None or len(cuda_allocator_env) == 0
     else {
         kv_pair.split(":")[0]: kv_pair.split(":")[1]
         for kv_pair in cuda_allocator_env.split(",")


### PR DESCRIPTION
## Description
When the user sets the value as `PYTORCH_CUDA_ALLOC_CONF=`, there is an error. This shouldn't be an error. In this case, the environment variable is set to an empty string we make sure to check this case.

## Checklist
Please feel free to remove inapplicable items for your PR.
- [ ] The PR title starts with [$CATEGORY] (such as [NN], [Model], [Doc], [Feature]])
- [ ] I've leverage the [tools](https://docs.google.com/document/d/1iHyj7zlmygKSk5gBPsqIqL5ASPzJSPREaNT_QdsiYA4/edit) to beautify the python and c++ code.
- [ ] The PR is complete and small, read the [Google eng practice (CL equals to PR)](https://google.github.io/eng-practices/review/developer/small-cls.html) to understand more about small PR. In DGL, we consider PRs with less than 200 lines of core code change are small (example, test and documentation could be exempted).
- [ ] All changes have test coverage
- [ ] Code is well-documented
- [ ] To the best of my knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change
- [ ] Related issue is referred in this PR
- [ ] If the PR is for a new model/paper, I've updated the example index [here](../examples/README.md).

## Changes
<!-- You could use following template
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)
-->
