### PR TITLE
[DeprecationWarning] Fixing multiple warnings related to the conversion of arrays with ndim > 0 to scalars.

### DIFF
--- a/python/dgl/nn/pytorch/explain/subgraphx.py
+++ b/python/dgl/nn/pytorch/explain/subgraphx.py
@@ -145,7 +145,7 @@ class SubgraphX(nn.Module):
         device = self.feat.device
         for _ in range(self.shapley_steps):
             permuted_space = np.random.permutation(coalition_space)
-            split_idx = int(np.where(permuted_space == split_point)[0])
+            split_idx = int(np.where(permuted_space == split_point)[0][0])
 
             selected_nodes = permuted_space[:split_idx]
 
@@ -490,7 +490,7 @@ class HeteroSubgraphX(nn.Module):
             selected_node_map = dict()
             for ntype, nodes in coalition_space.items():
                 permuted_space = np.random.permutation(nodes)
-                split_idx = int(np.where(permuted_space == split_point)[0])
+                split_idx = int(np.where(permuted_space == split_point)[0][0])
                 selected_node_map[ntype] = permuted_space[:split_idx]
 
             # Mask for coalition set S_i


### PR DESCRIPTION
## Description
<!-- Brief description. Refer to the related issues if existed.
It'll be great if relevant reviewers can be assigned as well.-->

This PR resolves multiple warnings:
```
tests/python/pytorch/nn/test_nn.py: 3520 warnings
  /usr/local/lib/python3.12/dist-packages/dgl/nn/pytorch/explain/subgraphx.py:148: DeprecationWarning: Conversion of an
 array with ndim > 0 to a scalar is deprecated, and will error in future. Ensure you extract a single element from your 
array before performing this operation. (Deprecated NumPy 1.25.)
    split_idx = int(np.where(permuted_space == split_point)[0])

tests/python/pytorch/nn/test_nn.py: 1380 warnings
  /usr/local/lib/python3.12/dist-packages/dgl/nn/pytorch/explain/subgraphx.py:493: DeprecationWarning: Conversion of an 
array with ndim > 0 to a scalar is deprecated, and will error in future. Ensure you extract a single element from your 
array before performing this operation. (Deprecated NumPy 1.25.)
    split_idx = int(np.where(permuted_space == split_point)[0])
```

## Checklist
Please feel free to remove inapplicable items for your PR.
- [x] The PR title starts with [$CATEGORY] (such as [NN], [Model], [Doc], [Feature]])
- [x] I've leverage the [tools](https://docs.google.com/document/d/1iHyj7zlmygKSk5gBPsqIqL5ASPzJSPREaNT_QdsiYA4/edit) to beautify the python and c++ code.
- [x] The PR is complete and small, read the [Google eng practice (CL equals to PR)](https://google.github.io/eng-practices/review/developer/small-cls.html) to understand more about small PR. In DGL, we consider PRs with less than 200 lines of core code change are small (example, test and documentation could be exempted).
- [x] To the best of my knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

