### PR TITLE
[Bug] Fixing `test_gpu_sampling_DataLoader` that fails with torch 2.7.

### DIFF
--- a/tests/python/pytorch/graphbolt/test_dataloader.py
+++ b/tests/python/pytorch/graphbolt/test_dataloader.py
@@ -88,11 +88,26 @@ def test_gpu_sampling_DataLoader(
             if platform == "win32"
             else "tcp://127.0.0.1:12345"
         )
-        thd.init_process_group(
-            init_method=init_method,
-            world_size=1,
-            rank=0,
-        )
+
+        from torch.torch_version import TorchVersion
+        if TorchVersion(torch.__version__) >= TorchVersion("2.7.0a"):
+            if not thd.is_mpi_available():
+                import warnings
+                warnings.warn("MPY backend should be available for " 
+                              "cooperative optimization")
+                return
+
+            thd.init_process_group(
+                backend="mpi",
+                init_method=init_method,
+            )
+        else:
+            thd.init_process_group(
+                init_method=init_method,
+                world_size=1,
+                rank=0,
+            )
+  
     N = 40
     B = 4
     num_layers = 2


### PR DESCRIPTION
## Description
<!-- Brief description. Refer to the related issues if existed.
It'll be great if relevant reviewers can be assigned as well.-->

Beginning with PyTorch `2.7.0a`, the `test_gpu_sampling_DataLoader` test consistently fails, producing the following error:
```
group = group or _get_default_group()
>       work = group.alltoall_base(
            output, input, output_split_sizes, input_split_sizes, opts
        )
E       RuntimeError: No backend type associated with device type cpu
E       This exception is thrown by __iter__ of MiniBatchTransformer(datapipe=Bufferer, transformer=_seeds_cooperative_exchange_1_wait_future)

/usr/local/lib/python3.12/dist-packages/torch/distributed/distributed_c10d.py:4390: RuntimeError
```

Since the `gloo` backend does not support `alltoall`:
```
        group = group or _get_default_group()
>       work = group.alltoall(output_tensor_list, input_tensor_list, opts)
E       RuntimeError: Backend gloo does not support alltoall
E       This exception is thrown by __iter__ of MiniBatchTransformer(datapipe=Bufferer, transformer=_seeds_cooperative_exchange_2)
```
and the `ucc` backend is slated for deprecation, the `mpi` backend is now the only viable option for this test.

This PR introduces backward compatibility, allowing the test to run on older and newer PyTorch versions.


## Checklist
Please feel free to remove inapplicable items for your PR.
- [x] The PR title starts with [$CATEGORY] (such as [NN], [Model], [Doc], [Feature]])
- [x] I've leverage the [tools](https://docs.google.com/document/d/1iHyj7zlmygKSk5gBPsqIqL5ASPzJSPREaNT_QdsiYA4/edit) to beautify the python and c++ code.
- [x] The PR is complete and small, read the [Google eng practice (CL equals to PR)](https://google.github.io/eng-practices/review/developer/small-cls.html) to understand more about small PR. In DGL, we consider PRs with less than 200 lines of core code change are small (example, test and documentation could be exempted).
- [x] All changes have test coverage
- [x] Code is well-documented
- [x] To the best of my knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

## Changes
<!-- You could use following template
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)
-->
