### PR TITLE
[GraphBolt][CUDA] Refactor `gb.unique_and_compact`, add `async_op`.

### DIFF
--- a/python/dgl/graphbolt/impl/neighbor_sampler.py
+++ b/python/dgl/graphbolt/impl/neighbor_sampler.py
@@ -561,8 +561,8 @@ class NeighborSamplerImpl(SubgraphSampler):
             deduplicate,
             sampler,
             overlap_fetch,
-            asynchronous,
-            layer_dependency,
+            asynchronous=asynchronous,
+            layer_dependency=layer_dependency,
         )
 
     def _init_seed(self, batch_dependency):

--- a/python/dgl/graphbolt/internal/sample_utils.py
+++ b/python/dgl/graphbolt/internal/sample_utils.py
@@ -15,6 +15,7 @@ def unique_and_compact(
     ],
     rank: int = 0,
     world_size: int = 1,
+    async_op: bool = False,
 ):
     """
     Compact a list of nodes tensor. The `rank` and `world_size` parameters are
@@ -22,7 +23,7 @@ def unique_and_compact(
     in `Deep Graph Library PR#4337<https://github.com/dmlc/dgl/pull/4337>`__ and
     was later first fully described in
     `Cooperative Minibatching in Graph Neural Networks
-    <https://arxiv.org/abs/2310.12403>`__
+    <https://arxiv.org/abs/2310.12403>`__.
     Cooperation between the GPUs eliminates duplicate work performed across the
     GPUs due to the overlapping sampled k-hop neighborhoods of seed nodes when
     performing GNN minibatching.
@@ -48,6 +49,9 @@ def unique_and_compact(
         The rank of the current process.
     world_size : int
         The number of processes.
+    async_op: bool
+        Boolean indicating whether the call is asynchronous. If so, the result
+        can be obtained by calling wait on the returned future.
 
     Returns
     -------
@@ -63,27 +67,35 @@ def unique_and_compact(
     """
     is_heterogeneous = isinstance(nodes, dict)
 
-    def unique_and_compact_per_type(nodes):
-        nums = [node.size(0) for node in nodes]
-        nodes = torch.cat(nodes)
-        empty_tensor = nodes.new_empty(0)
-        unique, compacted, _, offsets = torch.ops.graphbolt.unique_and_compact(
-            nodes, empty_tensor, empty_tensor, rank, world_size
-        )
-        compacted = compacted.split(nums)
-        return unique, list(compacted), offsets
+    if not is_heterogeneous:
+        homo_ntype = 'a'
+        nodes = {homo_ntype: nodes}
 
+    nums = {}
+    concat_nodes, empties = [], []
+    for ntype, nodes_of_type in nodes.items():
+        nums[ntype] = [node.size(0) for node in nodes_of_type]
+        concat_nodes.append(torch.cat(nodes_of_type))
+        empties.append(concat_nodes[-1].new_empty(0))
+    unique_fn = (
+        torch.ops.graphbolt.unique_and_compact_batched_async
+        if async_op
+        else torch.ops.graphbolt.unique_and_compact_batched
+    )
+    results = unique_fn(concat_nodes, empties, empties, rank, world_size)
+    unique, compacted, offsets = {}, {}, {}
+    for ntype, result in zip(nodes.keys(), results):
+        (
+            unique[ntype],
+            concat_compacted,
+            _,
+            offsets[ntype],
+        ) = result
+        compacted[ntype] = list(concat_compacted.split(nums[ntype]))
     if is_heterogeneous:
-        unique, compacted, offsets = {}, {}, {}
-        for ntype, nodes_of_type in nodes.items():
-            (
-                unique[ntype],
-                compacted[ntype],
-                offsets[ntype],
-            ) = unique_and_compact_per_type(nodes_of_type)
         return unique, compacted, offsets
     else:
