### PR TITLE
[Graphbolt] [NFC] Remove default backend torch.distributed.init_process_group calls

### DIFF
--- a/examples/graphbolt/pyg/multigpu/node_classification.py
+++ b/examples/graphbolt/pyg/multigpu/node_classification.py
@@ -391,6 +391,7 @@ def run(rank, world_size, args, dataset):
     # Set up multiprocessing environment.
     torch.cuda.set_device(rank)
     dist.init_process_group(
+        backend='cpu:gloo,cuda:nccl',
         init_method="tcp://127.0.0.1:12345",
         rank=rank,
         world_size=world_size,

--- a/tests/python/pytorch/graphbolt/test_dataloader.py
+++ b/tests/python/pytorch/graphbolt/test_dataloader.py
@@ -89,6 +89,7 @@ def test_gpu_sampling_DataLoader(
             else "tcp://127.0.0.1:12345"
         )
         thd.init_process_group(
+            backend='cpu:gloo,cuda:nccl',
             init_method=init_method,
             world_size=1,
             rank=0,


### PR DESCRIPTION
With newer pytorch versions, the behavior in these locations was changed from initializing nccl+gloo to only initializing gloo.

Now, all locations explicitly specify their desired backends. These additions maintain expected torch<=2.4 behavior on torch>=2.6. The changed test relies on both backends existing and would fail on newer torch versions.

See https://github.com/pytorch/pytorch/issues/147631