### PR TITLE
[DistGB] fix return_eids argument

### DIFF
--- a/python/dgl/distributed/graph_services.py
+++ b/python/dgl/distributed/graph_services.py
@@ -154,14 +154,12 @@ def _sample_neighbors_graphbolt(
         fanout = torch.LongTensor([fanout])
     assert isinstance(fanout, torch.Tensor), "Expect a tensor of fanout."
 
-    return_eids = g.edge_attributes is not None and EID in g.edge_attributes
     subgraph = g._sample_neighbors(
         nodes,
         None,
         fanout,
         replace=replace,
         probs_or_mask=probs_or_mask,
-        return_eids=return_eids,
     )
 
     # 3. Map local node IDs to global node IDs.
@@ -177,7 +175,7 @@ def _sample_neighbors_graphbolt(
     global_dst = global_nid_mapping[local_dst]
 
     global_eids = None
-    if return_eids:
+    if g.edge_attributes is not None and EID in g.edge_attributes:
         global_eids = g.edge_attributes[EID][subgraph.original_edge_ids]
     return LocalSampledGraph(
         global_src, global_dst, global_eids, subgraph.type_per_edge


### PR DESCRIPTION
## Description
<!-- Brief description. Refer to the related issues if existed.
It'll be great if relevant reviewers can be assigned as well.-->
Fix the issue introduced in https://github.com/dmlc/dgl/pull/7663 as `return_eids` argument is removed. If `EID` are stored in `g.edge_attributes`, they will be fetched into `subgraph.original_edge_ids`. Otherwise, EID are assumed to be `arange(0, num_edges). This assumption does not fit in DistGB.
## Checklist
Please feel free to remove inapplicable items for your PR.
- [ ] The PR title starts with [$CATEGORY] (such as [NN], [Model], [Doc], [Feature]])
- [ ] I've leverage the [tools](https://docs.google.com/document/d/1iHyj7zlmygKSk5gBPsqIqL5ASPzJSPREaNT_QdsiYA4/edit) to beautify the python and c++ code.
- [ ] The PR is complete and small, read the [Google eng practice (CL equals to PR)](https://google.github.io/eng-practices/review/developer/small-cls.html) to understand more about small PR. In DGL, we consider PRs with less than 200 lines of core code change are small (example, test and documentation could be exempted).
- [ ] All changes have test coverage
- [ ] Code is well-documented
- [ ] To the best of my knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change
- [ ] Related issue is referred in this PR
- [ ] If the PR is for a new model/paper, I've updated the example index [here](../examples/README.md).

## Changes
<!-- You could use following template
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)
-->
