### PR TITLE
[distGB] graphbolt graph edge's mask will be filled with 0 if these edges have no mask initial

### DIFF
--- a/python/dgl/distributed/dist_dataloader.py
+++ b/python/dgl/distributed/dist_dataloader.py
@@ -311,7 +311,7 @@ class Collator(ABC):
         raise NotImplementedError
 
     @staticmethod
-    def add_edge_attribute_to_graph(g, data_name):
+    def add_edge_attribute_to_graph(g, data_name, gb_padding=0):
         """Add data into the graph as an edge attribute.
 
         For some cases such as prob/mask-based sampling on GraphBolt partitions,
@@ -329,7 +329,7 @@ class Collator(ABC):
             The name of data that's stored in DistGraph.ndata/edata.
         """
         if g._use_graphbolt and data_name:
-            g.add_edge_attribute(data_name)
+            g.add_edge_attribute(data_name, gb_padding)
 
 
 class NodeCollator(Collator):
@@ -366,7 +366,7 @@ class NodeCollator(Collator):
     :doc:`Minibatch Training Tutorials <tutorials/large/L0_neighbor_sampling_overview>`.
     """
 
-    def __init__(self, g, nids, graph_sampler):
+    def __init__(self, g, nids, graph_sampler, gb_padding=0):
         self.g = g
         if not isinstance(nids, Mapping):
             assert (
@@ -380,7 +380,7 @@ class NodeCollator(Collator):
         # Add prob/mask into graphbolt partition's edge attributes if needed.
         if hasattr(self.graph_sampler, "prob"):
             Collator.add_edge_attribute_to_graph(
-                self.g, self.graph_sampler.prob
+                self.g, self.graph_sampler.prob, gb_padding
             )
 
     @property
@@ -612,6 +612,7 @@ class EdgeCollator(Collator):
         reverse_eids=None,
         reverse_etypes=None,
         negative_sampler=None,
+        gb_padding=0,
     ):
         self.g = g
         if not isinstance(eids, Mapping):
@@ -642,7 +643,7 @@ class EdgeCollator(Collator):
         # Add prob/mask into graphbolt partition's edge attributes if needed.
         if hasattr(self.graph_sampler, "prob"):
             Collator.add_edge_attribute_to_graph(
-                self.g, self.graph_sampler.prob
+                self.g, self.graph_sampler.prob, gb_padding
             )
 
     @property
@@ -864,6 +865,7 @@ class DistEdgeDataLoader(DistDataLoader):
             else:
                 dataloader_kwargs[k] = v
 
+        collator_kwargs["gb_padding"] = 1
         if device is None:
             # for the distributed case default to the CPU
             device = "cpu"

--- a/python/dgl/distributed/dist_dataloader.py
+++ b/python/dgl/distributed/dist_dataloader.py
@@ -311,7 +311,7 @@ class Collator(ABC):
         raise NotImplementedError
 
     @staticmethod
-    def add_edge_attribute_to_graph(g, data_name, gb_padding=0):
+    def add_edge_attribute_to_graph(g, data_name, gb_padding):
         """Add data into the graph as an edge attribute.
 
         For some cases such as prob/mask-based sampling on GraphBolt partitions,
@@ -348,6 +348,8 @@ class NodeCollator(Collator):
         The neighborhood sampler.
     gb_padding : int, optional
         The padding value for GraphBolt partitions' new edge_attributes.
+        e.g. some edges of specific types have no mask, the mask will be set as gb_padding.
+        the edge will not be sampled if the mask is 0.
 
     Examples
     --------
@@ -512,6 +514,10 @@ class EdgeCollator(Collator):
 
         A set of builtin negative samplers are provided in
         :ref:`the negative sampling module <api-dataloading-negative-sampling>`.
+    gb_padding : int, optional
+        The padding value for GraphBolt partitions' new edge_attributes if the attributes in DistGraph are None.
+        e.g. prob/mask-based sampling.
+        Only when the mask of one edge is set as 1, the edge will be sampled.
 
     Examples
     --------
