### PR TITLE
 [Test] Fixing issues related to `SampledHeteroCSC` and `StaticHeteroCSC` deprecation.

### DIFF
--- a/python/dgl/nn/pytorch/conv/cugraph_relgraphconv.py
+++ b/python/dgl/nn/pytorch/conv/cugraph_relgraphconv.py
@@ -9,7 +9,7 @@ from torch import nn
 from .cugraph_base import CuGraphBaseConv
 
 try:
-    from pylibcugraphops.pytorch import SampledHeteroCSC, StaticHeteroCSC
+    from pylibcugraphops.pytorch import HeteroCSC
     from pylibcugraphops.pytorch.operators import (
         agg_hg_basis_n2n_post as RelGraphConvAgg,
     )
@@ -188,27 +188,28 @@ class CuGraphRelGraphConv(CuGraphBaseConv):
                 max_in_degree = g.in_degrees().max().item()
 
             if max_in_degree < self.MAX_IN_DEGREE_MFG:
-                _graph = SampledHeteroCSC(
+                _graph = HeteroCSC(
                     offsets,
                     indices,
                     edge_types_perm,
-                    max_in_degree,
                     g.num_src_nodes(),
                     self.num_rels,
                 )
             else:
                 offsets_fg = self.pad_offsets(offsets, g.num_src_nodes() + 1)
-                _graph = StaticHeteroCSC(
+                _graph = HeteroCSC(
                     offsets_fg,
                     indices,
                     edge_types_perm,
+                    g.num_src_nodes(),
                     self.num_rels,
                 )
         else:
-            _graph = StaticHeteroCSC(
+            _graph = HeteroCSC(
                 offsets,
                 indices,
                 edge_types_perm,
+                g.num_src_nodes(),
                 self.num_rels,
             )
 


### PR DESCRIPTION

## Description
<!-- Brief description. Refer to the related issues if existed.
It'll be great if relevant reviewers can be assigned as well.-->

As we can see [here](https://github.com/pyg-team/pytorch_geometric/issues/8570):
```
test/nn/conv/cugraph/test_cugraph_rgcn_conv.py: 72 warnings
  /usr/local/lib/python3.10/dist-packages/pylibcugraphops/pytorch/graph.py:302: DeprecationWarning: SampledHeteroCSC is deprecated with the 23.08 release and will be removed in 23.10, use HeteroCSC instead.
    warnings.warn(
test/nn/conv/cugraph/test_cugraph_rgcn_conv.py: 72 warnings
  /usr/local/lib/python3.10/dist-packages/pylibcugraphops/pytorch/graph.py:330: DeprecationWarning: StaticHeteroCSC is deprecated with the 23.08 release and will be removed in 23.10, use HeteroCSC instead.
    warnings.warn(
```
the `SampledHeteroCSC` and `StaticHeteroCSC` classes were expected to be deprecated. Since `pylibcugraphops-24.8` does not contain these classes, the `examples/advanced/cugraph/rgcn.py` test fails. That PR addresses this issue by implementing the necessary changes.

## Checklist
Please feel free to remove inapplicable items for your PR.
- [x] The PR title starts with [$CATEGORY] (such as [NN], [Model], [Doc], [Feature]])
- [x] I've leverage the [tools](https://docs.google.com/document/d/1iHyj7zlmygKSk5gBPsqIqL5ASPzJSPREaNT_QdsiYA4/edit) to beautify the python and c++ code.
- [x] The PR is complete and small, read the [Google eng practice (CL equals to PR)](https://google.github.io/eng-practices/review/developer/small-cls.html) to understand more about small PR. In DGL, we consider PRs with less than 200 lines of core code change are small (example, test and documentation could be exempted).
- [x] To the best of my knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

## Changes
<!-- You could use following template
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)
-->
