### PR TITLE
[GraphBolt][CUDA] Get `world_size=1` somewhat for cooperative sampling.

### DIFF
--- a/python/dgl/graphbolt/subgraph_sampler.py
+++ b/python/dgl/graphbolt/subgraph_sampler.py
@@ -67,6 +67,7 @@ def all_to_all(outputs, inputs, group=None, async_op=False):
             self.temp_outputs = temp_outputs
 
         def wait(self):
+            """Returns the stored value when invoked."""
             handle = self.handle
             outputs = self.outputs
             temp_outputs = self.temp_outputs


### PR DESCRIPTION
## Description
Towards implementing #7273

The implementation of cooperative sampling is mostly done. The code path is tested with a single process for now while the expected outputs are not tested yet.

There will be multiple follow-up PRs to polish the code, test more throughly, add more documentation and get everything working.

I have to merge to master often because otherwise there will be too much code. When it is done, I will make sure the code is in good shape.

## Checklist
Please feel free to remove inapplicable items for your PR.
- [ ] The PR title starts with [$CATEGORY] (such as [NN], [Model], [Doc], [Feature]])
- [ ] I've leverage the [tools](https://docs.google.com/document/d/1iHyj7zlmygKSk5gBPsqIqL5ASPzJSPREaNT_QdsiYA4/edit) to beautify the python and c++ code.
- [ ] The PR is complete and small, read the [Google eng practice (CL equals to PR)](https://google.github.io/eng-practices/review/developer/small-cls.html) to understand more about small PR. In DGL, we consider PRs with less than 200 lines of core code change are small (example, test and documentation could be exempted).
- [ ] All changes have test coverage
- [ ] Code is well-documented
- [ ] To the best of my knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change
- [ ] Related issue is referred in this PR
- [ ] If the PR is for a new model/paper, I've updated the example index [here](../examples/README.md).

## Changes
<!-- You could use following template
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)
-->
