### PR TITLE
[GraphBolt][CUDA] Cooperative Minibatching initial exchange.

### DIFF
--- a/python/dgl/graphbolt/internal/sample_utils.py
+++ b/python/dgl/graphbolt/internal/sample_utils.py
@@ -349,6 +349,7 @@ def unique_and_compact_csc_formats(
             if is_homogeneous:
                 compacted_csc_formats = list(compacted_csc_formats.values())[0]
                 unique_nodes = list(unique_nodes.values())[0]
+                offsets = list(offsets.values())[0]
 
             return unique_nodes, compacted_csc_formats, offsets
 

--- a/python/dgl/graphbolt/subgraph_sampler.py
+++ b/python/dgl/graphbolt/subgraph_sampler.py
@@ -30,12 +30,16 @@ class _NoOpWaiter:
         return result
 
 
-def _shift(l: list, group=None):
-    cutoff = len(l) - thd.get_rank(group)
-    return l[cutoff:] + l[:cutoff]
+def _shift(inputs: list, group=None):
+    cutoff = len(inputs) - thd.get_rank(group)
+    return inputs[cutoff:] + inputs[:cutoff]
 
 
 def all_to_all(outputs, inputs, group=None, async_op=False):
+    """Wrapper for thd.all_to_all that permuted outputs and inputs before
+    calling it. The arguments have the permutation
+    `rank, ..., world_size - 1, 0, ..., rank - 1` and we make it
+    `0, world_size - 1` before calling `thd.all_to_all`."""
     shift_fn = partial(_shift, group=group)
     return thd.all_to_all(shift_fn(outputs), shift_fn(inputs), group, async_op)
 

--- a/python/dgl/graphbolt/subgraph_sampler.py
+++ b/python/dgl/graphbolt/subgraph_sampler.py
@@ -253,7 +253,7 @@ class SubgraphSampler(MiniBatchTransformer):
         unique_seeds, inverse_seeds, _ = minibatch._unique_future.wait()
         delattr(minibatch, "_unique_future")
         minibatch._seed_nodes = unique_seeds
-        minibatch._inverse_seeds = inverse_seeds
+        minibatch._seed_inverse_ids = inverse_seeds
         return minibatch
 
     def _sample(self, minibatch):

--- a/tests/python/pytorch/graphbolt/impl/test_neighbor_sampler.py
+++ b/tests/python/pytorch/graphbolt/impl/test_neighbor_sampler.py
@@ -65,7 +65,9 @@ def test_NeighborSampler_GraphFetch(
         graph.type_per_edge = None
     item_sampler = gb.ItemSampler(itemset, batch_size=2).copy_to(F.ctx())
     fanout = torch.LongTensor([2])
-    preprocess_fn = partial(gb.SubgraphSampler._preprocess, cooperative=False, async_op=False)
+    preprocess_fn = partial(
+        gb.SubgraphSampler._preprocess, cooperative=False, async_op=False
+    )
     datapipe = item_sampler.map(preprocess_fn)
     datapipe = datapipe.map(
         partial(gb.NeighborSampler._prepare, graph.node_type_to_id)

--- a/tests/python/pytorch/graphbolt/impl/test_neighbor_sampler.py
+++ b/tests/python/pytorch/graphbolt/impl/test_neighbor_sampler.py
@@ -65,7 +65,7 @@ def test_NeighborSampler_GraphFetch(
         graph.type_per_edge = None
     item_sampler = gb.ItemSampler(itemset, batch_size=2).copy_to(F.ctx())
     fanout = torch.LongTensor([2])
-    preprocess_fn = partial(gb.SubgraphSampler._preprocess, async_op=False)
+    preprocess_fn = partial(gb.SubgraphSampler._preprocess, cooperative=False, async_op=False)
     datapipe = item_sampler.map(preprocess_fn)
     datapipe = datapipe.map(
         partial(gb.NeighborSampler._prepare, graph.node_type_to_id)


### PR DESCRIPTION
## Description
Towards implementing #7273.

The code is untested right now. I need to merge some of the changes so that the PR size stays limited.

The initial exchange is required because each process needs to sample for the nodes they are assigned. There is no guarantee about any partitioning after things come from ItemSampler or when negative edges are added. Thus, initial exchange ensures that each process samples only for the nodes that they own.

Follow up work:

1. Exchanges after each sampling stage.
2. Add torch layer for GNN forward backward using Cooperative Minibatching and stored tensors including exchange information.
3. Add multi-GPU example showcasing Cooperative Minibatching.
4. Optimize Cooperative Minibatching using partitioning. (More details to come later.)


## Checklist
Please feel free to remove inapplicable items for your PR.
- [ ] The PR title starts with [$CATEGORY] (such as [NN], [Model], [Doc], [Feature]])
- [ ] I've leverage the [tools](https://docs.google.com/document/d/1iHyj7zlmygKSk5gBPsqIqL5ASPzJSPREaNT_QdsiYA4/edit) to beautify the python and c++ code.
- [ ] The PR is complete and small, read the [Google eng practice (CL equals to PR)](https://google.github.io/eng-practices/review/developer/small-cls.html) to understand more about small PR. In DGL, we consider PRs with less than 200 lines of core code change are small (example, test and documentation could be exempted).
- [ ] All changes have test coverage
- [ ] Code is well-documented
- [ ] To the best of my knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change
- [ ] Related issue is referred in this PR
- [ ] If the PR is for a new model/paper, I've updated the example index [here](../examples/README.md).

## Changes
<!-- You could use following template
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)
-->