@@ -616,7 +622,7 @@ class EdgeCollator(Collator):
         reverse_eids=None,
         reverse_etypes=None,
         negative_sampler=None,
-        gb_padding=0,
+        gb_padding=1,
     ):
         self.g = g
         if not isinstance(eids, Mapping):
@@ -869,7 +875,6 @@ class DistEdgeDataLoader(DistDataLoader):
             else:
                 dataloader_kwargs[k] = v
 
-        collator_kwargs["gb_padding"] = 1
         if device is None:
             # for the distributed case default to the CPU
             device = "cpu"

--- a/python/dgl/distributed/dist_dataloader.py
+++ b/python/dgl/distributed/dist_dataloader.py
@@ -349,7 +349,7 @@ class NodeCollator(Collator):
     gb_padding : int, optional
         The padding value for GraphBolt partitions' new edge_attributes if the attributes in DistGraph are None.
         e.g. prob/mask-based sampling.
-        Only when the mask of one edge is set as 1, the edge will be sampled in dgl.graphbolt.FusedCSCSamplingGraph.sample_neighbors.
+        Only when the mask of one edge is set as 1, an edge will be sampled in dgl.graphbolt.FusedCSCSamplingGraph.sample_neighbors.
         The argument will be used in add_edge_attribute_to_graph to add new edge_attributes in graphbolt.
 
     Examples
@@ -518,7 +518,7 @@ class EdgeCollator(Collator):
     gb_padding : int, optional
         The padding value for GraphBolt partitions' new edge_attributes if the attributes in DistGraph are None.
         e.g. prob/mask-based sampling.
-        Only when the mask of one edge is set as 1, the edge will be sampled in dgl.graphbolt.FusedCSCSamplingGraph.sample_neighbors.
+        Only when the mask of one edge is set as 1, an edge will be sampled in dgl.graphbolt.FusedCSCSamplingGraph.sample_neighbors.
         The argument will be used in add_edge_attribute_to_graph to add new edge_attributes in graphbolt.
     --------
     The following example shows how to train a 3-layer GNN for edge classification on a

--- a/python/dgl/distributed/dist_dataloader.py
+++ b/python/dgl/distributed/dist_dataloader.py
@@ -347,9 +347,10 @@ class NodeCollator(Collator):
     graph_sampler : dgl.dataloading.BlockSampler
         The neighborhood sampler.
     gb_padding : int, optional
-        The padding value for GraphBolt partitions' new edge_attributes.
-        e.g. some edges of specific types have no mask, the mask will be set as gb_padding.
-        the edge will not be sampled if the mask is 0.
+        The padding value for GraphBolt partitions' new edge_attributes if the attributes in DistGraph are None.
+        e.g. prob/mask-based sampling.
+        Only when the mask of one edge is set as 1, the edge will be sampled in dgl.graphbolt.FusedCSCSamplingGraph.sample_neighbors.
+        The argument will be used in add_edge_attribute_to_graph to add new edge_attributes in graphbolt.
 
     Examples
     --------
