### PR TITLE
[Performance] Add option to not validate graph node count

### DIFF
--- a/python/dgl/convert.py
+++ b/python/dgl/convert.py
@@ -37,6 +37,7 @@ def graph(
     device=None,
     row_sorted=False,
     col_sorted=False,
+    node_count_check=True,
 ):
     """Create a graph and return.
 
@@ -83,6 +84,9 @@ def graph(
     col_sorted : bool, optional
         Whether or not the columns of the COO are in ascending order within
         each row. This only has an effect when ``row_sorted`` is True.
+    node_count_check : bool, optional
+        When num_nodes is passed, whether we should perform sanity checks to
+        ensure they are valid. Note that this comes with a performance penalty.
 
     Returns
     -------
@@ -160,9 +164,11 @@ def graph(
             "graph, use dgl.from_networkx instead."
         )
 
-    (sparse_fmt, arrays), urange, vrange = utils.graphdata2tensors(data, idtype)
+    (sparse_fmt, arrays), urange, vrange = utils.graphdata2tensors(
+        data, idtype, infer_node_count=(node_count_check or num_nodes is None)
+    )
     if num_nodes is not None:  # override the number of nodes
-        if num_nodes < max(urange, vrange):
+        if node_count_check and num_nodes < max(urange, vrange):
             raise DGLError(
                 "The num_nodes argument must be larger than the max ID in the data,"
                 " but got {} and {}.".format(num_nodes, max(urange, vrange) - 1)


### PR DESCRIPTION
## Description
The node count validation forces a device/host sync and can have a significant performance penalty. The argument I added mirrors one on `create_block` added in https://github.com/dmlc/dgl/pull/7240. Seems like someone saw the same performance issue there.

## Checklist
Please feel free to remove inapplicable items for your PR.
- [x] The PR title starts with [$CATEGORY] (such as [NN], [Model], [Doc], [Feature]])
- [x] I've leverage the [tools](https://docs.google.com/document/d/1iHyj7zlmygKSk5gBPsqIqL5ASPzJSPREaNT_QdsiYA4/edit) to beautify the python and c++ code.
- [x] The PR is complete and small, read the [Google eng practice (CL equals to PR)](https://google.github.io/eng-practices/review/developer/small-cls.html) to understand more about small PR. In DGL, we consider PRs with less than 200 lines of core code change are small (example, test and documentation could be exempted).
- [ ] ~All changes have test coverage~. I did not find any existing coverage for this function
- [x] Code is well-documented
- [x] To the best of my knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change