### PR TITLE
[FutureWarning] Remove the usage of the deprecated parameter.

### DIFF
--- a/examples/distributed/graphsage/node_classification_unsupervised.py
+++ b/examples/distributed/graphsage/node_classification_unsupervised.py
@@ -175,7 +175,7 @@ def compute_acc(emb, labels, train_nids, val_nids, test_nids):
     labels = labels.cpu().numpy()
 
     emb = (emb - emb.mean(0, keepdims=True)) / emb.std(0, keepdims=True)
-    lr = lm.LogisticRegression(multi_class="multinomial", max_iter=10000)
+    lr = lm.LogisticRegression(max_iter=10000)
     lr.fit(emb[train_nids], labels[train_nids])
 
     pred = lr.predict(emb)

--- a/examples/pytorch/graphsage/advanced/model.py
+++ b/examples/pytorch/graphsage/advanced/model.py
@@ -104,7 +104,7 @@ def compute_acc_unsupervised(emb, labels, train_nids, val_nids, test_nids):
 
     emb = (emb - emb.mean(0, keepdims=True)) / emb.std(0, keepdims=True)
 
-    lr = lm.LogisticRegression(multi_class="multinomial", max_iter=10000)
+    lr = lm.LogisticRegression(max_iter=10000)
     lr.fit(emb[train_nids], train_labels)
 
     pred = lr.predict(emb)

--- a/examples/pytorch/graphsage/dist/train_dist_unsupervised.py
+++ b/examples/pytorch/graphsage/dist/train_dist_unsupervised.py
@@ -175,7 +175,7 @@ def compute_acc(emb, labels, train_nids, val_nids, test_nids):
     labels = labels.cpu().numpy()
 
     emb = (emb - emb.mean(0, keepdims=True)) / emb.std(0, keepdims=True)
-    lr = lm.LogisticRegression(multi_class="multinomial", max_iter=10000)
+    lr = lm.LogisticRegression(max_iter=10000)
     lr.fit(emb[train_nids], labels[train_nids])
 
     pred = lr.predict(emb)

--- a/examples/pytorch/metapath2vec/test.py
+++ b/examples/pytorch/metapath2vec/test.py
@@ -95,11 +95,11 @@ if __name__ == "__main__":
         file.close()
         print("beging predicting")
         clf_venue = LogisticRegression(
-            random_state=0, solver="lbfgs", multi_class="multinomial"
+            random_state=0, solver="lbfgs"
         ).fit(venue_training, venue_label)
         y_pred_venue = clf_venue.predict(venue_testing)
         clf_author = LogisticRegression(
-            random_state=0, solver="lbfgs", multi_class="multinomial"
+            random_state=0, solver="lbfgs"
         ).fit(author_training, author_label)
         y_pred_author = clf_author.predict(author_testing)
         macro_average_venue += f1_score(

--- a/examples/pytorch/multigpu/multi_gpu_link_prediction.py
+++ b/examples/pytorch/multigpu/multi_gpu_link_prediction.py
@@ -142,7 +142,7 @@ def compute_acc_unsupervised(emb, labels, train_nids, val_nids, test_nids):
     test_nids = test_nids.cpu().numpy()
     test_labels = labels[test_nids]
     emb = (emb - emb.mean(0, keepdims=True)) / emb.std(0, keepdims=True)
-    lr = lm.LogisticRegression(multi_class="multinomial", max_iter=10000)
+    lr = lm.LogisticRegression(max_iter=10000)
     lr.fit(emb[train_nids], train_labels)
     pred = lr.predict(emb)
     f1_micro_eval = skm.f1_score(val_labels, pred[val_nids], average="micro")

--- a/examples/pytorch/node2vec/model.py
+++ b/examples/pytorch/node2vec/model.py
@@ -191,7 +191,7 @@ class Node2vec(nn.Module):
         x_train, y_train = x_train.cpu().numpy(), y_train.cpu().numpy()
         x_val, y_val = x_val.cpu().numpy(), y_val.cpu().numpy()
         lr = LogisticRegression(
-            solver="lbfgs", multi_class="auto", max_iter=150
+            solver="lbfgs", max_iter=150
         ).fit(x_train, y_train)
 
         return lr.score(x_val, y_val)


### PR DESCRIPTION
## Description
<!-- Brief description. Refer to the related issues if existed.
It'll be great if relevant reviewers can be assigned as well.-->

By removing the deprecated `multi_class` parameter in `LogisticRegression(...)` calls, as indicated by following warnings, 
```
/usr/local/lib/python3.10/dist-packages/sklearn/linear_model/_logistic.py:1247: FutureWarning: 'multi_class' was deprecated in version 1.5 and will be removed in 1.7. From then on, it will always use 'multinomial'. Leave it to its default value to avoid this warning.
  warnings.warn(
```
we eliminate these warnings.


## Checklist
Please feel free to remove inapplicable items for your PR.
- [x] The PR title starts with [$CATEGORY] (such as [NN], [Model], [Doc], [Feature]])
- [x] I've leverage the [tools](https://docs.google.com/document/d/1iHyj7zlmygKSk5gBPsqIqL5ASPzJSPREaNT_QdsiYA4/edit) to beautify the python and c++ code.
- [x] The PR is complete and small, read the [Google eng practice (CL equals to PR)](https://google.github.io/eng-practices/review/developer/small-cls.html) to understand more about small PR. In DGL, we consider PRs with less than 200 lines of core code change are small (example, test and documentation could be exempted).

## Changes
<!-- You could use following template
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)
-->
