### PR TITLE
[FutureWarning] Resolving the warning related to the use of a single-element series.

### DIFF
--- a/examples/pytorch/eeg-gcnn/EEGGraphDataset.py
+++ b/examples/pytorch/eeg-gcnn/EEGGraphDataset.py
@@ -84,17 +84,20 @@ class EEGGraphDataset(DGLDataset):
     def get_geodesic_distance(
         self, montage_sensor1_idx, montage_sensor2_idx, coords_1010
     ):
+        def get_coord(ref_sensor, coord):
+            return float((coords_1010[coords_1010.label == ref_sensor][coord]).iloc[0])
+
         # get the reference sensor in the 10-10 system for the current montage pair in 10-20 system
         ref_sensor1 = self.ref_names[montage_sensor1_idx]
         ref_sensor2 = self.ref_names[montage_sensor2_idx]
 
-        x1 = float(coords_1010[coords_1010.label == ref_sensor1]["x"])
-        y1 = float(coords_1010[coords_1010.label == ref_sensor1]["y"])
-        z1 = float(coords_1010[coords_1010.label == ref_sensor1]["z"])
+        x1 = get_coord(ref_sensor1, "x")
+        y1 = get_coord(ref_sensor1, "y")
+        z1 = get_coord(ref_sensor1, "z")
 
-        x2 = float(coords_1010[coords_1010.label == ref_sensor2]["x"])
-        y2 = float(coords_1010[coords_1010.label == ref_sensor2]["y"])
-        z2 = float(coords_1010[coords_1010.label == ref_sensor2]["z"])
+        x2 = get_coord(ref_sensor2, "x")
+        y2 = get_coord(ref_sensor2, "y")
+        z2 = get_coord(ref_sensor2, "z")
 
         # https://math.stackexchange.com/questions/1304169/distance-between-two-points-on-a-sphere
         r = 1  # since coords are on unit sphere

--- a/examples/pytorch/eeg-gcnn/EEGGraphDataset.py
+++ b/examples/pytorch/eeg-gcnn/EEGGraphDataset.py
@@ -85,7 +85,9 @@ class EEGGraphDataset(DGLDataset):
         self, montage_sensor1_idx, montage_sensor2_idx, coords_1010
     ):
         def get_coord(ref_sensor, coord):
-            return float((coords_1010[coords_1010.label == ref_sensor][coord]).iloc[0])
+            return float(
+                (coords_1010[coords_1010.label == ref_sensor][coord]).iloc[0]
+            )
 
         # get the reference sensor in the 10-10 system for the current montage pair in 10-20 system
         ref_sensor1 = self.ref_names[montage_sensor1_idx]


### PR DESCRIPTION
## Description
<!-- Brief description. Refer to the related issues if existed.
It'll be great if relevant reviewers can be assigned as well.-->

The current PR fixes the following warnings:
```
/opt/dgl/dgl-source/examples/pytorch/eeg-gcnn/EEGGraphDataset.py:91: FutureWarning: Calling float on a single element Series is deprecated and will raise a TypeError in the future. Use float(ser.iloc[0]) instead
  x1 = float(coords_1010[coords_1010.label == ref_sensor1]["x"])
/opt/dgl/dgl-source/examples/pytorch/eeg-gcnn/EEGGraphDataset.py:92: FutureWarning: Calling float on a single element Series is deprecated and will raise a TypeError in the future. Use float(ser.iloc[0]) instead
  y1 = float(coords_1010[coords_1010.label == ref_sensor1]["y"])
/opt/dgl/dgl-source/examples/pytorch/eeg-gcnn/EEGGraphDataset.py:93: FutureWarning: Calling float on a single element Series is deprecated and will raise a TypeError in the future. Use float(ser.iloc[0]) instead
  z1 = float(coords_1010[coords_1010.label == ref_sensor1]["z"])
/opt/dgl/dgl-source/examples/pytorch/eeg-gcnn/EEGGraphDataset.py:95: FutureWarning: Calling float on a single element Series is deprecated and will raise a TypeError in the future. Use float(ser.iloc[0]) instead
  x2 = float(coords_1010[coords_1010.label == ref_sensor2]["x"])
/opt/dgl/dgl-source/examples/pytorch/eeg-gcnn/EEGGraphDataset.py:96: FutureWarning: Calling float on a single element Series is deprecated and will raise a TypeError in the future. Use float(ser.iloc[0]) instead
  y2 = float(coords_1010[coords_1010.label == ref_sensor2]["y"])
/opt/dgl/dgl-source/examples/pytorch/eeg-gcnn/EEGGraphDataset.py:97: FutureWarning: Calling float on a single element Series is deprecated and will raise a TypeError in the future. Use float(ser.iloc[0]) instead
  z2 = float(coords_1010[coords_1010.label == ref_sensor2]["z"])
/opt/dgl/dgl-source/examples/pytorch/eeg-gcnn/EEGGraphDataset.py:91: FutureWarning: Calling float on a single element Series is deprecated and will raise a TypeError in the future. Use float(ser.iloc[0]) instead
  x1 = float(coords_1010[coords_1010.label == ref_sensor1]["x"])
/opt/dgl/dgl-source/examples/pytorch/eeg-gcnn/EEGGraphDataset.py:92: FutureWarning: Calling float on a single element Series is deprecated and will raise a TypeError in the future. Use float(ser.iloc[0]) instead
  y1 = float(coords_1010[coords_1010.label == ref_sensor1]["y"])
/opt/dgl/dgl-source/examples/pytorch/eeg-gcnn/EEGGraphDataset.py:93: FutureWarning: Calling float on a single element Series is deprecated and will raise a TypeError in the future. Use float(ser.iloc[0]) instead
  z1 = float(coords_1010[coords_1010.label == ref_sensor1]["z"])
/opt/dgl/dgl-source/examples/pytorch/eeg-gcnn/EEGGraphDataset.py:95: FutureWarning: Calling float on a single element Series is deprecated and will raise a TypeError in the future. Use float(ser.iloc[0]) instead
  x2 = float(coords_1010[coords_1010.label == ref_sensor2]["x"])
/opt/dgl/dgl-source/examples/pytorch/eeg-gcnn/EEGGraphDataset.py:96: FutureWarning: Calling float on a single element Series is deprecated and will raise a TypeError in the future. Use float(ser.iloc[0]) instead
  y2 = float(coords_1010[coords_1010.label == ref_sensor2]["y"])
/opt/dgl/dgl-source/examples/pytorch/eeg-gcnn/EEGGraphDataset.py:97: FutureWarning: Calling float on a single element Series is deprecated and will raise a TypeError in the future. Use float(ser.iloc[0]) instead
```
## Checklist
Please feel free to remove inapplicable items for your PR.
- [x] The PR title starts with [$CATEGORY] (such as [NN], [Model], [Doc], [Feature]])
- [x] I've leverage the [tools](https://docs.google.com/document/d/1iHyj7zlmygKSk5gBPsqIqL5ASPzJSPREaNT_QdsiYA4/edit) to beautify the python and c++ code.
- [x] The PR is complete and small, read the [Google eng practice (CL equals to PR)](https://google.github.io/eng-practices/review/developer/small-cls.html) to understand more about small PR. In DGL, we consider PRs with less than 200 lines of core code change are small (example, test and documentation could be exempted).
- [x] To the best of my knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

## Changes
<!-- You could use following template
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)
-->
