### PR TITLE
[DeprecationWarning]: Resolving warning: conversion of an array with ndim > 0 to a scalar.

### DIFF
--- a/python/dgl/data/tu.py
+++ b/python/dgl/data/tu.py
@@ -406,7 +406,7 @@ class TUDataset(DGLBuiltinDataset):
                     int
                 )
             )
-            self.num_labels = int(max(DS_graph_labels) + 1)
+            self.num_labels = int(max(DS_graph_labels)[0] + 1)
             self.graph_labels = F.tensor(DS_graph_labels)
         elif os.path.exists(self._file_path("graph_attributes")):
             DS_graph_labels = loadtxt(

--- a/python/dgl/utils/data.py
+++ b/python/dgl/utils/data.py
@@ -94,7 +94,7 @@ def networkx2tensor(nx_graph, idtype, edge_id_attr_name=None):
         src = [0] * num_edges
         dst = [0] * num_edges
         for u, v, attr in nx_graph.edges(data=True):
-            eid = int(attr[edge_id_attr_name])
+            eid = int(attr[edge_id_attr_name][0])
             if eid < 0 or eid >= nx_graph.number_of_edges():
                 raise DGLError(
                     "Expect edge IDs to be a non-negative integer smaller than {:d}, "
@@ -278,7 +278,7 @@ def networkxbipartite2tensors(
                     "Expect the node {} to have attribute bipartite=1 "
                     "with edge {}".format(v, (u, v))
                 )
-            eid = int(attr[edge_id_attr_name])
+            eid = int(attr[edge_id_attr_name][0])
             if eid < 0 or eid >= nx_graph.number_of_edges():
                 raise DGLError(
                     "Expect edge IDs to be a non-negative integer smaller than {:d}, "


### PR DESCRIPTION
## Description
<!-- Brief description. Refer to the related issues if existed.
It'll be great if relevant reviewers can be assigned as well.-->

This PR provides a fix for the following deprecation warnings:
```
tests/python/common/data/test_data.py::test_as_graphpred_reprocess
  /usr/local/lib/python3.12/dist-packages/dgl/data/tu.py:409: DeprecationWarning: Conversion of an array with ndim > 0 
to a scalar is deprecated, and will error in future. Ensure you extract a single element from your array 
before performing this operation. (Deprecated NumPy 1.25.)
    self.num_labels = int(max(DS_graph_labels) + 1)


tests/python/common/test_heterograph.py::test_create[idtype0]
tests/python/common/test_heterograph.py::test_create[idtype0]
tests/python/common/test_heterograph.py::test_create[idtype1]
tests/python/common/test_heterograph.py::test_create[idtype1]
  /usr/local/lib/python3.12/dist-packages/dgl/utils/data.py:281: DeprecationWarning: Conversion of an array with ndim > 0 
to a scalar is deprecated, and will error in future. Ensure you extract a single element from your array 
before performing this operation. (Deprecated NumPy 1.25.)
    eid = int(attr[edge_id_attr_name])
```

## Checklist
Please feel free to remove inapplicable items for your PR.
- [x] The PR title starts with [$CATEGORY] (such as [NN], [Model], [Doc], [Feature]])
- [x] I've leverage the [tools](https://docs.google.com/document/d/1iHyj7zlmygKSk5gBPsqIqL5ASPzJSPREaNT_QdsiYA4/edit) to beautify the python and c++ code.
- [x] The PR is complete and small, read the [Google eng practice (CL equals to PR)](https://google.github.io/eng-practices/review/developer/small-cls.html) to understand more about small PR. In DGL, we consider PRs with less than 200 lines of core code change are small (example, test and documentation could be exempted).
- [x] To the best of my knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change


## Changes
<!-- You could use following template
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)
-->
