### PR TITLE
fix(dgl/runtime): add static_cast to fix clang compilation when using OpenMP

### DIFF
--- a/include/dgl/runtime/parallel_for.h
+++ b/include/dgl/runtime/parallel_for.h
@@ -85,7 +85,7 @@ void parallel_for(
     auto chunk_size = divup((end - begin), num_threads);
     auto begin_tid = begin + tid * chunk_size;
     if (begin_tid < end) {
-      auto end_tid = std::min(end, chunk_size + begin_tid);
+      auto end_tid = std::min(end, static_cast<size_t>(chunk_size + begin_tid));
       try {
         f(begin_tid, end_tid);
       } catch (...) {


### PR DESCRIPTION
This fixes a compilation issue on macOS when compiling with OpenMP support:

```
dgl/include/dgl/runtime/parallel_for.h:88:22: error: no matching function for call to 'min'
      auto end_tid = std::min(end, chunk_size + begin_tid);
                     ^~~~~~~~
```

Same kind of bug as in https://github.com/dmlc/dgl/issues/3631.