### PR TITLE
[GraphBolt][CUDA] Expose `UniqueAndCompact` offsets.

### DIFF
--- a/graphbolt/include/graphbolt/cuda_ops.h
+++ b/graphbolt/include/graphbolt/cuda_ops.h
@@ -288,7 +288,7 @@ torch::Tensor IndptrEdgeIdsImpl(
  * @param rank            The rank of the current GPU.
  * @param world_size      The total # GPUs, world size.
  *
- * @return
+ * @return (unique_ids, compacted_src_ids, compacted_dst_ids, unique_offsets)
  * - A tensor representing all unique elements in 'src_ids' and 'dst_ids' after
  * removing duplicates. The indices in this tensor precisely match the compacted
  * IDs of the corresponding elements.
@@ -296,6 +296,9 @@ torch::Tensor IndptrEdgeIdsImpl(
  * mapped to compacted IDs.
  * - The tensor corresponding to the 'dst_ids' tensor, where the entries are
  * mapped to compacted IDs.
+ * - The tensor corresponding to the offsets into the unique_ids tensor. Has
+ * size `world_size + 1` and unique_ids[offsets[i]: offsets[i + 1]] belongs to
+ * the rank `(rank + i) % world_size`.
  *
  * @example
  *   torch::Tensor src_ids = src

--- a/graphbolt/include/graphbolt/cuda_ops.h
+++ b/graphbolt/include/graphbolt/cuda_ops.h
@@ -306,7 +306,8 @@ torch::Tensor IndptrEdgeIdsImpl(
  *   torch::Tensor compacted_src_ids = std::get<1>(result);
  *   torch::Tensor compacted_dst_ids = std::get<2>(result);
  */
-std::tuple<torch::Tensor, torch::Tensor, torch::Tensor> UniqueAndCompact(
+std::tuple<torch::Tensor, torch::Tensor, torch::Tensor, torch::Tensor>
+UniqueAndCompact(
     const torch::Tensor src_ids, const torch::Tensor dst_ids,
     const torch::Tensor unique_dst_ids, const int64_t rank,
     const int64_t world_size);
@@ -316,7 +317,8 @@ std::tuple<torch::Tensor, torch::Tensor, torch::Tensor> UniqueAndCompact(
  * value is equal to the passing the ith elements of the input arguments to
  * UniqueAndCompact.
  */
-std::vector<std::tuple<torch::Tensor, torch::Tensor, torch::Tensor>>
+std::vector<
+    std::tuple<torch::Tensor, torch::Tensor, torch::Tensor, torch::Tensor>>
 UniqueAndCompactBatched(
     const std::vector<torch::Tensor>& src_ids,
     const std::vector<torch::Tensor>& dst_ids,

--- a/graphbolt/include/graphbolt/unique_and_compact.h
+++ b/graphbolt/include/graphbolt/unique_and_compact.h
@@ -56,20 +56,22 @@ namespace sampling {
  *   torch::Tensor compacted_src_ids = std::get<1>(result);
  *   torch::Tensor compacted_dst_ids = std::get<2>(result);
  */
-std::tuple<torch::Tensor, torch::Tensor, torch::Tensor> UniqueAndCompact(
+std::tuple<torch::Tensor, torch::Tensor, torch::Tensor, torch::Tensor>
+UniqueAndCompact(
     const torch::Tensor& src_ids, const torch::Tensor& dst_ids,
     const torch::Tensor unique_dst_ids, const int64_t rank,
     const int64_t world_size);
 
-std::vector<std::tuple<torch::Tensor, torch::Tensor, torch::Tensor>>
+std::vector<
+    std::tuple<torch::Tensor, torch::Tensor, torch::Tensor, torch::Tensor>>
 UniqueAndCompactBatched(
     const std::vector<torch::Tensor>& src_ids,
     const std::vector<torch::Tensor>& dst_ids,
     const std::vector<torch::Tensor> unique_dst_ids, const int64_t rank,
     const int64_t world_size);
 
-c10::intrusive_ptr<Future<
-    std::vector<std::tuple<torch::Tensor, torch::Tensor, torch::Tensor>>>>
+c10::intrusive_ptr<Future<std::vector<
+    std::tuple<torch::Tensor, torch::Tensor, torch::Tensor, torch::Tensor>>>>
 UniqueAndCompactBatchedAsync(
     const std::vector<torch::Tensor>& src_ids,
     const std::vector<torch::Tensor>& dst_ids,

--- a/graphbolt/include/graphbolt/unique_and_compact.h
+++ b/graphbolt/include/graphbolt/unique_and_compact.h
@@ -38,7 +38,7 @@ namespace sampling {
  * @param rank            The rank of the current GPU.
  * @param world_size      The total # GPUs, world size.
  *
- * @return
+ * @return (unique_ids, compacted_src_ids, compacted_dst_ids, unique_offsets)
  * - A tensor representing all unique elements in 'src_ids' and 'dst_ids' after
  * removing duplicates. The indices in this tensor precisely match the compacted
  * IDs of the corresponding elements.
@@ -46,6 +46,9 @@ namespace sampling {
  * mapped to compacted IDs.
  * - The tensor corresponding to the 'dst_ids' tensor, where the entries are
  * mapped to compacted IDs.
+ * - The tensor corresponding to the offsets into the unique_ids tensor. Has
+ * size `world_size + 1` and unique_ids[offsets[i]: offsets[i + 1]] belongs to
+ * the rank `(rank + i) % world_size`.
  *
  * @example
  *   torch::Tensor src_ids = src

--- a/graphbolt/src/python_binding.cc
+++ b/graphbolt/src/python_binding.cc
@@ -51,8 +51,8 @@ TORCH_LIBRARY(graphbolt, m) {
   m.class_<Future<c10::intrusive_ptr<FusedSampledSubgraph>>>(
        "FusedSampledSubgraphFuture")
       .def("wait", &Future<c10::intrusive_ptr<FusedSampledSubgraph>>::Wait);
-  m.class_<Future<
-      std::vector<std::tuple<torch::Tensor, torch::Tensor, torch::Tensor>>>>(
+  m.class_<Future<std::vector<
+      std::tuple<torch::Tensor, torch::Tensor, torch::Tensor, torch::Tensor>>>>(
        "UniqueAndCompactBatchedFuture")
       .def(
           "wait",

--- a/graphbolt/src/python_binding.cc
+++ b/graphbolt/src/python_binding.cc
@@ -56,8 +56,9 @@ TORCH_LIBRARY(graphbolt, m) {
        "UniqueAndCompactBatchedFuture")
       .def(
           "wait",
-          &Future<std::vector<
-              std::tuple<torch::Tensor, torch::Tensor, torch::Tensor>>>::Wait);
+          &Future<std::vector<std::tuple<
+              torch::Tensor, torch::Tensor, torch::Tensor, torch::Tensor>>>::
+              Wait);
   m.class_<Future<std::tuple<torch::Tensor, torch::Tensor, int64_t, int64_t>>>(
        "GpuGraphCacheQueryFuture")
       .def(

--- a/python/dgl/graphbolt/impl/in_subgraph_sampler.py
+++ b/python/dgl/graphbolt/impl/in_subgraph_sampler.py
@@ -74,6 +74,7 @@ class InSubgraphSampler(SubgraphSampler):
         (
             original_row_node_ids,
             compacted_csc_formats,
+            _,
         ) = unique_and_compact_csc_formats(subgraph.sampled_csc, seeds)
         subgraph = SampledSubgraphImpl(
             sampled_csc=compacted_csc_formats,

--- a/python/dgl/graphbolt/impl/neighbor_sampler.py
+++ b/python/dgl/graphbolt/impl/neighbor_sampler.py
@@ -507,7 +507,11 @@ class CompactPerLayer(MiniBatchTransformer):
     def _compact_per_layer_wait_future(minibatch):
         subgraph = minibatch.sampled_subgraphs[0]
         seeds = minibatch._seed_nodes
-        original_row_node_ids, compacted_csc_format = minibatch._future.wait()
+        (
+            original_row_node_ids,
+            compacted_csc_format,
+            _,
+        ) = minibatch._future.wait()
         delattr(minibatch, "_future")
         subgraph = SampledSubgraphImpl(
             sampled_csc=compacted_csc_format,

--- a/python/dgl/graphbolt/impl/neighbor_sampler.py
+++ b/python/dgl/graphbolt/impl/neighbor_sampler.py
@@ -471,6 +471,7 @@ class CompactPerLayer(MiniBatchTransformer):
             (
                 original_row_node_ids,
                 compacted_csc_format,
+                _,
             ) = unique_and_compact_csc_formats(subgraph.sampled_csc, seeds)
             subgraph = SampledSubgraphImpl(
                 sampled_csc=compacted_csc_format,

--- a/python/dgl/graphbolt/internal/sample_utils.py
+++ b/python/dgl/graphbolt/internal/sample_utils.py
@@ -43,7 +43,7 @@ def unique_and_compact(
         nums = [node.size(0) for node in nodes]
         nodes = torch.cat(nodes)
         empty_tensor = nodes.new_empty(0)
-        unique, compacted, _ = torch.ops.graphbolt.unique_and_compact(
+        unique, compacted, _, offsets = torch.ops.graphbolt.unique_and_compact(
             nodes, empty_tensor, empty_tensor, 0, 1
         )
         compacted = compacted.split(nums)
@@ -235,7 +235,12 @@ def unique_and_compact_csc_formats(
             unique_nodes = {}
             compacted_indices = {}
             for i, ntype in enumerate(ntypes):
-                unique_nodes[ntype], compacted_indices[ntype], _ = results[i]
+                (
+                    unique_nodes[ntype],
+                    compacted_indices[ntype],
+                    _,
+                    offsets,
+                ) = results[i]
 
             compacted_csc_formats = {}
             # Map back with the same order.

--- a/python/dgl/graphbolt/internal/sample_utils.py
+++ b/python/dgl/graphbolt/internal/sample_utils.py
@@ -17,7 +17,7 @@ def unique_and_compact(
     world_size: int = 1,
 ):
     """
-    Compact a list of nodes tensor. The rank and world_size parameters are
+    Compact a list of nodes tensor. The `rank` and `world_size` parameters are
     relevant when using Cooperative Minibatching, which was initially proposed
     in `Deep Graph Library PR#4337<https://github.com/dmlc/dgl/pull/4337>`__ and
     was later first fully described in

--- a/python/dgl/graphbolt/internal/sample_utils.py
+++ b/python/dgl/graphbolt/internal/sample_utils.py
@@ -67,7 +67,7 @@ def unique_and_compact(
         nums = [node.size(0) for node in nodes]
         nodes = torch.cat(nodes)
         empty_tensor = nodes.new_empty(0)
-        unique, compacted, offsets = torch.ops.graphbolt.unique_and_compact(
+        unique, compacted, _, offsets = torch.ops.graphbolt.unique_and_compact(
             nodes, empty_tensor, empty_tensor, rank, world_size
         )
         compacted = compacted.split(nums)
@@ -290,6 +290,7 @@ def unique_and_compact_csc_formats(
                 (
                     unique_nodes[ntype],
                     compacted_indices[ntype],
+                    _,
                     offsets[ntype],
                 ) = results[i]
 

--- a/python/dgl/graphbolt/internal/sample_utils.py
+++ b/python/dgl/graphbolt/internal/sample_utils.py
@@ -21,7 +21,7 @@ def unique_and_compact(
     relevant when using Cooperative Minibatching, which was initially proposed
     in `Deep Graph Library PR#4337<https://github.com/dmlc/dgl/pull/4337>`__ and
     was later first fully described in
-    `Cooperative Minibatching in Graph Neural Networks<https://arxiv.org/abs/2310.12403>`__. 
+    `Cooperative Minibatching in Graph Neural Networks<https://arxiv.org/abs/2310.12403>`__.
     Cooperation between the GPUs eliminates duplicate work performed across the
     GPUs due to the overlapping sampled k-hop neighborhoods of nodes when
     performing GNN minibatching.
@@ -55,7 +55,7 @@ def unique_and_compact(
         nodes list, where IDs inside are replaced with compacted node IDs.
         "Compacted node list" indicates that the node IDs in the input node
         list are replaced with mapped node IDs, where each type of node is
-        mapped to a contiguous space of IDs ranging from 0 to N. 
+        mapped to a contiguous space of IDs ranging from 0 to N.
         The unique nodes offsets tensor partitions the unique_nodes tensor. Has
         size `world_size + 1` and unique_nodes[offsets[i]: offsets[i + 1]]
         belongs to the rank `(rank + i) % world_size`.
@@ -75,9 +75,11 @@ def unique_and_compact(
     if is_heterogeneous:
         unique, compacted, offsets = {}, {}, {}
         for ntype, nodes_of_type in nodes.items():
-            unique[ntype], compacted[ntype], offsets[ntype] = unique_and_compact_per_type(
-                nodes_of_type
-            )
+            (
+                unique[ntype],
+                compacted[ntype],
+                offsets[ntype],
+            ) = unique_and_compact_per_type(nodes_of_type)
         return unique, compacted, offsets
     else:
         return unique_and_compact_per_type(nodes)

--- a/python/dgl/graphbolt/internal/sample_utils.py
+++ b/python/dgl/graphbolt/internal/sample_utils.py
@@ -21,7 +21,8 @@ def unique_and_compact(
     relevant when using Cooperative Minibatching, which was initially proposed
     in `Deep Graph Library PR#4337<https://github.com/dmlc/dgl/pull/4337>`__ and
     was later first fully described in
-    `Cooperative Minibatching in Graph Neural Networks<https://arxiv.org/abs/2310.12403>`__.
+    `Cooperative Minibatching in Graph Neural Networks
+    <https://arxiv.org/abs/2310.12403>`__
     Cooperation between the GPUs eliminates duplicate work performed across the
     GPUs due to the overlapping sampled k-hop neighborhoods of nodes when
     performing GNN minibatching.
@@ -156,9 +157,12 @@ def unique_and_compact_csc_formats(
     """
     Compact csc formats and return unique nodes (per type). The `rank` and
     `world_size` parameters are relevant when using Cooperative Minibatching,
-    which was initially proposed in `Deep Graph Library PR#4337<https://github.com/dmlc/dgl/pull/4337>`__
+    which was initially proposed in
+    `Deep Graph Library PR#4337<https://github.com/dmlc/dgl/pull/4337>`__
     and was later first fully described in
-    `Cooperative Minibatching in Graph Neural Networks<https://arxiv.org/abs/2310.12403>`__. Cooperation between the GPUs eliminates duplicate work performed across the
+    `Cooperative Minibatching in Graph Neural Networks
+    <https://arxiv.org/abs/2310.12403>`__
+    Cooperation between the GPUs eliminates duplicate work performed across the
     GPUs due to the overlapping sampled k-hop neighborhoods of nodes when
     performing GNN minibatching.
 

--- a/python/dgl/graphbolt/internal/sample_utils.py
+++ b/python/dgl/graphbolt/internal/sample_utils.py
@@ -67,7 +67,7 @@ def unique_and_compact(
         nums = [node.size(0) for node in nodes]
         nodes = torch.cat(nodes)
         empty_tensor = nodes.new_empty(0)
-        unique, compacted, _, offsets = torch.ops.graphbolt.unique_and_compact(
+        unique, compacted, offsets = torch.ops.graphbolt.unique_and_compact(
             nodes, empty_tensor, empty_tensor, rank, world_size
         )
         compacted = compacted.split(nums)
@@ -290,7 +290,6 @@ def unique_and_compact_csc_formats(
                 (
                     unique_nodes[ntype],
                     compacted_indices[ntype],
-                    _,
                     offsets[ntype],
                 ) = results[i]
 

--- a/python/dgl/graphbolt/internal/sample_utils.py
+++ b/python/dgl/graphbolt/internal/sample_utils.py
@@ -24,7 +24,7 @@ def unique_and_compact(
     `Cooperative Minibatching in Graph Neural Networks
     <https://arxiv.org/abs/2310.12403>`__
     Cooperation between the GPUs eliminates duplicate work performed across the
-    GPUs due to the overlapping sampled k-hop neighborhoods of nodes when
+    GPUs due to the overlapping sampled k-hop neighborhoods of seed nodes when
     performing GNN minibatching.
 
     When `world_size` is greater than 1, then the given ids are partitioned
@@ -163,7 +163,7 @@ def unique_and_compact_csc_formats(
     `Cooperative Minibatching in Graph Neural Networks
     <https://arxiv.org/abs/2310.12403>`__
     Cooperation between the GPUs eliminates duplicate work performed across the
-    GPUs due to the overlapping sampled k-hop neighborhoods of nodes when
+    GPUs due to the overlapping sampled k-hop neighborhoods of seed nodes when
     performing GNN minibatching.
 
     When `world_size` is greater than 1, then the given ids are partitioned

--- a/python/dgl/graphbolt/subgraph_sampler.py
+++ b/python/dgl/graphbolt/subgraph_sampler.py
@@ -163,7 +163,7 @@ class SubgraphSampler(MiniBatchTransformer):
                     compacted,
                 ) = compact_temporal_nodes(nodes, nodes_timestamp)
             else:
-                unique_seeds, compacted = unique_and_compact(nodes)
+                unique_seeds, compacted, _ = unique_and_compact(nodes)
                 nodes_timestamp = None
             compacted_seeds = {}
             # Map back in same order as collect.
@@ -212,7 +212,7 @@ class SubgraphSampler(MiniBatchTransformer):
                     compacted,
                 ) = compact_temporal_nodes(nodes, nodes_timestamp)
             else:
-                unique_seeds, compacted = unique_and_compact(nodes)
+                unique_seeds, compacted, _ = unique_and_compact(nodes)
                 nodes_timestamp = None
             # Map back in same order as collect.
             compacted_seeds = compacted[0].view(seeds.shape)

--- a/tests/python/pytorch/graphbolt/internal/test_sample_utils.py
+++ b/tests/python/pytorch/graphbolt/internal/test_sample_utils.py
@@ -50,7 +50,7 @@ def test_unique_and_compact_hetero():
         ],
     }
 
-    unique, compacted = gb.unique_and_compact(nodes_dict)
+    unique, compacted, _ = gb.unique_and_compact(nodes_dict)
     for ntype, nodes in unique.items():
         expected_nodes = expected_unique[ntype]
         assert torch.equal(nodes, expected_nodes)
@@ -84,7 +84,7 @@ def test_unique_and_compact_homo():
         torch.tensor([7, 8, 9, 0, 5], device=F.ctx()),
     ]
 
-    unique, compacted = gb.unique_and_compact(nodes_list)
+    unique, compacted, _ = gb.unique_and_compact(nodes_list)
 
     assert torch.equal(unique, expected_unique_N)
     assert isinstance(compacted, list)
@@ -133,7 +133,7 @@ def test_unique_and_compact_csc_formats_hetero():
         ),
     }
 
-    unique_nodes, compacted_csc_formats = gb.unique_and_compact_csc_formats(
+    unique_nodes, compacted_csc_formats, _ = gb.unique_and_compact_csc_formats(
         csc_formats, dst_nodes
     )
 
@@ -159,7 +159,7 @@ def test_unique_and_compact_csc_formats_homo():
     expected_indptr = indptr
     expected_indices = torch.tensor([3, 1, 0, 5, 2, 3, 2, 0, 5, 5, 4])
 
-    unique_nodes, compacted_csc_formats = gb.unique_and_compact_csc_formats(
+    unique_nodes, compacted_csc_formats, _ = gb.unique_and_compact_csc_formats(
         csc_formats, seeds
     )
 


### PR DESCRIPTION
## Description
Towards implementing #7273.

Tests will be in a follow-up PR.

## Checklist
Please feel free to remove inapplicable items for your PR.
- [ ] The PR title starts with [$CATEGORY] (such as [NN], [Model], [Doc], [Feature]])
- [ ] I've leverage the [tools](https://docs.google.com/document/d/1iHyj7zlmygKSk5gBPsqIqL5ASPzJSPREaNT_QdsiYA4/edit) to beautify the python and c++ code.
- [ ] The PR is complete and small, read the [Google eng practice (CL equals to PR)](https://google.github.io/eng-practices/review/developer/small-cls.html) to understand more about small PR. In DGL, we consider PRs with less than 200 lines of core code change are small (example, test and documentation could be exempted).
- [ ] All changes have test coverage
- [ ] Code is well-documented
- [ ] To the best of my knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change
- [ ] Related issue is referred in this PR
- [ ] If the PR is for a new model/paper, I've updated the example index [here](../examples/README.md).

## Changes
<!-- You could use following template
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)
-->
