### PR TITLE
[UnitTest] Fixing AttributeError: module 'numpy' has no attribute `exceptions`

### DIFF
--- a/tests/python/common/sampling/test_sampling.py
+++ b/tests/python/common/sampling/test_sampling.py
@@ -1774,7 +1774,7 @@ def test_sample_neighbors_exclude_edges_homoG(dtype, fused):
 
 @pytest.mark.parametrize("dtype", ["int32", "int64"])
 def test_global_uniform_negative_sampling(dtype):
-    warnings.simplefilter("ignore", np.exceptions.ComplexWarning)
+    warnings.simplefilter("ignore", np.ComplexWarning)
     g = dgl.graph(([], []), num_nodes=1000).to(F.ctx())
     src, dst = dgl.sampling.global_uniform_negative_sampling(
         g, 2000, False, True


### PR DESCRIPTION
## Description
<!-- Brief description. Refer to the related issues if existed.
It'll be great if relevant reviewers can be assigned as well.-->

This PR fixes a bug:
```
Line 3180: =================================== FAILURES ===================================
Line 3181: _________________ test_global_uniform_negative_sampling[int32] _________________
Line 3247: _________________ test_global_uniform_negative_sampling[int64] _________________
Line 3255: tests/python/common/sampling/test_sampling.py:1777:
Line 3256: _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
Line 3308: >       raise AttributeError("module {!r} has no attribute "
Line 3309:                              "{!r}".format(__name__, attr))
Line 3310: E       AttributeError: module 'numpy' has no attribute 'exceptions'
Line 3312: /usr/local/lib/python3.10/dist-packages/numpy/__init__.py:320: AttributeError
Line 3427: =========================== short test summary info ============================
Line 3428: FAILED tests/python/common/sampling/test_sampling.py::test_global_uniform_negative_sampling[int32]
Line 3429: FAILED tests/python/common/sampling/test_sampling.py::test_global_uniform_negative_sampling[int64]
```
where `common/sampling/test_sampling.py::test_global_uniform_negative_sampling` test fails.

## Checklist
Please feel free to remove inapplicable items for your PR.
- [x] The PR title starts with [$CATEGORY] (such as [NN], [Model], [Doc], [Feature]])
- [x] I've leverage the [tools](https://docs.google.com/document/d/1iHyj7zlmygKSk5gBPsqIqL5ASPzJSPREaNT_QdsiYA4/edit) to beautify the python and c++ code.
- [x] The PR is complete and small, read the [Google eng practice (CL equals to PR)](https://google.github.io/eng-practices/review/developer/small-cls.html) to understand more about small PR. In DGL, we consider PRs with less than 200 lines of core code change are small (example, test and documentation could be exempted).
- [x] To the best of my knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change


## Changes
<!-- You could use following template
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)
-->
