### PR TITLE
[GraphBolt][CUDA] Fix hetero `UniqueAndCompact` bug.

### DIFF
--- a/graphbolt/src/cuda/extension/unique_and_compact_map.cu
+++ b/graphbolt/src/cuda/extension/unique_and_compact_map.cu
@@ -18,6 +18,7 @@
  * @brief Unique and compact operator implementation on CUDA using hash table.
  */
 #include <graphbolt/cuda_ops.h>
+#include <thrust/iterator/reverse_iterator.h>
 #include <thrust/iterator/tabulate_output_iterator.h>
 #include <thrust/iterator/transform_iterator.h>
 
@@ -193,10 +194,9 @@ UniqueAndCompactBatchedHashMapBased(
         auto input_it = thrust::make_transform_iterator(
             index_it,
             ::cuda::proclaim_return_type<
-                ::cuda::std::tuple<int64_t*, index_t, int32_t, bool, bool>>(
+                ::cuda::std::tuple<int64_t*, index_t, int32_t, bool>>(
                 [=, map = map.ref(cuco::find)] __device__(auto it)
-                    -> ::cuda::std::tuple<
-                        int64_t*, index_t, int32_t, bool, bool> {
+                    -> ::cuda::std::tuple<int64_t*, index_t, int32_t, bool> {
                   const auto i = it.key;
                   const auto tensor_index = it.value;
                   const auto tensor_offset = i - offsets_dev_ptr[tensor_index];
@@ -211,9 +211,7 @@ UniqueAndCompactBatchedHashMapBased(
                   auto slot = map.find(key);
                   const auto valid = slot->second == i;
 
-                  return {
-                      &slot->second, node_id, batch_index, valid,
-                      i == batch_offset};
+                  return {&slot->second, node_id, batch_index, valid};
                 }));
         torch::optional<torch::Tensor> part_ids;
         if (world_size > 1) {
@@ -223,8 +221,9 @@ UniqueAndCompactBatchedHashMapBased(
         }
         auto unique_ids =
             torch::empty(offsets_ptr[2 * num_batches], src_ids[0].options());
-        auto unique_ids_offsets_dev = torch::empty(
-            num_batches + 1, src_ids[0].options().dtype(torch::kInt64));
+        auto unique_ids_offsets_dev = torch::full(
+            num_batches + 1, std::numeric_limits<int64_t>::max(),
+            src_ids[0].options().dtype(torch::kInt64));
         auto unique_ids_offsets_dev_ptr =
             unique_ids_offsets_dev.data_ptr<int64_t>();
         auto output_it = thrust::make_tabulate_output_iterator(
@@ -237,16 +236,16 @@ UniqueAndCompactBatchedHashMapBased(
                      world_size)] __device__(const int64_t i, const auto& t) {
                   *::cuda::std::get<0>(t) = i;
                   const auto node_id = ::cuda::std::get<1>(t);
-                  const auto is_i_equal_batch_offset = ::cuda::std::get<4>(t);
                   unique_ids_ptr[i] = node_id;
                   if (part_ids_ptr) {
                     part_ids_ptr[i] =
                         cuda::rank_assignment(node_id, rank, world_size);
                   }
-                  if (is_i_equal_batch_offset) {
-                    const auto batch_index = ::cuda::std::get<2>(t);
-                    unique_ids_offsets_dev_ptr[batch_index] = i;
-                  }
+                  const auto batch_index = ::cuda::std::get<2>(t);
+                  auto ref =
+                      ::cuda::atomic_ref<int64_t, ::cuda::thread_scope_device>{
+                          unique_ids_offsets_dev_ptr[batch_index]};
+                  ref.fetch_min(i, ::cuda::memory_order_relaxed);
                 }));
         CUB_CALL(
             DeviceSelect::If, input_it, output_it,
@@ -259,10 +258,27 @@ UniqueAndCompactBatchedHashMapBased(
             num_batches + 1,
             c10::TensorOptions().dtype(torch::kInt64).pinned_memory(true));
         auto unique_ids_offsets_ptr = unique_ids_offsets.data_ptr<int64_t>();
-        CUDA_CALL(cudaMemcpyAsync(
-            unique_ids_offsets_ptr, unique_ids_offsets_dev_ptr,
-            sizeof(int64_t) * (num_batches + 1), cudaMemcpyDeviceToHost,
-            stream));
+        {
+          auto unique_ids_offsets_dev2 =
+              torch::empty_like(unique_ids_offsets_dev);
+          auto unique_ids_offsets_dev2_ptr =
+              unique_ids_offsets_dev2.data_ptr<int64_t>();
+          CUB_CALL(
+              DeviceScan::InclusiveScan,
+              thrust::make_reverse_iterator(
+                  num_batches + 1 + unique_ids_offsets_dev_ptr),
+              thrust::make_reverse_iterator(
+                  num_batches + 1 +
+                  thrust::make_tabulate_output_iterator(
+                      [=] __device__(const auto i, const auto x) {
+                        unique_ids_offsets_dev2_ptr[i] = x;
+                        unique_ids_offsets_ptr[i] = x;
+                      })),
+              cub::Min{}, num_batches + 1);
+          unique_ids_offsets_dev = unique_ids_offsets_dev2;
+          unique_ids_offsets_dev_ptr =
+              unique_ids_offsets_dev.data_ptr<int64_t>();
+        }
         at::cuda::CUDAEvent unique_ids_offsets_event;
         unique_ids_offsets_event.record();
         torch::optional<torch::Tensor> index;


### PR DESCRIPTION
## Description
Fix the bug introduced in #7765 for the heterogenous case.

The hetero example regression test failed yesterday due to it.

The bug was that it left some entries uninitiailized if certain edge types contain no edges. When the uninitialized memory is accessed, it causes crash.

We fix it by initializing the memory to infinity, then using atomic min to write the correct values. It is possible that some entries might still be uninitialized due to the same reason. But this time, they will have the value infinity and a backward scan using min operation re-initializes those values to the correct value.

## Checklist
Please feel free to remove inapplicable items for your PR.
- [ ] The PR title starts with [$CATEGORY] (such as [NN], [Model], [Doc], [Feature]])
- [ ] I've leverage the [tools](https://docs.google.com/document/d/1iHyj7zlmygKSk5gBPsqIqL5ASPzJSPREaNT_QdsiYA4/edit) to beautify the python and c++ code.
- [ ] The PR is complete and small, read the [Google eng practice (CL equals to PR)](https://google.github.io/eng-practices/review/developer/small-cls.html) to understand more about small PR. In DGL, we consider PRs with less than 200 lines of core code change are small (example, test and documentation could be exempted).
- [ ] All changes have test coverage
- [ ] Code is well-documented
- [ ] To the best of my knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change
- [ ] Related issue is referred in this PR
- [ ] If the PR is for a new model/paper, I've updated the example index [here](../examples/README.md).

## Changes
<!-- You could use following template
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)
-->