-        return unique_and_compact_per_type(nodes)
+        return unique[homo_ntype], compacted[homo_ntype], offsets[homo_ntype]
 
 
 def compact_temporal_nodes(nodes, nodes_timestamp):
@@ -161,7 +173,7 @@ def unique_and_compact_csc_formats(
     `Deep Graph Library PR#4337<https://github.com/dmlc/dgl/pull/4337>`__
     and was later first fully described in
     `Cooperative Minibatching in Graph Neural Networks
-    <https://arxiv.org/abs/2310.12403>`__
+    <https://arxiv.org/abs/2310.12403>`__.
     Cooperation between the GPUs eliminates duplicate work performed across the
     GPUs due to the overlapping sampled k-hop neighborhoods of seed nodes when
     performing GNN minibatching.

--- a/python/dgl/graphbolt/internal/sample_utils.py
+++ b/python/dgl/graphbolt/internal/sample_utils.py
@@ -68,7 +68,7 @@ def unique_and_compact(
     is_heterogeneous = isinstance(nodes, dict)
 
     if not is_heterogeneous:
-        homo_ntype = 'a'
+        homo_ntype = "a"
         nodes = {homo_ntype: nodes}
 
     nums = {}
@@ -110,7 +110,11 @@ def unique_and_compact(
             if is_heterogeneous:
                 return unique, compacted, offsets
             else:
-                return unique[homo_ntype], compacted[homo_ntype], offsets[homo_ntype]
+                return (
+                    unique[homo_ntype],
+                    compacted[homo_ntype],
+                    offsets[homo_ntype],
+                )
 
     post_processer = _Waiter(results, nodes.keys(), nums)
     if async_op:

--- a/python/dgl/graphbolt/subgraph_sampler.py
+++ b/python/dgl/graphbolt/subgraph_sampler.py
@@ -75,7 +75,7 @@ class SubgraphSampler(MiniBatchTransformer):
         return minibatch
 
     @staticmethod
-    def _preprocess(minibatch, async_op: bool = False):
+    def _preprocess(minibatch, async_op: bool):
         if minibatch.seeds is None:
             raise ValueError(
                 f"Invalid minibatch {minibatch}: `seeds` should have a value."

--- a/python/dgl/graphbolt/subgraph_sampler.py
+++ b/python/dgl/graphbolt/subgraph_sampler.py
@@ -1,6 +1,7 @@
 """Subgraph samplers"""
 
 from collections import defaultdict
+from functools import partial
 from typing import Dict
 
 import torch
@@ -13,6 +14,18 @@ from .minibatch_transformer import MiniBatchTransformer
 __all__ = [
     "SubgraphSampler",
 ]
+
+
+class _NoOpWaiter:
+    def __init__(self, result):
+        self.result = result
+
+    def wait(self):
+        """Returns the stored value when invoked."""
+        result = self.result
+        # Ensure there is no memory leak.
+        self.result = None
+        return result
 
 
 @functional_datapipe("sample_subgraph")
@@ -35,7 +48,9 @@ class SubgraphSampler(MiniBatchTransformer):
     args : Non-Keyword Arguments
         Arguments to be passed into sampling_stages.
     kwargs : Keyword Arguments
-        Arguments to be passed into sampling_stages.
+        Arguments to be passed into sampling_stages. Preprocessing stage makes
+        use of the `asynchronous` parameter before it is passed to
+        the sampling stages.
     """
 
     def __init__(
@@ -44,7 +59,11 @@ class SubgraphSampler(MiniBatchTransformer):
         *args,
         **kwargs,
     ):
-        datapipe = datapipe.transform(self._preprocess)
+        async_op = kwargs.get("asynchronous", False)
+        preprocess_fn = partial(self._preprocess, async_op=async_op)
+        datapipe = datapipe.transform(preprocess_fn)
+        if async_op:
+            datapipe = datapipe.buffer().transform(self._wait_preprocess_future)
         datapipe = self.sampling_stages(datapipe, *args, **kwargs)
         datapipe = datapipe.transform(self._postprocess)
         super().__init__(datapipe)
@@ -56,19 +75,30 @@ class SubgraphSampler(MiniBatchTransformer):
         return minibatch
 
     @staticmethod
-    def _preprocess(minibatch):
-        if minibatch.seeds is not None:
-            (
-                seeds,
-                seeds_timestamp,
-                minibatch.compacted_seeds,
-            ) = SubgraphSampler._seeds_preprocess(minibatch)
-        else:
+    def _preprocess(minibatch, async_op: bool = False):
+        if minibatch.seeds is None:
             raise ValueError(
                 f"Invalid minibatch {minibatch}: `seeds` should have a value."
             )
-        minibatch._seed_nodes = seeds
-        minibatch._seeds_timestamp = seeds_timestamp
+        results = SubgraphSampler._seeds_preprocess(minibatch, async_op)
+        if async_op:
+            minibatch._preprocess_future = results
+        else:
+            (
+                minibatch._seed_nodes,
+                minibatch._seeds_timestamp,
+                minibatch.compacted_seeds,
+            ) = results
+        return minibatch
+
+    @staticmethod
+    def _wait_preprocess_future(minibatch):
+        (
+            minibatch._seed_nodes,
+            minibatch._seeds_timestamp,
+            minibatch.compacted_seeds,
+        ) = minibatch._preprocess_future.wait()
+        delattr(minibatch, "_preprocess_future")
         return minibatch
 
     def _sample(self, minibatch):
@@ -89,7 +119,7 @@ class SubgraphSampler(MiniBatchTransformer):
         return datapipe.transform(self._sample)
 
     @staticmethod
-    def _seeds_preprocess(minibatch):
+    def _seeds_preprocess(minibatch, async_op):
         """Preprocess `seeds` in a minibatch to construct `unique_seeds`,
         `node_timestamp` and `compacted_seeds` for further sampling. It
         optionally incorporates timestamps for temporal graphs, organizing and
@@ -100,6 +130,9 @@ class SubgraphSampler(MiniBatchTransformer):
         ----------
         minibatch: MiniBatch
             The minibatch.
+        async_op: bool
+            Boolean indicating whether the call is asynchronous. If so, the
+            result can be obtained by calling wait on the returned future.
 
         Returns
         -------
@@ -131,7 +164,9 @@ class SubgraphSampler(MiniBatchTransformer):
                         if hasattr(minibatch, "timestamp")
                         else None
                     )
-                    return seeds, nodes_timestamp, None
+                    result = _NoOpWaiter((seeds, nodes_timestamp, None))
+                    break
+                result = None
                 assert typed_seeds.ndim == 2, (
                     "Only tensor with shape 1*N and N*M is "
                     + f"supported now, but got {typed_seeds.shape}."
@@ -155,28 +190,55 @@ class SubgraphSampler(MiniBatchTransformer):
                             minibatch.timestamp[seed_type]
                         )
                         nodes_timestamp[ntype].append(neg_timestamp)
-            # Unique and compact the collected nodes.
-            if use_timestamp:
-                (
-                    unique_seeds,
-                    nodes_timestamp,
-                    compacted,
-                ) = compact_temporal_nodes(nodes, nodes_timestamp)
-            else:
-                unique_seeds, compacted, _ = unique_and_compact(nodes)
-                nodes_timestamp = None
-            compacted_seeds = {}
-            # Map back in same order as collect.
-            for seed_type, typed_seeds in seeds.items():
-                ntypes = seed_type_str_to_ntypes(
-                    seed_type, typed_seeds.shape[1]
-                )
-                compacted_seed = []
-                for ntype in ntypes:
-                    compacted_seed.append(compacted[ntype].pop(0))
-                compacted_seeds[seed_type] = (
-                    torch.cat(compacted_seed).view(len(ntypes), -1).T
-                )
+
+            class _Waiter:
+                def __init__(self, nodes, nodes_timestamp, seeds):
+                    # Unique and compact the collected nodes.
+                    if use_timestamp:
+                        self.future = compact_temporal_nodes(
+                            nodes, nodes_timestamp
+                        )
+                    else:
+                        self.future = unique_and_compact(
+                            nodes, async_op=async_op
+                        )
+                    self.seeds = seeds
+
+                def wait(self):
+                    """Returns the stored value when invoked."""
+                    if use_timestamp:
+                        unique_seeds, nodes_timestamp, compacted = self.future
+                    else:
+                        unique_seeds, compacted, _ = (
+                            self.future.wait() if async_op else self.future
+                        )
+                        nodes_timestamp = None
+                    seeds = self.seeds
+                    # Ensure there is no memory leak.
+                    self.future = self.seeds = None
+
+                    compacted_seeds = {}
+                    # Map back in same order as collect.
+                    for seed_type, typed_seeds in seeds.items():
+                        ntypes = seed_type_str_to_ntypes(
+                            seed_type, typed_seeds.shape[1]
+                        )
+                        compacted_seed = []
+                        for ntype in ntypes:
+                            compacted_seed.append(compacted[ntype].pop(0))
+                        compacted_seeds[seed_type] = (
+                            torch.cat(compacted_seed).view(len(ntypes), -1).T
+                        )
+
+                    return (
+                        unique_seeds,
+                        nodes_timestamp,
+                        compacted_seeds,
+                    )
+
+            # When typed_seeds is not a one-dimensional tensor
+            if result is None:
+                result = _Waiter(nodes, nodes_timestamp, seeds)
         else:
             # When seeds is a one-dimensional tensor, it represents seed nodes,
             # which does not need to do unique and compact.
@@ -186,41 +248,68 @@ class SubgraphSampler(MiniBatchTransformer):
                     if hasattr(minibatch, "timestamp")
                     else None
                 )
-                return seeds, nodes_timestamp, None
-            # Collect nodes from all types of input.
-            nodes = [seeds.view(-1)]
-            nodes_timestamp = None
-            if use_timestamp:
-                # Timestamp for source and destination nodes are the same.
-                negative_ratio = (
-                    seeds.shape[0] // minibatch.timestamp.shape[0] - 1
-                )
-                neg_timestamp = minibatch.timestamp.repeat_interleave(
-                    negative_ratio
-                )
-                seeds_timestamp = torch.cat(
-                    (minibatch.timestamp, neg_timestamp)
-                )
-                nodes_timestamp = [
-                    seeds_timestamp for _ in range(seeds.shape[1])
-                ]
-            # Unique and compact the collected nodes.
-            if use_timestamp:
-                (
-                    unique_seeds,
-                    nodes_timestamp,
-                    compacted,
-                ) = compact_temporal_nodes(nodes, nodes_timestamp)
+                result = _NoOpWaiter((seeds, nodes_timestamp, None))
             else:
-                unique_seeds, compacted, _ = unique_and_compact(nodes)
+                # Collect nodes from all types of input.
+                nodes = [seeds.view(-1)]
                 nodes_timestamp = None
-            # Map back in same order as collect.
-            compacted_seeds = compacted[0].view(seeds.shape)
-        return (
-            unique_seeds,
-            nodes_timestamp,
-            compacted_seeds,
-        )
+                if use_timestamp:
+                    # Timestamp for source and destination nodes are the same.
+                    negative_ratio = (
+                        seeds.shape[0] // minibatch.timestamp.shape[0] - 1
+                    )
+                    neg_timestamp = minibatch.timestamp.repeat_interleave(
+                        negative_ratio
+                    )
+                    seeds_timestamp = torch.cat(
+                        (minibatch.timestamp, neg_timestamp)
+                    )
+                    nodes_timestamp = [
+                        seeds_timestamp for _ in range(seeds.shape[1])
+                    ]
+
+                class _Waiter:
+                    def __init__(self, nodes, nodes_timestamp, seeds):
+                        # Unique and compact the collected nodes.
+                        if use_timestamp:
+                            self.future = compact_temporal_nodes(
+                                nodes, nodes_timestamp
+                            )
+                        else:
+                            self.future = unique_and_compact(
+                                nodes, async_op=async_op
+                            )
+                        self.seeds = seeds
+
+                    def wait(self):
+                        """Returns the stored value when invoked."""
+                        if use_timestamp:
+                            (
+                                unique_seeds,
+                                nodes_timestamp,
+                                compacted,
+                            ) = self.future
+                        else:
+                            unique_seeds, compacted, _ = (
+                                self.future.wait() if async_op else self.future
+                            )
+                            nodes_timestamp = None
+                        seeds = self.seeds
+                        # Ensure there is no memory leak.
+                        self.future = self.seeds = None
+
+                        # Map back in same order as collect.
+                        compacted_seeds = compacted[0].view(seeds.shape)
+
+                        return (
+                            unique_seeds,
+                            nodes_timestamp,
+                            compacted_seeds,
+                        )
+
+                result = _Waiter(nodes, nodes_timestamp, seeds)
+
+        return result if async_op else result.wait()
 
     def sample_subgraphs(
         self, seeds, seeds_timestamp, seeds_pre_time_window=None

--- a/tests/python/pytorch/graphbolt/impl/test_neighbor_sampler.py
+++ b/tests/python/pytorch/graphbolt/impl/test_neighbor_sampler.py
@@ -65,7 +65,8 @@ def test_NeighborSampler_GraphFetch(
         graph.type_per_edge = None
     item_sampler = gb.ItemSampler(itemset, batch_size=2).copy_to(F.ctx())
     fanout = torch.LongTensor([2])
-    datapipe = item_sampler.map(gb.SubgraphSampler._preprocess)
+    preprocess_fn = partial(gb.SubgraphSampler._preprocess, async_op=False)
+    datapipe = item_sampler.map(preprocess_fn)
     datapipe = datapipe.map(
         partial(gb.NeighborSampler._prepare, graph.node_type_to_id)
     )

--- a/tests/python/pytorch/graphbolt/test_dataloader.py
+++ b/tests/python/pytorch/graphbolt/test_dataloader.py
@@ -137,7 +137,7 @@ def test_gpu_sampling_DataLoader(
         if num_gpu_cached_edges > 0:
             bufferer_cnt += 2 * num_layers
     if asynchronous:
-        bufferer_cnt += 2 * num_layers
+        bufferer_cnt += 2 * num_layers + 1  # _preprocess stage has 1.
     datapipe_graph = traverse_dps(dataloader)
     bufferers = find_dps(
         datapipe_graph,


### PR DESCRIPTION
## Description
Somehow, the PR ended up being this long because there are various branches.

I wonder if there is a way to generalize...

## Checklist
Please feel free to remove inapplicable items for your PR.
- [ ] The PR title starts with [$CATEGORY] (such as [NN], [Model], [Doc], [Feature]])
- [ ] I've leverage the [tools](https://docs.google.com/document/d/1iHyj7zlmygKSk5gBPsqIqL5ASPzJSPREaNT_QdsiYA4/edit) to beautify the python and c++ code.
- [ ] The PR is complete and small, read the [Google eng practice (CL equals to PR)](https://google.github.io/eng-practices/review/developer/small-cls.html) to understand more about small PR. In DGL, we consider PRs with less than 200 lines of core code change are small (example, test and documentation could be exempted).
- [ ] All changes have test coverage
- [ ] Code is well-documented
- [ ] To the best of my knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change
- [ ] Related issue is referred in this PR
- [ ] If the PR is for a new model/paper, I've updated the example index [here](../examples/README.md).

## Changes
<!-- You could use following template
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)
-->