@@ -372,7 +373,7 @@ class NodeCollator(Collator):
     :doc:`Minibatch Training Tutorials <tutorials/large/L0_neighbor_sampling_overview>`.
     """
 
-    def __init__(self, g, nids, graph_sampler, gb_padding=0):
+    def __init__(self, g, nids, graph_sampler, gb_padding=1):
         self.g = g
         if not isinstance(nids, Mapping):
             assert (
@@ -517,9 +518,8 @@ class EdgeCollator(Collator):
     gb_padding : int, optional
         The padding value for GraphBolt partitions' new edge_attributes if the attributes in DistGraph are None.
         e.g. prob/mask-based sampling.
-        Only when the mask of one edge is set as 1, the edge will be sampled.
-
-    Examples
+        Only when the mask of one edge is set as 1, the edge will be sampled in dgl.graphbolt.FusedCSCSamplingGraph.sample_neighbors.
+        The argument will be used in add_edge_attribute_to_graph to add new edge_attributes in graphbolt.
     --------
     The following example shows how to train a 3-layer GNN for edge classification on a
     set of edges ``train_eid`` on a homogeneous undirected graph. Each node takes

--- a/python/dgl/distributed/dist_dataloader.py
+++ b/python/dgl/distributed/dist_dataloader.py
@@ -327,6 +327,8 @@ class Collator(ABC):
             The graph.
         data_name : str
             The name of data that's stored in DistGraph.ndata/edata.
+        gb_padding : int, optional
+            The padding value for GraphBolt partitions' new edge_attributes.
         """
         if g._use_graphbolt and data_name:
             g.add_edge_attribute(data_name, gb_padding)
@@ -344,6 +346,8 @@ class NodeCollator(Collator):
         The node set to compute outputs.
     graph_sampler : dgl.dataloading.BlockSampler
         The neighborhood sampler.
+    gb_padding : int, optional
+        The padding value for GraphBolt partitions' new edge_attributes.
 
     Examples
     --------

--- a/python/dgl/distributed/dist_graph.py
+++ b/python/dgl/distributed/dist_graph.py
@@ -171,10 +171,11 @@ class AddEdgeAttributeFromKVRequest(rpc.Request):
             # Initialize the edge attribute.
             num_edges = g.total_num_edges
 
-            # Padding is used here to fill missing edge attributes (e.g., 'prob' or 'mask') for certain edge types.
-            # In DGLGraph, some edges may not have attributes or their values could be None.
-            # GraphBolt, however, samples edges based on specific attributes (like 'mask' == 1), so we pad the missing attributes with default values (e.g., 1 for 'mask')
-            # to ensure that all edges can be sampled consistently, regardless of whether their attributes are available in the DGLGraph.
+            # Padding is used to fill missing edge attributes (e.g., 'prob' or 'mask') for certain edge types.
+            # In DGLGraph, some edges may lack these attributes or have them set to None, but DGL will still sample these edges.
+            # In contrast, GraphBolt samples edges based on specific attributes (e.g., 'mask' == 1) and will skip edges with missing attributes.
+            # To ensure consistent sampling behavior in GraphBolt, we pad missing attributes with default values (e.g., 'mask' = 1),
+            # allowing all edges to be sampled, even if their attributes were missing or None in DGLGraph.
             attr_data = torch.full((num_edges,), self._padding, dtype=data_type)
             # Map data from kvstore to the local partition for inner edges only.
             num_inner_edges = gpb.metadata()[gpb.partid]["num_edges"]

--- a/python/dgl/distributed/dist_graph.py
+++ b/python/dgl/distributed/dist_graph.py
@@ -170,10 +170,7 @@ class AddEdgeAttributeFromKVRequest(rpc.Request):
             gpb = server_state.partition_book
             # Initialize the edge attribute.
             num_edges = g.total_num_edges
-            if self._padding == 0:
-                attr_data = torch.zeros(num_edges, dtype=data_type)
-            else:
-                attr_data = torch.full((num_edges,), self._padding, dtype=data_type)
+            attr_data = torch.full((num_edges,), self._padding, dtype=data_type)
             # Map data from kvstore to the local partition for inner edges only.
             num_inner_edges = gpb.metadata()[gpb.partid]["num_edges"]
             homo_eids = g.edge_attributes[EID][:num_inner_edges]

--- a/python/dgl/distributed/dist_graph.py
+++ b/python/dgl/distributed/dist_graph.py
@@ -1628,6 +1628,8 @@ class DistGraph:
         ----------
         name : str
             The name of the edge attribute.
