### PR TITLE
[Doc] Fix typo in parameter names in cluster_gcn.py

### DIFF
--- a/python/dgl/dataloading/cluster_gcn.py
+++ b/python/dgl/dataloading/cluster_gcn.py
@@ -30,7 +30,7 @@ class ClusterGCNSampler(Sampler):
         The number of partitions.
     cache_path : str
         The path to the cache directory for storing the partition result.
-    balance_ntypes, balkance_edges, mode :
+    balance_ntypes, balance_edges, mode :
         Passed to :func:`dgl.metis_partition_assignment`.
     prefetch_ndata : list[str], optional
         The node data to prefetch for the subgraph.


### PR DESCRIPTION
## Description
fixed typo in docstring

## Checklist
Please feel free to remove inapplicable items for your PR.
- [x] The PR title starts with [$CATEGORY] (such as [NN], [Model], [Doc], [Feature]])


- [x] To the best of my knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change


## Changes
<!-- You could use following template
- fixed typo balkance to balance
-->
