### PR TITLE
[DeprecationWarning] Resolve Warnings for Extraction Filters.

### DIFF
--- a/python/dgl/data/utils.py
+++ b/python/dgl/data/utils.py
@@ -244,7 +244,7 @@ def check_sha1(filename, sha1_hash):
     return sha1.hexdigest() == sha1_hash
 
 
-def extract_archive(file, target_dir, overwrite=True):
+def extract_archive(file, target_dir, overwrite=True, filter='data'):
     """Extract archive file.
 
     Parameters
@@ -282,7 +282,7 @@ def extract_archive(file, target_dir, overwrite=True):
                     member_path = os.path.join(path, member.name)
                     if not is_within_directory(path, member_path):
                         raise Exception("Attempted Path Traversal in Tar File")
-                tar.extractall(path, members, numeric_owner=numeric_owner)
+                tar.extractall(path, members, numeric_owner=numeric_owner, filter=filter)
 
             safe_extract(archive, path=target_dir)
     elif file.endswith(".gz"):

--- a/python/dgl/graphbolt/internal_utils.py
+++ b/python/dgl/graphbolt/internal_utils.py
@@ -313,7 +313,7 @@ def check_sha1(filename, sha1_hash):
     return sha1.hexdigest() == sha1_hash
 
 
-def extract_archive(file, target_dir, overwrite=True):
+def extract_archive(file, target_dir, overwrite=True, filter='data'):
     """Extract archive file.
 
     Parameters
@@ -351,7 +351,7 @@ def extract_archive(file, target_dir, overwrite=True):
                     member_path = os.path.join(path, member.name)
                     if not is_within_directory(path, member_path):
                         raise Exception("Attempted Path Traversal in Tar File")
-                tar.extractall(path, members, numeric_owner=numeric_owner)
+                tar.extractall(path, members, numeric_owner=numeric_owner, filter=filter)
 
             safe_extract(archive, path=target_dir)
     elif file.endswith(".gz"):


### PR DESCRIPTION
## Description
<!-- Brief description. Refer to the related issues if existed.
It'll be great if relevant reviewers can be assigned as well.-->

Adding the `filter` parameter  to the `extract_archive` functions eliminates the following warnings:
```
tests/python/common/data/test_data.py::test_extract_archive
tests/python/common/data/test_utils.py::test_extract_archive
  /usr/lib/python3.12/tarfile.py:2254: DeprecationWarning: Python 3.14 will, by default, filter extracted tar archives 
and reject files or modify their metadata. Use the filter argument to control this behavior.
    warnings.warn(
```

For more details, please refer to [the following resource](https://docs.python.org/3.12/library/tarfile.html#tarfile-extraction-filter).

## Checklist
Please feel free to remove inapplicable items for your PR.
- [x] The PR title starts with [$CATEGORY] (such as [NN], [Model], [Doc], [Feature]])
- [x] I've leverage the [tools](https://docs.google.com/document/d/1iHyj7zlmygKSk5gBPsqIqL5ASPzJSPREaNT_QdsiYA4/edit) to beautify the python and c++ code.
- [x] The PR is complete and small, read the [Google eng practice (CL equals to PR)](https://google.github.io/eng-practices/review/developer/small-cls.html) to understand more about small PR. In DGL, we consider PRs with less than 200 lines of core code change are small (example, test and documentation could be exempted).
- [x] To the best of my knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change


## Changes
<!-- You could use following template
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)
-->