+        padding : int, optional
+            The padding value for the new edge attribute.
         """
         # Sanity checks.
         if not self._use_graphbolt:

--- a/tests/distributed/test_distributed_sampling.py
+++ b/tests/distributed/test_distributed_sampling.py
@@ -7,7 +7,7 @@ import traceback
 import unittest
 from pathlib import Path
 
-import dgl.backend as F
+import backend as F
 import dgl
 import numpy as np
 import pytest

--- a/tests/distributed/test_distributed_sampling.py
+++ b/tests/distributed/test_distributed_sampling.py
@@ -7,8 +7,9 @@ import traceback
 import unittest
 from pathlib import Path
 
-import backend as F
 import dgl
+
+import dgl.backend as F
 import numpy as np
 import pytest
 import torch
@@ -1919,6 +1920,9 @@ def check_hetero_dist_edge_dataloader_gb(
 
     block = next(iter(loader))[2][0]
     assert block.num_src_nodes("n1") > 0
+    assert block.num_edges("r12") > 0
+    assert block.num_edges("r13") > 0
+    assert block.num_edges("r23") > 0
 
 
 def test_hetero_dist_edge_dataloader_gb(

--- a/tests/distributed/test_distributed_sampling.py
+++ b/tests/distributed/test_distributed_sampling.py
@@ -1862,6 +1862,9 @@ def test_local_sampling_heterograph(num_parts, use_graphbolt, prob_or_mask):
 def check_hetero_dist_edge_dataloader_gb(
     tmpdir, num_server, use_graphbolt=True
 ):
+    # Custom function to create a heterogeneous graph, ensuring that edges with missing masks
+    # can still be used to sample in DistEdgeDataloader. create_random_hetero does not support this case,
+    # so this function was added to handle the requirement.
     def create_hetero_graph():
         num_nodes = {"n1": 210, "n2": 200, "n3": 220, "n4": 230}
         etypes = [("n1", "r12", "n2"), ("n2", "r23", "n3"), ("n3", "r34", "n4")]

--- a/tests/distributed/test_distributed_sampling.py
+++ b/tests/distributed/test_distributed_sampling.py
@@ -7,9 +7,8 @@ import traceback
 import unittest
 from pathlib import Path
 
-import dgl
-
 import dgl.backend as F
+import dgl
 import numpy as np
 import pytest
 import torch

--- a/tests/distributed/test_distributed_sampling.py
+++ b/tests/distributed/test_distributed_sampling.py
@@ -1882,9 +1882,9 @@ def check_mask_hetero_sampling_gb(tmpdir, num_server, use_graphbolt=True):
     generate_ip_config("rpc_ip_config.txt", num_server, num_server)
 
     g = create_hetero_graph()
-    indices = torch.randperm(g.num_edges("r34"))[:10]
+    eids = torch.randperm(g.num_edges("r34"))[:10]
     mask = torch.zeros(g.num_edges("r34"), dtype=torch.bool)
-    mask[indices] = True
+    mask[eids] = True
 
     num_parts = num_server
 
@@ -1900,17 +1900,14 @@ def check_mask_hetero_sampling_gb(tmpdir, num_server, use_graphbolt=True):
         store_eids=True,
     )
 
-    pserver_list = []
-
     part_config = tmpdir / "test_sampling.json"
 
     dgl.distributed.initialize("rpc_ip_config.txt")
     dist_graph = DistGraph("test_sampling", part_config=part_config)
-    print(dist_graph.local_partition)
 
     os.environ["DGL_DIST_DEBUG"] = "1"
 
-    edges = {("n3", "r34", "n4"): indices}
+    edges = {("n3", "r34", "n4"): eids}
     sampler = dgl.dataloading.MultiLayerNeighborSampler([10, 10], mask="mask")
     loader = dgl.dataloading.DistEdgeDataLoader(
         dist_graph, edges, sampler, batch_size=64


### PR DESCRIPTION
Add a new parameter "padding" to add_edge_attribute, the edge's mask will be filled with padding rather than 0.
When use DistEdgeDataloader the padding will be set to 1 to fully sample the edge with no mask.