### PR TITLE
[DeprecationWarning] Replacing soon-to-be-deprecated `lazyInitCUDA` with `lazyInitDevice(at::kCUDA)`

### DIFF
--- a/graphbolt/src/cuda/common.h
+++ b/graphbolt/src/cuda/common.h
@@ -58,7 +58,9 @@ struct CUDAWorkspaceAllocator {
   // Required by thrust to satisfy allocator requirements.
   using value_type = value_t;
 
-  explicit CUDAWorkspaceAllocator() { at::globalContext().lazyInitDevice(at::kCUDA); }
+  explicit CUDAWorkspaceAllocator() {
+    at::globalContext().lazyInitDevice(at::kCUDA);
+  }
 
   template <class U>
   CUDAWorkspaceAllocator(CUDAWorkspaceAllocator<U> const&) noexcept {}

--- a/graphbolt/src/cuda/common.h
+++ b/graphbolt/src/cuda/common.h
@@ -58,7 +58,7 @@ struct CUDAWorkspaceAllocator {
   // Required by thrust to satisfy allocator requirements.
   using value_type = value_t;
 
-  explicit CUDAWorkspaceAllocator() { at::globalContext().lazyInitCUDA(); }
+  explicit CUDAWorkspaceAllocator() { at::globalContext().lazyInitDevice(at::kCUDA); }
 
   template <class U>
   CUDAWorkspaceAllocator(CUDAWorkspaceAllocator<U> const&) noexcept {}

--- a/tensoradapter/pytorch/torch.cpp
+++ b/tensoradapter/pytorch/torch.cpp
@@ -28,7 +28,7 @@ TA_EXPORTS void CPURawDelete(void* ptr) {
 
 #ifdef DGL_USE_CUDA
 TA_EXPORTS void* CUDARawAlloc(size_t nbytes, cudaStream_t stream) {
-  at::globalContext().lazyInitCUDA();
+  at::globalContext().lazyInitDevice(at::kCUDA);
   return c10::cuda::CUDACachingAllocator::raw_alloc_with_stream(nbytes, stream);
 }
 


### PR DESCRIPTION
This PR resolves multiple warnings:
```
[W110 03:11:01.976023226 Context.h:353] Warning: lazyInitCUDA is deprecated. Please use lazyInitDevice(at::kCUDA) instead. (function lazyInitCUDA)
[W110 03:11:01.979291350 Context.h:353] Warning: lazyInitCUDA is deprecated. Please use lazyInitDevice(at::kCUDA) instead. (function lazyInitCUDA)
[W110 03:11:01.980258297 Context.h:353] Warning: lazyInitCUDA is deprecated. Please use lazyInitDevice(at::kCUDA) instead. (function lazyInitCUDA)
[W110 03:11:01.983385323 Context.h:353] Warning: lazyInitCUDA is deprecated. Please use lazyInitDevice(at::kCUDA) instead. (function lazyInitCUDA)
[W110 03:11:01.984356630 Context.h:353] Warning: lazyInitCUDA is deprecated. Please use lazyInitDevice(at::kCUDA) instead. (function lazyInitCUDA)
```

generated by `examples/bgnn/run.py` test.

## Description
<!-- Brief description. Refer to the related issues if existed.
It'll be great if relevant reviewers can be assigned as well.-->

## Checklist
Please feel free to remove inapplicable items for your PR.
- [x] The PR title starts with [$CATEGORY] (such as [NN], [Model], [Doc], [Feature]])
- [x] I've leverage the [tools](https://docs.google.com/document/d/1iHyj7zlmygKSk5gBPsqIqL5ASPzJSPREaNT_QdsiYA4/edit) to beautify the python and c++ code.
- [x] The PR is complete and small, read the [Google eng practice (CL equals to PR)](https://google.github.io/eng-practices/review/developer/small-cls.html) to understand more about small PR. In DGL, we consider PRs with less than 200 lines of core code change are small (example, test and documentation could be exempted).
- [x] To the best of my knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

## Changes
<!-- You could use following template
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)
-->
