### PR TITLE
[DistDGL] back-compatible with dgl.dataloading

### DIFF
--- a/python/dgl/dataloading/dataloader.py
+++ b/python/dgl/dataloading/dataloader.py
@@ -1502,6 +1502,15 @@ class EdgeCollator:
         return NewEdgeCollator(*args, **kwargs)
 
 
+def _remove_kwargs_dist(kwargs):
+    if "num_workers" in kwargs:
+        del kwargs["num_workers"]
+    if "pin_memory" in kwargs:
+        del kwargs["pin_memory"]
+        print("Distributed DataLoaders do not support pin_memory.")
+    return kwargs
+
+
 class DistDataLoader:
     """Deprecated. Please use :class:`~dgl.distributed.DistDataLoader` instead."""
 

--- a/python/dgl/dataloading/dataloader.py
+++ b/python/dgl/dataloading/dataloader.py
@@ -1503,6 +1503,7 @@ class EdgeCollator:
 
 
 def _remove_kwargs_dist(kwargs):
+    """Deprecated."""
     if "num_workers" in kwargs:
         del kwargs["num_workers"]
     if "pin_memory" in kwargs:

--- a/python/dgl/distributed/dist_dataloader.py
+++ b/python/dgl/distributed/dist_dataloader.py
@@ -7,7 +7,6 @@ from collections.abc import Mapping
 from .. import backend as F, transforms, utils
 from ..base import EID, NID
 from ..convert import heterograph
-from ..dataloading.dataloader import _remove_kwargs_dist
 from .dist_context import get_sampler_pool
 
 __all__ = [
@@ -768,6 +767,15 @@ class EdgeCollator(Collator):
             return self._collate(items)
         else:
             return self._collate_with_negative_sampling(items)
+
+
+def _remove_kwargs_dist(kwargs):
+    if "num_workers" in kwargs:
+        del kwargs["num_workers"]
+    if "pin_memory" in kwargs:
+        del kwargs["pin_memory"]
+        print("Distributed DataLoaders do not support pin_memory.")
+    return kwargs
 
 
 class DistNodeDataLoader(DistDataLoader):

--- a/python/dgl/distributed/dist_dataloader.py
+++ b/python/dgl/distributed/dist_dataloader.py
@@ -7,6 +7,7 @@ from collections.abc import Mapping
 from .. import backend as F, transforms, utils
 from ..base import EID, NID
 from ..convert import heterograph
+from ..dataloading.dataloader import _remove_kwargs_dist
 from .dist_context import get_sampler_pool
 
 __all__ = [
@@ -767,15 +768,6 @@ class EdgeCollator(Collator):
             return self._collate(items)
         else:
             return self._collate_with_negative_sampling(items)
-
-
-def _remove_kwargs_dist(kwargs):
-    if "num_workers" in kwargs:
-        del kwargs["num_workers"]
-    if "pin_memory" in kwargs:
-        del kwargs["pin_memory"]
-        print("Distributed DataLoaders do not support pin_memory.")
-    return kwargs
 
 
 class DistNodeDataLoader(DistDataLoader):


### PR DESCRIPTION
## Description
<!-- Brief description. Refer to the related issues if existed.
It'll be great if relevant reviewers can be assigned as well.-->
Previously, we use `from dgl.dataloading.dist_dataloader import _remove_kwargs_dist`. From now on, we need to use `from dgl.dataloading.dataloader import _remove_kwargs_dist`
## Checklist
Please feel free to remove inapplicable items for your PR.
- [ ] The PR title starts with [$CATEGORY] (such as [NN], [Model], [Doc], [Feature]])
- [ ] I've leverage the [tools](https://docs.google.com/document/d/1iHyj7zlmygKSk5gBPsqIqL5ASPzJSPREaNT_QdsiYA4/edit) to beautify the python and c++ code.
- [ ] The PR is complete and small, read the [Google eng practice (CL equals to PR)](https://google.github.io/eng-practices/review/developer/small-cls.html) to understand more about small PR. In DGL, we consider PRs with less than 200 lines of core code change are small (example, test and documentation could be exempted).
- [ ] All changes have test coverage
- [ ] Code is well-documented
- [ ] To the best of my knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change
- [ ] Related issue is referred in this PR
- [ ] If the PR is for a new model/paper, I've updated the example index [here](../examples/README.md).

## Changes
<!-- You could use following template
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)
-->
