### PR TITLE
[Bugfix][nn/PyTorch]: add checks to avoid view/reshape (0, -1, *) on empty tensors

### DIFF
--- a/python/dgl/nn/pytorch/conv/edgegatconv.py
+++ b/python/dgl/nn/pytorch/conv/edgegatconv.py
@@ -368,10 +368,11 @@ class EdgeGATConv(nn.Module):
             # Residual.
             if self.res_fc is not None:
                 # Use -1 rather than self._num_heads to handle broadcasting.
-                resval = self.res_fc(h_dst).view(
-                    *dst_prefix_shape, -1, self._out_feats
-                )
-                rst = rst + resval
+                if h_dst.numel() != 0:
+                    resval = self.res_fc(h_dst).view(
+                        *dst_prefix_shape, -1, self._out_feats
+                    )
+                    rst = rst + resval
             # Bias.
             if self.bias is not None:
                 rst = rst + self.bias.view(

--- a/python/dgl/nn/pytorch/conv/gatconv.py
+++ b/python/dgl/nn/pytorch/conv/gatconv.py
@@ -348,10 +348,11 @@ class GATConv(nn.Module):
             # residual
             if self.res_fc is not None:
                 # Use -1 rather than self._num_heads to handle broadcasting
-                resval = self.res_fc(h_dst).view(
-                    *dst_prefix_shape, -1, self._out_feats
-                )
-                rst = rst + resval
+                if h_dst.numel() != 0:
+                    resval = self.res_fc(h_dst).view(
+                        *dst_prefix_shape, -1, self._out_feats
+                    )
+                    rst = rst + resval
             # bias
             if self.has_explicit_bias:
                 rst = rst + self.bias.view(

--- a/python/dgl/nn/pytorch/conv/gatv2conv.py
+++ b/python/dgl/nn/pytorch/conv/gatv2conv.py
@@ -320,10 +320,11 @@ class GATv2Conv(nn.Module):
             rst = graph.dstdata["ft"]
             # residual
             if self.res_fc is not None:
-                resval = self.res_fc(h_dst).view(
-                    h_dst.shape[0], -1, self._out_feats
-                )
-                rst = rst + resval
+                if h_dst.numel() != 0:
+                    resval = self.res_fc(h_dst).view(
+                        h_dst.shape[0], -1, self._out_feats
+                    )
+                    rst = rst + resval
             # activation
             if self.activation:
                 rst = self.activation(rst)


### PR DESCRIPTION
## Description
<!-- Brief description. Refer to the related issues if existed.
It'll be great if relevant reviewers can be assigned as well.-->

Added conditionals to skip calls to .view() or reshape on tensors with zero elements in three places. This prevents runtime errors caused by ambiguous shape inference when reshaping empty tensors.

Improves robustness when input tensors can be empty. 

Bug Issue: #7893 

## Checklist
Please feel free to remove inapplicable items for your PR.
- [x] The PR title starts with [$CATEGORY] (such as [NN], [Model], [Doc], [Feature]])
- [x] I've leverage the [tools](https://docs.google.com/document/d/1iHyj7zlmygKSk5gBPsqIqL5ASPzJSPREaNT_QdsiYA4/edit) to beautify the python and c++ code.
- [x] The PR is complete and small, read the [Google eng practice (CL equals to PR)](https://google.github.io/eng-practices/review/developer/small-cls.html) to understand more about small PR. In DGL, we consider PRs with less than 200 lines of core code change are small (example, test and documentation could be exempted).
- [x] All changes have test coverage
- [x] Code is well-documented
- [x] To the best of my knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change
- [x] Related issue is referred in this PR
- [x] If the PR is for a new model/paper, I've updated the example index [here](../examples/README.md).

## Changes
<!-- You could use following template
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)
-->
check changed files