### PR TITLE
Correcting the misleading reason for skipping the test.

### DIFF
--- a/tests/python/pytorch/graphbolt/impl/test_gpu_graph_cache.py
+++ b/tests/python/pytorch/graphbolt/impl/test_gpu_graph_cache.py
@@ -11,7 +11,9 @@ import torch
 @unittest.skipIf(
     F._default_context_str != "gpu"
     or torch.cuda.get_device_capability()[0] < 7,
-    reason="GPUCachedFeature requires a Volta or later generation NVIDIA GPU.",
+    reason="Pinned tests are available only on GPU."
+            if F._default_context_str != "gpu" else
+            "GPUCachedFeature requires a Volta or later generation NVIDIA GPU."
 )
 @pytest.mark.parametrize(
     "indptr_dtype",


### PR DESCRIPTION
## Description
<!-- Brief description. Refer to the related issues if existed.
It'll be great if relevant reviewers can be assigned as well.-->
When launched on CPU (`F._default_context_str != "gpu"`), the set of tests `test_gpu_graph_cache.py::test_gpu_graph_cache` generates misleading reason for skipping the test:
```
SKIPPED [60] ../../../usr/local/lib/python3.10/dist-packages/_pytest/unittest.py:357: GPUCachedFeature requires a Volta or later generation NVIDIA GPU.
```
I ran these tests on a GPU machine with `device_capability=8`.


## Checklist
Please feel free to remove inapplicable items for your PR.
- [x] I've leverage the [tools](https://docs.google.com/document/d/1iHyj7zlmygKSk5gBPsqIqL5ASPzJSPREaNT_QdsiYA4/edit) to beautify the python and c++ code.
- [x] The PR is complete and small, read the [Google eng practice (CL equals to PR)](https://google.github.io/eng-practices/review/developer/small-cls.html) to understand more about small PR. In DGL, we consider PRs with less than 200 lines of core code change are small (example, test and documentation could be exempted).
- [x] To the best of my knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

## Changes
<!-- You could use following template
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)
-->
