### PR TITLE
[UserWarning] Eliminating the use of the deprecated `verbose` parameter.

### DIFF
--- a/examples/pytorch/ogb/directional_GSN/main.py
+++ b/examples/pytorch/ogb/directional_GSN/main.py
@@ -302,7 +302,7 @@ def train(dataset, params):
 
     optimizer = optim.Adam(model.parameters(), lr=0.0008, weight_decay=1e-5)
     scheduler = optim.lr_scheduler.ReduceLROnPlateau(
-        optimizer, mode="min", factor=0.8, patience=8, verbose=True
+        optimizer, mode="min", factor=0.8, patience=8
     )
 
     epoch_train_losses, epoch_val_losses = [], []

--- a/examples/pytorch/ogb/ogbn-arxiv/gcn.py
+++ b/examples/pytorch/ogb/ogbn-arxiv/gcn.py
@@ -136,7 +136,6 @@ def run(
         mode="min",
         factor=0.5,
         patience=100,
-        verbose=True,
         min_lr=1e-3,
     )
 

--- a/examples/pytorch/ogb/ogbn-products/gat/gat.py
+++ b/examples/pytorch/ogb/ogbn-products/gat/gat.py
@@ -302,7 +302,6 @@ def run(
         mode="max",
         factor=0.7,
         patience=20,
-        verbose=True,
         min_lr=1e-4,
     )
 

--- a/examples/pytorch/ogb/ogbn-products/mlp/mlp.py
+++ b/examples/pytorch/ogb/ogbn-products/mlp/mlp.py
@@ -215,7 +215,6 @@ def run(
         mode="max",
         factor=0.7,
         patience=20,
-        verbose=True,
         min_lr=1e-4,
     )
 

--- a/examples/pytorch/ogb/ogbn-proteins/gat.py
+++ b/examples/pytorch/ogb/ogbn-proteins/gat.py
@@ -246,7 +246,7 @@ def run(
         model.parameters(), lr=args.lr, weight_decay=args.wd
     )
     lr_scheduler = optim.lr_scheduler.ReduceLROnPlateau(
-        optimizer, mode="max", factor=0.75, patience=50, verbose=True
+        optimizer, mode="max", factor=0.75, patience=50
     )
 
     total_time = 0


### PR DESCRIPTION
## Description
<!-- Brief description. Refer to the related issues if existed.
It'll be great if relevant reviewers can be assigned as well.-->
By removing the use of the deprecated verbose parameter, we are eliminating the associated warnings.
```
/usr/local/lib/python3.10/dist-packages/torch/optim/lr_scheduler.py:63: UserWarning: The verbose parameter is deprecated.
Please use get_last_lr() to access the learning rate.
  warnings.warn(
```

## Checklist
Please feel free to remove inapplicable items for your PR.
- [x] The PR title starts with [$CATEGORY] (such as [NN], [Model], [Doc], [Feature]])
- [x] I've leverage the [tools](https://docs.google.com/document/d/1iHyj7zlmygKSk5gBPsqIqL5ASPzJSPREaNT_QdsiYA4/edit) to beautify the python and c++ code.
- [x] The PR is complete and small, read the [Google eng practice (CL equals to PR)](https://google.github.io/eng-practices/review/developer/small-cls.html) to understand more about small PR. In DGL, we consider PRs with less than 200 lines of core code change are small (example, test and documentation could be exempted).
- [x] To the best of my knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change


## Changes
<!-- You could use following template
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)
-->
