### PR TITLE
[FutureWarning] Fixing warning generated by the use of `torch.cuda.amp.autocast*` fun…

### DIFF
--- a/python/dgl/backend/pytorch/sparse.py
+++ b/python/dgl/backend/pytorch/sparse.py
@@ -145,7 +145,7 @@ class empty_context:
 # and do it only in a nested autocast context.
 def _disable_autocast_if_enabled():
     if th.is_autocast_enabled():
-        return th.cuda.amp.autocast(enabled=False)
+        return th.amp.autocast('cuda', enabled=False)
     else:
         return empty_context()
 
@@ -154,8 +154,8 @@ def _cast_if_autocast_enabled(*args):
     if not th.is_autocast_enabled():
         return args
     else:
-        return th.cuda.amp.autocast_mode._cast(
-            args, th.get_autocast_gpu_dtype()
+        return th.amp.autocast_mode._cast( 
+            args, 'cuda', th.get_autocast_gpu_dtype()
         )
 
 


### PR DESCRIPTION
…ctions.

## Description
<!-- Brief description. Refer to the related issues if existed.
It'll be great if relevant reviewers can be assigned as well.-->
This PR provides a fix for the warnings:

```
/usr/local/lib/python3.10/dist-packages/dgl/backend/pytorch/sparse.py:148: FutureWarning: `torch.cuda.amp.autocast(args...)` 
is deprecated. Please use `torch.amp.autocast('cuda', args...)` instead.
  return th.cuda.amp.autocast(enabled=False)

/usr/local/lib/python3.10/dist-packages/dgl/backend/pytorch/sparse.py:157: FutureWarning: `torch.cuda.amp.autocast_mode._cast(value, dtype)` 
is deprecated. Please use `torch.amp.autocast_mode._cast(value, 'cuda', dtype)` instead.
  return th.cuda.amp.autocast_mode._cast(
```

## Checklist
Please feel free to remove inapplicable items for your PR.
- [x] The PR title starts with [$CATEGORY] (such as [NN], [Model], [Doc], [Feature]])
- [x] I've leverage the [tools](https://docs.google.com/document/d/1iHyj7zlmygKSk5gBPsqIqL5ASPzJSPREaNT_QdsiYA4/edit) to beautify the python and c++ code.
- [x] The PR is complete and small, read the [Google eng practice (CL equals to PR)](https://google.github.io/eng-practices/review/developer/small-cls.html) to understand more about small PR. In DGL, we consider PRs with less than 200 lines of core code change are small (example, test and documentation could be exempted).
- [x] To the best of my knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

## Changes
<!-- You could use following template
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)
-->
