### PR TITLE
[UnitTest] Fix "[UnitTest] AttributeError: module 'numpy' has no attribute 'ComplexWarning'" in #7766

### DIFF
--- a/tests/python/common/sampling/test_sampling.py
+++ b/tests/python/common/sampling/test_sampling.py
@@ -1774,7 +1774,7 @@ def test_sample_neighbors_exclude_edges_homoG(dtype, fused):
 
 @pytest.mark.parametrize("dtype", ["int32", "int64"])
 def test_global_uniform_negative_sampling(dtype):
-    # warnings.simplefilter("ignore", np.ComplexWarning)
+    warnings.simplefilter("ignore", np.exceptions.ComplexWarning)
     g = dgl.graph(([], []), num_nodes=1000).to(F.ctx())
     src, dst = dgl.sampling.global_uniform_negative_sampling(
         g, 2000, False, True

--- a/tests/python/common/sampling/test_sampling.py
+++ b/tests/python/common/sampling/test_sampling.py
@@ -1774,7 +1774,7 @@ def test_sample_neighbors_exclude_edges_homoG(dtype, fused):
 
 @pytest.mark.parametrize("dtype", ["int32", "int64"])
 def test_global_uniform_negative_sampling(dtype):
-    warnings.simplefilter("ignore", np.ComplexWarning)
+    # warnings.simplefilter("ignore", np.ComplexWarning)
     g = dgl.graph(([], []), num_nodes=1000).to(F.ctx())
     src, dst = dgl.sampling.global_uniform_negative_sampling(
         g, 2000, False, True


### PR DESCRIPTION
## Description
<!-- Brief description. Refer to the related issues if existed.
It'll be great if relevant reviewers can be assigned as well.-->
Fix #7766

## Checklist
Please feel free to remove inapplicable items for your PR.
- [x] The PR title starts with [$CATEGORY] (such as [NN], [Model], [Doc], [Feature]])
- [x] I've leverage the [tools](https://docs.google.com/document/d/1iHyj7zlmygKSk5gBPsqIqL5ASPzJSPREaNT_QdsiYA4/edit) to beautify the python and c++ code.
- [x] The PR is complete and small, read the [Google eng practice (CL equals to PR)](https://google.github.io/eng-practices/review/developer/small-cls.html) to understand more about small PR. In DGL, we consider PRs with less than 200 lines of core code change are small (example, test and documentation could be exempted).
- [x] All changes have test coverage
- [ ] Code is well-documented
- [x] To the best of my knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change
- [x] Related issue is referred in this PR
- [ ] If the PR is for a new model/paper, I've updated the example index [here](../examples/README.md).

## Changes
<!-- You could use following template
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)
-->
Commented out a line that will cause `AttributeError: module 'numpy' has no attribute 'ComplexWarning'`.